### PR TITLE
fix: support Gradle wrapper projects with whitespaces in path

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "snyk-config": "^2.2.1",
     "snyk-docker-plugin": "1.24.1",
     "snyk-go-plugin": "1.7.1",
-    "snyk-gradle-plugin": "2.10.0",
+    "snyk-gradle-plugin": "2.10.1",
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.3.0",
     "snyk-nodejs-lockfile-parser": "1.13.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Support Gradle projects with whitespaces in path that use a wrapper.