### PR TITLE
fix: Removing shell options which cause too verbose output

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-set -v
-set -x
-
 OUTPUT_FILE=snyk-result.json
 MONITOR_OUTPUT_FILE=snyk-monitor-result.json
 ERROR_FILE=snyk-error.log


### PR DESCRIPTION
Fix for issue [464](https://github.com/snyk/snyk/issues/464). The official Snyk Docker containers from Dockerhub run with a lot of verbose debug output. This PR removes some set statements which add some options to the environment. In particular:

-x  Print commands and their arguments as they are executed.
-v  Print shell input lines as they are read.