### PR TITLE
feat: Support SOURCE_DATE_EPOCH

### DIFF
--- a/src/lib/protect/datetime.js
+++ b/src/lib/protect/datetime.js
@@ -1,0 +1,6 @@
+module.exports = datetime;
+
+// https://reproducible-builds.org/docs/source-date-epoch/
+function datetime() {
+    return new Date(process.env.SOURCE_DATE_EPOCH ? (process.env.SOURCE_DATE_EPOCH * 1000) : new Date().getTime());
+}

--- a/src/lib/protect/patch.js
+++ b/src/lib/protect/patch.js
@@ -1,7 +1,5 @@
 module.exports = patch;
 
-const now = new Date();
-
 const debug = require('debug')('snyk');
 const chalk = require('chalk');
 const glob = require('glob');
@@ -18,6 +16,9 @@ const spinner = require('../spinner');
 const errors = require('../errors/legacy-errors');
 const analytics = require('../analytics');
 const getPatchFile = require('./fetch-patch');
+const datetime = require('./datetime');
+
+const now = datetime();
 
 function patch(vulns, live) {
   const lbl = 'Applying patches...';

--- a/src/lib/protect/write-patch-flag.js
+++ b/src/lib/protect/write-patch-flag.js
@@ -3,11 +3,12 @@ module.exports = writePatchFlag;
 const debug = require('debug')('snyk');
 const fs = require('fs');
 const path = require('path');
+const datetime = require('./datetime');
 
 function writePatchFlag(now, vuln) {
   if (!vuln) {
     vuln = now;
-    now = new Date();
+    now = datetime();
   }
 
   debug('writing flag for %s', vuln.id);


### PR DESCRIPTION
- [X] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Introduces support for `$SOURCE_DATE_EPOCH` to make the timestamps contained in the signal-desktop package distributed by Arch Linux deterministic, resolves #1536.

#### Where should the reviewer start?

Ensure `src/lib/protect/datetime.js` looks reasonable, afterwards verify the changes in `src/lib/protect/patch.js` and `src/lib/protect/write-patch-flag.js` that simply swap `new Date()` with `datetime()`.

#### How should this be manually tested?

`export SOURCE_DATE_EPOCH=0` and verify the `snyk-*.flag` files generated by snyk protect contain a datetime in `1970-01-01` instead of the current date. Afterwards `unset SOURCE_DATE_EPOCH`, delete `node_modules/` and ensure the regular behavior didn't change.

#### Any background context you want to provide?

Further reading (if necessary):
https://reproducible-builds.org/docs/source-date-epoch/
https://reproducible-builds.org/docs/timestamps/
https://github.com/bmwiedemann/theunreproduciblepackage/tree/master/timestamp

#### What are the relevant tickets?

#1536