### PR TITLE
style: add workaround suggestion to auth failure error message

### DIFF
--- a/src/lib/errors/authentication-failed-error.ts
+++ b/src/lib/errors/authentication-failed-error.ts
@@ -3,7 +3,8 @@ import * as config from '../config';
 
 export function AuthFailedError(
   errorMessage: string = 'Authentication failed. Please check the API token on ' +
-    config.ROOT,
+    config.ROOT +
+    '\nIf it is correctly configured, try running `snyk auth [api key]` instead',
   errorCode = 401,
 ) {
   const error = new CustomError(errorMessage);


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Adds a hint text for the "api key" argument to `snyk auth`

#### Where should the reviewer start?
On Windows, run a WSL 2.0 instance of Debian or other OS.
`snyk auth` appears to generate this error after hitting "Authorize" on the browser tab that pops up.

#### How should this be manually tested?
`npm run snyk-auth` on WSL 2.0. 

#### Any background context you want to provide?


#### What are the relevant tickets?
https://github.com/snyk/snyk/issues/898

#### Screenshots
![image](https://user-images.githubusercontent.com/2539092/106670906-a5aea100-657b-11eb-9916-c4904043a6f3.png)


#### Additional questions
