### PR TITLE
feat: check for sast/snyk code setting on org before running code test

### DIFF
--- a/src/lib/errors/unsupported-feature-for-org-error.ts
+++ b/src/lib/errors/unsupported-feature-for-org-error.ts
@@ -3,11 +3,14 @@ import { CustomError } from './custom-error';
 export class FeatureNotSupportedForOrgError extends CustomError {
   public readonly org: string;
 
-  constructor(org: string, additionalUserHelp = '') {
+  constructor(org: string, feature = 'Feature', additionalUserHelp = '') {
     super(`Unsupported action for org ${org}.`);
     this.code = 422;
     this.org = org;
 
-    this.userMessage = `Feature is not supported for org ${org}. ${additionalUserHelp}`;
+    this.userMessage =
+      `${feature} is not supported for org` +
+      (org ? ` ${org}` : '') +
+      (additionalUserHelp ? `: ${additionalUserHelp}` : '.');
   }
 }

--- a/src/lib/plugins/sast/settings.ts
+++ b/src/lib/plugins/sast/settings.ts
@@ -1,0 +1,25 @@
+import request = require('../../request');
+import snyk = require('../..');
+import * as config from '../../config';
+import { assembleQueryString } from '../../snyk-test/common';
+
+interface SastSettings {
+  sastEnabled: boolean;
+  code?: number;
+  error?: string;
+}
+
+export async function getSastSettingsForOrg(org): Promise<SastSettings> {
+  const response = await request({
+    method: 'GET',
+    headers: {
+      Authorization: `token ${snyk.api}`,
+    },
+    qs: assembleQueryString({ org }),
+    url: `${config.API}/cli-config/settings/sast`,
+    gzip: true,
+    json: true,
+  });
+
+  return (response as any).body;
+}


### PR DESCRIPTION
#### What does this PR do?

Fixes [COD-123](https://snyksec.atlassian.net/browse/COD-123).

This PR prevents snyk code analysis unless enabled for the orgaization.


#### How to test?

Run `snyk code test` for an organization that does not have it enabled.

```
❯ snyk code test --org=testorg
Snyk Code is not supported for org testorg.
```
