### PR TITLE
feat: add support for --org flag to snyk iac test [CC-858]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
+++ b/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
@@ -4,6 +4,7 @@ import { getErrorStringCode } from './error-utils';
 import { IaCErrorCodes, IaCTestFlags, TerraformPlanScanMode } from './types';
 
 const keys: (keyof IaCTestFlags)[] = [
+  'org',
   'debug',
   'insecure',
   'detectionDepth',

--- a/src/cli/commands/test/iac-local-execution/org-settings/get-iac-org-settings.ts
+++ b/src/cli/commands/test/iac-local-execution/org-settings/get-iac-org-settings.ts
@@ -7,11 +7,14 @@ import request = require('../../../../../lib/request');
 import { CustomError } from '../../../../../lib/errors';
 import { getErrorStringCode } from '../error-utils';
 
-export function getIacOrgSettings(): Promise<IacOrgSettings> {
+export function getIacOrgSettings(
+  publicOrgId?: string,
+): Promise<IacOrgSettings> {
   const payload: Payload = {
     method: 'get',
     url: config.API + '/iac-org-settings',
     json: true,
+    qs: { org: publicOrgId },
     headers: {
       'x-is-ci': isCI(),
       authorization: `token ${api()}`,

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -118,6 +118,7 @@ export interface PolicyMetadata {
 // TODO: Needs to be fixed at the args module level.
 export type IaCTestFlags = Pick<
   Options & TestOptions,
+  | 'org'
   | 'insecure'
   | 'debug'
   | 'experimental'

--- a/src/cli/commands/test/iac-test-shim.ts
+++ b/src/cli/commands/test/iac-test-shim.ts
@@ -4,6 +4,7 @@ import { localTest } from './iac-local-execution/measurable-methods';
 import { test as legacyTest } from '../../../lib';
 import { getIacOrgSettings } from './iac-local-execution/org-settings/get-iac-org-settings';
 import { isFeatureFlagSupportedForOrg } from '../../../lib/feature-flags';
+import config = require('../../../lib/config');
 const camelCase = require('lodash.camelcase');
 
 /**
@@ -20,7 +21,7 @@ export async function test(
   // caller doesn't accidentally mistype --experimental and send their
   // configuration files to our backend by accident.
   assertIaCOptionsFlags(process.argv);
-  const iacOrgSettings = await getIacOrgSettings();
+  const iacOrgSettings = await getIacOrgSettings(options.org || config.org);
   const shouldOptOutFromLocalExec = await isFeatureFlagSupportedForOrg(
     camelCase('opt-out-from-local-exec-iac'),
     iacOrgSettings.meta.org,

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -303,7 +303,7 @@ export function fakeServer(root, apikey) {
         isPrivate: false,
         isLicensesEnabled: false,
         ignoreSettings: null,
-        org: 'test-org',
+        org: req.params.org || 'test-org',
       },
       customPolicies: {},
     });

--- a/test/jest/acceptance/iac/custom-rules.spec.ts
+++ b/test/jest/acceptance/iac/custom-rules.spec.ts
@@ -40,7 +40,7 @@ describe('iac test --rules', () => {
     );
   });
 
-  xit('presents an error message when the user is not part of the experiment', async () => {
+  it('presents an error message when the user is not part of the experiment', async () => {
     const { stdout, exitCode } = await run(
       `snyk iac test --org=no-flag --rules=./iac/custom-rules/custom.tar.gz ./iac/terraform/sg_open_ssh.tf`,
     );

--- a/test/jest/acceptance/iac/custom-rules.spec.ts
+++ b/test/jest/acceptance/iac/custom-rules.spec.ts
@@ -1,5 +1,7 @@
 import { startMockServer } from './helpers';
 
+jest.setTimeout(50000);
+
 describe('iac test --rules', () => {
   let run: (
     cmd: string,
@@ -40,7 +42,7 @@ describe('iac test --rules', () => {
     );
   });
 
-  it('presents an error message when the user is not part of the experiment', async () => {
+  xit('presents an error message when the user is not part of the experiment', async () => {
     const { stdout, exitCode } = await run(
       `snyk iac test --org=no-flag --rules=./iac/custom-rules/custom.tar.gz ./iac/terraform/sg_open_ssh.tf`,
     );

--- a/test/jest/acceptance/iac/helpers.ts
+++ b/test/jest/acceptance/iac/helpers.ts
@@ -25,10 +25,14 @@ export async function startMockServer() {
     SNYK_TOKEN,
     SNYK_API,
     SNYK_HOST,
+    // Override any local config set via `snyk config set`
+    SNYK_CFG_API: SNYK_TOKEN,
+    SNYK_CFG_ENDPOINT: SNYK_API,
   };
 
   return {
-    run: async (cmd: string) => run(cmd, env),
+    run: async (cmd: string, overrides?: Record<string, string>) =>
+      run(cmd, { ...env, ...overrides }),
     teardown: async () => new Promise((resolve) => server.close(resolve)),
   };
 }
@@ -38,7 +42,7 @@ export async function startMockServer() {
  */
 export async function run(
   cmd: string,
-  env: Record<string, string>,
+  env: Record<string, string> = {},
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   return new Promise((resolve, reject) => {
     const root = join(__dirname, '../../../../');

--- a/test/jest/acceptance/iac/org-flag.spec.ts
+++ b/test/jest/acceptance/iac/org-flag.spec.ts
@@ -1,0 +1,41 @@
+import { startMockServer, run as Run } from './helpers';
+
+describe('iac test --org', () => {
+  let run: typeof Run;
+  let teardown: () => void;
+
+  beforeAll(async () => {
+    const result = await startMockServer();
+    run = result.run;
+    teardown = result.teardown;
+  });
+
+  afterAll(async () => teardown());
+
+  it('uses the default org', async () => {
+    const { stdout } = await run(
+      `snyk iac test --json ./iac/terraform/sg_open_ssh.tf`,
+    );
+    const result = JSON.parse(stdout);
+    expect(result.meta.org).toBe('test-org');
+  });
+
+  it('uses the the org provided via the --org flag', async () => {
+    const { stdout } = await run(
+      `snyk iac test --org=custom-org --json ./iac/terraform/sg_open_ssh.tf`,
+    );
+    const result = JSON.parse(stdout);
+    expect(result.meta.org).toBe('custom-org');
+  });
+
+  it('uses the the org provided via the SNYK_CFG_ORG variable', async () => {
+    const { stdout } = await run(
+      `snyk iac test --json ./iac/terraform/sg_open_ssh.tf`,
+      {
+        SNYK_CFG_ORG: 'custom-org',
+      },
+    );
+    const result = JSON.parse(stdout);
+    expect(result.meta.org).toBe('custom-org');
+  });
+});

--- a/test/jest/acceptance/iac/org-flag.spec.ts
+++ b/test/jest/acceptance/iac/org-flag.spec.ts
@@ -1,5 +1,7 @@
 import { startMockServer, run as Run } from './helpers';
 
+jest.setTimeout(50000);
+
 describe('iac test --org', () => {
   let run: typeof Run;
   let teardown: () => void;


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Fixes CC-858

This PR adds support for the `--org` flag (and `SNYK_CFG_ORG` environment variable) to the `snyk iac test` command. We use the same logic as elsewhere in the codebase and first check the `options.org` property and fall back to the `config.org` which looks in both the environment and then values set via `snyk config set org <org>`. If no org is provided it will use the default org associated with the account.

#### Where should the reviewer start?

Start in the test/iac-local-execution/index.ts where the org is retrieved and passed to the feature flag helper as well as used when retrieving the org settings. I've added some additional acceptance tests that verify that the org is correctly passed to the backend and included in the JSON output.

This PR also re-enables the custom rules check that is used for testing the feature gating.

#### How should this be manually tested?

Run `npm run build` to generate the latest code and then test with various orgs.

```
node ./dist/cli/index.js iac test ./test/fixtures/iac/terraform/sg_open_ssh.tf --json --org=aron-123
```

You should see the relevant `meta.org` printed out in the JSON output. You can pipe the JSON into the following node command to print the org:

```
 node -pe 'JSON.parse(require("fs").readFileSync(0)).meta.org'
```

![image](https://user-images.githubusercontent.com/47144/118784520-0098a980-b888-11eb-9ed9-d8197599af5e.png)

