### PR TITLE
chore: Introduce 'yaml' library to parse YAML IaC files [CC-854]

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,8 @@
     "tempfile": "^2.0.0",
     "update-notifier": "^5.1.0",
     "uuid": "^3.3.2",
-    "wrap-ansi": "^5.1.0"
+    "wrap-ansi": "^5.1.0",
+    "yaml": "^1.10.2"
   },
   "devDependencies": {
     "@types/agent-base": "^4.2.1",

--- a/src/cli/commands/test/iac-local-execution/file-loader.ts
+++ b/src/cli/commands/test/iac-local-execution/file-loader.ts
@@ -41,7 +41,6 @@ export async function loadFiles(
   if (filesToScan.length === 0) {
     throw new NoFilesToScanError();
   }
-
   return filesToScan;
 }
 
@@ -72,6 +71,10 @@ export async function tryLoadFileData(
     await fs.readFile(pathToScan, DEFAULT_ENCODING)
   ).toString();
 
+  if (fileContent === '') {
+    return null;
+  }
+
   return {
     filePath: pathToScan,
     fileType: fileType as IacFileTypes,
@@ -88,6 +91,7 @@ export class NoFilesToScanError extends CustomError {
       'Could not find any valid infrastructure as code files. Supported file extensions are tf, yml, yaml & json.\nMore information can be found by running `snyk iac test --help` or through our documentation:\nhttps://support.snyk.io/hc/en-us/articles/360012429477-Test-your-Kubernetes-files-with-our-CLI-tool\nhttps://support.snyk.io/hc/en-us/articles/360013723877-Test-your-Terraform-files-with-our-CLI-tool';
   }
 }
+
 export class FailedToLoadFileError extends CustomError {
   constructor(filename: string) {
     super('Failed to load file content');

--- a/src/lib/iac/iac-parser.ts
+++ b/src/lib/iac/iac-parser.ts
@@ -1,5 +1,5 @@
 //TODO(orka): take out into a new lib
-import * as YAML from 'js-yaml';
+import * as YAML from 'yaml';
 import * as debugLib from 'debug';
 import {
   IllegalIacFileErrorMsg,
@@ -30,7 +30,12 @@ function parseYamlOrJson(fileContent: string, filePath: string): any {
     case 'yaml':
     case 'yml':
       try {
-        return YAML.safeLoadAll(fileContent);
+        return YAML.parseAllDocuments(fileContent).map((doc) => {
+          if (doc.errors.length !== 0) {
+            throw doc.errors[0];
+          }
+          return doc.toJSON();
+        });
       } catch (e) {
         debug('Failed to parse iac config as a YAML');
       }

--- a/test/fixtures/iac/depth_detection/one/one.tf
+++ b/test/fixtures/iac/depth_detection/one/one.tf
@@ -1,0 +1,17 @@
+resource "aws_subnet" "private2" {
+  vpc_id = aws_vpc.main.id
+  cidr_block = "10.0.4.0/24"
+  availability_zone = "ap-northeast-1c"
+
+  tags = {
+    Name = "terraform-example/private2"
+  }
+}
+
+resource "aws_internet_gateway" "terraform_example" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "terraform-example/igw"
+  }
+}

--- a/test/fixtures/iac/depth_detection/root.tf
+++ b/test/fixtures/iac/depth_detection/root.tf
@@ -1,0 +1,11 @@
+resource "aws_s3_bucket" "s3_bucket" {
+  bucket = var.bucket_name
+
+  acl    = "public-read"
+  website {
+    index_document = "index.html"
+    error_document = "error.html"
+  }
+
+  tags = var.tags
+}

--- a/test/jest/unit/iac-unit-tests/file-loader.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/file-loader.fixtures.ts
@@ -35,6 +35,12 @@ export const nonIacFileStub = {
   fileType: 'sh',
 };
 
+export const emptyFileStub = {
+  fileContent: '',
+  filePath: path.join(mixedDirectory, 'this_shouldnt_load.yaml'),
+  fileType: 'yaml',
+};
+
 export const anotherNonIacFileStub = {
   fileContent,
   filePath: path.join(mixedDirectory, 'this_also_shouldnt_load.js'),

--- a/test/jest/unit/iac-unit-tests/file-loader.spec.ts
+++ b/test/jest/unit/iac-unit-tests/file-loader.spec.ts
@@ -21,6 +21,7 @@ import {
   level2FileStub,
   level3Directory,
   level3FileStub,
+  emptyFileStub,
 } from './file-loader.fixtures';
 
 describe('loadFiles', () => {
@@ -157,6 +158,28 @@ describe('loadFiles', () => {
         await expect(loadFiles(nonIacFileStub.filePath)).rejects.toThrow(
           NoFilesToScanError,
         );
+      });
+    });
+
+    describe('empty files', () => {
+      it('single empty file does not get scanned and throws an error', async () => {
+        mockFs({
+          [emptyFileStub.filePath]: emptyFileStub.fileContent,
+        });
+
+        await expect(loadFiles(emptyFileStub.filePath)).rejects.toThrow(
+          NoFilesToScanError,
+        );
+      });
+
+      it('empty file in directory is skipped', async () => {
+        mockFs({
+          [emptyFileStub.filePath]: emptyFileStub.fileContent,
+          [k8sFileStub.filePath]: k8sFileStub.fileContent,
+        });
+
+        const loadedFiles = await loadFiles('.');
+        expect(loadedFiles).toEqual([k8sFileStub]);
       });
     });
 

--- a/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
@@ -165,7 +165,7 @@ Describe "Snyk iac local test command"
 
     It "limits the depth of the directories"
       When run snyk iac test ../fixtures/iac/depth_detection/  --detection-depth=2
-      The status should equal 0 # no issues found
+      The status should equal 1 #  issues found
       # Only File
       The output should include "Testing one.tf..."
       The output should include "Infrastructure as code issues:"
@@ -177,7 +177,7 @@ Describe "Snyk iac local test command"
       The output should include "Tested root.tf for known issues, found"
 
       # Directory scan summary
-      The output should include "Tested 2 projects, no vulnerable paths were found."
+      The output should include "Tested 2 projects"
     End
 
     Describe "Testing status code when issues found"


### PR DESCRIPTION
## TL;DR
This PR introduces the “yaml” library as a robust way of parsing YAML files for the IaC flow.
It also removes the `js-yaml` library which is a transitive dependency.

### The Problem
The past few months, we have identified a few issues with the npm library we are using for parsing YAML files (`js-yaml`).
It detects both false positives and false negatives when parsing YAML files, which has not been ideal for us. We used to do workarounds to avoid the real issue, but we are now introducing support for CloudFormation (another YAML type) and it's time to address this.

#### Examples
**Example 1:**
 Library gets this string: `{{"foo": "bar"}: {"qux": "baz"}}` and it should fail as this is invalid yaml.
It does not fail, but it parses it like this: `[{"[object Object]":{"qux":"baz"}}]` which is not correct.
Runkit: https://runkit.com/embed/9tf55g330u5h

**Example 2:**
Library gets a CloudFormation yaml file with AWS intrinsic functions such as: 
 `key: !Equals [ !Ref EnvironmentName, prod ]`
This will throw an exception for unknown tag, which is fair and will fail. However this is still valid YAML.

### Options/Solutions

- We use an outdated version of `js-yaml@3.14.1`. We can upgrade to a newer version, which provides us with a functionality to extend the default schema to support tags like !Ref and !Equals etc. Example: 
```
jsYaml.CORE_SCHEMA.extend({
implicit: [],      
explicit: [
'Fn::Base64',
'Fn::Cidr',
'Fn::FindInMap',
'Fn::GetAtt',
'Fn::GetAZs',
'Fn::ImportValue',
'Fn::Join',
'Fn::Select',
'Fn::Split',
'Fn::Sub',
'Fn::Transform',
'Ref',
'Condition',
'Fn::And',
'Fn::Equals',
'Fn::If',
'Fn::Not',
'Fn::Or',
]
```
However, if we print the dependency of the package (see below), we will see that it is not only used in our code, but also in `@yarn/core`. This means that `js-yaml@3.14.1` will always be a dependency until yarn updates.

```
% npm ls --production js-yaml
snyk@1.0.0-monorepo /Users/iliannapapastefanou/Snyk-repos/snyk
├─┬ @snyk/snyk-cocoapods-plugin@2.5.2
│ └─┬ @snyk/cocoapods-lockfile-parser@3.6.2
│   └── js-yaml@3.14.1  deduped
├─┬ snyk-nodejs-lockfile-parser@1.34.2
│ ├─┬ @yarnpkg/core@2.4.0
│ │ └─┬ @yarnpkg/parsers@2.3.0
│ │   └── js-yaml@3.14.1  deduped
│ └── js-yaml@4.1.0 
└─┬ snyk-policy@1.19.0
  └── js-yaml@3.14.1
 ```
- Replacing the `js-yaml` library with a new one in the IaC code. We spiked different libraries and we have found one that it currently supports everything that we want and it's also extensible. 

### The Proposal
This PR is a proposal to replace it with a different npm library, called `yaml`. This library parses YAML contents correctly and ensures our current functionality does not break. 

**The proposed package itself is small, so we think adding this package is worth it - 91.7kB for the Minified bundle and 27kB for the Minified + Gzipped. Also, there are 0 direct dependencies. More: 
https://bundlephobia.com/result?p=yaml@1.10.2**
![image](https://user-images.githubusercontent.com/6989529/119007454-25c11100-b989-11eb-9e84-50daef0ab963.png)

#### What are the relevant tickets?
[CC-854]

[CC-854]: https://snyksec.atlassian.net/browse/CC-854