### PR TITLE
feat: support config attributes for reachability in gradle

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "snyk-cpp-plugin": "2.2.1",
     "snyk-docker-plugin": "4.20.2",
     "snyk-go-plugin": "1.17.0",
-    "snyk-gradle-plugin": "3.14.5",
+    "snyk-gradle-plugin": "3.15.0",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.26.0",
     "snyk-nodejs-lockfile-parser": "1.34.2",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Support config attributes for reachability in Gradle.

This change passes the gradle config attributes flags from the cli args to the call graph builder. 

e.g. running:
`snyk test --file=build.gradle.kts --reachable -PconfAttrs='buildtype:release,usage:java-runtime'`

More info at:
- https://github.com/snyk/java-call-graph-builder/pull/49
- https://github.com/snyk/snyk-gradle-plugin/pull/171

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/FLOW-689

#### Screenshots


#### Additional questions
