### PR TITLE
Add missing test suite for packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,6 +257,12 @@ jobs:
           condition: << parameters.package_tests >>
           steps:
             - run:
+                name: Run Package system tests
+                command: npm run test:packages-system
+      - when:
+          condition: << parameters.package_tests >>
+          steps:
+            - run:
                 name: Run Package acceptance tests
                 command: npm run test:packages-acceptance
       - when:
@@ -328,6 +334,12 @@ jobs:
             - run:
                 name: Run Package unit tests
                 command: npm run test:packages-unit
+      - when:
+          condition: << parameters.package_tests >>
+          steps:
+            - run:
+                name: Run Package system tests
+                command: npm run test:packages-system
       - when:
           condition: << parameters.package_tests >>
           steps:

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "test:jest-system": "jest --runInBand \"/test/jest/system/((.+)/)*[^/]+\\.spec\\.ts\"",
     "test:jest-acceptance": "jest --runInBand \"/test/jest/acceptance/((.+)/)*[^/]+\\.spec\\.ts\"",
     "test:packages-unit": "jest \"/packages/(.+)/test/unit/((.+)/)*[^/]+\\.spec\\.ts\"",
+    "test:packages-system": "jest \"/packages/(.+)/test/system/((.+)/)*[^/]+\\.spec\\.ts\"",
     "test:packages-acceptance": "jest \"/packages/(.+)/test/acceptance/((.+)/)*[^/]+\\.spec\\.ts\"",
     "test:test": "tap test/*.test.* -Rspec --timeout=300 --node-arg=-r --node-arg=ts-node/register",
     "test:smoke": "./scripts/run-smoke-tests-locally.sh",


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds the `test:packages-system` test suite for the packages to bring the test suites inline with the root package test suites.

Info on [test suites in CLI](https://miro.com/app/board/o9J_lRBdYJI=/)

