### PR TITLE
Surface errors when testing with --all-projects

### DIFF
--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -8,6 +8,7 @@ import { parsePackageString as moduleToObject } from 'snyk-module';
 import * as depGraphLib from '@snyk/dep-graph';
 import { IacScan } from './payload-schema';
 import * as Queue from 'promise-queue';
+import { EOL } from 'os';
 
 import {
   AffectedPackages,
@@ -571,6 +572,8 @@ async function assembleLocalPayloads(
     if (failedResults?.length) {
       await spinner.clear<void>(spinnerLbl)();
       if (!options.json && !options.quiet) {
+        const errorMessage = failedResults.map((f) => f.errMessage).join(EOL);
+        console.error(errorMessage);
         console.warn(
           chalk.bold.red(
             `✗ ${failedResults.length}/${failedResults.length +
@@ -579,6 +582,13 @@ async function assembleLocalPayloads(
           ),
         );
       }
+      debug(
+        'getDepsFromPlugin returned failed results, cannot run test/monitor',
+        failedResults,
+      );
+      throw new FailedToRunTestError(
+        'Your test request could not be completed. Please email support@snyk.io',
+      );
     }
     analytics.add('pluginName', deps.plugin.name);
     const javaVersion = get(

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-error/package.json
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-error/package.json
@@ -1,0 +1,10 @@
+{
+	foo
+  "name": "project-with-error",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-issues/node_modules/.package-lock.json
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-issues/node_modules/.package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "project-with-issues",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    }
+  }
+}

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-issues/node_modules/lodash/LICENSE
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-issues/node_modules/lodash/LICENSE
@@ -1,0 +1,47 @@
+Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
+
+Based on Underscore.js, copyright Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/lodash/lodash
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+====
+
+Copyright and related rights for sample code are waived via CC0. Sample
+code is defined as all source code displayed within the prose of the
+documentation.
+
+CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+====
+
+Files located in the node_modules and vendor directories are externally
+maintained libraries used by this software which have their own
+licenses; we recommend you read them, as their terms may differ from the
+terms above.

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-issues/node_modules/lodash/package.json
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-issues/node_modules/lodash/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "lodash",
+  "version": "4.17.21",
+  "description": "Lodash modular utilities.",
+  "keywords": "modules, stdlib, util",
+  "homepage": "https://lodash.com/",
+  "repository": "lodash/lodash",
+  "icon": "https://lodash.com/icon.svg",
+  "license": "MIT",
+  "main": "lodash.js",
+  "author": "John-David Dalton <john.david.dalton@gmail.com>",
+  "contributors": [
+    "John-David Dalton <john.david.dalton@gmail.com>",
+    "Mathias Bynens <mathias@qiwi.be>"
+  ],
+  "scripts": { "test": "echo \"See https://travis-ci.org/lodash-archive/lodash-cli for testing details.\"" }
+}

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-issues/package-lock.json
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-issues/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "project-with-issues",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    }
+  },
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    }
+  }
+}

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-issues/package.json
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-issues/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "project-with-issues",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "lodash": "^4.17.15"
+  }
+}

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-with-error/package.json
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-with-error/package.json
@@ -1,0 +1,10 @@
+{
+	foo
+  "name": "project-with-error",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-without-issues/node_modules/.package-lock.json
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-without-issues/node_modules/.package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "project-without-issues",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    }
+  }
+}

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-without-issues/node_modules/lodash/LICENSE
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-without-issues/node_modules/lodash/LICENSE
@@ -1,0 +1,47 @@
+Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
+
+Based on Underscore.js, copyright Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/lodash/lodash
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+====
+
+Copyright and related rights for sample code are waived via CC0. Sample
+code is defined as all source code displayed within the prose of the
+documentation.
+
+CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+====
+
+Files located in the node_modules and vendor directories are externally
+maintained libraries used by this software which have their own
+licenses; we recommend you read them, as their terms may differ from the
+terms above.

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-without-issues/node_modules/lodash/package.json
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-without-issues/node_modules/lodash/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "lodash",
+  "version": "4.17.21",
+  "description": "Lodash modular utilities.",
+  "keywords": "modules, stdlib, util",
+  "homepage": "https://lodash.com/",
+  "repository": "lodash/lodash",
+  "icon": "https://lodash.com/icon.svg",
+  "license": "MIT",
+  "main": "lodash.js",
+  "author": "John-David Dalton <john.david.dalton@gmail.com>",
+  "contributors": [
+    "John-David Dalton <john.david.dalton@gmail.com>",
+    "Mathias Bynens <mathias@qiwi.be>"
+  ],
+  "scripts": { "test": "echo \"See https://travis-ci.org/lodash-archive/lodash-cli for testing details.\"" }
+}

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-without-issues/package-lock.json
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-without-issues/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "project-without-issues",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    }
+  },
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    }
+  }
+}

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-without-issues/package.json
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-without-issues/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "project-without-issues",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "lodash": "^4.17.21"
+  }
+}

--- a/test/jest/acceptance/cli-args.spec.ts
+++ b/test/jest/acceptance/cli-args.spec.ts
@@ -1,53 +1,13 @@
-import { spawn } from 'cross-spawn';
 import * as fse from 'fs-extra';
 import * as path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { UnsupportedOptionCombinationError } from '../../../src/lib/errors/unsupported-option-combination-error';
+import { runCLI } from '../util/runCLI';
 
 const createOutputDirectory = (): string => {
   const outputPath = path.normalize(`test-output/${uuidv4()}`);
   fse.ensureDirSync(outputPath);
   return outputPath;
-};
-
-const cliPath = path.normalize('./dist/cli/index.js');
-
-type RunCLIResult = {
-  code: number;
-  stdout: string;
-  stderr: string;
-};
-
-const runCLI = (args: string): Promise<RunCLIResult> => {
-  return new Promise((resolve, reject) => {
-    const cli = spawn('node', [cliPath, ...args.split(' ')]);
-    const stdout: Buffer[] = [];
-    const stderr: Buffer[] = [];
-
-    cli.on('error', (error) => {
-      reject(error);
-    });
-
-    cli.stdout.on('data', (chunk) => {
-      stdout.push(Buffer.from(chunk));
-    });
-
-    cli.stderr.on('data', (chunk) => {
-      stderr.push(Buffer.from(chunk));
-    });
-
-    cli.on('close', (code) => {
-      resolve({
-        code: code || 0,
-        stdout: Buffer.concat(stdout)
-          .toString('utf-8')
-          .trim(),
-        stderr: Buffer.concat(stderr)
-          .toString('utf-8')
-          .trim(),
-      });
-    });
-  });
 };
 
 jest.setTimeout(1000 * 60 * 5);

--- a/test/jest/acceptance/snyk-test-all-projects-exit-codes.spec.ts
+++ b/test/jest/acceptance/snyk-test-all-projects-exit-codes.spec.ts
@@ -1,0 +1,42 @@
+import * as path from 'path';
+import { runCLI } from '../util/runCLI';
+
+jest.setTimeout(1000 * 60 * 5);
+
+describe('snyk test -all-projects should exit with 2 exit code', () => {
+  describe('when one of the projects being tested has errors', () => {
+    it('and the other has issues (vulnerabilities)', async () => {
+      const fixture = path.resolve(
+        __dirname,
+        '../../fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error',
+      );
+      console.log(fixture);
+      const { code, stderr } = await runCLI(`test --all-projects`, fixture);
+      expect(code).toEqual(2);
+      expect(stderr).toContain(
+        '1/2 potential projects failed to get dependencies. Run with `-d` for debug output.',
+      );
+      expect(stderr).toContain('Failed to read');
+      expect(stderr).toContain(
+        'test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-error/package.json. Error: Unexpected token f in JSON at position 3',
+      );
+    });
+
+    it('and the other has no issues', async () => {
+      const fixture = path.resolve(
+        __dirname,
+        '../../fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error',
+      );
+      console.log(fixture);
+      const { code, stderr } = await runCLI(`test --all-projects`, fixture);
+      expect(code).toEqual(2);
+      expect(stderr).toContain(
+        '1/2 potential projects failed to get dependencies. Run with `-d` for debug output.',
+      );
+      expect(stderr).toContain('Failed to read');
+      expect(stderr).toContain(
+        'test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-with-error/package.json. Error: Unexpected token f in JSON at position 3',
+      );
+    });
+  });
+});

--- a/test/jest/util/runCLI.ts
+++ b/test/jest/util/runCLI.ts
@@ -1,0 +1,18 @@
+import * as path from 'path';
+import { runCommand, RunCommandResult } from '../util/runCommand';
+
+type RunCLIResult = RunCommandResult;
+
+const runCLI = async (
+  args,
+  workingDirectory?: string,
+): Promise<RunCommandResult> => {
+  const cliPath = path.normalize('./dist/cli/index.js');
+  const cliAbsPath = path.resolve(process.cwd(), cliPath);
+  const ops = {
+    cwd: workingDirectory,
+  };
+  return await runCommand('node', [cliAbsPath, ...args.split(' ')], ops);
+};
+
+export { runCLI, RunCLIResult };

--- a/test/jest/util/runCommand.ts
+++ b/test/jest/util/runCommand.ts
@@ -1,0 +1,48 @@
+import { SpawnOptionsWithoutStdio } from 'child_process';
+import { spawn } from 'cross-spawn';
+
+type RunCommandResult = {
+  code: number;
+  stdout: string;
+  stderr: string;
+};
+
+type RunCommandOptions = SpawnOptionsWithoutStdio;
+
+const runCommand = (
+  command: string,
+  args: string[],
+  options?: RunCommandOptions,
+): Promise<RunCommandResult> => {
+  return new Promise((resolve, reject) => {
+    const cli = spawn(command, args, options);
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+
+    cli.on('error', (error) => {
+      reject(error);
+    });
+
+    cli.stdout.on('data', (chunk) => {
+      stdout.push(Buffer.from(chunk));
+    });
+
+    cli.stderr.on('data', (chunk) => {
+      stderr.push(Buffer.from(chunk));
+    });
+
+    cli.on('close', (code) => {
+      resolve({
+        code: code || 0,
+        stdout: Buffer.concat(stdout)
+          .toString('utf-8')
+          .trim(),
+        stderr: Buffer.concat(stderr)
+          .toString('utf-8')
+          .trim(),
+      });
+    });
+  });
+};
+
+export { runCommand, RunCommandResult };


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Makes sure that when you do a test with `snyk test --all-projects` where one of the projects has errors (i.e. would generate  an error and exit with exit code 2 when you run `snyk test` against it on its own), that the exit code is 2 and the error is not masked by a 0 or 1 coming from the result of the other projects. 

#### Any background context you want to provide?
https://github.com/snyk/architecture-decision-records/pull/28/files

#### What are the relevant tickets?
HAMMER-353
