### PR TITLE
feat: update gradle plugin to close gradle reachability parity gaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "snyk-cpp-plugin": "2.2.1",
     "snyk-docker-plugin": "4.20.2",
     "snyk-go-plugin": "1.17.0",
-    "snyk-gradle-plugin": "3.15.0",
+    "snyk-gradle-plugin": "3.16.0",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.26.0",
     "snyk-nodejs-lockfile-parser": "1.34.2",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Including some changes to better support reachability with gradle:

- Continue scanning if reachability fails
- Add call graph timeout
- More debug context.

For more context:
- https://github.com/snyk/snyk-gradle-plugin/pull/186
- https://github.com/snyk/java-call-graph-builder/pull/52

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/FLOW-821

#### Screenshots


#### Additional questions
