### PR TITLE
fix: code test json output should not print stack trace

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -113,7 +113,10 @@ async function handleError(args, error) {
     args.options.json &&
     !(error instanceof UnsupportedOptionCombinationError)
   ) {
-    console.log(stripAnsi(error.json || error.stack));
+    const output = vulnsFound
+      ? error.message
+      : stripAnsi(error.json || error.stack);
+    console.log(output);
   } else {
     if (!args.options.quiet) {
       const result = errors.message(error);

--- a/test/jest/unit/snyk-code-test.spec.ts
+++ b/test/jest/unit/snyk-code-test.spec.ts
@@ -172,33 +172,39 @@ describe('Test snyk code', () => {
     }
   });
 
-  it('succeed testing with correct exit code - with sarif output', async () => {
-    const options: Options & TestOptions = {
-      path: '',
-      traverseNodeModules: false,
-      showVulnPaths: 'none',
-      code: true,
-      sarif: true,
-    };
+  it.each([
+    ['sarif', { sarif: true }],
+    ['json', { json: true }],
+  ])(
+    'succeed testing with correct exit code - with %p output',
+    async (optionsName, optionsObject) => {
+      const options: Options & TestOptions = {
+        path: '',
+        traverseNodeModules: false,
+        showVulnPaths: 'none',
+        code: true,
+        ...optionsObject,
+      };
 
-    analyzeFoldersMock.mockResolvedValue(sampleAnalyzeFoldersResponse);
-    isSastEnabledForOrgSpy.mockResolvedValueOnce({
-      sastEnabled: true,
-    });
+      analyzeFoldersMock.mockResolvedValue(sampleAnalyzeFoldersResponse);
+      isSastEnabledForOrgSpy.mockResolvedValueOnce({
+        sastEnabled: true,
+      });
 
-    try {
-      await ecosystems.testEcosystem('code', ['some/path'], options);
-    } catch (error) {
-      const errMessage = error.message.trim();
-      const expectedOutput = jsonStringifyLargeObject(
-        sampleSarifResponse,
-      ).trim();
+      try {
+        await ecosystems.testEcosystem('code', ['some/path'], options);
+      } catch (error) {
+        const errMessage = error.message.trim();
+        const expectedOutput = jsonStringifyLargeObject(
+          sampleSarifResponse,
+        ).trim();
 
-      // exit code 1
-      expect(error.code).toBe('VULNS');
-      expect(errMessage).toBe(expectedOutput);
-    }
-  });
+        // exit code 1
+        expect(error.code).toBe('VULNS');
+        expect(errMessage).toBe(expectedOutput);
+      }
+    },
+  );
 
   it('succeed testing with correct exit code - with sarif output', async () => {
     const options: Options & TestOptions = {


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?


#### Where should the reviewer start?
We had an issue with showing stack trace of an error when calling `snyk code test --json` because we didn't check if the "failure" is because we have issue. which means there are vulnerabilities. 

This pr respects the old current logic as well as when we have json output for a payload that has issues

#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
