### PR TITLE
test: improve interface for mock server

### DIFF
--- a/test/jest/acceptance/iac/custom-rules.spec.ts
+++ b/test/jest/acceptance/iac/custom-rules.spec.ts
@@ -1,20 +1,9 @@
-import { startMockServer } from './helpers';
+import { setupMockServer } from './helpers';
 
 jest.setTimeout(50000);
 
 describe('iac test --rules', () => {
-  let run: (
-    cmd: string,
-  ) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
-  let teardown: () => void;
-
-  beforeAll(async () => {
-    const result = await startMockServer();
-    run = result.run;
-    teardown = result.teardown;
-  });
-
-  afterAll(async () => teardown());
+  const run = setupMockServer(beforeAll, afterAll);
 
   it('scans custom rules provided via the --rules flag', async () => {
     const { stdout, exitCode } = await run(

--- a/test/jest/acceptance/iac/org-flag.spec.ts
+++ b/test/jest/acceptance/iac/org-flag.spec.ts
@@ -1,18 +1,9 @@
-import { startMockServer, run as Run } from './helpers';
+import { setupMockServer } from './helpers';
 
 jest.setTimeout(50000);
 
 describe('iac test --org', () => {
-  let run: typeof Run;
-  let teardown: () => void;
-
-  beforeAll(async () => {
-    const result = await startMockServer();
-    run = result.run;
-    teardown = result.teardown;
-  });
-
-  afterAll(async () => teardown());
+  const run = setupMockServer(beforeAll, afterAll);
 
   it('uses the default org', async () => {
     const { stdout } = await run(


### PR DESCRIPTION
Consolidates all of the `startMockServer()` call behind a _slightly_ magical setup function. So now usage looks like:

```ts
    describe('some test', () => {
      const run = setupMockServer(beforeAll, afterAll);
 
      it('runs a command', () => {
         const { exitCode } = await run('echo "hello"');
         expect(exitCode).toEqual(1);
      });
    });
```
