### PR TITLE
fix: Update snyk-docker-plugin to fix exception [DC-1219]

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.2.1",
-    "snyk-docker-plugin": "4.20.3",
+    "snyk-docker-plugin": "4.20.8",
     "snyk-go-plugin": "1.17.0",
     "snyk-gradle-plugin": "3.16.0",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR updats the version of snyk-docker-plugin which has an updated version of docker-registry-v2-client library (used by snyk-docker-pull when docker daemon is not running on the machine). This update fixes an issue when getting multiarch manifest by its digest returning a manifest list, which resulted in a 'cannot read property digest of undefined' exception, when trying to access the manifest.config.digest object (as there is no config object in manifest list).


#### How should this be manually tested?

1. Run `npm install` (with this latest fix)
2. Run `node dist/cli/ container test mongo@sha256:64be89e169fc33f3fa140c2c548186be4acd972bd7174344505fc5630dcf707c`

#### Any background context you want to provide?
The latest fix in the docker-registry-2-client lib makes sure the getManifest always returns a manifest.v2 object rather than a list (in case a list is returned by the API call the default linux/amd64 arch is chosen and returned by it, if exists).
The fix in docker-registry-v2-client: https://github.com/snyk/docker-registry-v2-client/pull/62

#### What are the relevant tickets?

This resolves an open issue: https://github.com/snyk/snyk/issues/1892

#### Screenshots
Running `snyk container test mongo@sha256:64be89e169fc33f3fa140c2c548186be4acd972bd7174344505fc5630dcf707c` (without docker daemon running)

Before this change:
![image](https://user-images.githubusercontent.com/11232557/119675374-a5495700-be45-11eb-9220-d641c5ebe106.png)

After this change:
![image](https://user-images.githubusercontent.com/11232557/119674223-b5146b80-be44-11eb-9bcb-96c5d30c9085.png)
