### PR TITLE
feat: add support for resolutions in yarn2

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "snyk-gradle-plugin": "3.16.0",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.26.0",
-    "snyk-nodejs-lockfile-parser": "1.34.2",
+    "snyk-nodejs-lockfile-parser": "1.35.0",
     "snyk-nuget-plugin": "1.21.1",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "1.19.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This allows yarn2 repositories using resolutions to be tested successfully, with the correct resolved versions being picked up in the scan.