### PR TITLE
docs: Update IaC help docs with CloudFormation && --org option

### DIFF
--- a/help/commands-docs/_EXAMPLES.md
+++ b/help/commands-docs/_EXAMPLES.md
@@ -24,6 +24,7 @@ See `snyk container --help` for more details and examples:
 
 See `snyk iac --help` for more details and examples:
 
-    $ snyk iac test /path/to/Kubernetes.yaml
+    $ snyk iac test /path/to/cloudformation_file.yaml
+    $ snyk iac test /path/to/kubernetes_file.yaml
     $ snyk iac test /path/to/terraform_file.tf
     $ snyk iac test /path/to/tf-plan.json

--- a/help/commands-docs/iac-examples.md
+++ b/help/commands-docs/iac-examples.md
@@ -2,8 +2,11 @@
 
 [For more information see IaC help page](https://snyk.co/ucT6Q)
 
+- `Test CloudFormation file`:
+  \$ snyk iac test /path/to/cloudformation_file.yaml
+  
 - `Test kubernetes file`:
-  \$ snyk iac test /path/to/Kubernetes.yaml
+  \$ snyk iac test /path/to/kubernetes_file.yaml
 
 - `Test terraform file`:
   \$ snyk iac test /path/to/terraform_file.tf

--- a/help/commands-docs/iac.md
+++ b/help/commands-docs/iac.md
@@ -36,6 +36,16 @@ Find security issues in your Infrastructure as Code files.
   Save test output in JSON format directly to the specified file, regardless of whether or not you use the `--json` option.
   This is especially useful if you want to display the human-readable test output via stdout and at the same time save the JSON format output to a file.
 
+- `--org`=<ORG_NAME>:
+  Specify the <ORG_NAME> to run Snyk commands tied to a specific organization. This will influence private tests limits.
+  If you have multiple organizations, you can set a default from the CLI using:
+  
+  `$ snyk config set org`=<ORG_NAME>
+  
+  Setting a default will ensure all newly tested projects will be tested
+  under your default organization. If you need to override the default, you can use the `--org`=<ORG_NAME> argument.
+  Default: uses <ORG_NAME> that sets as default in your [Account settings](https://app.snyk.io/account)
+
 - `--sarif`:
   Return results in SARIF format.
 

--- a/src/cli/commands/test/iac-local-execution/file-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/file-parser.ts
@@ -166,8 +166,8 @@ export class FailedToDetectJsonConfigError extends CustomError {
     );
     this.code = IaCErrorCodes.FailedToDetectJsonConfigError;
     this.strCode = getErrorStringCode(this.code);
-    this.userMessage = `We were unable to detect whether the JSON file "${filename}" is a valid Kubernetes file or Terraform Plan. For Kubernetes it is missing the following fields: "${REQUIRED_K8S_FIELDS.join(
+    this.userMessage = `We were unable to detect whether the JSON file "${filename}" is either a valid Kubernetes file, CloudFormation file or a Terraform Plan. For Kubernetes it is missing the following fields: "${REQUIRED_K8S_FIELDS.join(
       '", "',
-    )}". For Terraform Plan it was expected to contain fields "planned_values.root_module" and "resource_changes". Please contact support@snyk.io, if possible with a redacted version of the file`;
+    )}".  For CloudFormation required fields are: "Resources". For Terraform Plan it was expected to contain fields "planned_values.root_module" and "resource_changes". Please contact support@snyk.io, if possible with a redacted version of the file`;
   }
 }


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- Updates help docs with CloudFormation Examples && with `--org` description
- Updates an error message to include CloudFormation

#### Screenshots
These show up in both `snyk --help` and `snyk iac --help` documentation pages:

`--org`
![image](https://user-images.githubusercontent.com/6989529/119806374-0de21380-beda-11eb-926e-abc02e7a6f45.png)

CloudFormation:
![image](https://user-images.githubusercontent.com/6989529/119806750-66b1ac00-beda-11eb-91af-79e98b265720.png)
