### PR TITLE
Add tests for existing exit codes for --all-projects

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,3 +26,4 @@ help/commands-docs/iac-examples.md @snyk/cloudconfig
 help/commands-docs/iac.md @snyk/cloudconfig
 packages/snyk-fix/ @snyk/tech-services
 packages/snyk-protect/ @snyk/hammer
+test/jest/util/ @snyk/hammer

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-error/package.json
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-error/package.json
@@ -1,0 +1,10 @@
+{
+	foo
+  "name": "project-with-error",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-issues/node_modules/.package-lock.json
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-issues/node_modules/.package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "project-with-issues",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "node_modules/lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    }
+  }
+}

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-issues/node_modules/lodash/LICENSE
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-issues/node_modules/lodash/LICENSE
@@ -1,0 +1,47 @@
+Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
+
+Based on Underscore.js, copyright Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/lodash/lodash
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+====
+
+Copyright and related rights for sample code are waived via CC0. Sample
+code is defined as all source code displayed within the prose of the
+documentation.
+
+CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+====
+
+Files located in the node_modules and vendor directories are externally
+maintained libraries used by this software which have their own
+licenses; we recommend you read them, as their terms may differ from the
+terms above.

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-issues/node_modules/lodash/package.json
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-issues/node_modules/lodash/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "lodash",
+  "version": "4.17.15",
+  "description": "Lodash modular utilities.",
+  "keywords": "modules, stdlib, util",
+  "homepage": "https://lodash.com/",
+  "repository": "lodash/lodash",
+  "icon": "https://lodash.com/icon.svg",
+  "license": "MIT",
+  "main": "lodash.js",
+  "author": "John-David Dalton <john.david.dalton@gmail.com>",
+  "contributors": [
+    "John-David Dalton <john.david.dalton@gmail.com>",
+    "Mathias Bynens <mathias@qiwi.be>"
+  ],
+  "scripts": { "test": "echo \"See https://travis-ci.org/lodash-archive/lodash-cli for testing details.\"" }
+}

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-issues/package-lock.json
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-issues/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "project-with-issues",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "dependencies": {
+        "lodash": "4.17.15"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    }
+  },
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    }
+  }
+}

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-issues/package.json
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error/project-with-issues/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "project-with-issues",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "lodash": "4.17.15"
+  }
+}

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-with-error/package.json
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-with-error/package.json
@@ -1,0 +1,10 @@
+{
+	foo
+  "name": "project-with-error",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-without-issues/node_modules/.package-lock.json
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-without-issues/node_modules/.package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "project-without-issues",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    }
+  }
+}

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-without-issues/node_modules/lodash/LICENSE
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-without-issues/node_modules/lodash/LICENSE
@@ -1,0 +1,47 @@
+Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
+
+Based on Underscore.js, copyright Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/lodash/lodash
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+====
+
+Copyright and related rights for sample code are waived via CC0. Sample
+code is defined as all source code displayed within the prose of the
+documentation.
+
+CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+====
+
+Files located in the node_modules and vendor directories are externally
+maintained libraries used by this software which have their own
+licenses; we recommend you read them, as their terms may differ from the
+terms above.

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-without-issues/node_modules/lodash/package.json
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-without-issues/node_modules/lodash/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "lodash",
+  "version": "4.17.21",
+  "description": "Lodash modular utilities.",
+  "keywords": "modules, stdlib, util",
+  "homepage": "https://lodash.com/",
+  "repository": "lodash/lodash",
+  "icon": "https://lodash.com/icon.svg",
+  "license": "MIT",
+  "main": "lodash.js",
+  "author": "John-David Dalton <john.david.dalton@gmail.com>",
+  "contributors": [
+    "John-David Dalton <john.david.dalton@gmail.com>",
+    "Mathias Bynens <mathias@qiwi.be>"
+  ],
+  "scripts": { "test": "echo \"See https://travis-ci.org/lodash-archive/lodash-cli for testing details.\"" }
+}

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-without-issues/package-lock.json
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-without-issues/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "project-without-issues",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    }
+  },
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    }
+  }
+}

--- a/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-without-issues/package.json
+++ b/test/fixtures/snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error/project-without-issues/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "project-without-issues",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "lodash": "^4.17.21"
+  }
+}

--- a/test/jest/acceptance/oauth-token.spec.ts
+++ b/test/jest/acceptance/oauth-token.spec.ts
@@ -4,6 +4,7 @@ import {
 } from '../../acceptance/workspace-helper';
 import { fakeServer } from '../../acceptance/fake-server';
 import cli = require('../../../src/cli/commands');
+import { chdir } from 'process';
 
 describe('test using OAuth token', () => {
   let oldkey: string;
@@ -21,7 +22,10 @@ describe('test using OAuth token', () => {
     'vulns-result.json',
   );
 
+  let origCwd: string;
+
   beforeAll(async () => {
+    origCwd = process.cwd();
     process.env.SNYK_API = `http://localhost:${port}${BASE_API}`;
     process.env.SNYK_HOST = `http://localhost:${port}`;
 
@@ -53,6 +57,7 @@ describe('test using OAuth token', () => {
     if (oldendpoint) {
       await cli.config('endpoint', oldendpoint);
     }
+    chdir(origCwd);
   });
 
   it('successfully tests a project with an OAuth env variable set', async () => {

--- a/test/jest/acceptance/snyk-test-all-projects-exit-codes.spec.ts
+++ b/test/jest/acceptance/snyk-test-all-projects-exit-codes.spec.ts
@@ -1,0 +1,32 @@
+import { createCLITestHarness } from '../util/snyk-cli-test-harness';
+
+jest.setTimeout(1000 * 60 * 5);
+
+describe('snyk test -all-projects with one project that has errors', () => {
+  describe('and another that has issues (vulnerabilities)', () => {
+    it('should exit with exit code 1', async () => {
+      const test = createCLITestHarness(
+        'snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error',
+      );
+      const { code, stderr } = await test.test();
+      expect(code).toEqual(1);
+      expect(stderr).toContain(
+        '1/2 potential projects failed to get dependencies. Run with `-d` for debug output.',
+      );
+    });
+  });
+
+  describe('and another has no issues (vulnerabilities)', () => {
+    // note: actually, this is a bug. It should really have exit code 2, but that is a big change that we need to do
+    it('should exit with exit code 0', async () => {
+      const test = createCLITestHarness(
+        'snyk-test-all-projects-exit-codes/project-with-no-issues-and-project-with-error',
+      );
+      const { code, stderr } = await test.test();
+      expect(code).toEqual(0);
+      expect(stderr).toContain(
+        '1/2 potential projects failed to get dependencies. Run with `-d` for debug output.',
+      );
+    });
+  });
+});

--- a/test/jest/util/runCommand.ts
+++ b/test/jest/util/runCommand.ts
@@ -1,0 +1,48 @@
+import { SpawnOptionsWithoutStdio } from 'child_process';
+import { spawn } from 'cross-spawn';
+
+type RunCommandResult = {
+  code: number;
+  stdout: string;
+  stderr: string;
+};
+
+type RunCommandOptions = SpawnOptionsWithoutStdio;
+
+const runCommand = (
+  command: string,
+  args: string[],
+  options?: RunCommandOptions,
+): Promise<RunCommandResult> => {
+  return new Promise((resolve, reject) => {
+    const cli = spawn(command, args, options);
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+
+    cli.on('error', (error) => {
+      reject(error);
+    });
+
+    cli.stdout.on('data', (chunk) => {
+      stdout.push(Buffer.from(chunk));
+    });
+
+    cli.stderr.on('data', (chunk) => {
+      stderr.push(Buffer.from(chunk));
+    });
+
+    cli.on('close', (code) => {
+      resolve({
+        code: code || 0,
+        stdout: Buffer.concat(stdout)
+          .toString('utf-8')
+          .trim(),
+        stderr: Buffer.concat(stderr)
+          .toString('utf-8')
+          .trim(),
+      });
+    });
+  });
+};
+
+export { runCommand, RunCommandResult, RunCommandOptions };

--- a/test/jest/util/runSnykCLI.ts
+++ b/test/jest/util/runSnykCLI.ts
@@ -1,0 +1,14 @@
+import * as path from 'path';
+import { runCommand, RunCommandResult, RunCommandOptions } from './runCommand';
+
+const cwd = process.cwd();
+
+const runSnykCLI = async (
+  args,
+  options?: RunCommandOptions,
+): Promise<RunCommandResult> => {
+  const cliAbsPath = path.resolve(cwd, './dist/cli/index.js');
+  return await runCommand('node', [cliAbsPath, ...args.split(' ')], options);
+};
+
+export { runSnykCLI };

--- a/test/jest/util/snyk-cli-test-harness.ts
+++ b/test/jest/util/snyk-cli-test-harness.ts
@@ -1,0 +1,22 @@
+import { runSnykCLI } from './runSnykCLI';
+import { RunCommandResult } from './runCommand';
+
+import * as path from 'path';
+
+type CLITestHarness = {
+  path: string;
+  test: () => Promise<RunCommandResult>;
+};
+
+const createCLITestHarness = (fixture: string): CLITestHarness => {
+  const fixturePath = path.resolve('test/fixtures', fixture);
+  return {
+    path: fixturePath,
+    test: () =>
+      runSnykCLI(`test --all-projects`, {
+        cwd: fixturePath,
+      }),
+  };
+};
+
+export { CLITestHarness, createCLITestHarness };


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds missing tests for exit codes when using `snyk test --all-projects`

