### PR TITLE
feat: add Python 3.8 and 3.9 Docker images

### DIFF
--- a/docker/Dockerfile.python-3.8
+++ b/docker/Dockerfile.python-3.8
@@ -1,0 +1,35 @@
+FROM python:3.8-slim
+
+MAINTAINER Snyk Ltd
+
+RUN mkdir /home/node
+WORKDIR /home/node
+
+# Install Python utilities, node, Snyk CLI
+RUN pip install pip pipenv virtualenv -U && \
+    apt-get update && \
+    apt-get install -y build-essential curl git && \
+    curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+    apt-get install -y nodejs jq && \
+    npm install --global snyk snyk-to-html && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    chmod -R a+wrx /home/node
+
+ENV HOME /home/node
+
+# The path at which the project is mounted (-v runtime arg)
+ENV PROJECT_PATH /project
+
+COPY docker-python-entrypoint.sh .
+COPY docker-entrypoint.sh .
+COPY snyk_report.css .
+
+ENV SNYK_INTEGRATION_NAME DOCKER_SNYK_CLI
+ENV SNYK_INTEGRATION_VERSION python-3.8
+
+ENTRYPOINT ["./docker-python-entrypoint.sh"]
+
+# Default command is `snyk test`
+# Override with `docker run ... snyk/snyk-cli <command> <args>`
+CMD ["test"]

--- a/docker/Dockerfile.python-3.9
+++ b/docker/Dockerfile.python-3.9
@@ -1,0 +1,35 @@
+FROM python:3.9-slim
+
+MAINTAINER Snyk Ltd
+
+RUN mkdir /home/node
+WORKDIR /home/node
+
+# Install Python utilities, node, Snyk CLI
+RUN pip install pip pipenv virtualenv -U && \
+    apt-get update && \
+    apt-get install -y build-essential curl git && \
+    curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+    apt-get install -y nodejs jq && \
+    npm install --global snyk snyk-to-html && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    chmod -R a+wrx /home/node
+
+ENV HOME /home/node
+
+# The path at which the project is mounted (-v runtime arg)
+ENV PROJECT_PATH /project
+
+COPY docker-python-entrypoint.sh .
+COPY docker-entrypoint.sh .
+COPY snyk_report.css .
+
+ENV SNYK_INTEGRATION_NAME DOCKER_SNYK_CLI
+ENV SNYK_INTEGRATION_VERSION python-3.9
+
+ENTRYPOINT ["./docker-python-entrypoint.sh"]
+
+# Default command is `snyk test`
+# Override with `docker run ... snyk/snyk-cli <command> <args>`
+CMD ["test"]


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Add Python 3.8 and 3.9 images. I am not sure where the build is hooked up. But I'm guessing there is some automation that splits on `.` and uses that as the tag? 

Perhaps a better versioning schema going forward would be to have the `Dockerfile.python-3` image defined as the latest Python version.  What are your thoughts on this?

#### Where should the reviewer start?


#### How should this be manually tested?

From within the `/docker` directory:

```bash
docker build -t snyk/snyk-cli:python-3.8 --file Dockerfile.python-3.8 .
docker build -t snyk/snyk-cli:python-3.9 --file Dockerfile.python-3.9 .
```

#### Any background context you want to provide?



#### What are the relevant tickets?


#### Screenshots


#### Additional questions
