### PR TITLE
feat: handle new monitor response from registry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@ src/lib/snyk-test/iac-test-result.ts @snyk/cloudconfig
 src/lib/snyk-test/payload-schema.ts @snyk/cloudconfig
 src/lib/snyk-test/run-iac-test.ts @snyk/cloudconfig
 test/acceptance/cli-test/iac/ @snyk/cloudconfig
+test/fixtures/container-projects/ @snyk/capsule
 test/fixtures/iac/ @snyk/cloudconfig
 test/smoke/spec/iac/ @snyk/cloudconfig
 test/smoke/.iac-data/ @snyk/cloudconfig

--- a/src/cli/commands/monitor/formatters/format-monitor-response.ts
+++ b/src/cli/commands/monitor/formatters/format-monitor-response.ts
@@ -5,6 +5,31 @@ import * as url from 'url';
 import { MonitorResult } from '../../../../lib/types';
 import * as config from '../../../../lib/config';
 
+export function formatErrorMonitorOutput(
+  packageManager,
+  res: MonitorResult,
+  options,
+  projectName?: string,
+): string {
+  const humanReadableName = projectName
+    ? `${res.path} (${projectName})`
+    : res.path;
+  const strOutput =
+    chalk.bold.white('\nMonitoring ' + humanReadableName + '...\n\n') +
+    '\n\n' +
+    (packageManager === 'maven'
+      ? chalk.yellow('Detected 0 dependencies (no project created)')
+      : '');
+
+  return options.json
+    ? JSON.stringify(
+        assign({}, res, {
+          packageManager,
+        }),
+      )
+    : strOutput;
+}
+
 export function formatMonitorOutput(
   packageManager,
   res: MonitorResult,

--- a/src/lib/ecosystems/monitor.ts
+++ b/src/lib/ecosystems/monitor.ts
@@ -8,7 +8,10 @@ import { MonitorResult, Options } from '../types';
 import * as spinner from '../../lib/spinner';
 import { getPlugin } from './plugins';
 import { BadResult, GoodResult } from '../../cli/commands/monitor/types';
-import { formatMonitorOutput } from '../../cli/commands/monitor/formatters/format-monitor-response';
+import {
+  formatErrorMonitorOutput,
+  formatMonitorOutput,
+} from '../../cli/commands/monitor/formatters/format-monitor-response';
 import { getExtraProjectCount } from '../plugins/get-extra-project-count';
 import {
   AuthFailedError,
@@ -148,19 +151,28 @@ export async function getFormattedMonitorOutput(
   options: Options,
 ): Promise<string> {
   for (const monitorResult of monitorResults) {
-    const monOutput = formatMonitorOutput(
-      monitorResult.scanResult.identity.type,
-      monitorResult as MonitorResult,
-      options,
-      monitorResult.projectName,
-      await getExtraProjectCount(
-        monitorResult.path,
+    let monOutput = '';
+    if (monitorResult.ok) {
+      monOutput = formatMonitorOutput(
+        monitorResult.scanResult.identity.type,
+        monitorResult as MonitorResult,
         options,
-        // TODO: Fix to pass the old "inspectResult.plugin.meta.allSubProjectNames", which ecosystem uses this?
-        // "allSubProjectNames" can become a Fact returned by a plugin.
-        {} as InspectResult,
-      ),
-    );
+        monitorResult.projectName,
+        await getExtraProjectCount(
+          monitorResult.path,
+          options,
+          // TODO: Fix to pass the old "inspectResult.plugin.meta.allSubProjectNames", which ecosystem uses this?
+          // "allSubProjectNames" can become a Fact returned by a plugin.
+          {} as InspectResult,
+        ),
+      );
+    } else {
+      monOutput = formatErrorMonitorOutput(
+        monitorResult.scanResult.identity.type,
+        monitorResult as MonitorResult,
+        options,
+      );
+    }
     results.push({
       ok: true,
       data: monOutput,

--- a/test/fixtures/container-projects/maven-project-0-dependencies-scan-result.json
+++ b/test/fixtures/container-projects/maven-project-0-dependencies-scan-result.json
@@ -1,0 +1,24 @@
+{
+  "facts": [
+    {
+      "type": "jarFingerprints",
+      "data": {
+        "fingerprints": [
+          {
+            "digest": "68fdac71ba58fe757c1976b4cb8861a3ead6e4a5",
+            "location": "/srv/error.jar"
+          }
+        ],
+        "origin":"snyk/kubernetes-monitor",
+        "path": "/srv"
+      }
+    }
+  ],
+  "identity": {
+    "targetFile": "/srv",
+    "type": "maven"
+  },
+  "target": {
+    "image": "docker-image|snyk/kubernetes-monitor"
+  }
+}

--- a/test/fixtures/container-projects/monitor-maven-project-0-dependencies-response.json
+++ b/test/fixtures/container-projects/monitor-maven-project-0-dependencies-response.json
@@ -1,0 +1,58 @@
+{
+  "ok": false,
+  "result": {
+    "issues": [
+    ],
+    "issuesData": {
+    },
+    "depGraphData": {
+      "schemaVersion": "1.1.0",
+      "pkgManager": {
+        "name": "maven"
+      },
+      "pkgs": [
+        {
+          "id": "io.github.snyk:my-maven-proj@0.0.1",
+          "info": {
+            "name": "io.github.snyk:my-maven-proj",
+            "version": "0.0.1"
+          }
+        }        ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "io.github.snyk:my-maven-proj@0.0.1",
+            "deps": []
+          }
+        ]
+      }
+    }
+  },
+  "path": "/srv",
+  "scanResult": {
+    "facts": [
+      {
+        "type": "jarFingerprints",
+        "data": {
+          "fingerprints": [
+            {
+              "digest": "68fdac71ba58fe757c1976b4cb8861a3ead6e4a5",
+              "location": "/srv/error.jar"
+            }
+          ],
+          "origin":"snyk/kubernetes-monitor",
+          "path": "/srv"
+        }
+      }
+    ],
+    "identity": {
+      "targetFile": "/srv",
+      "type": "maven"
+    },
+    "target": {
+      "image": "docker-image|snyk/kubernetes-monitor"
+    }
+  }
+}

--- a/test/fixtures/cpp-project/monitor-dependencies-response.json
+++ b/test/fixtures/cpp-project/monitor-dependencies-response.json
@@ -1,4 +1,5 @@
 {
+    "ok": true,
     "result": {
       "issues": [
         {

--- a/test/jest/system/ecosystems-monitor-docker.spec.ts
+++ b/test/jest/system/ecosystems-monitor-docker.spec.ts
@@ -1,0 +1,129 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as request from '../../../src/lib/request/promise';
+import * as dockerPlugin from 'snyk-docker-plugin';
+
+import { Options } from '../../../src/lib/types';
+import * as ecosystems from '../../../src/lib/ecosystems';
+import * as ecosystemsTypes from '../../../src/lib/ecosystems/types';
+import { getFormattedMonitorOutput } from '../../../src/lib/ecosystems/monitor';
+import { GoodResult, BadResult } from '../../../src/cli/commands/monitor/types';
+import { ScanResult } from 'snyk-docker-plugin';
+
+describe('monitorEcosystem docker/container', () => {
+  const fixturePath = path.join(
+    __dirname,
+    '../../fixtures',
+    'container-projects',
+  );
+  const cwd = process.cwd();
+
+  function readFixture(filename: string) {
+    const filePath = path.join(fixturePath, filename);
+    return fs.readFileSync(filePath, 'utf8');
+  }
+
+  function readJsonFixture(filename: string) {
+    const contents = readFixture(filename);
+    return JSON.parse(contents);
+  }
+
+  beforeAll(() => {
+    process.chdir(fixturePath);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  afterAll(() => {
+    process.chdir(cwd);
+  });
+
+  it('should return successful monitorResults from monitorEcosystem', async () => {
+    const mavenScanResult = readJsonFixture(
+      'maven-project-0-dependencies-scan-result.json',
+    ) as ScanResult;
+    const monitorDependenciesResponse = readJsonFixture(
+      'monitor-maven-project-0-dependencies-response.json',
+    ) as ecosystemsTypes.MonitorDependenciesResponse;
+
+    jest
+      .spyOn(dockerPlugin, 'scan')
+      .mockResolvedValue({ scanResults: [mavenScanResult] });
+    const makeRequestSpy = jest
+      .spyOn(request, 'makeRequest')
+      .mockResolvedValue(monitorDependenciesResponse);
+
+    const results: Array<GoodResult | BadResult> = [];
+
+    const [monitorResults, monitorErrors] = await ecosystems.monitorEcosystem(
+      'docker',
+      ['/srv'],
+      {
+        path: '/srv',
+        docker: true,
+        'app-vulns': true,
+        org: 'my-org',
+      },
+    );
+
+    const actualFormattedMonitorOutput = await getFormattedMonitorOutput(
+      results,
+      monitorResults,
+      monitorErrors,
+      {
+        path: '/srv',
+        docker: true,
+        'app-vulns': true,
+        org: 'my-org',
+      } as Options,
+    );
+
+    expect(makeRequestSpy.mock.calls[0][0]).toEqual({
+      method: 'PUT',
+      url: expect.stringContaining('/monitor-dependencies'),
+      json: true,
+      headers: {
+        'x-is-ci': expect.any(Boolean),
+        authorization: expect.stringContaining('token'),
+      },
+      body: {
+        scanResult: {
+          facts: [
+            {
+              type: 'jarFingerprints',
+              data: {
+                fingerprints: [
+                  {
+                    digest: '68fdac71ba58fe757c1976b4cb8861a3ead6e4a5',
+                    location: '/srv/error.jar',
+                  },
+                ],
+                origin: expect.any(String),
+                path: expect.any(String),
+              },
+            },
+          ],
+          identity: {
+            targetFile: expect.any(String),
+            type: 'maven',
+          },
+          target: {
+            image: expect.any(String),
+          },
+          name: undefined,
+        },
+        projectName: undefined,
+        method: 'cli',
+      },
+      qs: {
+        org: 'my-org',
+      },
+    });
+
+    expect(actualFormattedMonitorOutput).toContain(
+      'Detected 0 dependencies (no project created)',
+    );
+  });
+});


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
 Following the [ADR](https://github.com/snyk/architecture-decision-records/pull/25/files) Registry needs to ignore maven project type with 0 dependencies. And it will return a new response 200 with ok property as false. The
 ClI needs to handle this new flow to display to the user that this project was not created because it is a maven project type with 0 dependencies.

#### Where should the reviewer start?
There is an ADR ([here](https://github.com/snyk/architecture-decision-records/pull/25/files) WIP) to ignore Maven project type with 0 dependencies to be filtered and the project won't be created. It's already happened for SCM project import flow ([here](https://github.com/snyk/registry/blob/2b167e154881e84f39f09ba8f50004c8e42131d8/src/lib/deps-discovery/handlers/maven.ts#L268-L270)) and for non-SCM project import flow ([here](https://github.com/snyk/registry/blob/eee99817c50c897d4223a2b7ec566ec129e0f6f6/src/lib/import-apps/projects.ts#L454-L466)). We're extending this solution for the CLI container monitor flow ([here](https://github.com/snyk/registry/pull/21120)).
This is the Registry [PR](https://github.com/snyk/registry/pull/21120) that will handle the new flow. It'll be opened once we have the CLI version.


#### How should this be manually tested?
To check if the maven project type with 0 dependencies won't be created. You can run the command:
- create a `jar` without dependencies:
```
echo "nothing" > no-dependencies.jar
```

- create the Dockerfile with follow content:
```
FROM alpine:latest
  
COPY no-dependencies.jar /srv/no-dependencies.jar
```

- build the image
```
docker build -t snyk/image-with-jar-without-dependencies:0.0.1 .
```
- test in the CLI:
```
snyk container monitor snyk/image-with-jar-without-dependencies:0.0.1 --app-vulns
```

To check if the maven project type with dependencies will be created. You can run the command:
- create a `jar` with dependencies getting one form Maven Central:
```
curl -L https://search.maven.org/remotecontent\?filepath\=com/walmartlabs/concord/plugins/git/1.38.0/git-1.38.0.jar -o git-1.38.0.jar
```
- create the Dockerfile with follow content:
```
FROM alpine:latest
  
COPY git-1.38.0.jar /srv/git-1.38.0.jar
```
- build the image
```
docker build -t snyk/image-with-jar-with-dependencies:0.0.1 .
```
- test in the CLI:
```
snyk container monitor snyk/image-with-jar-with-dependencies:0.0.1 --app-vulns
```

#### Any background context you want to provide?


#### What are the relevant tickets?
- [Slack thread](https://snyk.slack.com/archives/C01342FUD53/p1621249886055800)
- [Jira ticket CAP-297](https://snyksec.atlassian.net/browse/CAP-297)
- [ADR](https://github.com/snyk/architecture-decision-records)

#### Screenshots

<img width="1341" alt="Screenshot 2021-05-28 at 15 17 23" src="https://user-images.githubusercontent.com/838518/119998963-9c709680-bfa7-11eb-9011-4e9afcd702b0.png">
<img width="1339" alt="Screenshot 2021-05-28 at 15 18 19" src="https://user-images.githubusercontent.com/838518/119998997-a5616800-bfa7-11eb-9297-92aeb8f0f457.png">

