### PR TITLE
Chore/fix tap test warning in danger js

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,3 +28,4 @@ help/commands-docs/iac.md @snyk/cloudconfig
 packages/snyk-fix/ @snyk/tech-services
 packages/snyk-protect/ @snyk/hammer
 test/jest/util/ @snyk/hammer
+dangerfile.js @snyk/hammer

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -51,20 +51,19 @@ if (danger.github && danger.github.pr) {
     );
   }
 
+  // `.spec.ts` is always used for Jest tests
+  // `.test.ts` is normally used for Tap tests and but there are also `.spec.ts` files which are used be Tap tests in test/acceptance.
+  // either way, we should warn about new `.test.ts` or `.spec.ts` files being created outside the `/test/jest` folder
   const newTestFiles = danger.git.created_files.filter((f) => {
     const inTestFolder = f.startsWith('test/');
-    const inLegacyAcceptanceTestsFolder = f.includes('test/acceptance/');
-    const testFilenameLooksLikeJest = f.includes('.spec.ts');
-    return (
-      inTestFolder &&
-      !inLegacyAcceptanceTestsFolder &&
-      !testFilenameLooksLikeJest
-    );
+    const isATestFile = f.includes('.test.ts') || f.includes('.spec.ts');
+    const inJestFolder = f.startsWith('test/jest/');
+    return inTestFolder && isATestFile && !inJestFolder;
   });
 
   if (newTestFiles.length) {
     const joinedFileList = newTestFiles.map((f) => '- `' + f + '`').join('\n');
-    const msg = `Looks like you added a new Tap test. Consider making it a Jest test instead. See files like \`test/*.spec.ts\` for examples. Files found:\n${joinedFileList}`;
+    const msg = `Looks like you added a new Tap test. Consider making it a Jest test instead. See files in \`test/jest/(unit|system|acceptance)\` for examples. Files found:\n${joinedFileList}`;
     warn(msg);
   }
 


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Fixes warning about new Tap tests in our DangerJS config.
