### PR TITLE
Feat: bump @snyk/fix package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@snyk/cloud-config-parser": "^1.9.2",
     "@snyk/code-client": "3.7.0",
     "@snyk/dep-graph": "^1.27.1",
-    "@snyk/fix": "1.601.0",
+    "@snyk/fix": "1.620.0",
     "@snyk/gemfile": "1.2.0",
     "@snyk/graphlib": "^2.1.9-patch.3",
     "@snyk/inquirer": "^7.3.3-patch",

--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -102,7 +102,7 @@ export interface ReachablePaths {
 }
 
 interface AnnotatedIssue extends IssueData {
-  credit: any;
+  credit: string[];
   name: string;
   version: string;
   from: string[];


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Use latest @snyk/fix package that has the child_process functionality separated into it's own package. No changes in behaviour.