### PR TITLE
feat: support detour flow for c/c++ given ff

### DIFF
--- a/src/lib/ecosystems/enhance-options.ts
+++ b/src/lib/ecosystems/enhance-options.ts
@@ -1,0 +1,27 @@
+import { Options } from '../types';
+
+import { Ecosystem } from './types';
+import { AuthFailedError } from '../errors';
+import { isFeatureFlagSupportedForOrg } from '../feature-flags';
+
+/**
+ * @deprecated: do not use it, it's going to be deleted soon as the new snyk-cpp-plugin flow is completed
+ */
+export async function hasToDetourToLegacyFlow(
+  ecosystem: Ecosystem,
+  options: Options,
+): Promise<boolean> {
+  if (ecosystem !== 'cpp' || !options.org) {
+    return false;
+  }
+
+  const response = await isFeatureFlagSupportedForOrg(
+    'snykLegacyCpp',
+    options.org,
+  );
+  if (response.code === 401) {
+    throw AuthFailedError(response.error, response.code);
+  }
+
+  return response.ok ? true : false;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -82,6 +82,8 @@ export interface Options {
   sarif?: boolean;
   'group-issues'?: boolean;
   quiet?: boolean;
+  // Used only with C/C++ Plugin. Allows different code flows
+  detour?: boolean;
 }
 
 // TODO(kyegupov): catch accessing ['undefined-properties'] via noImplicitAny

--- a/test/jest/unit/lib/ecosystems/enhance-options.spec.ts
+++ b/test/jest/unit/lib/ecosystems/enhance-options.spec.ts
@@ -1,0 +1,89 @@
+import { hasToDetourToLegacyFlow } from '../../../../../src/lib/ecosystems/enhance-options';
+import { Options } from '../../../../../src/lib/types';
+import * as featureFlags from '../../../../../src/lib/feature-flags';
+
+describe('enhance-options', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it.each`
+    actualEcosystem | expectedDetour
+    ${'docker'}     | ${false}
+    ${'code'}       | ${false}
+  `(
+    'hasCppToDetourFlow - ecosystem `$actualEcosystem` will always have detour set as false even if org has snykLegacyCpp ff',
+    async ({ actualEcosystem, expectedDetour }) => {
+      const ecosystem = actualEcosystem;
+      const options = { org: 'org-with-snyk-legacy-cpp-ff' } as Options;
+
+      const isFeatureFlagSupportedForOrgSpy = jest
+        .spyOn(featureFlags, 'isFeatureFlagSupportedForOrg')
+        .mockResolvedValue({
+          ok: true,
+        });
+
+      const enhancedOptions = {
+        ...options,
+        detour: await hasToDetourToLegacyFlow(ecosystem, options),
+      };
+
+      expect(isFeatureFlagSupportedForOrgSpy).toHaveBeenCalledTimes(0);
+
+      expect(enhancedOptions).toEqual({
+        detour: expectedDetour,
+        org: 'org-with-snyk-legacy-cpp-ff',
+      });
+    },
+  );
+
+  it('hasCppToDetourFlow - ecosystem `cpp` has detour set as false by default', async () => {
+    const ecosystem = 'cpp';
+    const options = { org: 'org-without-snyk-legacy-cpp-ff' } as Options;
+
+    const isFeatureFlagSupportedForOrgSpy = jest
+      .spyOn(featureFlags, 'isFeatureFlagSupportedForOrg')
+      .mockResolvedValue({
+        ok: false,
+      });
+
+    const enhancedOptions = {
+      ...options,
+      detour: await hasToDetourToLegacyFlow(ecosystem, options),
+    };
+
+    expect(isFeatureFlagSupportedForOrgSpy).toBeCalledWith(
+      'snykLegacyCpp',
+      'org-without-snyk-legacy-cpp-ff',
+    );
+
+    expect(enhancedOptions).toEqual({
+      detour: false,
+      org: 'org-without-snyk-legacy-cpp-ff',
+    });
+  });
+
+  it('hasCppToDetourFlow - ecosystem `cpp` has detour set as true when org has snykLegacyCpp feature flag', async () => {
+    const ecosystem = 'cpp';
+    const options = { org: 'org-with-snyk-legacy-cpp-ff' } as Options;
+
+    const isFeatureFlagSupportedForOrgSpy = jest
+      .spyOn(featureFlags, 'isFeatureFlagSupportedForOrg')
+      .mockResolvedValue({
+        ok: true,
+      });
+
+    const enhancedOptions = {
+      ...options,
+      detour: await hasToDetourToLegacyFlow(ecosystem, options),
+    };
+
+    expect(isFeatureFlagSupportedForOrgSpy).toBeCalledWith(
+      'snykLegacyCpp',
+      'org-with-snyk-legacy-cpp-ff',
+    );
+
+    expect(enhancedOptions).toEqual({
+      detour: true,
+      org: 'org-with-snyk-legacy-cpp-ff',
+    });
+  });
+});


### PR DESCRIPTION
This pr will allows the CLI of pass to snyk-cpp-plugin a detour option to trigger a different logic if an
org's have snykSourceCpp ff enabled, this is an intentional and temporary approach to avoid breaking
changes