### PR TITLE
[WIP] chore: get npm to grab token directly from env

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
 @snyk:registry=https://registry.npmjs.org
 engine-strict=true
 package-lock=false


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Our smoke tests started failing yesterday in yarn: https://github.com/snyk/snyk/actions/runs/918392114

This happens due to npm trying to grab NPM_TOKEN from the registry instead of from the environment variable, so I got rid of this line in `npmrc`.
https://snyk.slack.com/archives/G01AZS8UNUR/p1623182504130200
