### PR TITLE
fix: updated code-client version to remove deprecated dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@open-policy-agent/opa-wasm": "^1.2.0",
     "@snyk/cli-interface": "2.11.0",
     "@snyk/cloud-config-parser": "^1.9.2",
-    "@snyk/code-client": "3.7.0",
+    "@snyk/code-client": "3.8.1",
     "@snyk/dep-graph": "^1.27.1",
     "@snyk/fix": "1.620.0",
     "@snyk/gemfile": "1.2.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Updated `code-client` version to remove deprecated dependencies showing up when installing the CLI
`npm WARN deprecated @types/multimatch@4.0.0: This is a stub types definition. multimatch provides its own type definitions, so you do not need this installed.`
as requested here:
https://snyk.slack.com/archives/C01DGQ3AT09/p1623147347346700