### PR TITLE
smoke: get rid of changes from #1974 to fix broken test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,12 @@ commands:
       - run:
           name: Install dependencies
           command: npm install
+  update_local_npmrc_linux:
+    description: Update local .npmrc file (Linux)
+    steps:
+      - run:
+          name: Update local .npmrc file (Linux)
+          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
   build_ts:
     description: Build js files from ts
     steps:
@@ -163,6 +169,7 @@ jobs:
           command: |
             sudo npm install -g npm@7
       - show_node_version
+      - update_local_npmrc_linux
       - install_deps
       - build_ts
       - generate_help
@@ -223,6 +230,9 @@ jobs:
       - run:
           name: Setup Lerna
           command: npm install -g lerna@3.22.1
+      - run:
+          name: Update local .npmrc file (Windows)
+          command: echo "//registry.npmjs.org/:_authToken=$env:NPM_TOKEN" >> .npmrc
       - run:
           name: Install dependencies (Windows)
           command: npm install --ignore-scripts # ignore-scripts required because of postinstall script in snyk-resolve-deps package
@@ -324,6 +334,7 @@ jobs:
       - run: sudo npm install -g npm@7
       - show_node_version
       - install_lerna_linux
+      - update_local_npmrc_linux
       - install_deps
       - build_ts
       - run:
@@ -462,6 +473,7 @@ jobs:
             sudo npm install -g npm@7
       - show_node_version
       - install_lerna_linux
+      - update_local_npmrc_linux
       - install_deps
       - generate_help
       - run:


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Our smoke tests started failing yesterday in yarn: https://github.com/snyk/snyk/actions/runs/918392114

This happens due to npm trying to grab NPM_TOKEN from the registry instead of from the environment variable, so I got rid of the changes done in this PR: https://github.com/snyk/snyk/pull/1974/files
https://snyk.slack.com/archives/G01AZS8UNUR/p1623182504130200
