### PR TITLE
fix: use classifier in maven package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "snyk-go-plugin": "1.17.0",
     "snyk-gradle-plugin": "3.16.0",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "2.26.0",
+    "snyk-mvn-plugin": "2.26.1",
     "snyk-nodejs-lockfile-parser": "1.35.0",
     "snyk-nuget-plugin": "1.21.1",
     "snyk-php-plugin": "1.9.2",


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
use classifier in maven package name
see https://github.com/snyk/snyk-mvn-plugin/pull/108

![image](https://user-images.githubusercontent.com/58390344/121540988-9353e080-ca0f-11eb-8976-1c3db9b49c6e.png)

