### PR TITLE
chore: can generate docs without Docker

### DIFF
--- a/help/README.md
+++ b/help/README.md
@@ -49,9 +49,16 @@ Visually, it'll get rendered as underlined text. It's used to mark a "variable".
 
 ## Running locally
 
-- have docker running
+- Either have docker running, or have `groff` and `ronn` (really
+  [ronn-ng](https://github.com/apjanke/ronn-ng)) on your `$PATH`.
 - have `npm`/`npx` available
 
 ```
 $ npm run generate-help
+```
+
+Or, if you already have `groff` and `ronn`, and don't want to use Docker:
+
+```
+$ NO_DOCKER=1 npm run generate-help
 ```

--- a/help/generator/generate-docs.sh
+++ b/help/generator/generate-docs.sh
@@ -3,10 +3,17 @@ set -e
 
 IMAGE_NAME=ronn-ng
 
-if ! docker inspect --type=image $IMAGE_NAME >/dev/null 2>&1; then
-  echo "Docker image $IMAGE_NAME not found, building..."
-  docker build -t $IMAGE_NAME -f ./help/generator/ronn-ng.dockerfile ./help
+if [ -z "${NO_DOCKER:-}" ]; then
+  if ! docker inspect --type=image $IMAGE_NAME >/dev/null 2>&1; then
+    echo "Docker image $IMAGE_NAME not found, building..."
+    docker build -t $IMAGE_NAME -f ./help/generator/ronn-ng.dockerfile ./help
+  fi
 fi
 
 echo "Running npx command to run help generator"
-RONN_COMMAND="docker run -i ronn-ng" npx ts-node ./help/generator/generator.ts
+if [ -n "${NO_DOCKER:-}" ]; then
+  export RONN_COMMAND="ronn"
+else
+  export RONN_COMMAND="docker run -i ronn-ng"
+fi
+npx ts-node ./help/generator/generator.ts


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Developers can generate docs without Docker, by running `NO_DOCKER=1 npm
run generate-help`. This requires managing groff and ronn-ng on your
$PATH, but is nice for CLI developers who don't usually leave Docker
running but want to regenerate their docs a lot.

The default Docker-using behaviour of `npm run generate-help` is
unchanged.


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
