### PR TITLE
Fix: do not modify Pipfile.lock #1487

### DIFF
--- a/docker/docker-python-entrypoint.sh
+++ b/docker/docker-python-entrypoint.sh
@@ -22,8 +22,7 @@ installRequirementsTxtDeps() {
 installPipfileDeps() {
     pushd "${PROJECT_PATH}/"
     echo "Found Pipfile"
-    pipenv lock
-    pipenv install --system
+    pipenv install --system --deploy
     popd
 }
 


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Prevents _Pipfile.lock_ from being updated during a scan. 


#### Where should the reviewer start?

Consider the behaviour of the different `pipenv` commands and flags against the expected input and output requirements (explicitly, I presume that a _Pipfile.lock_ must be present, based on external advice received)


#### How should this be manually tested?

Craft a _Pipfile_ with dependencies that would ordinarily be removed by `pipenv lock` (e.g. a Mac only dependency) and create the corresponding _Pipfile.lock_. Observe that the _Pipfile.lock_ is unchanged at the end of the scan.

Craft an outdated _Pipfile.lock_ and observe that the scan fails.

Check that the behaviour where a _Pipfile.lock_ is not present at the start is acceptable (i.e. presumably it will fail).  


#### Any background context you want to provide?

I develop on Mac and run a snyk test in a lightly modified official Python 3 container, with my source mounted. This invariably modifies _Pipfile.lock_ (removing a Mac only dependency and adding a couple of others). I do not commit these changes and later Jenkins (on linux) builds containers for me apparently without any issues, from a fresh checkout.    

Without some change like this, there is presumably a chance that snyk could update dependencies thus fixing a security issue before a scan, while the committed _Pipfile.lock_ still contained the insecure library spec.    


#### What are the relevant tickets?

#1487 


