### PR TITLE
chore: allow @ts-ignore comments in test only

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,6 +44,12 @@
       "rules": {
         "id-blacklist": ["error", "exports"] // in TS, use "export" instead of Node's "module.exports"
       }
+    },
+    {
+      "files": "*.spec.*",
+      "rules": {
+        "@typescript-eslint/ban-ts-ignore": "off"
+      }
     }
   ]
 }


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Allow the use of `@ts-ignore` in tests where sometimes we need to delete mandatory properties or change the data to simulate a test scenario

