### PR TITLE
feat: update issue representation in CLI output

### DIFF
--- a/src/cli/commands/protect/prompts.ts
+++ b/src/cli/commands/protect/prompts.ts
@@ -48,7 +48,7 @@ function sort(prop) {
 function createSeverityBasedIssueHeading(msg: string, severity: SEVERITY) {
   // Example: ✗ Medium severity vulnerability found in xmldom
   const severityColor = getLegacySeveritiesColour(severity);
-  return severityColor.colorFunc(msg);
+  return severityColor(msg);
 }
 
 function sortUpgradePrompts(a, b) {

--- a/src/cli/commands/test/formatters/format-test-meta.ts
+++ b/src/cli/commands/test/formatters/format-test-meta.ts
@@ -87,7 +87,7 @@ export function formatTestMeta(
     if (legacyRes.licensesPolicy) {
       meta.push(
         chalk.bold(rightPadWithSpaces('Licenses: ', padToLength)) +
-          chalk.green('enabled'),
+          chalk.bold.white('enabled'),
       );
     }
   }

--- a/src/cli/commands/test/formatters/format-test-meta.ts
+++ b/src/cli/commands/test/formatters/format-test-meta.ts
@@ -87,7 +87,7 @@ export function formatTestMeta(
     if (legacyRes.licensesPolicy) {
       meta.push(
         chalk.bold(rightPadWithSpaces('Licenses: ', padToLength)) +
-          chalk.bold.white('enabled'),
+          chalk.bold('enabled'),
       );
     }
   }

--- a/src/cli/commands/test/formatters/format-test-results.ts
+++ b/src/cli/commands/test/formatters/format-test-results.ts
@@ -163,9 +163,8 @@ export function getDisplayedOutput(
       projectType as SupportedPackageManagers,
     )
   ) {
-    wizardAdvice = chalk.bold.green(
-      '\n\nRun `snyk wizard` to address these issues.',
-    );
+    wizardAdvice =
+      '\n\n► Run ' + chalk.bold(`snyk wizard`) + ' to address these issues.';
   }
   const dockerSuggestion = getDockerSuggestionText(options, config);
 

--- a/src/cli/commands/test/formatters/legacy-format-issue.ts
+++ b/src/cli/commands/test/formatters/legacy-format-issue.ts
@@ -104,7 +104,7 @@ function createSeverityBasedIssueHeading({
   }
 
   return (
-    severityColor.colorFunc(
+    severityColor(
       '✗ ' +
         titleCaseText(severity) +
         ` severity${originalSeverityStr} ` +

--- a/src/cli/commands/test/formatters/remediation-based-format-issues.ts
+++ b/src/cli/commands/test/formatters/remediation-based-format-issues.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { Icon } from '../../../../lib/theme';
 import * as config from '../../../../lib/config';
 import { TestOptions } from '../../../../lib/types';
 import {
@@ -167,7 +168,7 @@ function constructLicenseText(
     return [];
   }
 
-  const licenseTextArray = [chalk.bold.white('\nLicense issues:')];
+  const licenseTextArray = [chalk.bold('\nLicense issues:')];
 
   for (const id of Object.keys(basicLicenseInfo)) {
     const licenseText = formatIssue(
@@ -199,7 +200,7 @@ function constructPatchesText(
   if (!(Object.keys(patches).length > 0)) {
     return [];
   }
-  const patchedTextArray = [chalk.bold.white('\nPatchable issues:')];
+  const patchedTextArray = [chalk.bold('\nPatchable issues:')];
   for (const id of Object.keys(patches)) {
     if (!basicVulnInfo[id]) {
       continue;
@@ -210,7 +211,7 @@ function constructPatchesText(
 
     // todo: add vulnToPatch package name
     const packageAtVersion = `${basicVulnInfo[id].name}@${basicVulnInfo[id].version}`;
-    const patchedText = `\n  Patch available for ${chalk.bold.whiteBright(
+    const patchedText = `\n  Patch available for ${chalk.bold(
       packageAtVersion,
     )}\n`;
     const thisPatchFixes = formatIssue(
@@ -274,9 +275,9 @@ function processUpgrades(
     const upgradeDepTo = data.upgradeTo;
     const vulnIds =
       (data as UpgradeRemediation).vulns || (data as PinRemediation).vulns;
-    const upgradeText = `\n  Upgrade ${chalk.bold.whiteBright(
-      dep,
-    )} to ${chalk.bold.whiteBright(upgradeDepTo)} to fix\n`;
+    const upgradeText = `\n  Upgrade ${chalk.bold(dep)} to ${chalk.bold(
+      upgradeDepTo,
+    )} to fix\n`;
     sink.push(
       upgradeText + thisUpgradeFixes(vulnIds, basicVulnInfo, testOptions),
     );
@@ -294,7 +295,7 @@ function constructUpgradesText(
     return [];
   }
 
-  const upgradeTextArray = [chalk.bold.white('\nIssues to fix by upgrading:')];
+  const upgradeTextArray = [chalk.bold('\nIssues to fix by upgrading:')];
   processUpgrades(
     upgradeTextArray,
     upgrades,
@@ -317,7 +318,7 @@ function constructPinText(
 
   const upgradeTextArray: string[] = [];
   upgradeTextArray.push(
-    chalk.bold.white('\nIssues to fix by upgrading dependencies:'),
+    chalk.bold('\nIssues to fix by upgrading dependencies:'),
   );
 
   // First, direct upgrades
@@ -343,9 +344,9 @@ function constructPinText(
       const data = pins[pkgName];
       const vulnIds = data.vulns;
       const upgradeDepTo = data.upgradeTo;
-      const upgradeText = `\n  Pin ${chalk.bold.whiteBright(
-        pkgName,
-      )} to ${chalk.bold.whiteBright(upgradeDepTo)} to fix`;
+      const upgradeText = `\n  Pin ${chalk.bold(pkgName)} to ${chalk.bold(
+        upgradeDepTo,
+      )} to fix`;
       upgradeTextArray.push(upgradeText);
       upgradeTextArray.push(
         thisUpgradeFixes(vulnIds, basicVulnInfo, testOptions),
@@ -382,7 +383,7 @@ function constructUnfixableText(
     return [];
   }
   const unfixableIssuesTextArray = [
-    chalk.bold.white('\nIssues with no direct upgrade or patch:'),
+    chalk.bold('\nIssues with no direct upgrade or patch:'),
   ];
   for (const issue of unresolved) {
     const issueInfo = basicVulnInfo[issue.id];
@@ -464,7 +465,7 @@ export function formatIssue(
     introducedBy =
       paths.length === 1
         ? `\n    Introduced by: ${pathStr}`
-        : `\n    Introduced by: ${pathStr} and ${chalk.cyanBright(
+        : `\n    Introduced by: ${pathStr} and ${chalk.bold(
             '' + (paths.length - 1),
           )} other path(s)`;
   } else if (testOptions.showVulnPaths === 'all' && paths) {
@@ -493,10 +494,10 @@ export function formatIssue(
   }
 
   return (
-    severityColor.colorFunc(
-      `\n  ✗ [${titleCaseText(severity)}${originalSeverityStr}] ${chalk.bold(
-        title,
-      )}${newBadge}\n`,
+    severityColor(
+      `\n  ${Icon.ISSUE} [${titleCaseText(
+        severity,
+      )}${originalSeverityStr}] ${chalk.bold(title)}${newBadge}\n`,
     ) +
     reachabilityText +
     `    Info: [${config.ROOT}/vuln/${id}]` +

--- a/src/cli/commands/test/formatters/remediation-based-format-issues.ts
+++ b/src/cli/commands/test/formatters/remediation-based-format-issues.ts
@@ -167,7 +167,7 @@ function constructLicenseText(
     return [];
   }
 
-  const licenseTextArray = [chalk.bold.green('\nLicense issues:')];
+  const licenseTextArray = [chalk.bold.white('\nLicense issues:')];
 
   for (const id of Object.keys(basicLicenseInfo)) {
     const licenseText = formatIssue(
@@ -182,7 +182,7 @@ function constructLicenseText(
       undefined, // We can never override license rules, so no originalSeverity here
       basicLicenseInfo[id].legalInstructions,
     );
-    licenseTextArray.push('\n' + licenseText);
+    licenseTextArray.push(licenseText);
   }
   return licenseTextArray;
 }
@@ -199,7 +199,7 @@ function constructPatchesText(
   if (!(Object.keys(patches).length > 0)) {
     return [];
   }
-  const patchedTextArray = [chalk.bold.green('\nPatchable issues:')];
+  const patchedTextArray = [chalk.bold.white('\nPatchable issues:')];
   for (const id of Object.keys(patches)) {
     if (!basicVulnInfo[id]) {
       continue;
@@ -294,7 +294,7 @@ function constructUpgradesText(
     return [];
   }
 
-  const upgradeTextArray = [chalk.bold.green('\nIssues to fix by upgrading:')];
+  const upgradeTextArray = [chalk.bold.white('\nIssues to fix by upgrading:')];
   processUpgrades(
     upgradeTextArray,
     upgrades,
@@ -317,7 +317,7 @@ function constructPinText(
 
   const upgradeTextArray: string[] = [];
   upgradeTextArray.push(
-    chalk.bold.green('\nIssues to fix by upgrading dependencies:'),
+    chalk.bold.white('\nIssues to fix by upgrading dependencies:'),
   );
 
   // First, direct upgrades
@@ -393,10 +393,8 @@ function constructUnfixableText(
 
     const extraInfo =
       issue.fixedIn && issue.fixedIn.length
-        ? `\n  This issue was fixed in versions: ${chalk.bold(
-            issue.fixedIn.join(', '),
-          )}`
-        : '\n  No upgrade or patch available';
+        ? `\n    Fixed in: ${chalk.bold(issue.fixedIn.join(', '))}`
+        : '\n    No upgrade or patch available';
     unfixableIssuesTextArray.push(
       formatIssue(
         issue.id,
@@ -465,13 +463,13 @@ export function formatIssue(
     const pathStr = printPath(paths[0]);
     introducedBy =
       paths.length === 1
-        ? `\n    introduced by ${pathStr}`
-        : `\n    introduced by ${pathStr} and ${chalk.cyanBright(
+        ? `\n    Introduced by: ${pathStr}`
+        : `\n    Introduced by: ${pathStr} and ${chalk.cyanBright(
             '' + (paths.length - 1),
           )} other path(s)`;
   } else if (testOptions.showVulnPaths === 'all' && paths) {
     introducedBy =
-      '\n    introduced by:' +
+      '\n    Introduced by:' +
       paths
         .slice(0, 1000)
         .map((p) => '\n    ' + printPath(p))
@@ -496,12 +494,12 @@ export function formatIssue(
 
   return (
     severityColor.colorFunc(
-      `  ✗ ${chalk.bold(title)}${newBadge} [${titleCaseText(
-        severity,
-      )} Severity${originalSeverityStr}]`,
+      `\n  ✗ [${titleCaseText(severity)}${originalSeverityStr}] ${chalk.bold(
+        title,
+      )}${newBadge}\n`,
     ) +
     reachabilityText +
-    `[${config.ROOT}/vuln/${id}]` +
+    `    Info: [${config.ROOT}/vuln/${id}]` +
     name +
     reachableVia +
     introducedBy +

--- a/src/cli/commands/test/iac-output.ts
+++ b/src/cli/commands/test/iac-output.ts
@@ -35,7 +35,7 @@ function formatIacIssue(
   const severityColor = getSeveritiesColour(issue.severity);
 
   return (
-    severityColor.colorFunc(
+    severityColor(
       `  ✗ ${chalk.bold(issue.title)}${newBadge} [${titleCaseText(
         issue.severity,
       )} Severity]`,

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -329,7 +329,7 @@ function displayResult(
   if (options.iac && res.targetFile) {
     testingPath = pathLib.basename(res.targetFile);
   }
-  const prefix = chalk.bold.white('\nTesting ' + testingPath + '...\n\n');
+  const prefix = chalk.bold('\nTesting ' + testingPath + '...\n\n');
 
   // handle errors by extracting their message
   if (res instanceof Error) {

--- a/src/lib/plugins/sast/format/output-format.ts
+++ b/src/lib/plugins/sast/format/output-format.ts
@@ -43,19 +43,15 @@ export function getCodeDisplayedOutput(
 
 function getCodeIssuesSummary(issues: { [index: string]: string[] }): string {
   const lowSeverityText = issues.low.length
-    ? getLegacySeveritiesColour(SEVERITY.LOW).colorFunc(
-        ` ${issues.low.length} [Low] `,
-      )
+    ? getLegacySeveritiesColour(SEVERITY.LOW)(` ${issues.low.length} [Low] `)
     : '';
   const mediumSeverityText = issues.medium.length
-    ? getLegacySeveritiesColour(SEVERITY.MEDIUM).colorFunc(
+    ? getLegacySeveritiesColour(SEVERITY.MEDIUM)(
         ` ${issues.medium.length} [Medium] `,
       )
     : '';
   const highSeverityText = issues.high.length
-    ? getLegacySeveritiesColour(SEVERITY.HIGH).colorFunc(
-        `${issues.high.length} [High] `,
-      )
+    ? getLegacySeveritiesColour(SEVERITY.HIGH)(`${issues.high.length} [High] `)
     : '';
 
   const codeIssueCount =
@@ -95,7 +91,7 @@ function getIssues(
           rulesMap[ruleId].shortDescription?.text || rulesMap[ruleId].name;
         const ruleIdSeverityText = getLegacySeveritiesColour(
           severity.toLowerCase(),
-        ).colorFunc(` ✗ [${severity}] ${ruleName}`);
+        )(` ✗ [${severity}] ${ruleName}`);
         const artifactLocationUri = location.artifactLocation.uri;
         const startLine = location.region.startLine;
         const text = res.message.text;

--- a/src/lib/snyk-test/common.ts
+++ b/src/lib/snyk-test/common.ts
@@ -1,5 +1,5 @@
 import * as config from '../config';
-import chalk from 'chalk';
+import { colour } from '../theme';
 
 export function assembleQueryString(options) {
   const org = options.org || config.org || null;
@@ -49,64 +49,12 @@ export const SEVERITIES: Array<{
   },
 ];
 
-export const severitiesColourMapping = {
-  low: {
-    colorFunc(text) {
-      return chalk.blueBright(text);
-    },
-  },
-  medium: {
-    colorFunc(text) {
-      return chalk.yellowBright(text);
-    },
-  },
-  high: {
-    colorFunc(text) {
-      return chalk.redBright(text);
-    },
-  },
-  critical: {
-    colorFunc(text) {
-      return chalk.magentaBright(text);
-    },
-  },
-};
-
-export const legacySeveritiesColourMapping = {
-  low: {
-    colorFunc(text) {
-      return chalk.bold.blue(text);
-    },
-  },
-  medium: {
-    colorFunc(text) {
-      return chalk.bold.yellow(text);
-    },
-  },
-  high: {
-    colorFunc(text) {
-      return chalk.bold.red(text);
-    },
-  },
-  critical: {
-    colorFunc(text) {
-      return chalk.bold.magenta(text);
-    },
-  },
-};
-
-export const defaultSeverityColor = {
-  colorFunc(text) {
-    return chalk.grey(text);
-  },
-};
-
 export function getSeveritiesColour(severity: string) {
-  return severitiesColourMapping[severity] || defaultSeverityColor;
+  return colour.severity[severity] || colour.severity.low;
 }
 
 export function getLegacySeveritiesColour(severity: string) {
-  return legacySeveritiesColourMapping[severity] || defaultSeverityColor;
+  return colour.severity[severity] || colour.severity.low;
 }
 
 export enum FAIL_ON {

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,35 @@
+import chalk from 'chalk';
+
+export const Icon = {
+  RUN: '►',
+  VALID: '✔',
+  ISSUE: '✗',
+  WARNING: '⚠',
+  INFO: 'ℹ',
+};
+
+// const SEVERITY_CRITICAL = '#ff0bob';
+// const SEVERITY_HIGH = '#ff872f';
+// const SEVERITY_MEDIUM = '#edd55e';
+// const SEVERITY_LOW = '#bcbbc8';
+//
+// const STATUS_ERROR = '#ff872f';
+// const STATUS_SUCCESS = '#00d200';
+//
+// const REACHABILITY_REACHABLE = '';
+// const REACHABILITY_PARTIALLY = '';
+// const REACHABILITY_NON_REACHABLE = '';
+// const REACHABILITY_NO_INFO = '';
+
+export const colour = {
+  status: {
+    error: (text: string) => chalk.red(text),
+    success: (text: string) => chalk.green(text),
+  },
+  severity: {
+    critical: (text: string) => chalk.magenta(text),
+    high: (text: string) => chalk.red(text),
+    medium: (text: string) => chalk.yellow(text),
+    low: (text: string) => text,
+  },
+};

--- a/test/acceptance/display-test-results.test.ts
+++ b/test/acceptance/display-test-results.test.ts
@@ -32,11 +32,7 @@ test('`test ruby-app` remediation displayed', async (t) => {
       'upgrade advice displayed',
     );
     t.match(res, 'Tested 52 dependencies for known issues');
-    t.match(
-      res,
-      'This issue was fixed in versions: 1.2.3',
-      'fixed in is shown',
-    );
+    t.match(res, 'Fixed in: 1.2.3', 'fixed in is shown');
     t.match(
       res,
       'No upgrade or patch available',
@@ -170,7 +166,7 @@ test('`test npm-package-with-severity-override` show original severity upgrade',
     const { message } = error;
     t.match(
       message,
-      `[Low Severity (originally Medium)][${apiUrl.protocol}//${apiUrl.host}/vuln/npm:node-uuid:20160328]`,
+      `[Low (originally Medium)] Insecure Randomness\n    Info: [${apiUrl.protocol}//${apiUrl.host}/vuln/npm:node-uuid:20160328]`,
     );
   }
 
@@ -196,7 +192,7 @@ test('`test npm-package-with-severity-override` show original severity patches',
     t.match(message, 'Patch available for node-uuid@1.4.0');
     t.match(
       message,
-      `[Low Severity (originally Medium)][${apiUrl.protocol}//${apiUrl.host}/vuln/npm:node-uuid:20160328]`,
+      `[Low (originally Medium)] Insecure Randomness\n    Info: [${apiUrl.protocol}//${apiUrl.host}/vuln/npm:node-uuid:20160328]`,
     );
   }
 
@@ -246,7 +242,7 @@ test('`test npm-package-with-severity-override` show original severity unresolve
     const { message } = error;
     t.match(
       message,
-      `Malicious Package [Low Severity (originally Medium)][${apiUrl.protocol}//${apiUrl.host}/vuln/npm:node-uuid:20160328`,
+      `[Low (originally Medium)] Malicious Package\n    Info: [${apiUrl.protocol}//${apiUrl.host}/vuln/npm:node-uuid:20160328`,
     );
   }
 
@@ -271,7 +267,7 @@ test('`test npm-package-with-severity-override` dont show original severity if i
     const { message } = error;
     t.match(
       message,
-      `[Low Severity][${apiUrl.protocol}//${apiUrl.host}/vuln/npm:node-uuid:20160328]`,
+      `[Low] Insecure Randomness\n    Info: [${apiUrl.protocol}//${apiUrl.host}/vuln/npm:node-uuid:20160328]`,
     );
   }
 

--- a/test/acceptance/workspaces/pip-app-transitive-vuln/cli-output-actionable-remediation.txt
+++ b/test/acceptance/workspaces/pip-app-transitive-vuln/cli-output-actionable-remediation.txt
@@ -7,18 +7,26 @@ Tested 6 dependencies for known vulnerabilities, found 4 vulnerabilities, 4 vuln
 Issues to fix by upgrading dependencies:
 
   Upgrade flask to 1.0 to fix
-  ✗ Improper Input Validation [High Severity][http://localhost:12345/vuln/SNYK-PYTHON-FLASK-42185] in flask@0.12.2
-    introduced by flask@0.12.2
-  ✗ Denial of Service (DOS) [High Severity][http://localhost:12345/vuln/SNYK-PYTHON-FLASK-451637] in flask@0.12.2
-    introduced by flask@0.12.2
+
+  ✗ [High] Improper Input Validation
+    Info: [http://localhost:12345/vuln/SNYK-PYTHON-FLASK-42185] in flask@0.12.2
+    Introduced by: flask@0.12.2
+
+  ✗ [High] Denial of Service (DOS)
+    Info: [http://localhost:12345/vuln/SNYK-PYTHON-FLASK-451637] in flask@0.12.2
+    Introduced by: flask@0.12.2
 
   Pin Jinja2 to 2.10.1 to fix
-  ✗ Sandbox Escape [Medium Severity][http://localhost:12345/vuln/SNYK-PYTHON-JINJA2-174126] in Jinja2@2.9.6
-    introduced by flask@0.12.2 > Jinja2@2.9.6
+
+  ✗ [Medium] Sandbox Escape
+    Info: [http://localhost:12345/vuln/SNYK-PYTHON-JINJA2-174126] in Jinja2@2.9.6
+    Introduced by: flask@0.12.2 > Jinja2@2.9.6
 
   Pin Werkzeug to 0.15.3 to fix
-  ✗ Insufficient Randomness [High Severity][http://localhost:12345/vuln/SNYK-PYTHON-WERKZEUG-458931] in Werkzeug@0.12.2
-    introduced by flask@0.12.2 > Werkzeug@0.12.2
+
+  ✗ [High] Insufficient Randomness
+    Info: [http://localhost:12345/vuln/SNYK-PYTHON-WERKZEUG-458931] in Werkzeug@0.12.2
+    Introduced by: flask@0.12.2 > Werkzeug@0.12.2
 
 
 


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds a **theme.ts** file which will contains all the updated colours and icons used in the output.
It adds proper spacing for OSS and removes misused colours.

#### Any background context you want to provide?
This is the start for updating the CLI output. We want to to have a similar look&feel across the Snyk platform. 

#### Screenshots
Before
![Screenshot 2021-07-02 at 15 55 22](https://user-images.githubusercontent.com/818805/124278515-048a3d80-db4f-11eb-9ca3-58a059146d71.png)

After
![Screenshot 2021-07-02 at 15 54 27](https://user-images.githubusercontent.com/818805/124278531-0b18b500-db4f-11eb-9fb3-361ff257b1a9.png)

