### PR TITLE
fix: handle container no image name provided [CAP-228]

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.2.1",
-    "snyk-docker-plugin": "4.21.2",
+    "snyk-docker-plugin": "4.21.3",
     "snyk-go-plugin": "1.17.0",
     "snyk-gradle-plugin": "3.16.0",
     "snyk-module": "3.1.0",

--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -34,7 +34,11 @@ import { convertMultiResultToMultiCustom } from '../../../lib/plugins/convert-mu
 import { convertSingleResultToMultiCustom } from '../../../lib/plugins/convert-single-splugin-res-to-multi-custom';
 import { PluginMetadata } from '@snyk/cli-interface/legacy/plugin';
 import { getContributors } from '../../../lib/monitor/dev-count-analysis';
-import { FailedToRunTestError, MonitorError } from '../../../lib/errors';
+import {
+  FailedToRunTestError,
+  MonitorError,
+  MissingArgError,
+} from '../../../lib/errors';
 import { isMultiProjectScan } from '../../../lib/is-multi-project-scan';
 import { getEcosystem, monitorEcosystem } from '../../../lib/ecosystems';
 import { getFormattedMonitorOutput } from '../../../lib/ecosystems/monitor';
@@ -73,6 +77,12 @@ async function monitor(...args0: MethodArgs): Promise<any> {
 
   if (options.docker && options['remote-repo-url']) {
     throw new Error('`--remote-repo-url` is not supported for container scans');
+  }
+
+  // Handles no image arg provided to the container command until
+  // a validation interface is implemented in the docker plugin.
+  if (options.docker && paths.length === 0) {
+    throw new MissingArgError();
   }
 
   apiOrOAuthTokenExists();

--- a/src/cli/commands/process-command-args.ts
+++ b/src/cli/commands/process-command-args.ts
@@ -10,8 +10,8 @@ export function processCommandArgs<CommandOptions>(
   }
   args = args.filter(Boolean);
 
-  // populate with default path (cwd) if no path given
-  if (args.length === 0) {
+  // For repository scanning, populate with default path (cwd) if no path given
+  if (args.length === 0 && !options.docker) {
     args.unshift(process.cwd());
   }
 

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -5,6 +5,7 @@ import * as pathLib from 'path';
 const cloneDeep = require('lodash.clonedeep');
 const assign = require('lodash.assign');
 import chalk from 'chalk';
+import { MissingArgError } from '../../../lib/errors';
 
 import * as snyk from '../../../lib';
 import { isCI } from '../../../lib/is-ci';
@@ -67,6 +68,12 @@ async function test(...args: MethodArgs): Promise<TestCommandResult> {
   const options = setDefaultTestOptions(originalOptions);
   validateTestOptions(options);
   validateCredentials(options);
+
+  // Handles no image arg provided to the container command until
+  // a validation interface is implemented in the docker plugin.
+  if (options.docker && paths.length === 0) {
+    throw new MissingArgError();
+  }
 
   const ecosystem = getEcosystemForTest(options);
   if (ecosystem) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -26,7 +26,7 @@ import { updateCheck } from '../lib/updater';
 import {
   MissingTargetFileError,
   FileFlagBadInputError,
-  OptionMissingErrorError,
+  MissingOptionError,
   UnsupportedOptionCombinationError,
   ExcludeFlagBadInputError,
   CustomError,
@@ -394,7 +394,7 @@ function validateUnsupportedOptionCombinations(
 
   if (options.exclude) {
     if (!(options.allProjects || options.yarnWorkspaces)) {
-      throw new OptionMissingErrorError('--exclude', [
+      throw new MissingOptionError('--exclude', [
         '--yarn-workspaces',
         '--all-projects',
       ]);
@@ -440,7 +440,7 @@ function validateUnsupportedSarifCombinations(args) {
     args.options['docker'] &&
     !args.options['file']
   ) {
-    throw new OptionMissingErrorError('sarif', ['--file']);
+    throw new MissingOptionError('sarif', ['--file']);
   }
 
   if (
@@ -448,7 +448,7 @@ function validateUnsupportedSarifCombinations(args) {
     args.options['docker'] &&
     !args.options['file']
   ) {
-    throw new OptionMissingErrorError('sarif-file-output', ['--file']);
+    throw new MissingOptionError('sarif-file-output', ['--file']);
   }
 }
 

--- a/src/lib/ecosystems/monitor.ts
+++ b/src/lib/ecosystems/monitor.ts
@@ -52,6 +52,9 @@ export async function monitorEcosystem(
       ) {
         throw new DockerImageNotFoundError(path);
       }
+      if (ecosystem === 'docker' && error.message === 'invalid image format') {
+        throw new DockerImageNotFoundError(path);
+      }
 
       throw error;
     } finally {

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -17,6 +17,7 @@ export { TooManyVulnPaths } from './too-many-vuln-paths';
 export { AuthFailedError } from './authentication-failed-error';
 export { FeatureNotSupportedForOrgError } from './unsupported-feature-for-org-error';
 export { OptionMissingErrorError } from './option-missing-error';
+export { MissingArgError } from './missing-arg-error';
 export { ExcludeFlagBadInputError } from './exclude-flag-bad-input';
 export { UnsupportedOptionCombinationError } from './unsupported-option-combination-error';
 export { FeatureNotSupportedByPackageManagerError } from './feature-not-supported-by-package-manager-error';

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -16,7 +16,7 @@ export { FailedToRunTestError } from './failed-to-run-test-error';
 export { TooManyVulnPaths } from './too-many-vuln-paths';
 export { AuthFailedError } from './authentication-failed-error';
 export { FeatureNotSupportedForOrgError } from './unsupported-feature-for-org-error';
-export { OptionMissingErrorError } from './option-missing-error';
+export { MissingOptionError } from './missing-option-error';
 export { MissingArgError } from './missing-arg-error';
 export { ExcludeFlagBadInputError } from './exclude-flag-bad-input';
 export { UnsupportedOptionCombinationError } from './unsupported-option-combination-error';

--- a/src/lib/errors/missing-arg-error.ts
+++ b/src/lib/errors/missing-arg-error.ts
@@ -1,0 +1,11 @@
+import { CustomError } from './custom-error';
+
+export class MissingArgError extends CustomError {
+  constructor() {
+    const msg =
+      'Could not detect an image. Specify an image name to scan and try running the command again.';
+    super(msg);
+    this.code = 422;
+    this.userMessage = msg;
+  }
+}

--- a/src/lib/errors/missing-option-error.ts
+++ b/src/lib/errors/missing-option-error.ts
@@ -1,6 +1,6 @@
 import { CustomError } from './custom-error';
 
-export class OptionMissingErrorError extends CustomError {
+export class MissingOptionError extends CustomError {
   constructor(option: string, required: string[]) {
     const msg = `The ${option} option can only be use in combination with ${required
       .sort()

--- a/src/lib/snyk-test/assemble-payloads.ts
+++ b/src/lib/snyk-test/assemble-payloads.ts
@@ -9,6 +9,7 @@ import { assembleQueryString } from './common';
 import spinner = require('../spinner');
 import { findAndLoadPolicyForScanResult } from '../ecosystems/policy';
 import { getAuthHeader } from '../../lib/api-token';
+import { DockerImageNotFoundError } from '../errors';
 
 export async function assembleEcosystemPayloads(
   ecosystem: Ecosystem,
@@ -70,6 +71,15 @@ export async function assembleEcosystemPayloads(
     }
 
     return payloads;
+  } catch (error) {
+    if (ecosystem === 'docker' && error.message === 'authentication required') {
+      throw new DockerImageNotFoundError(options.path);
+    }
+    if (ecosystem === 'docker' && error.message === 'invalid image format') {
+      throw new DockerImageNotFoundError(options.path);
+    }
+
+    throw error;
   } finally {
     spinner.clear<void>(spinnerLbl)();
   }

--- a/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
+++ b/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
@@ -141,6 +141,21 @@ if (!isWindows) {
     }
   });
 
+  test('`monitor missing container image`', async (t) => {
+    chdirWorkspaces();
+    try {
+      await cli.monitor({ docker: true });
+      t.fail('should have failed');
+    } catch (err) {
+      t.match(
+        err.message,
+        'Could not detect an image. Specify an image name to scan and try running the command again.',
+        'show err message',
+      );
+      t.pass('throws err');
+    }
+  });
+
   test('`monitor non-existing`', async (t) => {
     chdirWorkspaces();
     try {

--- a/test/acceptance/cli-test/cli-test.generic.spec.ts
+++ b/test/acceptance/cli-test/cli-test.generic.spec.ts
@@ -34,6 +34,21 @@ export const GenericTests: AcceptanceTests = {
       t.end();
     },
 
+    '`test ` test missing container image': (params, utils) => async (t) => {
+      utils.chdirWorkspaces();
+      try {
+        await params.cli.test({ docker: true });
+        t.fail('should have failed');
+      } catch (err) {
+        t.match(
+          err.message,
+          'Could not detect an image. Specify an image name to scan and try running the command again.',
+          'show err message',
+        );
+        t.pass('throws err');
+      }
+    },
+
     'userMessage and error code correctly bubbles with npm': (
       params,
       utils,

--- a/test/process-command-args.spec.ts
+++ b/test/process-command-args.spec.ts
@@ -1,6 +1,6 @@
 import { processCommandArgs } from '../src/cli/commands/process-command-args';
 describe('display help message', () => {
-  it('should return expected options & paths when path is undefined', () => {
+  it('should return undefined options & `cwd` path when path is undefined', () => {
     const cliArgs = [undefined, {}];
     const defaultCurrentPath = process.cwd();
     const { options, paths } = processCommandArgs(...cliArgs);
@@ -9,7 +9,16 @@ describe('display help message', () => {
     expect(paths).toEqual([defaultCurrentPath]);
   });
 
-  it('should return expected options & paths when path is undefied + --json', () => {
+  it('should return no paths when running a container scan with no image', () => {
+    const cliArgs = [undefined, { docker: true }];
+    const defaultCurrentPath = [];
+    const { options, paths } = processCommandArgs(...cliArgs);
+
+    expect(options).toEqual({ docker: true });
+    expect(paths).toEqual(defaultCurrentPath);
+  });
+
+  it('should return undefined options & `cwd` path when path is undefined + --json', () => {
     const cliArgs = [undefined, { json: true }];
     const defaultCurrentPath = process.cwd();
     const { options, paths } = processCommandArgs(...cliArgs);
@@ -55,7 +64,7 @@ describe('display help message', () => {
     expect(options.allProjects).toBeTruthy();
   });
 
-  it('should return expected options & paths when packageName is provided', () => {
+  it('should return no options & packageName path when packageName is provided', () => {
     const cliArgs = ['semver@2'];
 
     const { options, paths } = processCommandArgs(...cliArgs);


### PR DESCRIPTION
#### Missed Anything?
- [x] Tests updated/written
- [x] merge only after snyk-docker-plugin is merged

#### What does this PR do?
This PR does the following:
* checks if the `container test` and `container monitor` commands receive an argument (the container image name) that shall be analysed;
* handles the errors returned by the scanning functions of the test and monitor commands

#### How should this be manually tested?
Old:
```
$ snyk container test
{"type":"Buffer","data":[]}
```
New:
```
$ snyk container test
Could not detect an image. Specify an image name to scan and try running the command again.
```
Same for the `monitor` command.