### PR TITLE
chore: force npm@7.17.0 for testing as npm@7.18 breaks tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,9 +165,9 @@ jobs:
           docker_layer_caching: true
       - install_shellspec
       - run:
-          name: Install npm@7
+          name: Install npm@7.17.0
           command: |
-            sudo npm install -g npm@7
+            sudo npm install -g npm@7.17.0
       - show_node_version
       - update_local_npmrc_linux
       - install_deps
@@ -331,7 +331,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/snyk
-      - run: sudo npm install -g npm@7
+      - run: sudo npm install -g npm@7.17.0
       - show_node_version
       - install_lerna_linux
       - update_local_npmrc_linux


### PR DESCRIPTION
Our tests are [currently failing](https://snyk.slack.com/archives/C0127HWU0E7/p1624264602306900). This is happening [because of an npm@7.18.1 issue](https://github.com/npm/cli/issues/3438).

Force usage of an older version of npm for testing to make sure our tests pass.