### PR TITLE
fix: print warning to stderr instead of stdout

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "snyk-python-plugin": "1.19.9",
     "snyk-resolve": "1.1.0",
     "snyk-resolve-deps": "4.7.2",
-    "snyk-sbt-plugin": "2.11.0",
+    "snyk-sbt-plugin": "2.11.1",
     "snyk-try-require": "1.3.1",
     "source-map-support": "^0.5.11",
     "strip-ansi": "^5.2.0",

--- a/src/lib/print-deps.ts
+++ b/src/lib/print-deps.ts
@@ -21,13 +21,13 @@ export async function maybePrintDepGraph(
   } else {
     if (options['print-deps']) {
       if (options.json) {
-        console.log(
+        console.warn(
           '--print-deps --json option not yet supported for large projects. Displaying graph json output instead',
         );
         // TODO @boost: add as output graphviz 'dot' file to visualize?
         console.log(JSON.stringify(depGraph.toJSON(), null, 2));
       } else {
-        console.log(
+        console.warn(
           '--print-deps option not yet supported for large projects. Try with --json.',
         );
       }


### PR DESCRIPTION
This will prevent mangling of JSON output and similar issues: snyk/snyk-to-html#95

Related PR that should be added here: https://github.com/snyk/snyk-sbt-plugin/pull/94 