### PR TITLE
fix: drop prettier as prod dep from @snyk/fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@snyk/cloud-config-parser": "^1.9.2",
     "@snyk/code-client": "3.9.0",
     "@snyk/dep-graph": "^1.27.1",
-    "@snyk/fix": "1.634.0",
+    "@snyk/fix": "1.641.0",
     "@snyk/gemfile": "1.2.0",
     "@snyk/graphlib": "^2.1.9-patch.3",
     "@snyk/inquirer": "^7.3.3-patch",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Release snyk cli with latest @snyk/fix that uses fix packages without `prettier` being in prod dependencies.