### PR TITLE
test: add new GitHub action test and fix the IaC SARIF output [CC-957]

### DIFF
--- a/src/cli/commands/test/iac-output.ts
+++ b/src/cli/commands/test/iac-output.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import * as Debug from 'debug';
 import * as pathLib from 'path';
+import { pathToFileURL } from 'url';
 import {
   IacTestResponse,
   AnnotatedIacIssue,
@@ -158,7 +159,7 @@ export function createSarifOutputForIac(
         // https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317498
         originalUriBaseIds: {
           [PROJECT_ROOT_KEY]: {
-            uri: 'file://' + pathLib.join(basePath, '/').replace(/\\/g, '/'),
+            uri: pathToFileURL(pathLib.join(basePath, '/')).href,
             description: {
               text: 'The root directory for all project files.',
             },

--- a/test/jest/acceptance/iac/file-output.spec.ts
+++ b/test/jest/acceptance/iac/file-output.spec.ts
@@ -2,6 +2,8 @@ import { readFileSync, unlinkSync } from 'fs';
 import * as path from 'path';
 import * as sarif from 'sarif';
 import { v4 as uuidv4 } from 'uuid';
+import { pathToFileURL } from 'url';
+
 import { startMockServer } from './helpers';
 import { MappedIacTestResponse } from '../../../../src/lib/snyk-test/iac-test-result';
 jest.setTimeout(50000);
@@ -179,8 +181,7 @@ describe('iac test --sarif-file-output', () => {
         jsonObj?.runs?.[0].originalUriBaseIds.PROJECTROOT.uri;
       expect(actualPhysicalLocation).toEqual(expectedPhysicalLocation);
       expect(actualProjectRoot).toEqual(
-        'file://' +
-          path.join(path.resolve(expectedProjectRoot), '/').replace(/\\/g, '/'),
+        pathToFileURL(path.join(path.resolve(expectedProjectRoot), '/')).href,
       );
     });
   });

--- a/test/jest/acceptance/iac/github-action/iac.spec.ts
+++ b/test/jest/acceptance/iac/github-action/iac.spec.ts
@@ -1,0 +1,55 @@
+import * as path from 'path';
+
+import { GithubActionTestRunner } from './runner';
+
+jest.setTimeout(50000);
+
+describe('GitHub action - IaC', () => {
+  describe.each([
+    {
+      relativeDir: '',
+      inputPath: path.resolve(
+        './test/fixtures',
+        './iac/kubernetes/pod-valid.json',
+      ), // absolute location to file
+    },
+    {
+      relativeDir: '',
+      inputPath: './iac/kubernetes/pod-valid.json', // a file
+    },
+    {
+      relativeDir: '',
+      inputPath: './iac', // one folder down
+    },
+    {
+      relativeDir: 'iac',
+      inputPath: '.', // current directory provided as .
+    },
+    {
+      relativeDir: 'iac',
+      inputPath: '', // current directory provided by default
+    },
+    {
+      relativeDir: 'iac/file-output',
+      inputPath: '../../iac', // one folder up
+    },
+  ])('when provided config: %j', ({ relativeDir, inputPath }) => {
+    let githubActionTestRunner: GithubActionTestRunner;
+
+    beforeAll(async () => {
+      githubActionTestRunner = await GithubActionTestRunner.build(
+        'iac',
+        relativeDir,
+        inputPath,
+      );
+    });
+
+    afterAll(async () => {
+      githubActionTestRunner.destroy();
+    });
+
+    it.each([[''], ['--legacy']])(`when running with flag %p`, async (flag) => {
+      await githubActionTestRunner.test(flag);
+    });
+  });
+});

--- a/test/jest/acceptance/iac/github-action/runner.ts
+++ b/test/jest/acceptance/iac/github-action/runner.ts
@@ -1,0 +1,117 @@
+import {
+  readFileSync,
+  existsSync,
+  unlinkSync,
+  readdirSync,
+  statSync,
+} from 'fs';
+import * as path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+import { pathToFileURL } from 'url';
+
+import { startMockServer } from '../helpers';
+
+const ROOT_DIR = './test/fixtures';
+
+export class GithubActionTestRunner {
+  constructor(
+    private command: string,
+    private workingDir: string,
+    private inputPath: string,
+    private run: (
+      cmd: string,
+      env: Record<string, string>,
+      cwd?: string,
+    ) => Promise<{ stdout: string; stderr: string; exitCode: number }>,
+    private teardown: () => void,
+  ) {}
+
+  static async build(
+    product: string,
+    relativeDir: string,
+    inputPath: string,
+  ): Promise<GithubActionTestRunner> {
+    const command = `snyk ${product} test ${path.join(inputPath)}`;
+    const workingDir = path.join(ROOT_DIR, relativeDir);
+
+    const { run, teardown } = await startMockServer();
+
+    return new GithubActionTestRunner(
+      command,
+      workingDir,
+      inputPath,
+      run,
+      teardown,
+    );
+  }
+
+  public async destroy() {
+    this.teardown();
+  }
+
+  public async test(flag: string) {
+    const sarif = await this.runAndGenerateSARIF(flag);
+    this.verifySARIFPaths(sarif);
+  }
+
+  private async runAndGenerateSARIF(flag: string): Promise<string> {
+    const sarifOutputFilename = path.join(__dirname, `${uuidv4()}.sarif`);
+
+    try {
+      const { stderr } = await this.run(
+        `${this.command} ${flag} --sarif-file-output=${sarifOutputFilename}`,
+        {},
+        this.workingDir,
+      );
+      expect(stderr).toEqual('');
+
+      return readFileSync(sarifOutputFilename, 'utf-8');
+    } finally {
+      if (existsSync(sarifOutputFilename)) {
+        unlinkSync(sarifOutputFilename);
+      }
+    }
+  }
+
+  private async verifySARIFPaths(sarif: string) {
+    const jsonObj = JSON.parse(sarif);
+
+    const actualPaths: Set<string> = new Set();
+    for await (const p of walk(path.resolve(this.workingDir, this.inputPath))) {
+      actualPaths.add(pathToFileURL(p).href); // URIs should use forward slash, not backward slash
+    }
+
+    const generatedPaths: Set<string> = new Set();
+    for (const run of jsonObj.runs) {
+      const projectRoot = run.originalUriBaseIds.PROJECTROOT.uri;
+
+      for (const result of run.results) {
+        for (const loc of result.locations) {
+          generatedPaths.add(
+            projectRoot + loc.physicalLocation.artifactLocation.uri,
+          );
+        }
+      }
+    }
+
+    for (const p of generatedPaths) {
+      expect(actualPaths).toContainEqual(p);
+    }
+  }
+}
+
+async function* walk(dir: string) {
+  if (!statSync(dir).isDirectory()) {
+    yield dir;
+    return;
+  }
+  const files = readdirSync(dir);
+  for (const file of files) {
+    const entry = path.join(dir, file);
+    if (statSync(entry).isDirectory()) {
+      yield* walk(entry);
+    } else {
+      yield entry;
+    }
+  }
+}

--- a/test/jest/acceptance/iac/helpers.ts
+++ b/test/jest/acceptance/iac/helpers.ts
@@ -31,8 +31,11 @@ export async function startMockServer() {
   };
 
   return {
-    run: async (cmd: string, overrides?: Record<string, string>) =>
-      run(cmd, { ...env, ...overrides }),
+    run: async (
+      cmd: string,
+      overrides?: Record<string, string>,
+      cwd?: string,
+    ) => run(cmd, { ...env, ...overrides }, cwd),
     teardown: async () => new Promise((resolve) => server.close(resolve)),
   };
 }
@@ -43,6 +46,7 @@ export async function startMockServer() {
 export async function run(
   cmd: string,
   env: Record<string, string> = {},
+  cwd?: string,
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   return new Promise((resolve, reject) => {
     const root = join(__dirname, '../../../../');
@@ -51,7 +55,7 @@ export async function run(
       cmd.trim().replace(/^snyk/, `node ${main}`),
       {
         env,
-        cwd: join(root, 'test/fixtures'),
+        cwd: cwd ?? join(root, 'test/fixtures'),
       },
       function(err, stdout, stderr) {
         // err.code indicates the shell exited with non-zero code


### PR DESCRIPTION
#### What does this PR do?
This implements the unit tests for the IaC GitHub action, with the aim of gating the CLI against breaking the SARIF output used by GitHub. Will start passing after https://github.com/snyk/snyk/pull/2052.

#### Where should the reviewer start?

#### How should this be manually tested?
Run `npx jest test/jest/acceptance/iac/github-action/iac.spec.ts`

#### Any background context you want to provide?
This PR came from an action to make sure we implement regression tests for our IaC GitHub action. The GitHub action would generally be used for scanning repos for security alerts, so may be run with the following file paths:
- `.`: the current way we run our action and which works
- nothing: equivalent of the above, but currently broken
- a relative directory nested inside the current directory
- a relative directory nested outside the current directory
- a file
The best way to test that the generated SARIF URIs are valid (without having to hard-code anything), is to build the paths and see if they match up to valid files in the local filesystem, as agreed in the [decision document](https://www.notion.so/snyk/Snyk-IaC-GitHub-action-Regression-testing-d3000b18cba44eaaae2f89d297b54ed7).


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CC-957