### PR TITLE
fix: handle printing of large trees when using json and print-deps flags

### DIFF
--- a/src/lib/print-deps.ts
+++ b/src/lib/print-deps.ts
@@ -3,6 +3,7 @@ import * as depGraphLib from '@snyk/dep-graph';
 import { DepDict, Options, MonitorOptions } from './types';
 import { legacyCommon as legacyApi } from '@snyk/cli-interface';
 import { countPathsToGraphRoot } from './utils';
+import { jsonStringifyLargeObject } from './json';
 
 export async function maybePrintDepGraph(
   options: Options | MonitorOptions,
@@ -25,7 +26,7 @@ export async function maybePrintDepGraph(
           '--print-deps --json option not yet supported for large projects. Displaying graph json output instead',
         );
         // TODO @boost: add as output graphviz 'dot' file to visualize?
-        console.log(JSON.stringify(depGraph.toJSON(), null, 2));
+        console.log(jsonStringifyLargeObject(depGraph.toJSON()));
       } else {
         console.warn(
           '--print-deps option not yet supported for large projects. Try with --json.',
@@ -44,7 +45,7 @@ export function maybePrintDepTree(
   if (options['print-deps']) {
     if (options.json) {
       // Will produce 2 JSON outputs, one for the deps, one for the vuln scan.
-      console.log(JSON.stringify(rootPackage, null, 2));
+      console.log(jsonStringifyLargeObject(rootPackage));
     } else {
       printDepsForTree({ [rootPackage.name!]: rootPackage });
     }


### PR DESCRIPTION
We had a regression with some users combining `--json` and `--print-deps` flags. CLI crashed on `RangeError: Invalid string length`. `jsonStringifyLargeObject` can handle this. Tested it with a previously failing project and it worked.

This is extending the improvements on JSON handling from https://github.com/snyk/snyk/pull/1516