### PR TITLE
leak less sensitive Snyk internal process details

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -8,6 +8,7 @@ import {
   SupportedUserReachableFacingCliArgs,
 } from '../lib/types';
 import { getContainerImageSavePath } from '../lib/container';
+import { obfuscateArgs } from '../lib/utils';
 
 export declare interface Global extends NodeJS.Global {
   ignoreUnknownCA: boolean;
@@ -277,7 +278,7 @@ export function args(rawArgv: string[]): Args {
     global.ignoreUnknownCA = true;
   }
 
-  debug(command, argv);
+  debug(command, obfuscateArgs(argv));
 
   return {
     command,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -44,6 +44,7 @@ import {
 } from '../lib/types';
 import { SarifFileOutputEmptyError } from '../lib/errors/empty-sarif-output-error';
 import { InvalidDetectionDepthValue } from '../lib/errors/invalid-detection-depth-value';
+import { obfuscateArgs } from '../lib/utils';
 
 const debug = Debug('snyk');
 const EXIT_CODES = {
@@ -56,7 +57,7 @@ async function runCommand(args: Args) {
   const commandResult = await args.method(...args.options._);
 
   const res = analytics.addDataAndSend({
-    args: args.options._,
+    args: obfuscateArgs(args.options._),
     command: args.command,
     org: args.options.org,
   });
@@ -164,7 +165,7 @@ async function handleError(args, error) {
   }
 
   const res = analytics.addDataAndSend({
-    args: args.options._,
+    args: obfuscateArgs(args.options._),
     command,
     org: args.options.org,
   });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,30 @@
+import * as cloneDeep from 'lodash.clonedeep';
 import { DepGraph } from '@snyk/dep-graph';
+import { ArgsOptions, MethodArgs } from '../cli/args';
 
 export function countPathsToGraphRoot(graph: DepGraph): number {
   return graph
     .getPkgs()
     .reduce((acc, pkg) => acc + graph.countPathsToRoot(pkg), 0);
+}
+
+export function obfuscateArgs(
+  args: ArgsOptions | MethodArgs,
+): ArgsOptions | MethodArgs {
+  const obfuscatedArgs = cloneDeep(args);
+  if (obfuscatedArgs['username']) {
+    obfuscatedArgs['username'] = 'username-set';
+  }
+  if (obfuscatedArgs[1] && obfuscatedArgs[1]['username']) {
+    obfuscatedArgs[1]['username'] = 'username-set';
+  }
+
+  if (obfuscatedArgs['password']) {
+    obfuscatedArgs['password'] = 'password-set';
+  }
+  if (obfuscatedArgs[1] && obfuscatedArgs[1]['password']) {
+    obfuscatedArgs[1]['password'] = 'password-set';
+  }
+
+  return obfuscatedArgs;
 }

--- a/test/jest/unit/lib/util.spec.ts
+++ b/test/jest/unit/lib/util.spec.ts
@@ -1,0 +1,66 @@
+import { obfuscateArgs } from '../../../../src/lib/utils';
+import { ArgsOptions, MethodArgs } from '../../../../src/cli/args';
+
+describe('Sanitize args', () => {
+  it('should obfuscate username and password when both are provided', () => {
+    const argsWithUsernameAndPassword: ArgsOptions = {
+      _doubleDashArgs: [],
+      _: ['snyk/goof-image:latest'],
+      org: 'demo-org',
+      username: 'fakeuser',
+      password: 'fakepass',
+      file: 'Dockerfile',
+    };
+
+    const resultWithFlag = obfuscateArgs(
+      argsWithUsernameAndPassword,
+    ) as ArgsOptions;
+
+    expect(resultWithFlag.username).toEqual('username-set');
+    expect(resultWithFlag.password).toEqual('password-set');
+    expect(resultWithFlag._[0]).toEqual('snyk/goof-image:latest');
+    expect(resultWithFlag.org).toEqual('demo-org');
+    expect(resultWithFlag.file).toEqual('Dockerfile');
+  });
+
+  it('should obfuscate personally identifiable information from args', () => {
+    const argsWithUsernameAndPassword: ArgsOptions = {
+      _doubleDashArgs: [],
+      _: ['snyk/goof-image:latest'],
+      org: 'demo-org',
+      username: 'fakeuser',
+      file: 'Dockerfile',
+    };
+
+    const resultWithFlag = obfuscateArgs(
+      argsWithUsernameAndPassword,
+    ) as ArgsOptions;
+
+    expect(resultWithFlag.username).toEqual('username-set');
+    expect(resultWithFlag.password).toBeUndefined();
+    expect(resultWithFlag._[0]).toEqual('snyk/goof-image:latest');
+    expect(resultWithFlag.org).toEqual('demo-org');
+    expect(resultWithFlag.file).toEqual('Dockerfile');
+  });
+
+  it('should obfuscate nested PII', () => {
+    const argsWithUsernameAndPassword: MethodArgs = [
+      'snyk/goof-image:latest',
+      {
+        _doubleDashArgs: [],
+        _: ['snyk/goof-image:latest'],
+        username: 'fakeuser',
+        password: 'fakepass',
+        debug: true,
+        docker: true,
+        experimental: true,
+      },
+    ];
+
+    const resultWithFlag = obfuscateArgs(argsWithUsernameAndPassword);
+
+    expect(resultWithFlag[0]).toEqual('snyk/goof-image:latest');
+    expect(resultWithFlag[1].username).toEqual('username-set');
+    expect(resultWithFlag[1].password).toEqual('password-set');
+  });
+});


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
  Leak less sensitive Snyk internal process details.

#### How should this be manually tested?
Run the command:
```
snyk container test alpine:latest --username=some_username --password=some_secret --debug

```
You should see debug output with obfuscated sensitive data.
```
 _: [ 'alpine:latest' ],
  username: 'username-set',
  password: 'password-set',
  debug: true,
  docker: true,
  experimental: true
```

#### What are the relevant tickets?
- [CAP-294](https://snyksec.atlassian.net/browse/CAP-294)

#### Screenshots
![Screenshot 2021-06-24 at 11 51 47](https://user-images.githubusercontent.com/838518/123250966-93111600-d4e2-11eb-8916-b1283a7c6ae0.png)

