### PR TITLE
feat: filter out non-vulnerable from summary

### DIFF
--- a/packages/snyk-fix/src/partition-by-vulnerable.ts
+++ b/packages/snyk-fix/src/partition-by-vulnerable.ts
@@ -1,0 +1,19 @@
+import { EntityToFix } from './types';
+
+export function partitionByVulnerable(
+  entities: EntityToFix[],
+): { vulnerable: EntityToFix[]; notVulnerable: EntityToFix[] } {
+  const vulnerable: EntityToFix[] = [];
+  const notVulnerable: EntityToFix[] = [];
+
+  for (const entity of entities) {
+    const hasIssues = entity.testResult.issues.length > 0;
+    if (hasIssues) {
+      vulnerable.push(entity);
+    } else {
+      notVulnerable.push(entity);
+    }
+  }
+
+  return { vulnerable, notVulnerable };
+}

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/pip-requirements/update-dependencies/__snapshots__/update-dependencies.spec.ts.snap
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/pip-requirements/update-dependencies/__snapshots__/update-dependencies.spec.ts.snap
@@ -19,7 +19,8 @@ Summary:
 
   6 issues: 2 High | 2 Medium | 2 Low
   6 issues are fixable
-  6 issues were successfully fixed"
+  6 issues were successfully fixed
+"
 `;
 
 exports[`fix *req*.txt / *.txt Python projects fixes multiple files via -r with the same name (some were already fixed) 1`] = `
@@ -43,7 +44,8 @@ Summary:
 
   6 issues: 3 High | 3 Medium
   6 issues are fixable
-  6 issues were successfully fixed"
+  6 issues were successfully fixed
+"
 `;
 
 exports[`fix *req*.txt / *.txt Python projects retains python markers 1`] = `

--- a/packages/snyk-fix/test/helpers/generate-entity-to-fix.ts
+++ b/packages/snyk-fix/test/helpers/generate-entity-to-fix.ts
@@ -16,10 +16,17 @@ export function generateEntityToFix(
   type: string,
   targetFile: string,
   contents: string,
+  withVulns = true,
   path?: string,
 ): EntityToFix {
   const scanResult = generateScanResult(type, targetFile);
-  const testResult = generateTestResult();
+  const testResult = withVulns
+    ? generateTestResult()
+    : {
+        issues: [],
+        issuesData: {},
+        depGraphData: ('' as unknown) as DepGraphData,
+      };
   const workspace = generateWorkspace(contents, path);
   const cliTestOptions = {
     command: 'python3',

--- a/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
@@ -66,6 +66,7 @@ Object {
   "fixSummary": "
  ✖ No successful fixes
 
+
 Unresolved items:
 
   package.json
@@ -78,7 +79,6 @@ Summary:
   1 issues: 1 High
   1 issues are fixable
   
-
 
 Tip: Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the issue persists contact support@snyk.io",
   "meta": Object {
@@ -104,7 +104,8 @@ Summary:
 
   1 issues: 1 High
   1 issues are fixable
-  1 issues were successfully fixed",
+  1 issues were successfully fixed
+",
   "meta": Object {
     "failed": 0,
     "fixed": 1,
@@ -206,7 +207,8 @@ Summary:
 
   2 issues: 2 High
   2 issues are fixable
-  2 issues were successfully fixed",
+  2 issues were successfully fixed
+",
   "meta": Object {
     "failed": 0,
     "fixed": 2,

--- a/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/show-results-summary.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/show-results-summary.spec.ts.snap
@@ -8,39 +8,73 @@ exports[`formatIssueCountBySeverity all vuln severities absent 1`] = `""`;
 
 exports[`formatIssueCountBySeverity all vuln severities present 1`] = `"1 Critical | 3 High | 15 Medium | 300 Low"`;
 
-exports[`generateFixedAndFailedSummary has failed only 1`] = `
+exports[`generateOverallSummary 100% not vulnerable 1`] = `
+"Summary:
+
+  Command run in dry run mode. Fixes are not applied.
+  1 items were not vulnerable
+
+      "
+`;
+
+exports[`generateOverallSummary has failed only 1`] = `
 "Summary:
 
   Command run in dry run mode. Fixes are not applied.
   1 items were not fixed
 
+  1 issues: 1 High
+  1 issues are fixable
+  "
+`;
+
+exports[`generateOverallSummary has fixed & failed & not vulnerable 1`] = `
+"Summary:
+
+  Command run in dry run mode. Fixes are not applied.
+  1 items were not fixed
+  1 items were successfully fixed
+  1 items were not vulnerable
+
+  2 issues: 2 High
+  2 issues are fixable
+  1 issues were successfully fixed
 "
 `;
 
-exports[`generateFixedAndFailedSummary has fixed & failed 1`] = `
+exports[`generateOverallSummary has fixed & failed 1`] = `
 "Summary:
 
   1 items were not fixed
   1 items were successfully fixed
 
+  2 issues: 2 High
+  2 issues are fixable
+  1 issues were successfully fixed
 "
 `;
 
-exports[`generateFixedAndFailedSummary has fixed only 1`] = `
+exports[`generateOverallSummary has fixed only 1`] = `
 "Summary:
 
   1 items were successfully fixed
 
+  1 issues: 1 High
+  1 issues are fixable
+  1 issues were successfully fixed
 "
 `;
 
-exports[`generateFixedAndFailedSummary has skipped & failed & plugin errors 1`] = `
+exports[`generateOverallSummary has skipped & failed & plugin errors 1`] = `
 "Summary:
 
   Command run in dry run mode. Fixes are not applied.
   2 items were not fixed
   1 items were successfully fixed
 
+  3 issues: 3 High
+  3 issues are fixable
+  1 issues were successfully fixed
 "
 `;
 
@@ -55,10 +89,23 @@ exports[`generateSuccessfulFixesSummary has fixed & failed 1`] = `
 `;
 
 exports[`generateUnresolvedSummary has failed upgrades & unsupported 1`] = `
-"Unresolved items:
+"
+
+Unresolved items:
 
   package.json
   ✖ npm is not supported"
+`;
+
+exports[`showResultsSummary called with no vulnerable projects to fix 1`] = `
+"
+✔ No vulnerable items to fix
+
+Summary:
+
+  1 items were not vulnerable
+
+      "
 `;
 
 exports[`showResultsSummary called with nothing to fix 1`] = `
@@ -101,6 +148,7 @@ exports[`showResultsSummary has unresolved only 1`] = `
 "
  ✖ No successful fixes
 
+
 Unresolved items:
 
   package.json
@@ -113,7 +161,6 @@ Summary:
   1 issues: 1 High
   1 issues are fixable
   
-
 
 Tip: Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the issue persists contact support@snyk.io"
 `;

--- a/packages/snyk-fix/test/unit/lib/output-formatters/format-unresolved-item.spec.ts
+++ b/packages/snyk-fix/test/unit/lib/output-formatters/format-unresolved-item.spec.ts
@@ -3,29 +3,29 @@ import { formatUnresolved } from '../../../../src/lib/output-formatters/format-u
 import { generateEntityToFix } from '../../../helpers/generate-entity-to-fix';
 
 describe('format unresolved item', () => {
-  it('formats unresolved as expected by default', async () => {
+  it('formats unresolved as expected by default', () => {
     const entity = generateEntityToFix(
       'pip',
       'requirements.txt',
       JSON.stringify({}),
     );
-    const res = await formatUnresolved(entity, 'Failed to process item');
+    const res = formatUnresolved(entity, 'Failed to process item');
     expect(stripAnsi(res)).toMatchSnapshot();
   });
 
-  it('formats ok when missing targetFile', async () => {
+  it('formats ok when missing targetFile', () => {
     const entity = generateEntityToFix(
       'npm',
       undefined as any,
       JSON.stringify({}),
     );
-    const res = await formatUnresolved(entity, 'Failed to process item');
+    const res = formatUnresolved(entity, 'Failed to process item');
     expect(stripAnsi(res)).toMatchSnapshot();
   });
 
-  it('formats ok with tip', async () => {
+  it('formats ok with tip', () => {
     const entity = generateEntityToFix('pip', 'Pipfile', JSON.stringify({}));
-    const res = await formatUnresolved(
+    const res = formatUnresolved(
       entity,
       'Failed to fix',
       'Make sure you have pipenv installed',

--- a/test/jest/unit/lib/commands/fix/fix.spec.ts
+++ b/test/jest/unit/lib/commands/fix/fix.spec.ts
@@ -218,7 +218,7 @@ describe('snyk fix (functional tests)', () => {
   );
 
   it(
-    'snyk fails to fix when all path fails to test with `snyk fix path1 path2` (non 0 error code)',
+    'snyk fails to fix when all paths fails to test with `snyk fix path1 path2` (non 0 error code)',
     async () => {
       // read data from console.log
       let stdoutMessages = '';
@@ -282,7 +282,7 @@ describe('snyk fix (functional tests)', () => {
         dryRun: true,
         quiet: true,
       });
-      expect(stripAnsi(res)).toMatch('No successful fixes');
+      expect(stripAnsi(res)).toMatch('✔ No vulnerable items to fix');
       expect(stdoutMessages).toEqual('');
       expect(stderrMessages).toEqual('');
     },


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- Immediately filter out non-vulnerable test results in @snyk/fix (results with no issu
es at all) and do not try to fix any of them. 
- Add a line to the summary that states how many were not vulnerable.
- drop all `0s` from summary

#### Where should the reviewer start?
https://github.com/snyk/snyk/pull/2051/files 
https://github.com/snyk/snyk/compare/feat/hide-non-vulnerable-projects?expand=1#diff-efd77b5a15a1593cba78b737b731cbd8406edfbd0045f62c6226db58b1b20b45R34




#### Screenshots
**Before**
<img width="898" alt="CleanShot 2021-06-22 at 18 21 26@2x" src="https://user-images.githubusercontent.com/2911613/122971185-ad35e180-d386-11eb-8b21-fd1198ed1a3b.png">

**After**
<img width="902" alt="CleanShot 2021-06-22 at 18 18 18@2x" src="https://user-images.githubusercontent.com/2911613/122970847-487a8700-d386-11eb-82e4-495d40e15b88.png">

<img width="713" alt="CleanShot 2021-06-23 at 12 54 30@2x" src="https://user-images.githubusercontent.com/2911613/123092271-39491700-d422-11eb-8e16-2b233ed45c07.png">

