### PR TITLE
fix: upgrade docker plugin with lib pull bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.2.1",
-    "snyk-docker-plugin": "4.20.8",
+    "snyk-docker-plugin": "4.21.2",
     "snyk-go-plugin": "1.17.0",
     "snyk-gradle-plugin": "3.16.0",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Upgrade docker plugin to the newest version, which in turn contains a fixed version of snyk-docker-pull, fixing an issue with occasionally getting an `Unexpected end of data` error

see https://github.com/snyk/snyk-docker-pull/pull/98

