### PR TITLE
fix: ensure tip to use --all-sub-projects is shown

### DIFF
--- a/src/lib/plugins/get-extra-project-count.ts
+++ b/src/lib/plugins/get-extra-project-count.ts
@@ -14,7 +14,7 @@ export async function getExtraProjectCount(
   if (
     inspectResult.plugin.meta &&
     inspectResult.plugin.meta.allSubProjectNames &&
-    inspectResult.plugin.meta.allSubProjectNames.length > 1
+    inspectResult.plugin.meta.allSubProjectNames.length > 0
   ) {
     return inspectResult.plugin.meta.allSubProjectNames.length;
   }

--- a/test/jest/unit/all-projects-from-plugins.spec.ts
+++ b/test/jest/unit/all-projects-from-plugins.spec.ts
@@ -3,7 +3,7 @@ import { legacyPlugin as pluginApi } from '@snyk/cli-interface';
 import { getExtraProjectCount } from '../../../src/lib/plugins/get-extra-project-count';
 
 describe('Detect extra projects available that could be tested using --all-projects', () => {
-  it('should return `undefined` when exists a single project', async () => {
+  it('should return `1` when a single sub-projects is found', async () => {
     const root = '';
     const inspectResult = {
       plugin: { meta: { allSubProjectNames: ['gradle-woof'] } },
@@ -15,7 +15,7 @@ describe('Detect extra projects available that could be tested using --all-proje
       options,
       inspectResult,
     );
-    const expectedResult = undefined;
+    const expectedResult = 1;
     expect(actualResult).toBe(expectedResult);
   });
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Gradle plugin stopped sending root project as a subProject
snyk/snyk-gradle-plugin#180 and this resulted in the logic that was working around in in CLI to stop working correctly, this PR fixes it to display the `tip` to use `--all-sub-projects` when we found at least 1 gradle sub-project
#### Screenshots

<img width="782" alt="CleanShot 2021-07-08 at 17 44 25@2x" src="https://user-images.githubusercontent.com/2911613/124960356-26366980-e014-11eb-864a-aad92b49a57f.png">



