### PR TITLE
Add JSON file to the CDN hosting

### DIFF
--- a/release-scripts/release.json
+++ b/release-scripts/release.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0.0-monorepo",
+  "assets": {
+    "snyk-alpine": {
+      "url": "https://static.snyk.io/cli/v1.0.0-monorepo/snyk-alpine",
+      "sha256": "snyk-alpine-sha256",
+      "sha256Url": "https://static.snyk.io/cli/v1.0.0-monorepo/snyk-alpine.sha256"
+    },
+    "snyk-linux": {
+      "url": "https://static.snyk.io/cli/v1.0.0-monorepo/snyk-linux",
+      "sha256": "snyk-linux-sha256",
+      "sha256Url": "https://static.snyk.io/cli/v1.0.0-monorepo/snyk-linux.sha256"
+    },
+    "snyk-macos": {
+      "url": "https://static.snyk.io/cli/v1.0.0-monorepo/snyk-macos",
+      "sha256": "snyk-macos-sha256",
+      "sha256Url": "https://static.snyk.io/cli/v1.0.0-monorepo/snyk-macos.sha256"
+    },
+    "snyk-win.exe": {
+      "url": "https://static.snyk.io/cli/v1.0.0-monorepo/snyk-win.exe",
+      "sha256": "snyk-win.exe-sha256",
+      "sha256Url": "https://static.snyk.io/cli/v1.0.0-monorepo/snyk-win.exe.sha256"
+    }
+  },
+  "schemaVersion": 1
+}

--- a/release-scripts/upload-artifacts.sh
+++ b/release-scripts/upload-artifacts.sh
@@ -17,8 +17,30 @@ declare -a StaticFiles=(
 latest_version=$(cat lerna.json | jq .version -r)
 new_tag="v${latest_version}"
 
+# We need to update versions and sha256 in version.json here
+if [[ $(uname -s) == "Darwin" ]];then
+  echo "this is Mac"
+  sed -i "" "s|1.0.0-monorepo|${latest_version}|g" ./release-scripts/release.json
+  sed -i "" "s|snyk-alpine-sha256|$(cat binary-releases/snyk-alpine.sha256)|" ./release-scripts/release.json
+  sed -i "" "s|snyk-linux-sha256|$(cat binary-releases/snyk-linux.sha256)|" ./release-scripts/release.json
+  sed -i "" "s|snyk-macos-sha256|$(cat binary-releases/snyk-macos.sha256)|" ./release-scripts/release.json
+  sed -i "" "s|snyk-win.exe-sha256|$(cat binary-releases/snyk-win.exe.sha256)|" ./release-scripts/release.json
+else
+  echo "this is Linux"
+  sed -i "s|1.0.0-monorepo|${latest_version}|g" ./release-scripts/release.json
+  sed -i "s|snyk-alpine-sha256|$(cat binary-releases/snyk-alpine.sha256)|" ./release-scripts/release.json
+  sed -i "s|snyk-linux-sha256|$(cat binary-releases/snyk-linux.sha256)|" ./release-scripts/release.json
+  sed -i "s|snyk-macos-sha256|$(cat binary-releases/snyk-macos.sha256)|" ./release-scripts/release.json
+  sed -i "s|snyk-win.exe-sha256|$(cat binary-releases/snyk-win.exe.sha256)|" ./release-scripts/release.json
+fi
+
+# sanity check if release.json is a valid JSON
+jq . ./release-scripts/release.json
+
+echo "${latest_version}" > ./release-scripts/version
+
 # Upload files to the GitHub release
-gh release create ${new_tag} ${StaticFiles[@]} \
+gh release create "${new_tag}" "${StaticFiles[@]}" \
   --title "${new_tag}" \
   --notes-file RELEASE_NOTES.txt
 
@@ -31,3 +53,8 @@ done
 for filename in "${StaticFiles[@]}"; do
   aws s3 cp "${filename}" s3://"${PUBLIC_S3_BUCKET}"/cli/latest/
 done
+
+aws s3 cp "release-scripts/release.json" s3://"${PUBLIC_S3_BUCKET}"/cli/"${new_tag}"/
+aws s3 cp "release-scripts/version" s3://"${PUBLIC_S3_BUCKET}"/cli/"${new_tag}"/
+aws s3 cp "release-scripts/release.json" s3://"${PUBLIC_S3_BUCKET}"/cli/latest/
+aws s3 cp "release-scripts/version" s3://"${PUBLIC_S3_BUCKET}"/cli/latest/


### PR DESCRIPTION
Part of the Snyk CLI executables hosting on our CDN, we want to expose a JSON to make it easier to query for versions.

Made the `release-scripts/version.json` with evolving data in mind.