### PR TITLE
feat: bump the sbt plugin to 2.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "snyk-python-plugin": "1.19.11",
     "snyk-resolve": "1.1.0",
     "snyk-resolve-deps": "4.7.2",
-    "snyk-sbt-plugin": "2.11.2",
+    "snyk-sbt-plugin": "2.11.3",
     "snyk-try-require": "1.3.1",
     "source-map-support": "^0.5.11",
     "strip-ansi": "^5.2.0",

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -591,11 +591,19 @@ async function assembleLocalPayloads(
       'meta.versionBuildInfo.metaBuildVersion.mvnVersion',
       null,
     );
+    const sbtVersion = get(
+      deps.plugin,
+      'meta.versionBuildInfo.metaBuildVersion.sbtVersion',
+      null,
+    );
     if (javaVersion) {
       analytics.add('javaVersion', javaVersion);
     }
     if (mvnVersion) {
       analytics.add('mvnVersion', mvnVersion);
+    }
+    if (sbtVersion) {
+      analytics.add('sbtVersion', sbtVersion);
     }
 
     for (const scannedProject of deps.scannedProjects) {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

The new version of the sbt plugin reports the sbt version used to run the analysis.

It also adds a fallback method of determining the `project` folder.

The sbt plugin PR for this version: https://github.com/snyk/snyk-sbt-plugin/pull/98.

#### Where should the reviewer start?

The changes to the analytics code.

#### How should this be manually tested?

Pull in the new version of the sbt plugin, and run locally.

#### Any background context you want to provide?

The sbt plugin PR for this version: https://github.com/snyk/snyk-sbt-plugin/pull/98.

#### What are the relevant tickets?

N/A

#### Screenshots

N/A

#### Additional questions

N/A