### PR TITLE
fix: split type for dockeranalysis and autodetecteduserinstructions fact

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.2.1",
-    "snyk-docker-plugin": "4.21.3",
+    "snyk-docker-plugin": "4.21.4",
     "snyk-go-plugin": "1.17.0",
     "snyk-gradle-plugin": "3.16.0",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
### What this does

Bumps version to support to include https://github.com/snyk/snyk-docker-plugin/pull/355