### PR TITLE
fix: make sure we suggest --all-sub-projects only when appropriate

### DIFF
--- a/src/lib/formatters/format-monitor-response.ts
+++ b/src/lib/formatters/format-monitor-response.ts
@@ -4,6 +4,8 @@ import * as url from 'url';
 
 import { MonitorResult } from '../types';
 import * as config from '../config';
+import { showAllProjectsTip } from './show-all-projects-tip';
+import { showGradleSubProjectsTip } from './show-all-sub-projects-tip';
 
 export function formatErrorMonitorOutput(
   packageManager,
@@ -37,12 +39,17 @@ export function formatMonitorOutput(
   foundProjectCount?: number,
 ): string {
   const manageUrl = buildManageUrl(res.id, res.org);
-  const advertiseGradleSubProjectsCount =
-    packageManager === 'gradle' &&
-    !options['gradle-sub-project'] &&
-    !options.allProjects;
-  const advertiseAllProjectsCount =
-    packageManager !== 'gradle' && !options.allProjects && foundProjectCount;
+  const gradleSubProjectsTip = showGradleSubProjectsTip(
+    packageManager,
+    options,
+    foundProjectCount,
+  );
+
+  const allProjectsTip = showAllProjectsTip(
+    packageManager,
+    options,
+    foundProjectCount,
+  );
   const issues = res.licensesPolicy ? 'issues' : 'vulnerabilities';
   const humanReadableName = projectName
     ? `${res.path} (${projectName})`
@@ -52,18 +59,10 @@ export function formatMonitorOutput(
     'Explore this snapshot at ' +
     res.uri +
     '\n\n' +
-    (advertiseGradleSubProjectsCount && foundProjectCount
-      ? chalk.bold.white(
-          `Tip: This project has multiple sub-projects (${foundProjectCount}), ` +
-            'use --all-sub-projects flag to scan all sub-projects.\n\n',
-        )
+    (gradleSubProjectsTip
+      ? chalk.bold.white(`${gradleSubProjectsTip}\n\n`)
       : '') +
-    (advertiseAllProjectsCount && foundProjectCount
-      ? chalk.bold.white(
-          `Tip: Detected multiple supported manifests (${foundProjectCount}), ` +
-            'use --all-projects to scan all of them at once.\n\n',
-        )
-      : '') +
+    (allProjectsTip ? chalk.bold.white(`${allProjectsTip}\n\n`) : '') +
     (res.isMonitored
       ? 'Notifications about newly disclosed ' +
         issues +

--- a/src/lib/formatters/show-all-projects-tip.ts
+++ b/src/lib/formatters/show-all-projects-tip.ts
@@ -1,0 +1,19 @@
+import { isMultiProjectScan } from '../is-multi-project-scan';
+
+export function showAllProjectsTip(
+  packageManager,
+  options,
+  foundProjectCount,
+): string {
+  if (
+    packageManager === 'gradle' ||
+    !foundProjectCount ||
+    isMultiProjectScan(options)
+  ) {
+    return '';
+  }
+  return (
+    `Tip: Detected multiple supported manifests (${foundProjectCount}), ` +
+    'use --all-projects to scan all of them at once.'
+  );
+}

--- a/src/lib/formatters/show-all-sub-projects-tip.ts
+++ b/src/lib/formatters/show-all-sub-projects-tip.ts
@@ -1,0 +1,21 @@
+import { isMultiProjectScan } from '../is-multi-project-scan';
+
+export function showGradleSubProjectsTip(
+  packageManager,
+  options,
+  foundProjectCount,
+): string {
+  if (
+    packageManager !== 'gradle' ||
+    !foundProjectCount ||
+    isMultiProjectScan(options) ||
+    options.allSubProjects
+  ) {
+    return '';
+  }
+
+  return (
+    `Tip: This project has multiple sub-projects (${foundProjectCount}), ` +
+    'use --all-sub-projects flag to scan all sub-projects.'
+  );
+}

--- a/src/lib/formatters/test/display-result.ts
+++ b/src/lib/formatters/test/display-result.ts
@@ -16,7 +16,6 @@ import {
   formatTestMeta,
 } from '../../../lib/formatters';
 import { getIacDisplayedOutput } from '../../../lib/formatters/iac-output';
-import { isMultiProjectScan } from '../../../lib/is-multi-project-scan';
 import {
   IacProjectType,
   IacProjectTypes,
@@ -26,6 +25,8 @@ import {
   dockerUserCTA,
   getDisplayedOutput,
 } from '../../../lib/formatters/test/format-test-results';
+import { showAllProjectsTip } from '../show-all-projects-tip';
+import { showGradleSubProjectsTip } from '../show-all-sub-projects-tip';
 
 export function displayResult(
   res: TestResult,
@@ -65,26 +66,21 @@ export function displayResult(
 
   let multiProjAdvice = '';
 
-  const advertiseGradleSubProjectsCount =
-    projectType === 'gradle' &&
-    !options['gradle-sub-project'] &&
-    !options.allProjects &&
-    foundProjectCount;
-  if (advertiseGradleSubProjectsCount) {
-    multiProjAdvice = chalk.bold.white(
-      `\n\nTip: This project has multiple sub-projects (${foundProjectCount}), ` +
-        'use --all-sub-projects flag to scan all sub-projects.',
-    );
+  const gradleSubProjectsTip = showGradleSubProjectsTip(
+    projectType,
+    options,
+    foundProjectCount,
+  );
+  if (gradleSubProjectsTip) {
+    multiProjAdvice = chalk.bold.white(`\n\n${gradleSubProjectsTip}`);
   }
-  const advertiseAllProjectsCount =
-    projectType !== 'gradle' &&
-    !isMultiProjectScan(options) &&
-    foundProjectCount;
-  if (advertiseAllProjectsCount) {
-    multiProjAdvice = chalk.bold.white(
-      `\n\nTip: Detected multiple supported manifests (${foundProjectCount}), ` +
-        'use --all-projects to scan all of them at once.',
-    );
+  const allProjectsTip = showAllProjectsTip(
+    projectType,
+    options,
+    foundProjectCount,
+  );
+  if (allProjectsTip) {
+    multiProjAdvice = chalk.bold.white(`\n\n${allProjectsTip}`);
   }
 
   // OK  => no vulns found, return

--- a/test/acceptance/cli-test/cli-test.gradle.spec.ts
+++ b/test/acceptance/cli-test/cli-test.gradle.spec.ts
@@ -359,11 +359,10 @@ export const GradleTests: AcceptanceTests = {
         /Tested 2 projects/,
         'number projects tested displayed properly',
       );
-      t.match(res, '(2)', '2 sub projects found');
-      t.match(
+      t.notMatch(
         res,
         /use --all-sub-projects flag to scan all sub-projects/,
-        'all-sub-projects flag is suggested',
+        'all-sub-projects flag is NOT suggested as we already scanned with it',
       );
       for (let i = 0; i < tests.length; i++) {
         const meta = tests[i]

--- a/test/jest/unit/lib/formatters/__snapshots__/format-monitor-response.spec.ts.snap
+++ b/test/jest/unit/lib/formatters/__snapshots__/format-monitor-response.spec.ts.snap
@@ -38,8 +38,6 @@ Monitoring src/lib/jens...
 
 Explore this snapshot at https://example.com/project
 
-Tip: This project has multiple sub-projects (7), use --all-sub-projects flag to scan all sub-projects.
-
 Notifications about newly disclosed issues related to these dependencies will be emailed to you.
 "
 `;

--- a/test/jest/unit/lib/formatters/show-all-projects-tip.spec.ts
+++ b/test/jest/unit/lib/formatters/show-all-projects-tip.spec.ts
@@ -1,0 +1,21 @@
+import { showAllProjectsTip } from '../../../../../src/lib/formatters/show-all-projects-tip';
+
+describe('showAllProjectsTip', () => {
+  it('gradle project scanned with --all-sub-projects', () => {
+    expect(showAllProjectsTip('gradle', { allSubProjects: true }, 1)).toEqual(
+      '',
+    );
+  });
+  it('gradle project scanned without --all-sub-projects with 0 detected extra projects', () => {
+    expect(showAllProjectsTip('gradle', {}, 0)).toEqual('');
+  });
+  it('npm project + detected 8 other projects', () => {
+    expect(showAllProjectsTip('npm', {}, 8)).toEqual(
+      'Tip: Detected multiple supported manifests (8), use --all-projects to scan all of them at once.',
+    );
+  });
+
+  it('gradle project + detected 8 other projects', () => {
+    expect(showAllProjectsTip('gradle', {}, 8)).toEqual('');
+  });
+});

--- a/test/jest/unit/lib/formatters/show-all-sub-projects-tip.spec.ts
+++ b/test/jest/unit/lib/formatters/show-all-sub-projects-tip.spec.ts
@@ -1,0 +1,40 @@
+import { showGradleSubProjectsTip } from '../../../../../src/lib/formatters/show-all-sub-projects-tip';
+
+describe('showAllProjectsTip', () => {
+  it('gradle project tested with --gradle-sub-project should show tip', () => {
+    expect(
+      showGradleSubProjectsTip('gradle', { gradleSubProject: true }, 1),
+    ).toEqual(
+      'Tip: This project has multiple sub-projects (1), use --all-sub-projects flag to scan all sub-projects.',
+    );
+  });
+  it('gradle project tested with --sub-project should show tip', () => {
+    expect(showGradleSubProjectsTip('gradle', { subProject: true }, 1)).toEqual(
+      'Tip: This project has multiple sub-projects (1), use --all-sub-projects flag to scan all sub-projects.',
+    );
+  });
+
+  it('gradle project tested with --all-projects should NOT show tip', () => {
+    expect(
+      showGradleSubProjectsTip('gradle', { allProjects: true }, 1),
+    ).toEqual('');
+  });
+
+  it('gradle project scanned with --all-sub-projects should NOT show tip', () => {
+    expect(
+      showGradleSubProjectsTip('gradle', { allSubProjects: true }, 1),
+    ).toEqual('');
+  });
+  it('gradle project scanned without --all-sub-projects with 0 detected extra projects should NOT show tip', () => {
+    expect(showGradleSubProjectsTip('gradle', {}, 0)).toEqual('');
+  });
+  it('npm project + detected 8 other projects should NOT show tip', () => {
+    expect(showGradleSubProjectsTip('npm', {}, 8)).toEqual('');
+  });
+
+  it('gradle project + detected 8 other projects should show tip', () => {
+    expect(showGradleSubProjectsTip('gradle', {}, 8)).toEqual(
+      'Tip: This project has multiple sub-projects (8), use --all-sub-projects flag to scan all sub-projects.',
+    );
+  });
+});


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Now that the https://github.com/snyk/snyk/pull/2080 is merged and contains some baseline tests:
- split up the tip generation into relevant functions
- test each function
- noticed a bug with the Gradle ` --all-sub-projects` so fixing that as well to only display a tip to try `--all-sub-projects` when all conditions are met:
    - the scan is not already using --all-sub-projects
    - project type is gradle
    - we detected some projects that could also be scanned


#### Where should the reviewer start?
https://github.com/snyk/snyk/compare/refacfactor/display-tips?expand=1#diff-9b0a855c48a95a2016a99f89e5ab64cdb002c87b2e5271bce6e91c51adb543feR42

#### How should this be manually tested?
`snyk test` on a gradle project with options that match the test scenarios

