### PR TITLE
fix: bump docker plugin version with fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.2.1",
-    "snyk-docker-plugin": "4.21.3",
+    "snyk-docker-plugin": "4.22.1",
     "snyk-go-plugin": "1.17.0",
     "snyk-gradle-plugin": "3.16.0",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Bumps snyk-docker-plugin, which in turn has a bumped docker-pull library, which in turn has a bumped docker-v2 library upgrade, which contains these fixes:

Some CRs return a redirect URI with just the path
(without the hostname), which breaks our redirect handling which is
expecting a full URL. This fix adds the hostname and protocol in case
they are missing

When the content type is wrongly set to text instead of binary, response
body is returned as string instead of a buffer. This forces a buffer
response


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/DC-1007

