### PR TITLE
chore: commit static help files in repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,12 +128,6 @@ commands:
       - run:
           name: NPM version
           command: npm --version
-  generate_help:
-    description: Generate CLI help files
-    steps:
-      - run:
-          name: Run CLI help text builder
-          command: npm run generate-help
   install_github_cli:
     description: Install GitHub CLI (gh)
     steps:
@@ -160,16 +154,12 @@ jobs:
       - image: circleci/node:<< parameters.node_version >>
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 19.03.13
-          docker_layer_caching: true
       - install_shellspec
       - run: sudo npm install -g npm@7
       - show_node_version
       - update_local_npmrc_linux
       - install_deps
       - build_ts
-      - generate_help
       - run:
           name: Run auth
           command: npm run snyk-auth
@@ -420,8 +410,6 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 19.03.13
       - run:
           name: Install npm@7
           command: |
@@ -429,7 +417,6 @@ jobs:
       - show_node_version
       - install_lerna_linux
       - install_deps
-      - generate_help
       - run:
           name: Update package versions
           command: ./release-scripts/update-versions.sh
@@ -456,9 +443,6 @@ jobs:
     resource_class: small
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 19.03.13
-          docker_layer_caching: true
       - run:
           name: Should I release?
           command: ./release-scripts/should-i-release.sh
@@ -472,7 +456,6 @@ jobs:
       - install_lerna_linux
       - update_local_npmrc_linux
       - install_deps
-      - generate_help
       - run:
           name: Update package versions
           command: ./release-scripts/update-versions.sh

--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,6 @@ snyk_report.html
 !/docker/snyk_report.css
 cert.pem
 key.pem
-help/commands-md
-help/commands-txt
-help/commands-man
 **/tsconfig.tsbuildinfo
 __outputs__
 *.tgz

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -82,4 +82,20 @@ if (danger.github && danger.github.pr) {
       `You are modifying something in test/smoke directory, yet you are not on the branch starting with ${SMOKE_TEST_BRANCH}. You can prefix your branch with ${SMOKE_TEST_BRANCH} and Smoke tests will trigger for this PR.`,
     );
   }
+
+  // Regenerate help manually
+  const modifiedHelpFiles =
+    danger.git.modified_files.some((f) =>
+      f.startsWith('help/commands-docs/'),
+    ) ||
+    danger.git.created_files.some((f) => f.startsWith('help/commands-docs/'));
+  const modifiedGeneratedHelpFiles =
+    danger.git.modified_files.some((f) => f.startsWith('help/commands-txt/')) ||
+    danger.git.created_files.some((f) => f.startsWith('help/commands-txt/'));
+
+  if (modifiedHelpFiles && !modifiedGeneratedHelpFiles) {
+    fail(
+      "You've modified help files in /help/commands-docs. You need to regenerate manpages locally by running `npm run generate-help` and commiting the changed files. See [README in /help for more details](https://github.com/snyk/snyk/blob/master/help/README.md)",
+    );
+  }
 }

--- a/help/README.md
+++ b/help/README.md
@@ -17,13 +17,13 @@ This system improves authoring, as markdown is easier to format. It's keeping th
 
 Contact **Team Hammer** or open an issue in this repository when in doubt.
 
-Keep all changes in `help/commands-docs` folder, as other folders are ignored by `.gitignore` file and are auto-generated in CI pipeline.
+Keep all changes in `help/commands-docs` folder, as that is used as source for generating Markdown, ronn and txt files. When you are done editing, or you want to preview your changes, run the `npm run generate-help` (see "Running locally" below for troubleshooting). Then commit all changes, including the generated files.
 
 See other documents and help files for hints on how to format arguments. Keep formatting simple, as the transformation to `roff` might have issues with complex structures.
 
 ### CLI options
 
-```md
+```markdown
 - `--severity-threshold`=low|medium|high|critical:
   Only report vulnerabilities of provided level or higher.
 ```
@@ -34,13 +34,13 @@ CLI flag should be in backticks. Options (filenames, org names…) should use Ke
 
 There is one non-standard markdown extension:
 
-```md
+```markdown
 <KEYWORD>
 ```
 
 Visually, it'll get rendered as underlined text. It's used to mark a "variable". For example this command flag:
 
-```md
+```markdown
 - `--sarif-file-output`=<OUTPUT_FILE_PATH>:
   (only in `test` command)
   Save test output in SARIF format directly to the <OUTPUT_FILE_PATH> file, regardless of whether or not you use the `--sarif` option.

--- a/help/commands-man/snyk-auth.1
+++ b/help/commands-man/snyk-auth.1
@@ -1,0 +1,84 @@
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "SNYK\-AUTH" "1" "July 2021" "Snyk.io"
+.SH "NAME"
+\fBsnyk\-auth\fR \- Authenticate Snyk CLI with a Snyk account
+.SH "SYNOPSIS"
+\fBsnyk\fR \fBauth\fR [\fIAPI_TOKEN\fR] [\fIOPTIONS\fR]
+.SH "DESCRIPTION"
+Authenticate Snyk CLI with a Snyk account\. Running \fB$ snyk auth\fR without an \fIAPI_TOKEN\fR will open a browser window and asks you to login with Snyk account and authorize\. When inputting an \fIAPI_TOKEN\fR, it will be validated with Snyk API\.
+.P
+When running in a CI environment \fIAPI_TOKEN\fR is required\.
+.SH "OPTIONS"
+.TP
+[\fIAPI_TOKEN\fR]
+Your Snyk token\. May be an user token or a service account\.
+.br
+How to get your account token \fIhttps://snyk\.co/ucT6J\fR
+.br
+How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
+.br
+
+.SS "Flags available accross all commands"
+.TP
+\fB\-\-insecure\fR
+Ignore unknown certificate authorities\.
+.TP
+\fB\-d\fR
+Output debug logs\.
+.TP
+\fB\-\-quiet\fR, \fB\-q\fR
+Silence all output\.
+.TP
+\fB\-\-version\fR, \fB\-v\fR
+Prints versions\.
+.TP
+[\fICOMMAND\fR] \fB\-\-help\fR, \fB\-\-help\fR [\fICOMMAND\fR], \fB\-h\fR
+Prints a help text\. You may specify a \fICOMMAND\fR to get more details\.
+.SH "EXIT CODES"
+Possible exit codes and their meaning:
+.P
+\fB0\fR: success, no vulns found
+.br
+\fB1\fR: action_needed, vulns found
+.br
+\fB2\fR: failure, try to re\-run command
+.br
+\fB3\fR: failure, no supported projects detected
+.br
+.SH "ENVIRONMENT"
+You can set these environment variables to change CLI run settings\.
+.TP
+\fBSNYK_TOKEN\fR
+Snyk authorization token\. Setting this envvar will override the token that may be available in your \fBsnyk config\fR settings\.
+.IP
+How to get your account token \fIhttps://snyk\.co/ucT6J\fR
+.br
+How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
+.br
+
+.TP
+\fBSNYK_CFG_KEY\fR
+Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+.IP
+E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
+.TP
+\fBSNYK_REGISTRY_USERNAME\fR
+Specify a username to use when connecting to a container registry\. Note that using the \fB\-\-username\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.TP
+\fBSNYK_REGISTRY_PASSWORD\fR
+Specify a password to use when connecting to a container registry\. Note that using the \fB\-\-password\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.SH "Connecting to Snyk API"
+By default Snyk CLI will connect to \fBhttps://snyk\.io/api/v1\fR\.
+.TP
+\fBSNYK_API\fR
+Sets API host to use for Snyk requests\. Useful for on\-premise instances and configuring proxies\. If set with \fBhttp\fR protocol CLI will upgrade the requests to \fBhttps\fR\. Unless \fBSNYK_HTTP_PROTOCOL_UPGRADE\fR is set to \fB0\fR\.
+.TP
+\fBSNYK_HTTP_PROTOCOL_UPGRADE\fR=0
+If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
+.TP
+\fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+.SH "NOTICES"
+.SS "Snyk API usage policy"
+The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-config.1
+++ b/help/commands-man/snyk-config.1
@@ -1,0 +1,98 @@
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "SNYK\-CONFIG" "1" "July 2021" "Snyk.io"
+.SH "NAME"
+\fBsnyk\-config\fR \- Manage Snyk CLI configuration
+.SH "SYNOPSIS"
+\fBsnyk\fR \fBconfig\fR \fBget|set|clear\fR [\fIKEY\fR[=\fIVALUE\fR]] [\fIOPTIONS\fR]
+.SH "DESCRIPTION"
+Manage your local Snyk CLI config file\.
+.P
+This command does not manage the \fB\.snyk\fR file that\'s part of your project\. See \fBsnyk policy\fR, \fBsnyk ignore\fR or \fBsnyk wizard\fR\.
+.SH "COMMANDS"
+.TP
+\fBget\fR \fIKEY\fR
+Print a config value\.
+.TP
+\fBset\fR \fIKEY\fR=\fIVALUE\fR
+Create a new config value\.
+.TP
+\fBunset\fR \fIKEY\fR
+Remove a config value\.
+.TP
+\fBclear\fR
+Remove all config values\.
+.SH "OPTIONS"
+.SS "Supported <var>KEY</var> values"
+.TP
+\fBapi\fR
+API token to use when calling Snyk API\.
+.TP
+\fBendpoint\fR
+Defines the API endpoint to use\.
+.TP
+\fBdisable\-analytics\fR
+Turns off analytics reporting\.
+.SS "Flags available accross all commands"
+.TP
+\fB\-\-insecure\fR
+Ignore unknown certificate authorities\.
+.TP
+\fB\-d\fR
+Output debug logs\.
+.TP
+\fB\-\-quiet\fR, \fB\-q\fR
+Silence all output\.
+.TP
+\fB\-\-version\fR, \fB\-v\fR
+Prints versions\.
+.TP
+[\fICOMMAND\fR] \fB\-\-help\fR, \fB\-\-help\fR [\fICOMMAND\fR], \fB\-h\fR
+Prints a help text\. You may specify a \fICOMMAND\fR to get more details\.
+.SH "EXIT CODES"
+Possible exit codes and their meaning:
+.P
+\fB0\fR: success, no vulns found
+.br
+\fB1\fR: action_needed, vulns found
+.br
+\fB2\fR: failure, try to re\-run command
+.br
+\fB3\fR: failure, no supported projects detected
+.br
+.SH "ENVIRONMENT"
+You can set these environment variables to change CLI run settings\.
+.TP
+\fBSNYK_TOKEN\fR
+Snyk authorization token\. Setting this envvar will override the token that may be available in your \fBsnyk config\fR settings\.
+.IP
+How to get your account token \fIhttps://snyk\.co/ucT6J\fR
+.br
+How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
+.br
+
+.TP
+\fBSNYK_CFG_KEY\fR
+Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+.IP
+E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
+.TP
+\fBSNYK_REGISTRY_USERNAME\fR
+Specify a username to use when connecting to a container registry\. Note that using the \fB\-\-username\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.TP
+\fBSNYK_REGISTRY_PASSWORD\fR
+Specify a password to use when connecting to a container registry\. Note that using the \fB\-\-password\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.SH "Connecting to Snyk API"
+By default Snyk CLI will connect to \fBhttps://snyk\.io/api/v1\fR\.
+.TP
+\fBSNYK_API\fR
+Sets API host to use for Snyk requests\. Useful for on\-premise instances and configuring proxies\. If set with \fBhttp\fR protocol CLI will upgrade the requests to \fBhttps\fR\. Unless \fBSNYK_HTTP_PROTOCOL_UPGRADE\fR is set to \fB0\fR\.
+.TP
+\fBSNYK_HTTP_PROTOCOL_UPGRADE\fR=0
+If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
+.TP
+\fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+.SH "NOTICES"
+.SS "Snyk API usage policy"
+The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-container.1
+++ b/help/commands-man/snyk-container.1
@@ -1,0 +1,119 @@
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "SNYK\-CONTAINER" "1" "July 2021" "Snyk.io"
+.SH "NAME"
+\fBsnyk\-container\fR \- Test container images for vulnerabilities
+.SH "SYNOPSIS"
+\fBsnyk\fR \fBcontainer\fR [\fICOMMAND\fR] [\fIOPTIONS\fR] [\fIIMAGE\fR]
+.SH "DESCRIPTION"
+Find vulnerabilities in your container images\.
+.SH "COMMANDS"
+.TP
+\fBtest\fR
+Test for any known vulnerabilities\.
+.TP
+\fBmonitor\fR
+Record the state of dependencies and any vulnerabilities on snyk\.io\.
+.SH "OPTIONS"
+.TP
+\fB\-\-exclude\-base\-image\-vulns\fR
+Exclude from display base image vulnerabilities\.
+.TP
+\fB\-\-file\fR=\fIFILE_PATH\fR
+Include the path to the image\'s Dockerfile for more detailed advice\.
+.TP
+\fB\-\-platform\fR=\fIPLATFORM\fR
+For multi\-architecture images, specify the platform to test\. [linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7 or linux/arm/v6]
+.TP
+\fB\-\-json\fR
+Prints results in JSON format\.
+.TP
+\fB\-\-json\-file\-output\fR=\fIOUTPUT_FILE_PATH\fR
+(only in \fBtest\fR command) Save test output in JSON format directly to the specified file, regardless of whether or not you use the \fB\-\-json\fR option\. This is especially useful if you want to display the human\-readable test output via stdout and at the same time save the JSON format output to a file\.
+.TP
+\fB\-\-sarif\fR
+Return results in SARIF format\.
+.TP
+\fB\-\-sarif\-file\-output\fR=\fIOUTPUT_FILE_PATH\fR
+(only in \fBtest\fR command) Save test output in SARIF format directly to the \fIOUTPUT_FILE_PATH\fR file, regardless of whether or not you use the \fB\-\-sarif\fR option\. This is especially useful if you want to display the human\-readable test output via stdout and at the same time save the SARIF format output to a file\.
+.TP
+\fB\-\-print\-deps\fR
+Print the dependency tree before sending it for analysis\.
+.TP
+\fB\-\-project\-name\fR=\fIPROJECT_NAME\fR
+Specify a custom Snyk project name\.
+.TP
+\fB\-\-policy\-path\fR=\fIPATH_TO_POLICY_FILE\fR
+Manually pass a path to a snyk policy file\.
+.TP
+\fB\-\-severity\-threshold\fR=low|medium|high|critical
+Only report vulnerabilities of provided level or higher\.
+.TP
+\fB\-\-username\fR=\fICONTAINER_REGISTRY_USERNAME\fR
+Specify a username to use when connecting to a container registry\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.TP
+\fB\-\-password\fR=\fICONTAINER_REGISTRY_PASSWORD\fR
+Specify a password to use when connecting to a container registry\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.SS "Flags available accross all commands"
+.TP
+\fB\-\-insecure\fR
+Ignore unknown certificate authorities\.
+.TP
+\fB\-d\fR
+Output debug logs\.
+.TP
+\fB\-\-quiet\fR, \fB\-q\fR
+Silence all output\.
+.TP
+\fB\-\-version\fR, \fB\-v\fR
+Prints versions\.
+.TP
+[\fICOMMAND\fR] \fB\-\-help\fR, \fB\-\-help\fR [\fICOMMAND\fR], \fB\-h\fR
+Prints a help text\. You may specify a \fICOMMAND\fR to get more details\.
+.SH "EXIT CODES"
+Possible exit codes and their meaning:
+.P
+\fB0\fR: success, no vulns found
+.br
+\fB1\fR: action_needed, vulns found
+.br
+\fB2\fR: failure, try to re\-run command
+.br
+\fB3\fR: failure, no supported projects detected
+.br
+.SH "ENVIRONMENT"
+You can set these environment variables to change CLI run settings\.
+.TP
+\fBSNYK_TOKEN\fR
+Snyk authorization token\. Setting this envvar will override the token that may be available in your \fBsnyk config\fR settings\.
+.IP
+How to get your account token \fIhttps://snyk\.co/ucT6J\fR
+.br
+How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
+.br
+
+.TP
+\fBSNYK_CFG_KEY\fR
+Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+.IP
+E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
+.TP
+\fBSNYK_REGISTRY_USERNAME\fR
+Specify a username to use when connecting to a container registry\. Note that using the \fB\-\-username\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.TP
+\fBSNYK_REGISTRY_PASSWORD\fR
+Specify a password to use when connecting to a container registry\. Note that using the \fB\-\-password\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.SH "Connecting to Snyk API"
+By default Snyk CLI will connect to \fBhttps://snyk\.io/api/v1\fR\.
+.TP
+\fBSNYK_API\fR
+Sets API host to use for Snyk requests\. Useful for on\-premise instances and configuring proxies\. If set with \fBhttp\fR protocol CLI will upgrade the requests to \fBhttps\fR\. Unless \fBSNYK_HTTP_PROTOCOL_UPGRADE\fR is set to \fB0\fR\.
+.TP
+\fBSNYK_HTTP_PROTOCOL_UPGRADE\fR=0
+If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
+.TP
+\fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+.SH "NOTICES"
+.SS "Snyk API usage policy"
+The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-help.1
+++ b/help/commands-man/snyk-help.1
@@ -1,0 +1,73 @@
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "SNYK\-HELP" "1" "July 2021" "Snyk.io"
+.SH "NAME"
+\fBsnyk\-help\fR \- Prints help topics
+.SH "SYNOPSIS"
+\fBsnyk\fR \fBhelp\fR [\fITOPIC\fR] [\fIOPTIONS\fR]
+.SH "DESCRIPTION"
+Prints help information\. Pass in name of a command as \fITOPIC\fR\.
+.SH "OPTIONS"
+.SS "Flags available accross all commands"
+.TP
+\fB\-\-insecure\fR
+Ignore unknown certificate authorities\.
+.TP
+\fB\-d\fR
+Output debug logs\.
+.TP
+\fB\-\-quiet\fR, \fB\-q\fR
+Silence all output\.
+.TP
+\fB\-\-version\fR, \fB\-v\fR
+Prints versions\.
+.TP
+[\fICOMMAND\fR] \fB\-\-help\fR, \fB\-\-help\fR [\fICOMMAND\fR], \fB\-h\fR
+Prints a help text\. You may specify a \fICOMMAND\fR to get more details\.
+.SH "EXIT CODES"
+Possible exit codes and their meaning:
+.P
+\fB0\fR: success, no vulns found
+.br
+\fB1\fR: action_needed, vulns found
+.br
+\fB2\fR: failure, try to re\-run command
+.br
+\fB3\fR: failure, no supported projects detected
+.br
+.SH "ENVIRONMENT"
+You can set these environment variables to change CLI run settings\.
+.TP
+\fBSNYK_TOKEN\fR
+Snyk authorization token\. Setting this envvar will override the token that may be available in your \fBsnyk config\fR settings\.
+.IP
+How to get your account token \fIhttps://snyk\.co/ucT6J\fR
+.br
+How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
+.br
+
+.TP
+\fBSNYK_CFG_KEY\fR
+Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+.IP
+E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
+.TP
+\fBSNYK_REGISTRY_USERNAME\fR
+Specify a username to use when connecting to a container registry\. Note that using the \fB\-\-username\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.TP
+\fBSNYK_REGISTRY_PASSWORD\fR
+Specify a password to use when connecting to a container registry\. Note that using the \fB\-\-password\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.SH "Connecting to Snyk API"
+By default Snyk CLI will connect to \fBhttps://snyk\.io/api/v1\fR\.
+.TP
+\fBSNYK_API\fR
+Sets API host to use for Snyk requests\. Useful for on\-premise instances and configuring proxies\. If set with \fBhttp\fR protocol CLI will upgrade the requests to \fBhttps\fR\. Unless \fBSNYK_HTTP_PROTOCOL_UPGRADE\fR is set to \fB0\fR\.
+.TP
+\fBSNYK_HTTP_PROTOCOL_UPGRADE\fR=0
+If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
+.TP
+\fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+.SH "NOTICES"
+.SS "Snyk API usage policy"
+The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-iac.1
+++ b/help/commands-man/snyk-iac.1
@@ -1,0 +1,138 @@
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "SNYK\-IAC" "1" "July 2021" "Snyk.io"
+.SH "NAME"
+\fBsnyk\-iac\fR \- Find security issues in your Infrastructure as Code files
+.SH "SYNOPSIS"
+\fBsnyk\fR \fBiac\fR [\fICOMMAND\fR] [\fIOPTIONS\fR] \fIPATH\fR
+.SH "DESCRIPTION"
+Find security issues in your Infrastructure as Code files\.
+.P
+For more information see IaC help page \fIhttps://snyk\.co/ucT6Q\fR
+.SH "COMMANDS"
+.TP
+\fBtest\fR
+Test for any known issue\.
+.SH "OPTIONS"
+.TP
+\fB\-\-detection\-depth\fR=\fIDEPTH\fR
+(only in \fBtest\fR command)
+.br
+Indicate the maximum depth of sub\-directories to search\. \fIDEPTH\fR must be a number\.
+.IP
+Default: No Limit
+.br
+Example: \fB\-\-detection\-depth=3\fR
+.br
+Will limit search to provided directory (or current directory if no \fIPATH\fR provided) plus two levels of subdirectories\.
+.TP
+\fB\-\-severity\-threshold\fR=low|medium|high
+Only report vulnerabilities of provided level or higher\.
+.TP
+\fB\-\-json\fR
+Prints results in JSON format\.
+.TP
+\fB\-\-json\-file\-output\fR=\fIOUTPUT_FILE_PATH\fR
+(only in \fBtest\fR command) Save test output in JSON format directly to the specified file, regardless of whether or not you use the \fB\-\-json\fR option\. This is especially useful if you want to display the human\-readable test output via stdout and at the same time save the JSON format output to a file\.
+.TP
+\fB\-\-org\fR=\fIORG_NAME\fR
+Specify the \fIORG_NAME\fR to run Snyk commands tied to a specific organization\. This will influence private tests limits\. If you have multiple organizations, you can set a default from the CLI using:
+.IP
+\fB$ snyk config set org\fR=\fIORG_NAME\fR
+.IP
+Setting a default will ensure all newly tested projects will be tested under your default organization\. If you need to override the default, you can use the \fB\-\-org\fR=\fIORG_NAME\fR argument\. Default: uses \fIORG_NAME\fR that sets as default in your Account settings \fIhttps://app\.snyk\.io/account\fR
+.TP
+\fB\-\-sarif\fR
+Return results in SARIF format\.
+.TP
+\fB\-\-sarif\-file\-output\fR=\fIOUTPUT_FILE_PATH\fR
+(only in \fBtest\fR command) Save test output in SARIF format directly to the \fIOUTPUT_FILE_PATH\fR file, regardless of whether or not you use the \fB\-\-sarif\fR option\. This is especially useful if you want to display the human\-readable test output via stdout and at the same time save the SARIF format output to a file\.
+.TP
+\fB\-\-scan=\fR\fITERRAFORM_PLAN_SCAN_MODE\fR
+Dedicated flag for Terraform plan scanning modes\.
+.br
+It enables to control whether the scan should analyse the full final state (e\.g\. \fBplanned\-values\fR), or the proposed changes only (e\.g\. \fBresource\-changes\fR)\.
+.br
+Default: If the \fB\-\-scan\fR flag is not provided it would scan the proposed changes only by default\.
+.br
+Example #1: \fB\-\-scan=planned\-values\fR (full state scan) Example #2: \fB\-\-scan=resource\-changes\fR (proposed changes scan)
+.SS "Flags available accross all commands"
+.TP
+\fB\-\-insecure\fR
+Ignore unknown certificate authorities\.
+.TP
+\fB\-d\fR
+Output debug logs\.
+.TP
+\fB\-\-quiet\fR, \fB\-q\fR
+Silence all output\.
+.TP
+\fB\-\-version\fR, \fB\-v\fR
+Prints versions\.
+.TP
+[\fICOMMAND\fR] \fB\-\-help\fR, \fB\-\-help\fR [\fICOMMAND\fR], \fB\-h\fR
+Prints a help text\. You may specify a \fICOMMAND\fR to get more details\.
+.SH "EXAMPLES"
+For more information see IaC help page \fIhttps://snyk\.co/ucT6Q\fR
+.TP
+\fBTest CloudFormation file\fR
+$ snyk iac test /path/to/cloudformation_file\.yaml
+.TP
+\fBTest kubernetes file\fR
+$ snyk iac test /path/to/kubernetes_file\.yaml
+.TP
+\fBTest terraform file\fR
+$ snyk iac test /path/to/terraform_file\.tf
+.TP
+\fBTest terraform plan file\fR
+$ snyk iac test /path/to/tf\-plan\.json
+.TP
+\fBTest matching files in a directory\fR
+$ snyk iac test /path/to/directory
+.SH "EXIT CODES"
+Possible exit codes and their meaning:
+.P
+\fB0\fR: success, no vulns found
+.br
+\fB1\fR: action_needed, vulns found
+.br
+\fB2\fR: failure, try to re\-run command
+.br
+\fB3\fR: failure, no supported projects detected
+.br
+.SH "ENVIRONMENT"
+You can set these environment variables to change CLI run settings\.
+.TP
+\fBSNYK_TOKEN\fR
+Snyk authorization token\. Setting this envvar will override the token that may be available in your \fBsnyk config\fR settings\.
+.IP
+How to get your account token \fIhttps://snyk\.co/ucT6J\fR
+.br
+How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
+.br
+
+.TP
+\fBSNYK_CFG_KEY\fR
+Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+.IP
+E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
+.TP
+\fBSNYK_REGISTRY_USERNAME\fR
+Specify a username to use when connecting to a container registry\. Note that using the \fB\-\-username\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.TP
+\fBSNYK_REGISTRY_PASSWORD\fR
+Specify a password to use when connecting to a container registry\. Note that using the \fB\-\-password\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.SH "Connecting to Snyk API"
+By default Snyk CLI will connect to \fBhttps://snyk\.io/api/v1\fR\.
+.TP
+\fBSNYK_API\fR
+Sets API host to use for Snyk requests\. Useful for on\-premise instances and configuring proxies\. If set with \fBhttp\fR protocol CLI will upgrade the requests to \fBhttps\fR\. Unless \fBSNYK_HTTP_PROTOCOL_UPGRADE\fR is set to \fB0\fR\.
+.TP
+\fBSNYK_HTTP_PROTOCOL_UPGRADE\fR=0
+If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
+.TP
+\fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+.SH "NOTICES"
+.SS "Snyk API usage policy"
+The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-ignore.1
+++ b/help/commands-man/snyk-ignore.1
@@ -1,0 +1,88 @@
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "SNYK\-IGNORE" "1" "July 2021" "Snyk.io"
+.SH "NAME"
+\fBsnyk\-ignore\fR \- Modifies the \.snyk policy to ignore stated issues
+.SH "SYNOPSIS"
+\fBsnyk\fR \fBignore\fR \fB\-\-id\fR=\fIISSUE_ID\fR [\fB\-\-expiry\fR=\fIEXPIRY\fR] [\fB\-\-reason\fR=\fIREASON\fR] [\fIOPTIONS\fR]
+.SH "DESCRIPTION"
+Ignore a certain issue, according to its snyk ID for all occurrences\. This will update your local \fB\.snyk\fR to contain a similar block:
+.P
+\fByaml ignore: \'<ISSUE_ID>\': \- \'*\': reason: <REASON> expires: <EXPIRY>\fR
+.SH "OPTIONS"
+.TP
+\fB\-\-id\fR=\fIISSUE_ID\fR
+Snyk ID for the issue to ignore\. Required\.
+.TP
+\fB\-\-expiry\fR=\fIEXPIRY\fR
+Expiry date, according to RFC2822 \fIhttps://tools\.ietf\.org/html/rfc2822\fR
+.TP
+\fB\-\-reason\fR=\fIREASON\fR
+Human\-readable \fIREASON\fR to ignore this issue\.
+.SS "Flags available accross all commands"
+.TP
+\fB\-\-insecure\fR
+Ignore unknown certificate authorities\.
+.TP
+\fB\-d\fR
+Output debug logs\.
+.TP
+\fB\-\-quiet\fR, \fB\-q\fR
+Silence all output\.
+.TP
+\fB\-\-version\fR, \fB\-v\fR
+Prints versions\.
+.TP
+[\fICOMMAND\fR] \fB\-\-help\fR, \fB\-\-help\fR [\fICOMMAND\fR], \fB\-h\fR
+Prints a help text\. You may specify a \fICOMMAND\fR to get more details\.
+.SH "EXAMPLES"
+.TP
+\fBIgnore a specific vulnerability\fR
+$ snyk ignore \-\-id=\'npm:qs:20170213\' \-\-expiry=\'2021\-01\-10\' \-\-reason=\'Module not affected by this vuln\'
+.SH "EXIT CODES"
+Possible exit codes and their meaning:
+.P
+\fB0\fR: success, no vulns found
+.br
+\fB1\fR: action_needed, vulns found
+.br
+\fB2\fR: failure, try to re\-run command
+.br
+\fB3\fR: failure, no supported projects detected
+.br
+.SH "ENVIRONMENT"
+You can set these environment variables to change CLI run settings\.
+.TP
+\fBSNYK_TOKEN\fR
+Snyk authorization token\. Setting this envvar will override the token that may be available in your \fBsnyk config\fR settings\.
+.IP
+How to get your account token \fIhttps://snyk\.co/ucT6J\fR
+.br
+How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
+.br
+
+.TP
+\fBSNYK_CFG_KEY\fR
+Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+.IP
+E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
+.TP
+\fBSNYK_REGISTRY_USERNAME\fR
+Specify a username to use when connecting to a container registry\. Note that using the \fB\-\-username\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.TP
+\fBSNYK_REGISTRY_PASSWORD\fR
+Specify a password to use when connecting to a container registry\. Note that using the \fB\-\-password\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.SH "Connecting to Snyk API"
+By default Snyk CLI will connect to \fBhttps://snyk\.io/api/v1\fR\.
+.TP
+\fBSNYK_API\fR
+Sets API host to use for Snyk requests\. Useful for on\-premise instances and configuring proxies\. If set with \fBhttp\fR protocol CLI will upgrade the requests to \fBhttps\fR\. Unless \fBSNYK_HTTP_PROTOCOL_UPGRADE\fR is set to \fB0\fR\.
+.TP
+\fBSNYK_HTTP_PROTOCOL_UPGRADE\fR=0
+If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
+.TP
+\fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+.SH "NOTICES"
+.SS "Snyk API usage policy"
+The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-monitor.1
+++ b/help/commands-man/snyk-monitor.1
@@ -1,0 +1,233 @@
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "SNYK\-MONITOR" "1" "July 2021" "Snyk.io"
+.SH "NAME"
+\fBsnyk\-monitor\fR \- Snapshot and continuously monitor your project
+.SH "SYNOPSIS"
+\fBsnyk\fR \fBmonitor\fR [\fIOPTIONS\fR]
+.SH "DESCRIPTION"
+Create a project on the Snyk website that will be continuously monitored for new vulnerabilities\. After running this command you will see it by logging in to the website and viewing Your projects\.
+.SH "OPTIONS"
+To see command\-specific flags and usage, see \fBhelp\fR command, e\.g\. \fBsnyk container \-\-help\fR\. For advanced usage, we offer language and context specific flags, listed further down this document\.
+.TP
+\fB\-\-all\-projects\fR
+(only in \fBtest\fR and \fBmonitor\fR commands) Auto\-detect all projects in working directory
+.TP
+\fB\-\-detection\-depth\fR=\fIDEPTH\fR
+(only in \fBtest\fR and \fBmonitor\fR commands) Use with \-\-all\-projects or \-\-yarn\-workspaces to indicate how many sub\-directories to search\. \fBDEPTH\fR must be a number\.
+.IP
+Default: 4 (the current working directory and 3 sub\-directories)
+.TP
+\fB\-\-exclude\fR=\fIDIRECTORY\fR[,\fIDIRECTORY\fR]\|\.\|\.\|\.>
+(only in \fBtest\fR and \fBmonitor\fR commands) Can be used with \-\-all\-projects and \-\-yarn\-workspaces to indicate sub\-directories and files to exclude\. Must be comma separated\.
+.IP
+If using with \fB\-\-detection\-depth\fR exclude ignores directories at any level deep\.
+.TP
+\fB\-\-prune\-repeated\-subdependencies\fR, \fB\-p\fR
+(only in \fBtest\fR and \fBmonitor\fR commands) Prune dependency trees, removing duplicate sub\-dependencies\. Will still find all vulnerabilities, but potentially not all of the vulnerable paths\.
+.TP
+\fB\-\-print\-deps\fR
+(only in \fBtest\fR and \fBmonitor\fR commands) Print the dependency tree before sending it for analysis\.
+.TP
+\fB\-\-remote\-repo\-url\fR=\fIURL\fR
+Set or override the remote URL for the repository that you would like to monitor\.
+.TP
+\fB\-\-dev\fR
+Include development\-only dependencies\. Applicable only for some package managers\. E\.g\. \fIdevDependencies\fR in npm or \fI:development\fR dependencies in Gemfile\.
+.IP
+Default: scan only production dependencies
+.TP
+\fB\-\-org\fR=\fIORG_NAME\fR
+Specify the \fIORG_NAME\fR to run Snyk commands tied to a specific organization\. This will influence where will new projects be created after running \fBmonitor\fR command, some features availability and private tests limits\. If you have multiple organizations, you can set a default from the CLI using:
+.IP
+\fB$ snyk config set org\fR=\fIORG_NAME\fR
+.IP
+Setting a default will ensure all newly monitored projects will be created under your default organization\. If you need to override the default, you can use the \fB\-\-org\fR=\fIORG_NAME\fR argument\.
+.IP
+Default: uses \fIORG_NAME\fR that sets as default in your Account settings \fIhttps://app\.snyk\.io/account\fR
+.TP
+\fB\-\-file\fR=\fIFILE\fR
+Sets a package file\.
+.IP
+When testing locally or monitoring a project, you can specify the file that Snyk should inspect for package information\. When ommitted Snyk will try to detect the appropriate file for your project\.
+.TP
+\fB\-\-ignore\-policy\fR
+Ignores all set policies\. The current policy in \fB\.snyk\fR file, Org level ignores and the project policy on snyk\.io\.
+.TP
+\fB\-\-trust\-policies\fR
+Applies and uses ignore rules from your dependencies\' Snyk policies, otherwise ignore policies are only shown as a suggestion\.
+.TP
+\fB\-\-show\-vulnerable\-paths\fR=none|some|all
+Display the dependency paths from the top level dependencies, down to the vulnerable packages\. Doesn\'t affect output when using JSON \fB\-\-json\fR output\.
+.IP
+Default: \fIsome\fR (a few example paths shown) \fIfalse\fR is an alias for \fInone\fR\.
+.TP
+\fB\-\-project\-name\fR=\fIPROJECT_NAME\fR
+Specify a custom Snyk project name\.
+.TP
+\fB\-\-policy\-path\fR=\fIPATH_TO_POLICY_FILE\fR`
+Manually pass a path to a snyk policy file\.
+.TP
+\fB\-\-json\fR
+Prints results in JSON format\.
+.TP
+\fB\-\-json\-file\-output\fR=\fIOUTPUT_FILE_PATH\fR
+(only in \fBtest\fR command) Save test output in JSON format directly to the specified file, regardless of whether or not you use the \fB\-\-json\fR option\. This is especially useful if you want to display the human\-readable test output via stdout and at the same time save the JSON format output to a file\.
+.TP
+\fB\-\-sarif\fR
+Return results in SARIF format\.
+.TP
+\fB\-\-sarif\-file\-output\fR=\fIOUTPUT_FILE_PATH\fR
+(only in \fBtest\fR command) Save test output in SARIF format directly to the \fIOUTPUT_FILE_PATH\fR file, regardless of whether or not you use the \fB\-\-sarif\fR option\. This is especially useful if you want to display the human\-readable test output via stdout and at the same time save the SARIF format output to a file\.
+.TP
+\fB\-\-severity\-threshold\fR=low|medium|high|critical
+Only report vulnerabilities of provided level or higher\.
+.TP
+\fB\-\-fail\-on\fR=all|upgradable|patchable
+Only fail when there are vulnerabilities that can be fixed\.
+.IP
+\fIall\fR fails when there is at least one vulnerability that can be either upgraded or patched\. \fIupgradable\fR fails when there is at least one vulnerability that can be upgraded\. \fIpatchable\fR fails when there is at least one vulnerability that can be patched\.
+.IP
+If vulnerabilities do not have a fix and this option is being used, tests will pass\.
+.TP
+\fB\-\-dry\-run\fR
+(only in \fBprotect\fR command) Don\'t apply updates or patches during \fBprotect\fR command run\.
+.TP
+\fB\-\-\fR [\fICOMPILER_OPTIONS\fR]
+Pass extra arguments directly to Gradle or Maven\. E\.g\. \fBsnyk test \-\- \-\-build\-cache\fR
+.P
+Below are flags that are influencing CLI behavior for specific projects, languages and contexts:
+.SS "Maven options"
+.TP
+\fB\-\-scan\-all\-unmanaged\fR
+Auto detects maven jars, aars, and wars in given directory\. Individual testing can be done with \fB\-\-file\fR=\fIJAR_FILE_NAME\fR
+.TP
+\fB\-\-reachable\fR
+(only in \fBtest\fR and \fBmonitor\fR commands) Analyze your source code to find which vulnerable functions and packages are called\.
+.TP
+\fB\-\-reachable\-timeout\fR=\fITIMEOUT\fR
+The amount of time (in seconds) to wait for Snyk to gather reachability data\. If it takes longer than \fITIMEOUT\fR, Reachable Vulnerabilities are not reported\. This does not affect regular test or monitor output\.
+.IP
+Default: 300 (5 minutes)\.
+.SS "Gradle options"
+More information about Gradle CLI options \fIhttps://snyk\.co/ucT6P\fR
+.IP "\[ci]" 4
+\fB\-\-sub\-project\fR=\fINAME\fR, \fB\-\-gradle\-sub\-project\fR=\fINAME\fR: For Gradle "multi project" configurations, test a specific sub\-project\.
+.IP "\[ci]" 4
+\fB\-\-all\-sub\-projects\fR: For "multi project" configurations, test all sub\-projects\.
+.IP "\[ci]" 4
+\fB\-\-configuration\-matching\fR=\fICONFIGURATION_REGEX\fR: Resolve dependencies using only configuration(s) that match the provided Java regular expression, e\.g\. \fB^releaseRuntimeClasspath$\fR\.
+.IP "\[ci]" 4
+\fB\-\-configuration\-attributes\fR=\fIATTRIBUTE\fR[,\fIATTRIBUTE\fR]\|\.\|\.\|\.: Select certain values of configuration attributes to resolve the dependencies\. E\.g\. \fBbuildtype:release,usage:java\-runtime\fR
+.IP "\[ci]" 4
+\fB\-\-reachable\fR: (only in \fBtest\fR and \fBmonitor\fR commands) Analyze your source code to find which vulnerable functions and packages are called\.
+.IP "\[ci]" 4
+\fB\-\-reachable\-timeout\fR=\fITIMEOUT\fR: The amount of time (in seconds) to wait for Snyk to gather reachability data\. If it takes longer than \fITIMEOUT\fR, Reachable Vulnerabilities are not reported\. This does not affect regular test or monitor output\.
+.IP
+Default: 300 (5 minutes)\.
+.IP "\[ci]" 4
+\fB\-\-init\-script\fR=\fIFILE\fR For projects that contain a gradle initialization script\.
+.IP "" 0
+.SS "\.Net & NuGet options"
+.TP
+\fB\-\-assets\-project\-name\fR
+When monitoring a \.NET project using NuGet \fBPackageReference\fR use the project name in project\.assets\.json, if found\.
+.TP
+\fB\-\-packages\-folder\fR
+Custom path to packages folder
+.TP
+\fB\-\-project\-name\-prefix\fR=\fIPREFIX_STRING\fR
+When monitoring a \.NET project, use this flag to add a custom prefix to the name of files inside a project along with any desired separators, e\.g\. \fBsnyk monitor \-\-file=my\-project\.sln \-\-project\-name\-prefix=my\-group/\fR\. This is useful when you have multiple projects with the same name in other sln files\.
+.SS "npm options"
+.TP
+\fB\-\-strict\-out\-of\-sync\fR=true|false
+Control testing out of sync lockfiles\.
+.IP
+Default: true
+.SS "Yarn options"
+.TP
+\fB\-\-strict\-out\-of\-sync\fR=true|false
+Control testing out of sync lockfiles\.
+.IP
+Default: true
+.TP
+\fB\-\-yarn\-workspaces\fR
+(only in \fBtest\fR and \fBmonitor\fR commands) Detect and scan yarn workspaces\. You can specify how many sub\-directories to search using \fB\-\-detection\-depth\fR and exclude directories and files using \fB\-\-exclude\fR\.
+.SS "CocoaPods options"
+.TP
+\fB\-\-strict\-out\-of\-sync\fR=true|false
+Control testing out of sync lockfiles\.
+.IP
+Default: false
+.SS "Python options"
+.TP
+\fB\-\-command\fR=\fICOMMAND\fR
+Indicate which specific Python commands to use based on Python version\. The default is \fBpython\fR which executes your systems default python version\. Run \'python \-V\' to find out what version is it\. If you are using multiple Python versions, use this parameter to specify the correct Python command for execution\.
+.IP
+Default: \fBpython\fR Example: \fB\-\-command=python3\fR
+.TP
+\fB\-\-skip\-unresolved\fR=true|false
+Allow skipping packages that are not found in the environment\.
+.SS "Flags available accross all commands"
+.TP
+\fB\-\-insecure\fR
+Ignore unknown certificate authorities\.
+.TP
+\fB\-d\fR
+Output debug logs\.
+.TP
+\fB\-\-quiet\fR, \fB\-q\fR
+Silence all output\.
+.TP
+\fB\-\-version\fR, \fB\-v\fR
+Prints versions\.
+.TP
+[\fICOMMAND\fR] \fB\-\-help\fR, \fB\-\-help\fR [\fICOMMAND\fR], \fB\-h\fR
+Prints a help text\. You may specify a \fICOMMAND\fR to get more details\.
+.SH "EXIT CODES"
+Possible exit codes and their meaning:
+.P
+\fB0\fR: success, no vulns found
+.br
+\fB1\fR: action_needed, vulns found
+.br
+\fB2\fR: failure, try to re\-run command
+.br
+\fB3\fR: failure, no supported projects detected
+.br
+.SH "ENVIRONMENT"
+You can set these environment variables to change CLI run settings\.
+.TP
+\fBSNYK_TOKEN\fR
+Snyk authorization token\. Setting this envvar will override the token that may be available in your \fBsnyk config\fR settings\.
+.IP
+How to get your account token \fIhttps://snyk\.co/ucT6J\fR
+.br
+How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
+.br
+
+.TP
+\fBSNYK_CFG_KEY\fR
+Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+.IP
+E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
+.TP
+\fBSNYK_REGISTRY_USERNAME\fR
+Specify a username to use when connecting to a container registry\. Note that using the \fB\-\-username\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.TP
+\fBSNYK_REGISTRY_PASSWORD\fR
+Specify a password to use when connecting to a container registry\. Note that using the \fB\-\-password\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.SH "Connecting to Snyk API"
+By default Snyk CLI will connect to \fBhttps://snyk\.io/api/v1\fR\.
+.TP
+\fBSNYK_API\fR
+Sets API host to use for Snyk requests\. Useful for on\-premise instances and configuring proxies\. If set with \fBhttp\fR protocol CLI will upgrade the requests to \fBhttps\fR\. Unless \fBSNYK_HTTP_PROTOCOL_UPGRADE\fR is set to \fB0\fR\.
+.TP
+\fBSNYK_HTTP_PROTOCOL_UPGRADE\fR=0
+If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
+.TP
+\fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+.SH "NOTICES"
+.SS "Snyk API usage policy"
+The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-policy.1
+++ b/help/commands-man/snyk-policy.1
@@ -1,0 +1,76 @@
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "SNYK\-POLICY" "1" "July 2021" "Snyk.io"
+.SH "NAME"
+\fBsnyk\-policy\fR \- Display the \.snyk policy for a package
+.SH "SYNOPSIS"
+\fBsnyk\fR \fBpolicy\fR [\fIPATH_TO_POLICY_FILE\fR] [\fIOPTIONS\fR]
+.SH "DESCRIPTION"
+Displays a \fB\.snyk\fR policy file\.
+.SH "OPTIONS"
+.TP
+\fIPATH_TO_POLICY_FILE\fR
+Manually pass a path to a snyk policy file\.
+.SS "Flags available accross all commands"
+.TP
+\fB\-\-insecure\fR
+Ignore unknown certificate authorities\.
+.TP
+\fB\-d\fR
+Output debug logs\.
+.TP
+\fB\-\-quiet\fR, \fB\-q\fR
+Silence all output\.
+.TP
+\fB\-\-version\fR, \fB\-v\fR
+Prints versions\.
+.TP
+[\fICOMMAND\fR] \fB\-\-help\fR, \fB\-\-help\fR [\fICOMMAND\fR], \fB\-h\fR
+Prints a help text\. You may specify a \fICOMMAND\fR to get more details\.
+.SH "EXIT CODES"
+Possible exit codes and their meaning:
+.P
+\fB0\fR: success, no vulns found
+.br
+\fB1\fR: action_needed, vulns found
+.br
+\fB2\fR: failure, try to re\-run command
+.br
+\fB3\fR: failure, no supported projects detected
+.br
+.SH "ENVIRONMENT"
+You can set these environment variables to change CLI run settings\.
+.TP
+\fBSNYK_TOKEN\fR
+Snyk authorization token\. Setting this envvar will override the token that may be available in your \fBsnyk config\fR settings\.
+.IP
+How to get your account token \fIhttps://snyk\.co/ucT6J\fR
+.br
+How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
+.br
+
+.TP
+\fBSNYK_CFG_KEY\fR
+Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+.IP
+E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
+.TP
+\fBSNYK_REGISTRY_USERNAME\fR
+Specify a username to use when connecting to a container registry\. Note that using the \fB\-\-username\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.TP
+\fBSNYK_REGISTRY_PASSWORD\fR
+Specify a password to use when connecting to a container registry\. Note that using the \fB\-\-password\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.SH "Connecting to Snyk API"
+By default Snyk CLI will connect to \fBhttps://snyk\.io/api/v1\fR\.
+.TP
+\fBSNYK_API\fR
+Sets API host to use for Snyk requests\. Useful for on\-premise instances and configuring proxies\. If set with \fBhttp\fR protocol CLI will upgrade the requests to \fBhttps\fR\. Unless \fBSNYK_HTTP_PROTOCOL_UPGRADE\fR is set to \fB0\fR\.
+.TP
+\fBSNYK_HTTP_PROTOCOL_UPGRADE\fR=0
+If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
+.TP
+\fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+.SH "NOTICES"
+.SS "Snyk API usage policy"
+The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-protect.1
+++ b/help/commands-man/snyk-protect.1
@@ -1,0 +1,76 @@
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "SNYK\-PROTECT" "1" "July 2021" "Snyk.io"
+.SH "NAME"
+\fBsnyk\-protect\fR \- Applies the patches specified in your \.snyk file to the local file system
+.SH "SYNOPSIS"
+\fBsnyk\fR \fBprotect\fR [\fIOPTIONS\fR]
+.SH "DESCRIPTION"
+\fB$ snyk protect\fR is used to apply patches to your vulnerable dependencies\. It\'s useful after opening a fix pull request from our website (GitHub only) or after running snyk wizard on the CLI\. snyk protect reads a \.snyk policy file to determine what patches to apply\.
+.SH "OPTIONS"
+.TP
+\fB\-\-dry\-run\fR
+Don\'t apply updates or patches when running\.
+.SS "Flags available accross all commands"
+.TP
+\fB\-\-insecure\fR
+Ignore unknown certificate authorities\.
+.TP
+\fB\-d\fR
+Output debug logs\.
+.TP
+\fB\-\-quiet\fR, \fB\-q\fR
+Silence all output\.
+.TP
+\fB\-\-version\fR, \fB\-v\fR
+Prints versions\.
+.TP
+[\fICOMMAND\fR] \fB\-\-help\fR, \fB\-\-help\fR [\fICOMMAND\fR], \fB\-h\fR
+Prints a help text\. You may specify a \fICOMMAND\fR to get more details\.
+.SH "EXIT CODES"
+Possible exit codes and their meaning:
+.P
+\fB0\fR: success, no vulns found
+.br
+\fB1\fR: action_needed, vulns found
+.br
+\fB2\fR: failure, try to re\-run command
+.br
+\fB3\fR: failure, no supported projects detected
+.br
+.SH "ENVIRONMENT"
+You can set these environment variables to change CLI run settings\.
+.TP
+\fBSNYK_TOKEN\fR
+Snyk authorization token\. Setting this envvar will override the token that may be available in your \fBsnyk config\fR settings\.
+.IP
+How to get your account token \fIhttps://snyk\.co/ucT6J\fR
+.br
+How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
+.br
+
+.TP
+\fBSNYK_CFG_KEY\fR
+Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+.IP
+E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
+.TP
+\fBSNYK_REGISTRY_USERNAME\fR
+Specify a username to use when connecting to a container registry\. Note that using the \fB\-\-username\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.TP
+\fBSNYK_REGISTRY_PASSWORD\fR
+Specify a password to use when connecting to a container registry\. Note that using the \fB\-\-password\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.SH "Connecting to Snyk API"
+By default Snyk CLI will connect to \fBhttps://snyk\.io/api/v1\fR\.
+.TP
+\fBSNYK_API\fR
+Sets API host to use for Snyk requests\. Useful for on\-premise instances and configuring proxies\. If set with \fBhttp\fR protocol CLI will upgrade the requests to \fBhttps\fR\. Unless \fBSNYK_HTTP_PROTOCOL_UPGRADE\fR is set to \fB0\fR\.
+.TP
+\fBSNYK_HTTP_PROTOCOL_UPGRADE\fR=0
+If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
+.TP
+\fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+.SH "NOTICES"
+.SS "Snyk API usage policy"
+The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-test.1
+++ b/help/commands-man/snyk-test.1
@@ -1,0 +1,233 @@
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "SNYK\-TEST" "1" "July 2021" "Snyk.io"
+.SH "NAME"
+\fBsnyk\-test\fR \- test local project for vulnerabilities
+.SH "SYNOPSIS"
+\fBsnyk\fR \fBtest\fR [\fIOPTIONS\fR]
+.SH "DESCRIPTION"
+Test command checks locally installed projects for vulnerabilities\. It tries to autodetect supported manifest files with dependencies and test those\.
+.SH "OPTIONS"
+To see command\-specific flags and usage, see \fBhelp\fR command, e\.g\. \fBsnyk container \-\-help\fR\. For advanced usage, we offer language and context specific flags, listed further down this document\.
+.TP
+\fB\-\-all\-projects\fR
+(only in \fBtest\fR and \fBmonitor\fR commands) Auto\-detect all projects in working directory
+.TP
+\fB\-\-detection\-depth\fR=\fIDEPTH\fR
+(only in \fBtest\fR and \fBmonitor\fR commands) Use with \-\-all\-projects or \-\-yarn\-workspaces to indicate how many sub\-directories to search\. \fBDEPTH\fR must be a number\.
+.IP
+Default: 4 (the current working directory and 3 sub\-directories)
+.TP
+\fB\-\-exclude\fR=\fIDIRECTORY\fR[,\fIDIRECTORY\fR]\|\.\|\.\|\.>
+(only in \fBtest\fR and \fBmonitor\fR commands) Can be used with \-\-all\-projects and \-\-yarn\-workspaces to indicate sub\-directories and files to exclude\. Must be comma separated\.
+.IP
+If using with \fB\-\-detection\-depth\fR exclude ignores directories at any level deep\.
+.TP
+\fB\-\-prune\-repeated\-subdependencies\fR, \fB\-p\fR
+(only in \fBtest\fR and \fBmonitor\fR commands) Prune dependency trees, removing duplicate sub\-dependencies\. Will still find all vulnerabilities, but potentially not all of the vulnerable paths\.
+.TP
+\fB\-\-print\-deps\fR
+(only in \fBtest\fR and \fBmonitor\fR commands) Print the dependency tree before sending it for analysis\.
+.TP
+\fB\-\-remote\-repo\-url\fR=\fIURL\fR
+Set or override the remote URL for the repository that you would like to monitor\.
+.TP
+\fB\-\-dev\fR
+Include development\-only dependencies\. Applicable only for some package managers\. E\.g\. \fIdevDependencies\fR in npm or \fI:development\fR dependencies in Gemfile\.
+.IP
+Default: scan only production dependencies
+.TP
+\fB\-\-org\fR=\fIORG_NAME\fR
+Specify the \fIORG_NAME\fR to run Snyk commands tied to a specific organization\. This will influence where will new projects be created after running \fBmonitor\fR command, some features availability and private tests limits\. If you have multiple organizations, you can set a default from the CLI using:
+.IP
+\fB$ snyk config set org\fR=\fIORG_NAME\fR
+.IP
+Setting a default will ensure all newly monitored projects will be created under your default organization\. If you need to override the default, you can use the \fB\-\-org\fR=\fIORG_NAME\fR argument\.
+.IP
+Default: uses \fIORG_NAME\fR that sets as default in your Account settings \fIhttps://app\.snyk\.io/account\fR
+.TP
+\fB\-\-file\fR=\fIFILE\fR
+Sets a package file\.
+.IP
+When testing locally or monitoring a project, you can specify the file that Snyk should inspect for package information\. When ommitted Snyk will try to detect the appropriate file for your project\.
+.TP
+\fB\-\-ignore\-policy\fR
+Ignores all set policies\. The current policy in \fB\.snyk\fR file, Org level ignores and the project policy on snyk\.io\.
+.TP
+\fB\-\-trust\-policies\fR
+Applies and uses ignore rules from your dependencies\' Snyk policies, otherwise ignore policies are only shown as a suggestion\.
+.TP
+\fB\-\-show\-vulnerable\-paths\fR=none|some|all
+Display the dependency paths from the top level dependencies, down to the vulnerable packages\. Doesn\'t affect output when using JSON \fB\-\-json\fR output\.
+.IP
+Default: \fIsome\fR (a few example paths shown) \fIfalse\fR is an alias for \fInone\fR\.
+.TP
+\fB\-\-project\-name\fR=\fIPROJECT_NAME\fR
+Specify a custom Snyk project name\.
+.TP
+\fB\-\-policy\-path\fR=\fIPATH_TO_POLICY_FILE\fR`
+Manually pass a path to a snyk policy file\.
+.TP
+\fB\-\-json\fR
+Prints results in JSON format\.
+.TP
+\fB\-\-json\-file\-output\fR=\fIOUTPUT_FILE_PATH\fR
+(only in \fBtest\fR command) Save test output in JSON format directly to the specified file, regardless of whether or not you use the \fB\-\-json\fR option\. This is especially useful if you want to display the human\-readable test output via stdout and at the same time save the JSON format output to a file\.
+.TP
+\fB\-\-sarif\fR
+Return results in SARIF format\.
+.TP
+\fB\-\-sarif\-file\-output\fR=\fIOUTPUT_FILE_PATH\fR
+(only in \fBtest\fR command) Save test output in SARIF format directly to the \fIOUTPUT_FILE_PATH\fR file, regardless of whether or not you use the \fB\-\-sarif\fR option\. This is especially useful if you want to display the human\-readable test output via stdout and at the same time save the SARIF format output to a file\.
+.TP
+\fB\-\-severity\-threshold\fR=low|medium|high|critical
+Only report vulnerabilities of provided level or higher\.
+.TP
+\fB\-\-fail\-on\fR=all|upgradable|patchable
+Only fail when there are vulnerabilities that can be fixed\.
+.IP
+\fIall\fR fails when there is at least one vulnerability that can be either upgraded or patched\. \fIupgradable\fR fails when there is at least one vulnerability that can be upgraded\. \fIpatchable\fR fails when there is at least one vulnerability that can be patched\.
+.IP
+If vulnerabilities do not have a fix and this option is being used, tests will pass\.
+.TP
+\fB\-\-dry\-run\fR
+(only in \fBprotect\fR command) Don\'t apply updates or patches during \fBprotect\fR command run\.
+.TP
+\fB\-\-\fR [\fICOMPILER_OPTIONS\fR]
+Pass extra arguments directly to Gradle or Maven\. E\.g\. \fBsnyk test \-\- \-\-build\-cache\fR
+.P
+Below are flags that are influencing CLI behavior for specific projects, languages and contexts:
+.SS "Maven options"
+.TP
+\fB\-\-scan\-all\-unmanaged\fR
+Auto detects maven jars, aars, and wars in given directory\. Individual testing can be done with \fB\-\-file\fR=\fIJAR_FILE_NAME\fR
+.TP
+\fB\-\-reachable\fR
+(only in \fBtest\fR and \fBmonitor\fR commands) Analyze your source code to find which vulnerable functions and packages are called\.
+.TP
+\fB\-\-reachable\-timeout\fR=\fITIMEOUT\fR
+The amount of time (in seconds) to wait for Snyk to gather reachability data\. If it takes longer than \fITIMEOUT\fR, Reachable Vulnerabilities are not reported\. This does not affect regular test or monitor output\.
+.IP
+Default: 300 (5 minutes)\.
+.SS "Gradle options"
+More information about Gradle CLI options \fIhttps://snyk\.co/ucT6P\fR
+.IP "\[ci]" 4
+\fB\-\-sub\-project\fR=\fINAME\fR, \fB\-\-gradle\-sub\-project\fR=\fINAME\fR: For Gradle "multi project" configurations, test a specific sub\-project\.
+.IP "\[ci]" 4
+\fB\-\-all\-sub\-projects\fR: For "multi project" configurations, test all sub\-projects\.
+.IP "\[ci]" 4
+\fB\-\-configuration\-matching\fR=\fICONFIGURATION_REGEX\fR: Resolve dependencies using only configuration(s) that match the provided Java regular expression, e\.g\. \fB^releaseRuntimeClasspath$\fR\.
+.IP "\[ci]" 4
+\fB\-\-configuration\-attributes\fR=\fIATTRIBUTE\fR[,\fIATTRIBUTE\fR]\|\.\|\.\|\.: Select certain values of configuration attributes to resolve the dependencies\. E\.g\. \fBbuildtype:release,usage:java\-runtime\fR
+.IP "\[ci]" 4
+\fB\-\-reachable\fR: (only in \fBtest\fR and \fBmonitor\fR commands) Analyze your source code to find which vulnerable functions and packages are called\.
+.IP "\[ci]" 4
+\fB\-\-reachable\-timeout\fR=\fITIMEOUT\fR: The amount of time (in seconds) to wait for Snyk to gather reachability data\. If it takes longer than \fITIMEOUT\fR, Reachable Vulnerabilities are not reported\. This does not affect regular test or monitor output\.
+.IP
+Default: 300 (5 minutes)\.
+.IP "\[ci]" 4
+\fB\-\-init\-script\fR=\fIFILE\fR For projects that contain a gradle initialization script\.
+.IP "" 0
+.SS "\.Net & NuGet options"
+.TP
+\fB\-\-assets\-project\-name\fR
+When monitoring a \.NET project using NuGet \fBPackageReference\fR use the project name in project\.assets\.json, if found\.
+.TP
+\fB\-\-packages\-folder\fR
+Custom path to packages folder
+.TP
+\fB\-\-project\-name\-prefix\fR=\fIPREFIX_STRING\fR
+When monitoring a \.NET project, use this flag to add a custom prefix to the name of files inside a project along with any desired separators, e\.g\. \fBsnyk monitor \-\-file=my\-project\.sln \-\-project\-name\-prefix=my\-group/\fR\. This is useful when you have multiple projects with the same name in other sln files\.
+.SS "npm options"
+.TP
+\fB\-\-strict\-out\-of\-sync\fR=true|false
+Control testing out of sync lockfiles\.
+.IP
+Default: true
+.SS "Yarn options"
+.TP
+\fB\-\-strict\-out\-of\-sync\fR=true|false
+Control testing out of sync lockfiles\.
+.IP
+Default: true
+.TP
+\fB\-\-yarn\-workspaces\fR
+(only in \fBtest\fR and \fBmonitor\fR commands) Detect and scan yarn workspaces\. You can specify how many sub\-directories to search using \fB\-\-detection\-depth\fR and exclude directories and files using \fB\-\-exclude\fR\.
+.SS "CocoaPods options"
+.TP
+\fB\-\-strict\-out\-of\-sync\fR=true|false
+Control testing out of sync lockfiles\.
+.IP
+Default: false
+.SS "Python options"
+.TP
+\fB\-\-command\fR=\fICOMMAND\fR
+Indicate which specific Python commands to use based on Python version\. The default is \fBpython\fR which executes your systems default python version\. Run \'python \-V\' to find out what version is it\. If you are using multiple Python versions, use this parameter to specify the correct Python command for execution\.
+.IP
+Default: \fBpython\fR Example: \fB\-\-command=python3\fR
+.TP
+\fB\-\-skip\-unresolved\fR=true|false
+Allow skipping packages that are not found in the environment\.
+.SS "Flags available accross all commands"
+.TP
+\fB\-\-insecure\fR
+Ignore unknown certificate authorities\.
+.TP
+\fB\-d\fR
+Output debug logs\.
+.TP
+\fB\-\-quiet\fR, \fB\-q\fR
+Silence all output\.
+.TP
+\fB\-\-version\fR, \fB\-v\fR
+Prints versions\.
+.TP
+[\fICOMMAND\fR] \fB\-\-help\fR, \fB\-\-help\fR [\fICOMMAND\fR], \fB\-h\fR
+Prints a help text\. You may specify a \fICOMMAND\fR to get more details\.
+.SH "EXIT CODES"
+Possible exit codes and their meaning:
+.P
+\fB0\fR: success, no vulns found
+.br
+\fB1\fR: action_needed, vulns found
+.br
+\fB2\fR: failure, try to re\-run command
+.br
+\fB3\fR: failure, no supported projects detected
+.br
+.SH "ENVIRONMENT"
+You can set these environment variables to change CLI run settings\.
+.TP
+\fBSNYK_TOKEN\fR
+Snyk authorization token\. Setting this envvar will override the token that may be available in your \fBsnyk config\fR settings\.
+.IP
+How to get your account token \fIhttps://snyk\.co/ucT6J\fR
+.br
+How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
+.br
+
+.TP
+\fBSNYK_CFG_KEY\fR
+Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+.IP
+E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
+.TP
+\fBSNYK_REGISTRY_USERNAME\fR
+Specify a username to use when connecting to a container registry\. Note that using the \fB\-\-username\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.TP
+\fBSNYK_REGISTRY_PASSWORD\fR
+Specify a password to use when connecting to a container registry\. Note that using the \fB\-\-password\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.SH "Connecting to Snyk API"
+By default Snyk CLI will connect to \fBhttps://snyk\.io/api/v1\fR\.
+.TP
+\fBSNYK_API\fR
+Sets API host to use for Snyk requests\. Useful for on\-premise instances and configuring proxies\. If set with \fBhttp\fR protocol CLI will upgrade the requests to \fBhttps\fR\. Unless \fBSNYK_HTTP_PROTOCOL_UPGRADE\fR is set to \fB0\fR\.
+.TP
+\fBSNYK_HTTP_PROTOCOL_UPGRADE\fR=0
+If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
+.TP
+\fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+.SH "NOTICES"
+.SS "Snyk API usage policy"
+The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-wizard.1
+++ b/help/commands-man/snyk-wizard.1
@@ -1,0 +1,82 @@
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "SNYK\-WIZARD" "1" "July 2021" "Snyk.io"
+.SH "NAME"
+\fBsnyk\-wizard\fR \- Configure your policy file to update, auto patch and ignore vulnerabilities
+.SH "SYNOPSIS"
+\fBsnyk\fR \fBwizard\fR [\fIOPTIONS\fR]
+.SH "DESCRIPTION"
+Snyk\'s wizard will:
+.IP "\[ci]" 4
+Enumerate your local dependencies and query Snyk\'s servers for vulnerabilities
+.IP "\[ci]" 4
+Guide you through fixing found vulnerabilities
+.IP "\[ci]" 4
+Create a \.snyk policy file to guide snyk commands such as \fBtest\fR and \fBprotect\fR
+.IP "\[ci]" 4
+Remember your dependencies to alert you when new vulnerabilities are disclosed
+.IP "" 0
+.SH "OPTIONS"
+.SS "Flags available accross all commands"
+.TP
+\fB\-\-insecure\fR
+Ignore unknown certificate authorities\.
+.TP
+\fB\-d\fR
+Output debug logs\.
+.TP
+\fB\-\-quiet\fR, \fB\-q\fR
+Silence all output\.
+.TP
+\fB\-\-version\fR, \fB\-v\fR
+Prints versions\.
+.TP
+[\fICOMMAND\fR] \fB\-\-help\fR, \fB\-\-help\fR [\fICOMMAND\fR], \fB\-h\fR
+Prints a help text\. You may specify a \fICOMMAND\fR to get more details\.
+.SH "EXIT CODES"
+Possible exit codes and their meaning:
+.P
+\fB0\fR: success, no vulns found
+.br
+\fB1\fR: action_needed, vulns found
+.br
+\fB2\fR: failure, try to re\-run command
+.br
+\fB3\fR: failure, no supported projects detected
+.br
+.SH "ENVIRONMENT"
+You can set these environment variables to change CLI run settings\.
+.TP
+\fBSNYK_TOKEN\fR
+Snyk authorization token\. Setting this envvar will override the token that may be available in your \fBsnyk config\fR settings\.
+.IP
+How to get your account token \fIhttps://snyk\.co/ucT6J\fR
+.br
+How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
+.br
+
+.TP
+\fBSNYK_CFG_KEY\fR
+Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+.IP
+E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
+.TP
+\fBSNYK_REGISTRY_USERNAME\fR
+Specify a username to use when connecting to a container registry\. Note that using the \fB\-\-username\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.TP
+\fBSNYK_REGISTRY_PASSWORD\fR
+Specify a password to use when connecting to a container registry\. Note that using the \fB\-\-password\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.SH "Connecting to Snyk API"
+By default Snyk CLI will connect to \fBhttps://snyk\.io/api/v1\fR\.
+.TP
+\fBSNYK_API\fR
+Sets API host to use for Snyk requests\. Useful for on\-premise instances and configuring proxies\. If set with \fBhttp\fR protocol CLI will upgrade the requests to \fBhttps\fR\. Unless \fBSNYK_HTTP_PROTOCOL_UPGRADE\fR is set to \fB0\fR\.
+.TP
+\fBSNYK_HTTP_PROTOCOL_UPGRADE\fR=0
+If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
+.TP
+\fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+.SH "NOTICES"
+.SS "Snyk API usage policy"
+The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-woof.1
+++ b/help/commands-man/snyk-woof.1
@@ -1,0 +1,76 @@
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "SNYK\-WOOF" "1" "July 2021" "Snyk.io"
+.SH "NAME"
+\fBsnyk\-woof\fR \- W00f
+.SH "SYNOPSIS"
+\fBsnyk\fR \fBwoof\fR [\fIOPTIONS\fR]
+.SH "DESCRIPTION"
+Easter egg that prints a Patch ascii art\.
+.SH "OPTIONS"
+.TP
+\fB\-\-language\fR=\fILANGUAGE\fR
+Woof in a specific language\. \fILANGUAGE\fR should be a ISO 639\-1 code\.
+.SS "Flags available accross all commands"
+.TP
+\fB\-\-insecure\fR
+Ignore unknown certificate authorities\.
+.TP
+\fB\-d\fR
+Output debug logs\.
+.TP
+\fB\-\-quiet\fR, \fB\-q\fR
+Silence all output\.
+.TP
+\fB\-\-version\fR, \fB\-v\fR
+Prints versions\.
+.TP
+[\fICOMMAND\fR] \fB\-\-help\fR, \fB\-\-help\fR [\fICOMMAND\fR], \fB\-h\fR
+Prints a help text\. You may specify a \fICOMMAND\fR to get more details\.
+.SH "EXIT CODES"
+Possible exit codes and their meaning:
+.P
+\fB0\fR: success, no vulns found
+.br
+\fB1\fR: action_needed, vulns found
+.br
+\fB2\fR: failure, try to re\-run command
+.br
+\fB3\fR: failure, no supported projects detected
+.br
+.SH "ENVIRONMENT"
+You can set these environment variables to change CLI run settings\.
+.TP
+\fBSNYK_TOKEN\fR
+Snyk authorization token\. Setting this envvar will override the token that may be available in your \fBsnyk config\fR settings\.
+.IP
+How to get your account token \fIhttps://snyk\.co/ucT6J\fR
+.br
+How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
+.br
+
+.TP
+\fBSNYK_CFG_KEY\fR
+Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+.IP
+E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
+.TP
+\fBSNYK_REGISTRY_USERNAME\fR
+Specify a username to use when connecting to a container registry\. Note that using the \fB\-\-username\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.TP
+\fBSNYK_REGISTRY_PASSWORD\fR
+Specify a password to use when connecting to a container registry\. Note that using the \fB\-\-password\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.SH "Connecting to Snyk API"
+By default Snyk CLI will connect to \fBhttps://snyk\.io/api/v1\fR\.
+.TP
+\fBSNYK_API\fR
+Sets API host to use for Snyk requests\. Useful for on\-premise instances and configuring proxies\. If set with \fBhttp\fR protocol CLI will upgrade the requests to \fBhttps\fR\. Unless \fBSNYK_HTTP_PROTOCOL_UPGRADE\fR is set to \fB0\fR\.
+.TP
+\fBSNYK_HTTP_PROTOCOL_UPGRADE\fR=0
+If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
+.TP
+\fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+.SH "NOTICES"
+.SS "Snyk API usage policy"
+The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk.1
+++ b/help/commands-man/snyk.1
@@ -1,0 +1,312 @@
+.\" generated with Ronn-NG/v0.9.1
+.\" http://github.com/apjanke/ronn-ng/tree/0.9.1
+.TH "SNYK" "1" "July 2021" "Snyk.io"
+.SH "NAME"
+\fBsnyk\fR \- CLI and build\-time tool to find & fix known vulnerabilities in open\-source dependencies
+.SH "SYNOPSIS"
+\fBsnyk\fR [\fICOMMAND\fR] [\fISUBCOMMAND\fR] [\fIOPTIONS\fR] [\fIPACKAGE\fR] [\-\- \fICOMPILER_OPTIONS\fR]
+.SH "DESCRIPTION"
+Snyk helps you find, fix and monitor known vulnerabilities in open source dependencies\.
+.br
+For more information see https://snyk\.io
+.SS "Not sure where to start?"
+.IP "1." 4
+authenticate with \fB$ snyk auth\fR
+.IP "2." 4
+test your local project with \fB$ snyk test\fR
+.IP "3." 4
+get alerted for new vulnerabilities with \fB$ snyk monitor\fR
+.IP "" 0
+.SH "COMMANDS"
+To see command\-specific flags and usage, see \fBhelp\fR command, e\.g\. \fBsnyk container \-\-help\fR\. Available top\-level CLI commands:
+.TP
+\fBauth\fR [\fIAPI_TOKEN\fR]
+Authenticate Snyk CLI with a Snyk account\.
+.TP
+\fBtest\fR
+Test local project for vulnerabilities\.
+.TP
+\fBmonitor\fR
+Snapshot and continuously monitor your project\.
+.TP
+\fBcontainer\fR
+Test container images for vulnerabilities\. See \fBsnyk container \-\-help\fR for full instructions\.
+.TP
+\fBiac\fR
+Find security issues in your Infrastructure as Code files\. See \fBsnyk iac \-\-help\fR for full instructions\.
+.TP
+\fBconfig\fR
+Manage Snyk CLI configuration\.
+.TP
+\fBprotect\fR
+Applies the patches specified in your \.snyk file to the local file system\.
+.TP
+\fBpolicy\fR
+Display the \.snyk policy for a package\.
+.TP
+\fBignore\fR
+Modifies the \.snyk policy to ignore stated issues\.
+.TP
+\fBwizard\fR
+Configure your policy file to update, auto patch and ignore vulnerabilities\. Snyk wizard updates your \.snyk file\.
+.SH "OPTIONS"
+To see command\-specific flags and usage, see \fBhelp\fR command, e\.g\. \fBsnyk container \-\-help\fR\. For advanced usage, we offer language and context specific flags, listed further down this document\.
+.TP
+\fB\-\-all\-projects\fR
+(only in \fBtest\fR and \fBmonitor\fR commands) Auto\-detect all projects in working directory
+.TP
+\fB\-\-detection\-depth\fR=\fIDEPTH\fR
+(only in \fBtest\fR and \fBmonitor\fR commands) Use with \-\-all\-projects or \-\-yarn\-workspaces to indicate how many sub\-directories to search\. \fBDEPTH\fR must be a number\.
+.IP
+Default: 4 (the current working directory and 3 sub\-directories)
+.TP
+\fB\-\-exclude\fR=\fIDIRECTORY\fR[,\fIDIRECTORY\fR]\|\.\|\.\|\.>
+(only in \fBtest\fR and \fBmonitor\fR commands) Can be used with \-\-all\-projects and \-\-yarn\-workspaces to indicate sub\-directories and files to exclude\. Must be comma separated\.
+.IP
+If using with \fB\-\-detection\-depth\fR exclude ignores directories at any level deep\.
+.TP
+\fB\-\-prune\-repeated\-subdependencies\fR, \fB\-p\fR
+(only in \fBtest\fR and \fBmonitor\fR commands) Prune dependency trees, removing duplicate sub\-dependencies\. Will still find all vulnerabilities, but potentially not all of the vulnerable paths\.
+.TP
+\fB\-\-print\-deps\fR
+(only in \fBtest\fR and \fBmonitor\fR commands) Print the dependency tree before sending it for analysis\.
+.TP
+\fB\-\-remote\-repo\-url\fR=\fIURL\fR
+Set or override the remote URL for the repository that you would like to monitor\.
+.TP
+\fB\-\-dev\fR
+Include development\-only dependencies\. Applicable only for some package managers\. E\.g\. \fIdevDependencies\fR in npm or \fI:development\fR dependencies in Gemfile\.
+.IP
+Default: scan only production dependencies
+.TP
+\fB\-\-org\fR=\fIORG_NAME\fR
+Specify the \fIORG_NAME\fR to run Snyk commands tied to a specific organization\. This will influence where will new projects be created after running \fBmonitor\fR command, some features availability and private tests limits\. If you have multiple organizations, you can set a default from the CLI using:
+.IP
+\fB$ snyk config set org\fR=\fIORG_NAME\fR
+.IP
+Setting a default will ensure all newly monitored projects will be created under your default organization\. If you need to override the default, you can use the \fB\-\-org\fR=\fIORG_NAME\fR argument\.
+.IP
+Default: uses \fIORG_NAME\fR that sets as default in your Account settings \fIhttps://app\.snyk\.io/account\fR
+.TP
+\fB\-\-file\fR=\fIFILE\fR
+Sets a package file\.
+.IP
+When testing locally or monitoring a project, you can specify the file that Snyk should inspect for package information\. When ommitted Snyk will try to detect the appropriate file for your project\.
+.TP
+\fB\-\-ignore\-policy\fR
+Ignores all set policies\. The current policy in \fB\.snyk\fR file, Org level ignores and the project policy on snyk\.io\.
+.TP
+\fB\-\-trust\-policies\fR
+Applies and uses ignore rules from your dependencies\' Snyk policies, otherwise ignore policies are only shown as a suggestion\.
+.TP
+\fB\-\-show\-vulnerable\-paths\fR=none|some|all
+Display the dependency paths from the top level dependencies, down to the vulnerable packages\. Doesn\'t affect output when using JSON \fB\-\-json\fR output\.
+.IP
+Default: \fIsome\fR (a few example paths shown) \fIfalse\fR is an alias for \fInone\fR\.
+.TP
+\fB\-\-project\-name\fR=\fIPROJECT_NAME\fR
+Specify a custom Snyk project name\.
+.TP
+\fB\-\-policy\-path\fR=\fIPATH_TO_POLICY_FILE\fR`
+Manually pass a path to a snyk policy file\.
+.TP
+\fB\-\-json\fR
+Prints results in JSON format\.
+.TP
+\fB\-\-json\-file\-output\fR=\fIOUTPUT_FILE_PATH\fR
+(only in \fBtest\fR command) Save test output in JSON format directly to the specified file, regardless of whether or not you use the \fB\-\-json\fR option\. This is especially useful if you want to display the human\-readable test output via stdout and at the same time save the JSON format output to a file\.
+.TP
+\fB\-\-sarif\fR
+Return results in SARIF format\.
+.TP
+\fB\-\-sarif\-file\-output\fR=\fIOUTPUT_FILE_PATH\fR
+(only in \fBtest\fR command) Save test output in SARIF format directly to the \fIOUTPUT_FILE_PATH\fR file, regardless of whether or not you use the \fB\-\-sarif\fR option\. This is especially useful if you want to display the human\-readable test output via stdout and at the same time save the SARIF format output to a file\.
+.TP
+\fB\-\-severity\-threshold\fR=low|medium|high|critical
+Only report vulnerabilities of provided level or higher\.
+.TP
+\fB\-\-fail\-on\fR=all|upgradable|patchable
+Only fail when there are vulnerabilities that can be fixed\.
+.IP
+\fIall\fR fails when there is at least one vulnerability that can be either upgraded or patched\. \fIupgradable\fR fails when there is at least one vulnerability that can be upgraded\. \fIpatchable\fR fails when there is at least one vulnerability that can be patched\.
+.IP
+If vulnerabilities do not have a fix and this option is being used, tests will pass\.
+.TP
+\fB\-\-dry\-run\fR
+(only in \fBprotect\fR command) Don\'t apply updates or patches during \fBprotect\fR command run\.
+.TP
+\fB\-\-\fR [\fICOMPILER_OPTIONS\fR]
+Pass extra arguments directly to Gradle or Maven\. E\.g\. \fBsnyk test \-\- \-\-build\-cache\fR
+.P
+Below are flags that are influencing CLI behavior for specific projects, languages and contexts:
+.SS "Maven options"
+.TP
+\fB\-\-scan\-all\-unmanaged\fR
+Auto detects maven jars, aars, and wars in given directory\. Individual testing can be done with \fB\-\-file\fR=\fIJAR_FILE_NAME\fR
+.TP
+\fB\-\-reachable\fR
+(only in \fBtest\fR and \fBmonitor\fR commands) Analyze your source code to find which vulnerable functions and packages are called\.
+.TP
+\fB\-\-reachable\-timeout\fR=\fITIMEOUT\fR
+The amount of time (in seconds) to wait for Snyk to gather reachability data\. If it takes longer than \fITIMEOUT\fR, Reachable Vulnerabilities are not reported\. This does not affect regular test or monitor output\.
+.IP
+Default: 300 (5 minutes)\.
+.SS "Gradle options"
+More information about Gradle CLI options \fIhttps://snyk\.co/ucT6P\fR
+.IP "\[ci]" 4
+\fB\-\-sub\-project\fR=\fINAME\fR, \fB\-\-gradle\-sub\-project\fR=\fINAME\fR: For Gradle "multi project" configurations, test a specific sub\-project\.
+.IP "\[ci]" 4
+\fB\-\-all\-sub\-projects\fR: For "multi project" configurations, test all sub\-projects\.
+.IP "\[ci]" 4
+\fB\-\-configuration\-matching\fR=\fICONFIGURATION_REGEX\fR: Resolve dependencies using only configuration(s) that match the provided Java regular expression, e\.g\. \fB^releaseRuntimeClasspath$\fR\.
+.IP "\[ci]" 4
+\fB\-\-configuration\-attributes\fR=\fIATTRIBUTE\fR[,\fIATTRIBUTE\fR]\|\.\|\.\|\.: Select certain values of configuration attributes to resolve the dependencies\. E\.g\. \fBbuildtype:release,usage:java\-runtime\fR
+.IP "\[ci]" 4
+\fB\-\-reachable\fR: (only in \fBtest\fR and \fBmonitor\fR commands) Analyze your source code to find which vulnerable functions and packages are called\.
+.IP "\[ci]" 4
+\fB\-\-reachable\-timeout\fR=\fITIMEOUT\fR: The amount of time (in seconds) to wait for Snyk to gather reachability data\. If it takes longer than \fITIMEOUT\fR, Reachable Vulnerabilities are not reported\. This does not affect regular test or monitor output\.
+.IP
+Default: 300 (5 minutes)\.
+.IP "\[ci]" 4
+\fB\-\-init\-script\fR=\fIFILE\fR For projects that contain a gradle initialization script\.
+.IP "" 0
+.SS "\.Net & NuGet options"
+.TP
+\fB\-\-assets\-project\-name\fR
+When monitoring a \.NET project using NuGet \fBPackageReference\fR use the project name in project\.assets\.json, if found\.
+.TP
+\fB\-\-packages\-folder\fR
+Custom path to packages folder
+.TP
+\fB\-\-project\-name\-prefix\fR=\fIPREFIX_STRING\fR
+When monitoring a \.NET project, use this flag to add a custom prefix to the name of files inside a project along with any desired separators, e\.g\. \fBsnyk monitor \-\-file=my\-project\.sln \-\-project\-name\-prefix=my\-group/\fR\. This is useful when you have multiple projects with the same name in other sln files\.
+.SS "npm options"
+.TP
+\fB\-\-strict\-out\-of\-sync\fR=true|false
+Control testing out of sync lockfiles\.
+.IP
+Default: true
+.SS "Yarn options"
+.TP
+\fB\-\-strict\-out\-of\-sync\fR=true|false
+Control testing out of sync lockfiles\.
+.IP
+Default: true
+.TP
+\fB\-\-yarn\-workspaces\fR
+(only in \fBtest\fR and \fBmonitor\fR commands) Detect and scan yarn workspaces\. You can specify how many sub\-directories to search using \fB\-\-detection\-depth\fR and exclude directories and files using \fB\-\-exclude\fR\.
+.SS "CocoaPods options"
+.TP
+\fB\-\-strict\-out\-of\-sync\fR=true|false
+Control testing out of sync lockfiles\.
+.IP
+Default: false
+.SS "Python options"
+.TP
+\fB\-\-command\fR=\fICOMMAND\fR
+Indicate which specific Python commands to use based on Python version\. The default is \fBpython\fR which executes your systems default python version\. Run \'python \-V\' to find out what version is it\. If you are using multiple Python versions, use this parameter to specify the correct Python command for execution\.
+.IP
+Default: \fBpython\fR Example: \fB\-\-command=python3\fR
+.TP
+\fB\-\-skip\-unresolved\fR=true|false
+Allow skipping packages that are not found in the environment\.
+.SS "Flags available accross all commands"
+.TP
+\fB\-\-insecure\fR
+Ignore unknown certificate authorities\.
+.TP
+\fB\-d\fR
+Output debug logs\.
+.TP
+\fB\-\-quiet\fR, \fB\-q\fR
+Silence all output\.
+.TP
+\fB\-\-version\fR, \fB\-v\fR
+Prints versions\.
+.TP
+[\fICOMMAND\fR] \fB\-\-help\fR, \fB\-\-help\fR [\fICOMMAND\fR], \fB\-h\fR
+Prints a help text\. You may specify a \fICOMMAND\fR to get more details\.
+.SH "EXAMPLES"
+.TP
+\fBAuthenticate in your CI without user interaction\fR
+$ snyk auth MY_API_TOKEN
+.TP
+\fBTest a project in current folder for known vulnerabilities\fR
+$ snyk test
+.TP
+\fBTest a specific dependency for vulnerabilities\fR
+$ snyk test ionic@1\.6\.5
+.P
+More examples:
+.IP "" 4
+.nf
+$ snyk test \-\-show\-vulnerable\-paths=false
+$ snyk monitor \-\-org=my\-team
+$ snyk monitor \-\-project\-name=my\-project
+.fi
+.IP "" 0
+.SS "Container scanning"
+See \fBsnyk container \-\-help\fR for more details and examples:
+.IP "" 4
+.nf
+$ snyk container test ubuntu:18\.04 \-\-org=my\-team
+$ snyk container test app:latest \-\-file=Dockerfile \-\-policy\-path=path/to/\.snyk
+.fi
+.IP "" 0
+.SS "Infrastructure as Code (IAC) scanning"
+See \fBsnyk iac \-\-help\fR for more details and examples:
+.IP "" 4
+.nf
+$ snyk iac test /path/to/cloudformation_file\.yaml
+$ snyk iac test /path/to/kubernetes_file\.yaml
+$ snyk iac test /path/to/terraform_file\.tf
+$ snyk iac test /path/to/tf\-plan\.json
+.fi
+.IP "" 0
+.SH "EXIT CODES"
+Possible exit codes and their meaning:
+.P
+\fB0\fR: success, no vulns found
+.br
+\fB1\fR: action_needed, vulns found
+.br
+\fB2\fR: failure, try to re\-run command
+.br
+\fB3\fR: failure, no supported projects detected
+.br
+.SH "ENVIRONMENT"
+You can set these environment variables to change CLI run settings\.
+.TP
+\fBSNYK_TOKEN\fR
+Snyk authorization token\. Setting this envvar will override the token that may be available in your \fBsnyk config\fR settings\.
+.IP
+How to get your account token \fIhttps://snyk\.co/ucT6J\fR
+.br
+How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
+.br
+
+.TP
+\fBSNYK_CFG_KEY\fR
+Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+.IP
+E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
+.TP
+\fBSNYK_REGISTRY_USERNAME\fR
+Specify a username to use when connecting to a container registry\. Note that using the \fB\-\-username\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.TP
+\fBSNYK_REGISTRY_PASSWORD\fR
+Specify a password to use when connecting to a container registry\. Note that using the \fB\-\-password\fR flag will override this value\. This will be ignored in favour of local Docker binary credentials when Docker is present\.
+.SH "Connecting to Snyk API"
+By default Snyk CLI will connect to \fBhttps://snyk\.io/api/v1\fR\.
+.TP
+\fBSNYK_API\fR
+Sets API host to use for Snyk requests\. Useful for on\-premise instances and configuring proxies\. If set with \fBhttp\fR protocol CLI will upgrade the requests to \fBhttps\fR\. Unless \fBSNYK_HTTP_PROTOCOL_UPGRADE\fR is set to \fB0\fR\.
+.TP
+\fBSNYK_HTTP_PROTOCOL_UPGRADE\fR=0
+If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
+.TP
+\fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+.SH "NOTICES"
+.SS "Snyk API usage policy"
+The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-md/snyk-auth.md
+++ b/help/commands-md/snyk-auth.md
@@ -1,0 +1,95 @@
+# snyk-auth(1) -- Authenticate Snyk CLI with a Snyk account
+
+## SYNOPSIS
+
+`snyk` `auth` \[<API_TOKEN>\] \[<OPTIONS>\]
+
+## DESCRIPTION
+
+Authenticate Snyk CLI with a Snyk account. Running `$ snyk auth` without an <API_TOKEN> will open a browser window and asks you to login with Snyk account and authorize. When inputting an <API_TOKEN>, it will be validated with Snyk API.
+
+When running in a CI environment <API_TOKEN> is required.
+
+## OPTIONS
+
+- \[<API_TOKEN>\]:
+  Your Snyk token. May be an user token or a service account.<br />
+  [How to get your account token](https://snyk.co/ucT6J)<br />
+  [How to use Service Accounts](https://snyk.co/ucT6L)<br />
+
+
+
+
+### Flags available accross all commands
+
+- `--insecure`:
+  Ignore unknown certificate authorities.
+
+- `-d`:
+  Output debug logs.
+
+- `--quiet`, `-q`:
+  Silence all output.
+
+- `--version`, `-v`:
+  Prints versions.
+
+- \[<COMMAND>\] `--help`, `--help` \[<COMMAND>\], `-h`:
+  Prints a help text. You may specify a <COMMAND> to get more details.
+
+
+
+
+## EXIT CODES
+
+Possible exit codes and their meaning:
+
+**0**: success, no vulns found<br />
+**1**: action_needed, vulns found<br />
+**2**: failure, try to re-run command<br />
+**3**: failure, no supported projects detected<br />
+
+
+## ENVIRONMENT
+
+You can set these environment variables to change CLI run settings.
+
+- `SNYK_TOKEN`:
+  Snyk authorization token. Setting this envvar will override the token that may be available in your `snyk config` settings.
+
+  [How to get your account token](https://snyk.co/ucT6J)<br />
+  [How to use Service Accounts](https://snyk.co/ucT6L)<br />
+
+- `SNYK_CFG_KEY`:
+  Allows you to override any key that's also available as `snyk config` option.
+
+  E.g. `SNYK_CFG_ORG`=myorg will override default org option in `config` with "myorg".
+
+- `SNYK_REGISTRY_USERNAME`:
+  Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+- `SNYK_REGISTRY_PASSWORD`:
+  Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+## Connecting to Snyk API
+
+By default Snyk CLI will connect to `https://snyk.io/api/v1`.
+
+- `SNYK_API`:
+  Sets API host to use for Snyk requests. Useful for on-premise instances and configuring proxies. If set with `http` protocol CLI will upgrade the requests to `https`. Unless `SNYK_HTTP_PROTOCOL_UPGRADE` is set to `0`.
+
+- `SNYK_HTTP_PROTOCOL_UPGRADE`=0:
+  If set to the value of `0`, API requests aimed at `http` URLs will not be upgraded to `https`. If not set, the default behavior will be to upgrade these requests from `http` to `https`. Useful e.g., for reverse proxies.
+
+- `HTTPS_PROXY` and `HTTP_PROXY`:
+  Allows you to specify a proxy to use for `https` and `http` calls. The `https` in the `HTTPS_PROXY` means that _requests using `https` protocol_ will use this proxy. The proxy itself doesn't need to use `https`.
+
+
+## NOTICES
+
+### Snyk API usage policy
+
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the [terms & conditions](https://snyk.co/ucT6N)
+

--- a/help/commands-md/snyk-config.md
+++ b/help/commands-md/snyk-config.md
@@ -1,0 +1,115 @@
+# snyk-config(1) -- Manage Snyk CLI configuration
+
+## SYNOPSIS
+
+`snyk` `config` `get|set|clear` \[<KEY>\[=<VALUE>\]\] \[<OPTIONS>\]
+
+## DESCRIPTION
+
+Manage your local Snyk CLI config file.
+
+This command does not manage the `.snyk` file that's part of your project. See `snyk policy`, `snyk ignore` or `snyk wizard`.
+
+## COMMANDS
+
+- `get` <KEY>:
+  Print a config value.
+
+- `set` <KEY>=<VALUE>:
+  Create a new config value.
+
+- `unset` <KEY>:
+  Remove a config value.
+
+- `clear`:
+  Remove all config values.
+
+## OPTIONS
+
+### Supported <KEY> values
+
+- `api`:
+  API token to use when calling Snyk API.
+
+- `endpoint`:
+  Defines the API endpoint to use.
+
+- `disable-analytics`:
+  Turns off analytics reporting.
+
+
+
+
+### Flags available accross all commands
+
+- `--insecure`:
+  Ignore unknown certificate authorities.
+
+- `-d`:
+  Output debug logs.
+
+- `--quiet`, `-q`:
+  Silence all output.
+
+- `--version`, `-v`:
+  Prints versions.
+
+- \[<COMMAND>\] `--help`, `--help` \[<COMMAND>\], `-h`:
+  Prints a help text. You may specify a <COMMAND> to get more details.
+
+
+
+
+## EXIT CODES
+
+Possible exit codes and their meaning:
+
+**0**: success, no vulns found<br />
+**1**: action_needed, vulns found<br />
+**2**: failure, try to re-run command<br />
+**3**: failure, no supported projects detected<br />
+
+
+## ENVIRONMENT
+
+You can set these environment variables to change CLI run settings.
+
+- `SNYK_TOKEN`:
+  Snyk authorization token. Setting this envvar will override the token that may be available in your `snyk config` settings.
+
+  [How to get your account token](https://snyk.co/ucT6J)<br />
+  [How to use Service Accounts](https://snyk.co/ucT6L)<br />
+
+- `SNYK_CFG_KEY`:
+  Allows you to override any key that's also available as `snyk config` option.
+
+  E.g. `SNYK_CFG_ORG`=myorg will override default org option in `config` with "myorg".
+
+- `SNYK_REGISTRY_USERNAME`:
+  Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+- `SNYK_REGISTRY_PASSWORD`:
+  Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+## Connecting to Snyk API
+
+By default Snyk CLI will connect to `https://snyk.io/api/v1`.
+
+- `SNYK_API`:
+  Sets API host to use for Snyk requests. Useful for on-premise instances and configuring proxies. If set with `http` protocol CLI will upgrade the requests to `https`. Unless `SNYK_HTTP_PROTOCOL_UPGRADE` is set to `0`.
+
+- `SNYK_HTTP_PROTOCOL_UPGRADE`=0:
+  If set to the value of `0`, API requests aimed at `http` URLs will not be upgraded to `https`. If not set, the default behavior will be to upgrade these requests from `http` to `https`. Useful e.g., for reverse proxies.
+
+- `HTTPS_PROXY` and `HTTP_PROXY`:
+  Allows you to specify a proxy to use for `https` and `http` calls. The `https` in the `HTTPS_PROXY` means that _requests using `https` protocol_ will use this proxy. The proxy itself doesn't need to use `https`.
+
+
+## NOTICES
+
+### Snyk API usage policy
+
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the [terms & conditions](https://snyk.co/ucT6N)
+

--- a/help/commands-md/snyk-container.md
+++ b/help/commands-md/snyk-container.md
@@ -1,0 +1,140 @@
+# snyk-container(1) -- Test container images for vulnerabilities
+
+## SYNOPSIS
+
+`snyk` `container` \[<COMMAND>\] \[<OPTIONS>\] \[<IMAGE>\]
+
+## DESCRIPTION
+
+Find vulnerabilities in your container images.
+
+## COMMANDS
+
+- `test`:
+  Test for any known vulnerabilities.
+
+- `monitor`:
+  Record the state of dependencies and any vulnerabilities on snyk.io.
+
+## OPTIONS
+
+- `--exclude-base-image-vulns`:
+  Exclude from display base image vulnerabilities.
+
+- `--file`=<FILE_PATH>:
+  Include the path to the image's Dockerfile for more detailed advice.
+
+- `--platform`=<PLATFORM>:
+  For multi-architecture images, specify the platform to test.
+  [linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7 or linux/arm/v6]
+
+- `--json`:
+  Prints results in JSON format.
+
+- `--json-file-output`=<OUTPUT_FILE_PATH>:
+  (only in `test` command)
+  Save test output in JSON format directly to the specified file, regardless of whether or not you use the `--json` option.
+  This is especially useful if you want to display the human-readable test output via stdout and at the same time save the JSON format output to a file.
+
+- `--sarif`:
+  Return results in SARIF format.
+
+- `--sarif-file-output`=<OUTPUT_FILE_PATH>:
+  (only in `test` command)
+  Save test output in SARIF format directly to the <OUTPUT_FILE_PATH> file, regardless of whether or not you use the `--sarif` option.
+  This is especially useful if you want to display the human-readable test output via stdout and at the same time save the SARIF format output to a file.
+
+- `--print-deps`:
+  Print the dependency tree before sending it for analysis.
+
+- `--project-name`=<PROJECT_NAME>:
+  Specify a custom Snyk project name.
+
+- `--policy-path`=<PATH_TO_POLICY_FILE>:
+  Manually pass a path to a snyk policy file.
+
+- `--severity-threshold`=low|medium|high|critical:
+  Only report vulnerabilities of provided level or higher.
+
+- `--username`=<CONTAINER_REGISTRY_USERNAME>:
+  Specify a username to use when connecting to a container registry. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+- `--password`=<CONTAINER_REGISTRY_PASSWORD>:
+  Specify a password to use when connecting to a container registry. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+
+
+
+### Flags available accross all commands
+
+- `--insecure`:
+  Ignore unknown certificate authorities.
+
+- `-d`:
+  Output debug logs.
+
+- `--quiet`, `-q`:
+  Silence all output.
+
+- `--version`, `-v`:
+  Prints versions.
+
+- \[<COMMAND>\] `--help`, `--help` \[<COMMAND>\], `-h`:
+  Prints a help text. You may specify a <COMMAND> to get more details.
+
+
+
+
+## EXIT CODES
+
+Possible exit codes and their meaning:
+
+**0**: success, no vulns found<br />
+**1**: action_needed, vulns found<br />
+**2**: failure, try to re-run command<br />
+**3**: failure, no supported projects detected<br />
+
+
+## ENVIRONMENT
+
+You can set these environment variables to change CLI run settings.
+
+- `SNYK_TOKEN`:
+  Snyk authorization token. Setting this envvar will override the token that may be available in your `snyk config` settings.
+
+  [How to get your account token](https://snyk.co/ucT6J)<br />
+  [How to use Service Accounts](https://snyk.co/ucT6L)<br />
+
+- `SNYK_CFG_KEY`:
+  Allows you to override any key that's also available as `snyk config` option.
+
+  E.g. `SNYK_CFG_ORG`=myorg will override default org option in `config` with "myorg".
+
+- `SNYK_REGISTRY_USERNAME`:
+  Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+- `SNYK_REGISTRY_PASSWORD`:
+  Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+## Connecting to Snyk API
+
+By default Snyk CLI will connect to `https://snyk.io/api/v1`.
+
+- `SNYK_API`:
+  Sets API host to use for Snyk requests. Useful for on-premise instances and configuring proxies. If set with `http` protocol CLI will upgrade the requests to `https`. Unless `SNYK_HTTP_PROTOCOL_UPGRADE` is set to `0`.
+
+- `SNYK_HTTP_PROTOCOL_UPGRADE`=0:
+  If set to the value of `0`, API requests aimed at `http` URLs will not be upgraded to `https`. If not set, the default behavior will be to upgrade these requests from `http` to `https`. Useful e.g., for reverse proxies.
+
+- `HTTPS_PROXY` and `HTTP_PROXY`:
+  Allows you to specify a proxy to use for `https` and `http` calls. The `https` in the `HTTPS_PROXY` means that _requests using `https` protocol_ will use this proxy. The proxy itself doesn't need to use `https`.
+
+
+## NOTICES
+
+### Snyk API usage policy
+
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the [terms & conditions](https://snyk.co/ucT6N)
+

--- a/help/commands-md/snyk-help.md
+++ b/help/commands-md/snyk-help.md
@@ -1,0 +1,88 @@
+# snyk-help(1) -- Prints help topics
+
+## SYNOPSIS
+
+`snyk` `help` \[<TOPIC>\] \[<OPTIONS>\]
+
+## DESCRIPTION
+
+Prints help information. Pass in name of a command as <TOPIC>.
+
+## OPTIONS
+
+
+
+
+### Flags available accross all commands
+
+- `--insecure`:
+  Ignore unknown certificate authorities.
+
+- `-d`:
+  Output debug logs.
+
+- `--quiet`, `-q`:
+  Silence all output.
+
+- `--version`, `-v`:
+  Prints versions.
+
+- \[<COMMAND>\] `--help`, `--help` \[<COMMAND>\], `-h`:
+  Prints a help text. You may specify a <COMMAND> to get more details.
+
+
+
+
+## EXIT CODES
+
+Possible exit codes and their meaning:
+
+**0**: success, no vulns found<br />
+**1**: action_needed, vulns found<br />
+**2**: failure, try to re-run command<br />
+**3**: failure, no supported projects detected<br />
+
+
+## ENVIRONMENT
+
+You can set these environment variables to change CLI run settings.
+
+- `SNYK_TOKEN`:
+  Snyk authorization token. Setting this envvar will override the token that may be available in your `snyk config` settings.
+
+  [How to get your account token](https://snyk.co/ucT6J)<br />
+  [How to use Service Accounts](https://snyk.co/ucT6L)<br />
+
+- `SNYK_CFG_KEY`:
+  Allows you to override any key that's also available as `snyk config` option.
+
+  E.g. `SNYK_CFG_ORG`=myorg will override default org option in `config` with "myorg".
+
+- `SNYK_REGISTRY_USERNAME`:
+  Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+- `SNYK_REGISTRY_PASSWORD`:
+  Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+## Connecting to Snyk API
+
+By default Snyk CLI will connect to `https://snyk.io/api/v1`.
+
+- `SNYK_API`:
+  Sets API host to use for Snyk requests. Useful for on-premise instances and configuring proxies. If set with `http` protocol CLI will upgrade the requests to `https`. Unless `SNYK_HTTP_PROTOCOL_UPGRADE` is set to `0`.
+
+- `SNYK_HTTP_PROTOCOL_UPGRADE`=0:
+  If set to the value of `0`, API requests aimed at `http` URLs will not be upgraded to `https`. If not set, the default behavior will be to upgrade these requests from `http` to `https`. Useful e.g., for reverse proxies.
+
+- `HTTPS_PROXY` and `HTTP_PROXY`:
+  Allows you to specify a proxy to use for `https` and `http` calls. The `https` in the `HTTPS_PROXY` means that _requests using `https` protocol_ will use this proxy. The proxy itself doesn't need to use `https`.
+
+
+## NOTICES
+
+### Snyk API usage policy
+
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the [terms & conditions](https://snyk.co/ucT6N)
+

--- a/help/commands-md/snyk-iac.md
+++ b/help/commands-md/snyk-iac.md
@@ -1,0 +1,157 @@
+# snyk-iac(1) -- Find security issues in your Infrastructure as Code files
+
+## SYNOPSIS
+
+`snyk` `iac` \[<COMMAND>\] \[<OPTIONS>\] <PATH>
+
+## DESCRIPTION
+
+Find security issues in your Infrastructure as Code files.
+
+[For more information see IaC help page](https://snyk.co/ucT6Q)
+
+## COMMANDS
+
+- `test`:
+  Test for any known issue.
+
+## OPTIONS
+
+- `--detection-depth`=<DEPTH>:
+  (only in `test` command)  
+  Indicate the maximum depth of sub-directories to search. <DEPTH> must be a number.
+
+  Default: No Limit  
+  Example: `--detection-depth=3`  
+  Will limit search to provided directory (or current directory if no <PATH> provided) plus two levels of subdirectories.
+
+- `--severity-threshold`=low|medium|high:
+  Only report vulnerabilities of provided level or higher.
+
+- `--json`:
+  Prints results in JSON format.
+
+- `--json-file-output`=<OUTPUT_FILE_PATH>:
+  (only in `test` command)
+  Save test output in JSON format directly to the specified file, regardless of whether or not you use the `--json` option.
+  This is especially useful if you want to display the human-readable test output via stdout and at the same time save the JSON format output to a file.
+
+- `--org`=<ORG_NAME>:
+  Specify the <ORG_NAME> to run Snyk commands tied to a specific organization. This will influence private tests limits.
+  If you have multiple organizations, you can set a default from the CLI using:
+
+  `$ snyk config set org`=<ORG_NAME>
+
+  Setting a default will ensure all newly tested projects will be tested
+  under your default organization. If you need to override the default, you can use the `--org`=<ORG_NAME> argument.
+  Default: uses <ORG_NAME> that sets as default in your [Account settings](https://app.snyk.io/account)
+
+- `--sarif`:
+  Return results in SARIF format.
+
+- `--sarif-file-output`=<OUTPUT_FILE_PATH>:
+  (only in `test` command)
+  Save test output in SARIF format directly to the <OUTPUT_FILE_PATH> file, regardless of whether or not you use the `--sarif` option.
+  This is especially useful if you want to display the human-readable test output via stdout and at the same time save the SARIF format output to a file.
+
+- `--scan=`<TERRAFORM_PLAN_SCAN_MODE>:
+  Dedicated flag for Terraform plan scanning modes.  
+  It enables to control whether the scan should analyse the full final state (e.g. `planned-values`), or the proposed changes only (e.g. `resource-changes`).  
+  Default: If the `--scan` flag is not provided it would scan the proposed changes only by default.  
+  Example #1: `--scan=planned-values` (full state scan)
+  Example #2: `--scan=resource-changes` (proposed changes scan)
+
+
+
+
+### Flags available accross all commands
+
+- `--insecure`:
+  Ignore unknown certificate authorities.
+
+- `-d`:
+  Output debug logs.
+
+- `--quiet`, `-q`:
+  Silence all output.
+
+- `--version`, `-v`:
+  Prints versions.
+
+- \[<COMMAND>\] `--help`, `--help` \[<COMMAND>\], `-h`:
+  Prints a help text. You may specify a <COMMAND> to get more details.
+
+
+## EXAMPLES
+
+[For more information see IaC help page](https://snyk.co/ucT6Q)
+
+- `Test CloudFormation file`:
+  \$ snyk iac test /path/to/cloudformation_file.yaml
+
+- `Test kubernetes file`:
+  \$ snyk iac test /path/to/kubernetes_file.yaml
+
+- `Test terraform file`:
+  \$ snyk iac test /path/to/terraform_file.tf
+
+- `Test terraform plan file`:
+  \$ snyk iac test /path/to/tf-plan.json
+
+- `Test matching files in a directory`:
+  \$ snyk iac test /path/to/directory
+
+
+## EXIT CODES
+
+Possible exit codes and their meaning:
+
+**0**: success, no vulns found<br />
+**1**: action_needed, vulns found<br />
+**2**: failure, try to re-run command<br />
+**3**: failure, no supported projects detected<br />
+
+
+## ENVIRONMENT
+
+You can set these environment variables to change CLI run settings.
+
+- `SNYK_TOKEN`:
+  Snyk authorization token. Setting this envvar will override the token that may be available in your `snyk config` settings.
+
+  [How to get your account token](https://snyk.co/ucT6J)<br />
+  [How to use Service Accounts](https://snyk.co/ucT6L)<br />
+
+- `SNYK_CFG_KEY`:
+  Allows you to override any key that's also available as `snyk config` option.
+
+  E.g. `SNYK_CFG_ORG`=myorg will override default org option in `config` with "myorg".
+
+- `SNYK_REGISTRY_USERNAME`:
+  Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+- `SNYK_REGISTRY_PASSWORD`:
+  Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+## Connecting to Snyk API
+
+By default Snyk CLI will connect to `https://snyk.io/api/v1`.
+
+- `SNYK_API`:
+  Sets API host to use for Snyk requests. Useful for on-premise instances and configuring proxies. If set with `http` protocol CLI will upgrade the requests to `https`. Unless `SNYK_HTTP_PROTOCOL_UPGRADE` is set to `0`.
+
+- `SNYK_HTTP_PROTOCOL_UPGRADE`=0:
+  If set to the value of `0`, API requests aimed at `http` URLs will not be upgraded to `https`. If not set, the default behavior will be to upgrade these requests from `http` to `https`. Useful e.g., for reverse proxies.
+
+- `HTTPS_PROXY` and `HTTP_PROXY`:
+  Allows you to specify a proxy to use for `https` and `http` calls. The `https` in the `HTTPS_PROXY` means that _requests using `https` protocol_ will use this proxy. The proxy itself doesn't need to use `https`.
+
+
+## NOTICES
+
+### Snyk API usage policy
+
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the [terms & conditions](https://snyk.co/ucT6N)
+

--- a/help/commands-md/snyk-ignore.md
+++ b/help/commands-md/snyk-ignore.md
@@ -1,0 +1,109 @@
+# snyk-ignore(1) -- Modifies the .snyk policy to ignore stated issues
+
+## SYNOPSIS
+
+`snyk` `ignore` `--id`=<ISSUE_ID> \[`--expiry`=<EXPIRY>\] \[`--reason`=<REASON>\] \[<OPTIONS>\]
+
+## DESCRIPTION
+
+Ignore a certain issue, according to its snyk ID for all occurrences. This will update your local `.snyk` to contain a similar block:
+
+```yaml
+ignore:
+  '<ISSUE_ID>':
+    - '*':
+        reason: <REASON>
+        expires: <EXPIRY>
+```
+
+## OPTIONS
+
+- `--id`=<ISSUE_ID>:
+  Snyk ID for the issue to ignore. Required.
+
+- `--expiry`=<EXPIRY>:
+  Expiry date, according to [RFC2822](https://tools.ietf.org/html/rfc2822)
+
+- `--reason`=<REASON>:
+  Human-readable <REASON> to ignore this issue.
+
+
+
+
+### Flags available accross all commands
+
+- `--insecure`:
+  Ignore unknown certificate authorities.
+
+- `-d`:
+  Output debug logs.
+
+- `--quiet`, `-q`:
+  Silence all output.
+
+- `--version`, `-v`:
+  Prints versions.
+
+- \[<COMMAND>\] `--help`, `--help` \[<COMMAND>\], `-h`:
+  Prints a help text. You may specify a <COMMAND> to get more details.
+
+
+## EXAMPLES
+
+- `Ignore a specific vulnerability`:
+  \$ snyk ignore --id='npm:qs:20170213' --expiry='2021-01-10' --reason='Module not affected by this vuln'
+
+
+## EXIT CODES
+
+Possible exit codes and their meaning:
+
+**0**: success, no vulns found<br />
+**1**: action_needed, vulns found<br />
+**2**: failure, try to re-run command<br />
+**3**: failure, no supported projects detected<br />
+
+
+## ENVIRONMENT
+
+You can set these environment variables to change CLI run settings.
+
+- `SNYK_TOKEN`:
+  Snyk authorization token. Setting this envvar will override the token that may be available in your `snyk config` settings.
+
+  [How to get your account token](https://snyk.co/ucT6J)<br />
+  [How to use Service Accounts](https://snyk.co/ucT6L)<br />
+
+- `SNYK_CFG_KEY`:
+  Allows you to override any key that's also available as `snyk config` option.
+
+  E.g. `SNYK_CFG_ORG`=myorg will override default org option in `config` with "myorg".
+
+- `SNYK_REGISTRY_USERNAME`:
+  Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+- `SNYK_REGISTRY_PASSWORD`:
+  Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+## Connecting to Snyk API
+
+By default Snyk CLI will connect to `https://snyk.io/api/v1`.
+
+- `SNYK_API`:
+  Sets API host to use for Snyk requests. Useful for on-premise instances and configuring proxies. If set with `http` protocol CLI will upgrade the requests to `https`. Unless `SNYK_HTTP_PROTOCOL_UPGRADE` is set to `0`.
+
+- `SNYK_HTTP_PROTOCOL_UPGRADE`=0:
+  If set to the value of `0`, API requests aimed at `http` URLs will not be upgraded to `https`. If not set, the default behavior will be to upgrade these requests from `http` to `https`. Useful e.g., for reverse proxies.
+
+- `HTTPS_PROXY` and `HTTP_PROXY`:
+  Allows you to specify a proxy to use for `https` and `http` calls. The `https` in the `HTTPS_PROXY` means that _requests using `https` protocol_ will use this proxy. The proxy itself doesn't need to use `https`.
+
+
+## NOTICES
+
+### Snyk API usage policy
+
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the [terms & conditions](https://snyk.co/ucT6N)
+

--- a/help/commands-md/snyk-monitor.md
+++ b/help/commands-md/snyk-monitor.md
@@ -1,0 +1,286 @@
+# snyk-monitor(1) -- Snapshot and continuously monitor your project
+
+## SYNOPSIS
+
+`snyk` `monitor` \[<OPTIONS>\]
+
+## DESCRIPTION
+
+Create a project on the Snyk website that will be continuously monitored for new vulnerabilities. After running this command you will see it by logging in to the website and viewing Your projects.
+
+
+## OPTIONS
+
+To see command-specific flags and usage, see `help` command, e.g. `snyk container --help`.
+For advanced usage, we offer language and context specific flags, listed further down this document.
+
+- `--all-projects`:
+  (only in `test` and `monitor` commands)
+  Auto-detect all projects in working directory
+
+- `--detection-depth`=<DEPTH>:
+  (only in `test` and `monitor` commands)
+  Use with --all-projects or --yarn-workspaces to indicate how many sub-directories to search. `DEPTH` must be a number.
+
+  Default: 4 (the current working directory and 3 sub-directories)
+
+- `--exclude`=<DIRECTORY>[,<DIRECTORY>]...>:
+  (only in `test` and `monitor` commands)
+  Can be used with --all-projects and --yarn-workspaces to indicate sub-directories and files to exclude. Must be comma separated.
+
+  If using with `--detection-depth` exclude ignores directories at any level deep.
+
+- `--prune-repeated-subdependencies`, `-p`:
+  (only in `test` and `monitor` commands)
+  Prune dependency trees, removing duplicate sub-dependencies.
+  Will still find all vulnerabilities, but potentially not all of the vulnerable paths.
+
+- `--print-deps`:
+  (only in `test` and `monitor` commands)
+  Print the dependency tree before sending it for analysis.
+
+- `--remote-repo-url`=<URL>:
+  Set or override the remote URL for the repository that you would like to monitor.
+
+- `--dev`:
+  Include development-only dependencies. Applicable only for some package managers. E.g. _devDependencies_ in npm or _:development_ dependencies in Gemfile.
+
+  Default: scan only production dependencies
+
+- `--org`=<ORG_NAME>:
+  Specify the <ORG_NAME> to run Snyk commands tied to a specific organization. This will influence where will new projects be created after running `monitor` command, some features availability and private tests limits.
+  If you have multiple organizations, you can set a default from the CLI using:
+
+  `$ snyk config set org`=<ORG_NAME>
+
+  Setting a default will ensure all newly monitored projects will be created
+  under your default organization. If you need to override the default, you can use the `--org`=<ORG_NAME> argument.
+
+  Default: uses <ORG_NAME> that sets as default in your [Account settings](https://app.snyk.io/account)
+
+- `--file`=<FILE>:
+  Sets a package file.
+
+  When testing locally or monitoring a project, you can specify the file that Snyk should inspect for package information. When ommitted Snyk will try to detect the appropriate file for your project.
+
+- `--ignore-policy`:
+  Ignores all set policies. The current policy in `.snyk` file, Org level ignores and the project policy on snyk.io.
+
+- `--trust-policies`:
+  Applies and uses ignore rules from your dependencies' Snyk policies, otherwise ignore policies are only shown as a suggestion.
+
+- `--show-vulnerable-paths`=none|some|all:
+  Display the dependency paths from the top level dependencies, down to the vulnerable packages. Doesn't affect output when using JSON `--json` output.
+
+  Default: <some> (a few example paths shown)
+  <false> is an alias for <none>.
+
+- `--project-name`=<PROJECT_NAME>:
+  Specify a custom Snyk project name.
+
+- `--policy-path`=<PATH_TO_POLICY_FILE>`:
+  Manually pass a path to a snyk policy file.
+
+- `--json`:
+  Prints results in JSON format.
+
+- `--json-file-output`=<OUTPUT_FILE_PATH>:
+  (only in `test` command)
+  Save test output in JSON format directly to the specified file, regardless of whether or not you use the `--json` option.
+  This is especially useful if you want to display the human-readable test output via stdout and at the same time save the JSON format output to a file.
+
+- `--sarif`:
+  Return results in SARIF format.
+
+- `--sarif-file-output`=<OUTPUT_FILE_PATH>:
+  (only in `test` command)
+  Save test output in SARIF format directly to the <OUTPUT_FILE_PATH> file, regardless of whether or not you use the `--sarif` option.
+  This is especially useful if you want to display the human-readable test output via stdout and at the same time save the SARIF format output to a file.
+
+- `--severity-threshold`=low|medium|high|critical:
+  Only report vulnerabilities of provided level or higher.
+
+- `--fail-on`=all|upgradable|patchable:
+  Only fail when there are vulnerabilities that can be fixed.
+
+  <all> fails when there is at least one vulnerability that can be either upgraded or patched.
+  <upgradable> fails when there is at least one vulnerability that can be upgraded.
+  <patchable> fails when there is at least one vulnerability that can be patched.
+
+  If vulnerabilities do not have a fix and this option is being used, tests will pass.
+
+- `--dry-run`:
+  (only in `protect` command)
+  Don't apply updates or patches during `protect` command run.
+
+- `--` \[<COMPILER_OPTIONS>\]:
+  Pass extra arguments directly to Gradle or Maven.
+  E.g. `snyk test -- --build-cache`
+
+Below are flags that are influencing CLI behavior for specific projects, languages and contexts:
+
+### Maven options
+
+- `--scan-all-unmanaged`:
+  Auto detects maven jars, aars, and wars in given directory. Individual testing can be done with `--file`=<JAR_FILE_NAME>
+
+- `--reachable`:
+  (only in `test` and `monitor` commands)
+  Analyze your source code to find which vulnerable
+  functions and packages are called.
+
+- `--reachable-timeout`=<TIMEOUT>:
+  The amount of time (in seconds) to wait for Snyk to gather reachability data. If it takes longer than <TIMEOUT>, Reachable Vulnerabilities are not reported. This does not affect regular test or monitor output.
+
+  Default: 300 (5 minutes).
+
+### Gradle options
+
+[More information about Gradle CLI options](https://snyk.co/ucT6P)
+
+- `--sub-project`=<NAME>, `--gradle-sub-project`=<NAME>:
+  For Gradle "multi project" configurations, test a specific sub-project.
+
+- `--all-sub-projects`:
+  For "multi project" configurations, test all sub-projects.
+
+- `--configuration-matching`=<CONFIGURATION_REGEX>:
+  Resolve dependencies using only configuration(s) that match the provided Java regular expression, e.g. `^releaseRuntimeClasspath$`.
+
+- `--configuration-attributes`=<ATTRIBUTE>[,<ATTRIBUTE>]...:
+  Select certain values of configuration attributes to resolve the dependencies. E.g. `buildtype:release,usage:java-runtime`
+
+- `--reachable`:
+  (only in `test` and `monitor` commands)
+  Analyze your source code to find which vulnerable
+  functions and packages are called.
+
+- `--reachable-timeout`=<TIMEOUT>:
+  The amount of time (in seconds) to wait for Snyk to gather reachability data. If it takes longer than <TIMEOUT>, Reachable Vulnerabilities are not reported. This does not affect regular test or monitor output.
+
+  Default: 300 (5 minutes).
+
+- `--init-script`=<FILE>
+  For projects that contain a gradle initialization script.
+
+### .Net & NuGet options
+
+- `--assets-project-name`:
+  When monitoring a .NET project using NuGet `PackageReference` use the project name in project.assets.json, if found.
+
+- `--packages-folder`:
+  Custom path to packages folder
+
+- `--project-name-prefix`=<PREFIX_STRING>:
+  When monitoring a .NET project, use this flag to add a custom prefix to the name of files inside a project along with any desired separators, e.g. `snyk monitor --file=my-project.sln --project-name-prefix=my-group/`. This is useful when you have multiple projects with the same name in other sln files.
+
+### npm options
+
+- `--strict-out-of-sync`=true|false:
+  Control testing out of sync lockfiles.
+
+  Default: true
+
+### Yarn options
+
+- `--strict-out-of-sync`=true|false:
+  Control testing out of sync lockfiles.
+
+  Default: true
+
+- `--yarn-workspaces`:
+  (only in `test` and `monitor` commands)
+  Detect and scan yarn workspaces. You can specify how many sub-directories to search using `--detection-depth` and exclude directories and files using `--exclude`.
+
+### CocoaPods options
+
+- `--strict-out-of-sync`=true|false:
+  Control testing out of sync lockfiles.
+
+  Default: false
+
+### Python options
+
+- `--command`=<COMMAND>:
+  Indicate which specific Python commands to use based on Python version. The default is `python` which executes your systems default python version. Run 'python -V' to find out what version is it. If you are using multiple Python versions, use this parameter to specify the correct Python command for execution.
+
+  Default: `python`
+  Example: `--command=python3`
+
+- `--skip-unresolved`=true|false:
+  Allow skipping packages that are not found in the environment.
+
+
+### Flags available accross all commands
+
+- `--insecure`:
+  Ignore unknown certificate authorities.
+
+- `-d`:
+  Output debug logs.
+
+- `--quiet`, `-q`:
+  Silence all output.
+
+- `--version`, `-v`:
+  Prints versions.
+
+- \[<COMMAND>\] `--help`, `--help` \[<COMMAND>\], `-h`:
+  Prints a help text. You may specify a <COMMAND> to get more details.
+
+
+
+
+## EXIT CODES
+
+Possible exit codes and their meaning:
+
+**0**: success, no vulns found<br />
+**1**: action_needed, vulns found<br />
+**2**: failure, try to re-run command<br />
+**3**: failure, no supported projects detected<br />
+
+
+## ENVIRONMENT
+
+You can set these environment variables to change CLI run settings.
+
+- `SNYK_TOKEN`:
+  Snyk authorization token. Setting this envvar will override the token that may be available in your `snyk config` settings.
+
+  [How to get your account token](https://snyk.co/ucT6J)<br />
+  [How to use Service Accounts](https://snyk.co/ucT6L)<br />
+
+- `SNYK_CFG_KEY`:
+  Allows you to override any key that's also available as `snyk config` option.
+
+  E.g. `SNYK_CFG_ORG`=myorg will override default org option in `config` with "myorg".
+
+- `SNYK_REGISTRY_USERNAME`:
+  Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+- `SNYK_REGISTRY_PASSWORD`:
+  Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+## Connecting to Snyk API
+
+By default Snyk CLI will connect to `https://snyk.io/api/v1`.
+
+- `SNYK_API`:
+  Sets API host to use for Snyk requests. Useful for on-premise instances and configuring proxies. If set with `http` protocol CLI will upgrade the requests to `https`. Unless `SNYK_HTTP_PROTOCOL_UPGRADE` is set to `0`.
+
+- `SNYK_HTTP_PROTOCOL_UPGRADE`=0:
+  If set to the value of `0`, API requests aimed at `http` URLs will not be upgraded to `https`. If not set, the default behavior will be to upgrade these requests from `http` to `https`. Useful e.g., for reverse proxies.
+
+- `HTTPS_PROXY` and `HTTP_PROXY`:
+  Allows you to specify a proxy to use for `https` and `http` calls. The `https` in the `HTTPS_PROXY` means that _requests using `https` protocol_ will use this proxy. The proxy itself doesn't need to use `https`.
+
+
+## NOTICES
+
+### Snyk API usage policy
+
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the [terms & conditions](https://snyk.co/ucT6N)
+

--- a/help/commands-md/snyk-policy.md
+++ b/help/commands-md/snyk-policy.md
@@ -1,0 +1,91 @@
+# snyk-policy(1) -- Display the .snyk policy for a package
+
+## SYNOPSIS
+
+`snyk` `policy` \[<PATH_TO_POLICY_FILE>\] \[<OPTIONS>\]
+
+## DESCRIPTION
+
+Displays a `.snyk` policy file.
+
+## OPTIONS
+
+- <PATH_TO_POLICY_FILE>:
+  Manually pass a path to a snyk policy file.
+
+
+
+
+### Flags available accross all commands
+
+- `--insecure`:
+  Ignore unknown certificate authorities.
+
+- `-d`:
+  Output debug logs.
+
+- `--quiet`, `-q`:
+  Silence all output.
+
+- `--version`, `-v`:
+  Prints versions.
+
+- \[<COMMAND>\] `--help`, `--help` \[<COMMAND>\], `-h`:
+  Prints a help text. You may specify a <COMMAND> to get more details.
+
+
+
+
+## EXIT CODES
+
+Possible exit codes and their meaning:
+
+**0**: success, no vulns found<br />
+**1**: action_needed, vulns found<br />
+**2**: failure, try to re-run command<br />
+**3**: failure, no supported projects detected<br />
+
+
+## ENVIRONMENT
+
+You can set these environment variables to change CLI run settings.
+
+- `SNYK_TOKEN`:
+  Snyk authorization token. Setting this envvar will override the token that may be available in your `snyk config` settings.
+
+  [How to get your account token](https://snyk.co/ucT6J)<br />
+  [How to use Service Accounts](https://snyk.co/ucT6L)<br />
+
+- `SNYK_CFG_KEY`:
+  Allows you to override any key that's also available as `snyk config` option.
+
+  E.g. `SNYK_CFG_ORG`=myorg will override default org option in `config` with "myorg".
+
+- `SNYK_REGISTRY_USERNAME`:
+  Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+- `SNYK_REGISTRY_PASSWORD`:
+  Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+## Connecting to Snyk API
+
+By default Snyk CLI will connect to `https://snyk.io/api/v1`.
+
+- `SNYK_API`:
+  Sets API host to use for Snyk requests. Useful for on-premise instances and configuring proxies. If set with `http` protocol CLI will upgrade the requests to `https`. Unless `SNYK_HTTP_PROTOCOL_UPGRADE` is set to `0`.
+
+- `SNYK_HTTP_PROTOCOL_UPGRADE`=0:
+  If set to the value of `0`, API requests aimed at `http` URLs will not be upgraded to `https`. If not set, the default behavior will be to upgrade these requests from `http` to `https`. Useful e.g., for reverse proxies.
+
+- `HTTPS_PROXY` and `HTTP_PROXY`:
+  Allows you to specify a proxy to use for `https` and `http` calls. The `https` in the `HTTPS_PROXY` means that _requests using `https` protocol_ will use this proxy. The proxy itself doesn't need to use `https`.
+
+
+## NOTICES
+
+### Snyk API usage policy
+
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the [terms & conditions](https://snyk.co/ucT6N)
+

--- a/help/commands-md/snyk-protect.md
+++ b/help/commands-md/snyk-protect.md
@@ -1,0 +1,91 @@
+# snyk-protect(1) -- Applies the patches specified in your .snyk file to the local file system
+
+## SYNOPSIS
+
+`snyk` `protect` \[<OPTIONS>\]
+
+## DESCRIPTION
+
+`$ snyk protect` is used to apply patches to your vulnerable dependencies. It's useful after opening a fix pull request from our website (GitHub only) or after running snyk wizard on the CLI. snyk protect reads a .snyk policy file to determine what patches to apply.
+
+## OPTIONS
+
+- `--dry-run`:
+  Don't apply updates or patches when running.
+
+
+
+
+### Flags available accross all commands
+
+- `--insecure`:
+  Ignore unknown certificate authorities.
+
+- `-d`:
+  Output debug logs.
+
+- `--quiet`, `-q`:
+  Silence all output.
+
+- `--version`, `-v`:
+  Prints versions.
+
+- \[<COMMAND>\] `--help`, `--help` \[<COMMAND>\], `-h`:
+  Prints a help text. You may specify a <COMMAND> to get more details.
+
+
+
+
+## EXIT CODES
+
+Possible exit codes and their meaning:
+
+**0**: success, no vulns found<br />
+**1**: action_needed, vulns found<br />
+**2**: failure, try to re-run command<br />
+**3**: failure, no supported projects detected<br />
+
+
+## ENVIRONMENT
+
+You can set these environment variables to change CLI run settings.
+
+- `SNYK_TOKEN`:
+  Snyk authorization token. Setting this envvar will override the token that may be available in your `snyk config` settings.
+
+  [How to get your account token](https://snyk.co/ucT6J)<br />
+  [How to use Service Accounts](https://snyk.co/ucT6L)<br />
+
+- `SNYK_CFG_KEY`:
+  Allows you to override any key that's also available as `snyk config` option.
+
+  E.g. `SNYK_CFG_ORG`=myorg will override default org option in `config` with "myorg".
+
+- `SNYK_REGISTRY_USERNAME`:
+  Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+- `SNYK_REGISTRY_PASSWORD`:
+  Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+## Connecting to Snyk API
+
+By default Snyk CLI will connect to `https://snyk.io/api/v1`.
+
+- `SNYK_API`:
+  Sets API host to use for Snyk requests. Useful for on-premise instances and configuring proxies. If set with `http` protocol CLI will upgrade the requests to `https`. Unless `SNYK_HTTP_PROTOCOL_UPGRADE` is set to `0`.
+
+- `SNYK_HTTP_PROTOCOL_UPGRADE`=0:
+  If set to the value of `0`, API requests aimed at `http` URLs will not be upgraded to `https`. If not set, the default behavior will be to upgrade these requests from `http` to `https`. Useful e.g., for reverse proxies.
+
+- `HTTPS_PROXY` and `HTTP_PROXY`:
+  Allows you to specify a proxy to use for `https` and `http` calls. The `https` in the `HTTPS_PROXY` means that _requests using `https` protocol_ will use this proxy. The proxy itself doesn't need to use `https`.
+
+
+## NOTICES
+
+### Snyk API usage policy
+
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the [terms & conditions](https://snyk.co/ucT6N)
+

--- a/help/commands-md/snyk-test.md
+++ b/help/commands-md/snyk-test.md
@@ -1,0 +1,286 @@
+# snyk-test(1) -- test local project for vulnerabilities
+
+## SYNOPSIS
+
+`snyk` `test` \[<OPTIONS>\]
+
+## DESCRIPTION
+
+Test command checks locally installed projects for vulnerabilities. It tries to autodetect supported manifest files with dependencies and test those.
+
+
+## OPTIONS
+
+To see command-specific flags and usage, see `help` command, e.g. `snyk container --help`.
+For advanced usage, we offer language and context specific flags, listed further down this document.
+
+- `--all-projects`:
+  (only in `test` and `monitor` commands)
+  Auto-detect all projects in working directory
+
+- `--detection-depth`=<DEPTH>:
+  (only in `test` and `monitor` commands)
+  Use with --all-projects or --yarn-workspaces to indicate how many sub-directories to search. `DEPTH` must be a number.
+
+  Default: 4 (the current working directory and 3 sub-directories)
+
+- `--exclude`=<DIRECTORY>[,<DIRECTORY>]...>:
+  (only in `test` and `monitor` commands)
+  Can be used with --all-projects and --yarn-workspaces to indicate sub-directories and files to exclude. Must be comma separated.
+
+  If using with `--detection-depth` exclude ignores directories at any level deep.
+
+- `--prune-repeated-subdependencies`, `-p`:
+  (only in `test` and `monitor` commands)
+  Prune dependency trees, removing duplicate sub-dependencies.
+  Will still find all vulnerabilities, but potentially not all of the vulnerable paths.
+
+- `--print-deps`:
+  (only in `test` and `monitor` commands)
+  Print the dependency tree before sending it for analysis.
+
+- `--remote-repo-url`=<URL>:
+  Set or override the remote URL for the repository that you would like to monitor.
+
+- `--dev`:
+  Include development-only dependencies. Applicable only for some package managers. E.g. _devDependencies_ in npm or _:development_ dependencies in Gemfile.
+
+  Default: scan only production dependencies
+
+- `--org`=<ORG_NAME>:
+  Specify the <ORG_NAME> to run Snyk commands tied to a specific organization. This will influence where will new projects be created after running `monitor` command, some features availability and private tests limits.
+  If you have multiple organizations, you can set a default from the CLI using:
+
+  `$ snyk config set org`=<ORG_NAME>
+
+  Setting a default will ensure all newly monitored projects will be created
+  under your default organization. If you need to override the default, you can use the `--org`=<ORG_NAME> argument.
+
+  Default: uses <ORG_NAME> that sets as default in your [Account settings](https://app.snyk.io/account)
+
+- `--file`=<FILE>:
+  Sets a package file.
+
+  When testing locally or monitoring a project, you can specify the file that Snyk should inspect for package information. When ommitted Snyk will try to detect the appropriate file for your project.
+
+- `--ignore-policy`:
+  Ignores all set policies. The current policy in `.snyk` file, Org level ignores and the project policy on snyk.io.
+
+- `--trust-policies`:
+  Applies and uses ignore rules from your dependencies' Snyk policies, otherwise ignore policies are only shown as a suggestion.
+
+- `--show-vulnerable-paths`=none|some|all:
+  Display the dependency paths from the top level dependencies, down to the vulnerable packages. Doesn't affect output when using JSON `--json` output.
+
+  Default: <some> (a few example paths shown)
+  <false> is an alias for <none>.
+
+- `--project-name`=<PROJECT_NAME>:
+  Specify a custom Snyk project name.
+
+- `--policy-path`=<PATH_TO_POLICY_FILE>`:
+  Manually pass a path to a snyk policy file.
+
+- `--json`:
+  Prints results in JSON format.
+
+- `--json-file-output`=<OUTPUT_FILE_PATH>:
+  (only in `test` command)
+  Save test output in JSON format directly to the specified file, regardless of whether or not you use the `--json` option.
+  This is especially useful if you want to display the human-readable test output via stdout and at the same time save the JSON format output to a file.
+
+- `--sarif`:
+  Return results in SARIF format.
+
+- `--sarif-file-output`=<OUTPUT_FILE_PATH>:
+  (only in `test` command)
+  Save test output in SARIF format directly to the <OUTPUT_FILE_PATH> file, regardless of whether or not you use the `--sarif` option.
+  This is especially useful if you want to display the human-readable test output via stdout and at the same time save the SARIF format output to a file.
+
+- `--severity-threshold`=low|medium|high|critical:
+  Only report vulnerabilities of provided level or higher.
+
+- `--fail-on`=all|upgradable|patchable:
+  Only fail when there are vulnerabilities that can be fixed.
+
+  <all> fails when there is at least one vulnerability that can be either upgraded or patched.
+  <upgradable> fails when there is at least one vulnerability that can be upgraded.
+  <patchable> fails when there is at least one vulnerability that can be patched.
+
+  If vulnerabilities do not have a fix and this option is being used, tests will pass.
+
+- `--dry-run`:
+  (only in `protect` command)
+  Don't apply updates or patches during `protect` command run.
+
+- `--` \[<COMPILER_OPTIONS>\]:
+  Pass extra arguments directly to Gradle or Maven.
+  E.g. `snyk test -- --build-cache`
+
+Below are flags that are influencing CLI behavior for specific projects, languages and contexts:
+
+### Maven options
+
+- `--scan-all-unmanaged`:
+  Auto detects maven jars, aars, and wars in given directory. Individual testing can be done with `--file`=<JAR_FILE_NAME>
+
+- `--reachable`:
+  (only in `test` and `monitor` commands)
+  Analyze your source code to find which vulnerable
+  functions and packages are called.
+
+- `--reachable-timeout`=<TIMEOUT>:
+  The amount of time (in seconds) to wait for Snyk to gather reachability data. If it takes longer than <TIMEOUT>, Reachable Vulnerabilities are not reported. This does not affect regular test or monitor output.
+
+  Default: 300 (5 minutes).
+
+### Gradle options
+
+[More information about Gradle CLI options](https://snyk.co/ucT6P)
+
+- `--sub-project`=<NAME>, `--gradle-sub-project`=<NAME>:
+  For Gradle "multi project" configurations, test a specific sub-project.
+
+- `--all-sub-projects`:
+  For "multi project" configurations, test all sub-projects.
+
+- `--configuration-matching`=<CONFIGURATION_REGEX>:
+  Resolve dependencies using only configuration(s) that match the provided Java regular expression, e.g. `^releaseRuntimeClasspath$`.
+
+- `--configuration-attributes`=<ATTRIBUTE>[,<ATTRIBUTE>]...:
+  Select certain values of configuration attributes to resolve the dependencies. E.g. `buildtype:release,usage:java-runtime`
+
+- `--reachable`:
+  (only in `test` and `monitor` commands)
+  Analyze your source code to find which vulnerable
+  functions and packages are called.
+
+- `--reachable-timeout`=<TIMEOUT>:
+  The amount of time (in seconds) to wait for Snyk to gather reachability data. If it takes longer than <TIMEOUT>, Reachable Vulnerabilities are not reported. This does not affect regular test or monitor output.
+
+  Default: 300 (5 minutes).
+
+- `--init-script`=<FILE>
+  For projects that contain a gradle initialization script.
+
+### .Net & NuGet options
+
+- `--assets-project-name`:
+  When monitoring a .NET project using NuGet `PackageReference` use the project name in project.assets.json, if found.
+
+- `--packages-folder`:
+  Custom path to packages folder
+
+- `--project-name-prefix`=<PREFIX_STRING>:
+  When monitoring a .NET project, use this flag to add a custom prefix to the name of files inside a project along with any desired separators, e.g. `snyk monitor --file=my-project.sln --project-name-prefix=my-group/`. This is useful when you have multiple projects with the same name in other sln files.
+
+### npm options
+
+- `--strict-out-of-sync`=true|false:
+  Control testing out of sync lockfiles.
+
+  Default: true
+
+### Yarn options
+
+- `--strict-out-of-sync`=true|false:
+  Control testing out of sync lockfiles.
+
+  Default: true
+
+- `--yarn-workspaces`:
+  (only in `test` and `monitor` commands)
+  Detect and scan yarn workspaces. You can specify how many sub-directories to search using `--detection-depth` and exclude directories and files using `--exclude`.
+
+### CocoaPods options
+
+- `--strict-out-of-sync`=true|false:
+  Control testing out of sync lockfiles.
+
+  Default: false
+
+### Python options
+
+- `--command`=<COMMAND>:
+  Indicate which specific Python commands to use based on Python version. The default is `python` which executes your systems default python version. Run 'python -V' to find out what version is it. If you are using multiple Python versions, use this parameter to specify the correct Python command for execution.
+
+  Default: `python`
+  Example: `--command=python3`
+
+- `--skip-unresolved`=true|false:
+  Allow skipping packages that are not found in the environment.
+
+
+### Flags available accross all commands
+
+- `--insecure`:
+  Ignore unknown certificate authorities.
+
+- `-d`:
+  Output debug logs.
+
+- `--quiet`, `-q`:
+  Silence all output.
+
+- `--version`, `-v`:
+  Prints versions.
+
+- \[<COMMAND>\] `--help`, `--help` \[<COMMAND>\], `-h`:
+  Prints a help text. You may specify a <COMMAND> to get more details.
+
+
+
+
+## EXIT CODES
+
+Possible exit codes and their meaning:
+
+**0**: success, no vulns found<br />
+**1**: action_needed, vulns found<br />
+**2**: failure, try to re-run command<br />
+**3**: failure, no supported projects detected<br />
+
+
+## ENVIRONMENT
+
+You can set these environment variables to change CLI run settings.
+
+- `SNYK_TOKEN`:
+  Snyk authorization token. Setting this envvar will override the token that may be available in your `snyk config` settings.
+
+  [How to get your account token](https://snyk.co/ucT6J)<br />
+  [How to use Service Accounts](https://snyk.co/ucT6L)<br />
+
+- `SNYK_CFG_KEY`:
+  Allows you to override any key that's also available as `snyk config` option.
+
+  E.g. `SNYK_CFG_ORG`=myorg will override default org option in `config` with "myorg".
+
+- `SNYK_REGISTRY_USERNAME`:
+  Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+- `SNYK_REGISTRY_PASSWORD`:
+  Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+## Connecting to Snyk API
+
+By default Snyk CLI will connect to `https://snyk.io/api/v1`.
+
+- `SNYK_API`:
+  Sets API host to use for Snyk requests. Useful for on-premise instances and configuring proxies. If set with `http` protocol CLI will upgrade the requests to `https`. Unless `SNYK_HTTP_PROTOCOL_UPGRADE` is set to `0`.
+
+- `SNYK_HTTP_PROTOCOL_UPGRADE`=0:
+  If set to the value of `0`, API requests aimed at `http` URLs will not be upgraded to `https`. If not set, the default behavior will be to upgrade these requests from `http` to `https`. Useful e.g., for reverse proxies.
+
+- `HTTPS_PROXY` and `HTTP_PROXY`:
+  Allows you to specify a proxy to use for `https` and `http` calls. The `https` in the `HTTPS_PROXY` means that _requests using `https` protocol_ will use this proxy. The proxy itself doesn't need to use `https`.
+
+
+## NOTICES
+
+### Snyk API usage policy
+
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the [terms & conditions](https://snyk.co/ucT6N)
+

--- a/help/commands-md/snyk-wizard.md
+++ b/help/commands-md/snyk-wizard.md
@@ -1,0 +1,93 @@
+# snyk-wizard(1) -- Configure your policy file to update, auto patch and ignore vulnerabilities
+
+## SYNOPSIS
+
+`snyk` `wizard` \[<OPTIONS>\]
+
+## DESCRIPTION
+
+Snyk's wizard will:
+
+- Enumerate your local dependencies and query Snyk's servers for vulnerabilities
+- Guide you through fixing found vulnerabilities
+- Create a .snyk policy file to guide snyk commands such as `test` and `protect`
+- Remember your dependencies to alert you when new vulnerabilities are disclosed
+
+## OPTIONS
+
+
+
+
+### Flags available accross all commands
+
+- `--insecure`:
+  Ignore unknown certificate authorities.
+
+- `-d`:
+  Output debug logs.
+
+- `--quiet`, `-q`:
+  Silence all output.
+
+- `--version`, `-v`:
+  Prints versions.
+
+- \[<COMMAND>\] `--help`, `--help` \[<COMMAND>\], `-h`:
+  Prints a help text. You may specify a <COMMAND> to get more details.
+
+
+
+
+## EXIT CODES
+
+Possible exit codes and their meaning:
+
+**0**: success, no vulns found<br />
+**1**: action_needed, vulns found<br />
+**2**: failure, try to re-run command<br />
+**3**: failure, no supported projects detected<br />
+
+
+## ENVIRONMENT
+
+You can set these environment variables to change CLI run settings.
+
+- `SNYK_TOKEN`:
+  Snyk authorization token. Setting this envvar will override the token that may be available in your `snyk config` settings.
+
+  [How to get your account token](https://snyk.co/ucT6J)<br />
+  [How to use Service Accounts](https://snyk.co/ucT6L)<br />
+
+- `SNYK_CFG_KEY`:
+  Allows you to override any key that's also available as `snyk config` option.
+
+  E.g. `SNYK_CFG_ORG`=myorg will override default org option in `config` with "myorg".
+
+- `SNYK_REGISTRY_USERNAME`:
+  Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+- `SNYK_REGISTRY_PASSWORD`:
+  Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+## Connecting to Snyk API
+
+By default Snyk CLI will connect to `https://snyk.io/api/v1`.
+
+- `SNYK_API`:
+  Sets API host to use for Snyk requests. Useful for on-premise instances and configuring proxies. If set with `http` protocol CLI will upgrade the requests to `https`. Unless `SNYK_HTTP_PROTOCOL_UPGRADE` is set to `0`.
+
+- `SNYK_HTTP_PROTOCOL_UPGRADE`=0:
+  If set to the value of `0`, API requests aimed at `http` URLs will not be upgraded to `https`. If not set, the default behavior will be to upgrade these requests from `http` to `https`. Useful e.g., for reverse proxies.
+
+- `HTTPS_PROXY` and `HTTP_PROXY`:
+  Allows you to specify a proxy to use for `https` and `http` calls. The `https` in the `HTTPS_PROXY` means that _requests using `https` protocol_ will use this proxy. The proxy itself doesn't need to use `https`.
+
+
+## NOTICES
+
+### Snyk API usage policy
+
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the [terms & conditions](https://snyk.co/ucT6N)
+

--- a/help/commands-md/snyk-woof.md
+++ b/help/commands-md/snyk-woof.md
@@ -1,0 +1,91 @@
+# snyk-woof(1) -- W00f
+
+## SYNOPSIS
+
+`snyk` `woof` \[<OPTIONS>\]
+
+## DESCRIPTION
+
+Easter egg that prints a Patch ascii art.
+
+## OPTIONS
+
+- `--language`=<LANGUAGE>:
+  Woof in a specific language. <LANGUAGE> should be a ISO 639-1 code.
+
+
+
+
+### Flags available accross all commands
+
+- `--insecure`:
+  Ignore unknown certificate authorities.
+
+- `-d`:
+  Output debug logs.
+
+- `--quiet`, `-q`:
+  Silence all output.
+
+- `--version`, `-v`:
+  Prints versions.
+
+- \[<COMMAND>\] `--help`, `--help` \[<COMMAND>\], `-h`:
+  Prints a help text. You may specify a <COMMAND> to get more details.
+
+
+
+
+## EXIT CODES
+
+Possible exit codes and their meaning:
+
+**0**: success, no vulns found<br />
+**1**: action_needed, vulns found<br />
+**2**: failure, try to re-run command<br />
+**3**: failure, no supported projects detected<br />
+
+
+## ENVIRONMENT
+
+You can set these environment variables to change CLI run settings.
+
+- `SNYK_TOKEN`:
+  Snyk authorization token. Setting this envvar will override the token that may be available in your `snyk config` settings.
+
+  [How to get your account token](https://snyk.co/ucT6J)<br />
+  [How to use Service Accounts](https://snyk.co/ucT6L)<br />
+
+- `SNYK_CFG_KEY`:
+  Allows you to override any key that's also available as `snyk config` option.
+
+  E.g. `SNYK_CFG_ORG`=myorg will override default org option in `config` with "myorg".
+
+- `SNYK_REGISTRY_USERNAME`:
+  Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+- `SNYK_REGISTRY_PASSWORD`:
+  Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+## Connecting to Snyk API
+
+By default Snyk CLI will connect to `https://snyk.io/api/v1`.
+
+- `SNYK_API`:
+  Sets API host to use for Snyk requests. Useful for on-premise instances and configuring proxies. If set with `http` protocol CLI will upgrade the requests to `https`. Unless `SNYK_HTTP_PROTOCOL_UPGRADE` is set to `0`.
+
+- `SNYK_HTTP_PROTOCOL_UPGRADE`=0:
+  If set to the value of `0`, API requests aimed at `http` URLs will not be upgraded to `https`. If not set, the default behavior will be to upgrade these requests from `http` to `https`. Useful e.g., for reverse proxies.
+
+- `HTTPS_PROXY` and `HTTP_PROXY`:
+  Allows you to specify a proxy to use for `https` and `http` calls. The `https` in the `HTTPS_PROXY` means that _requests using `https` protocol_ will use this proxy. The proxy itself doesn't need to use `https`.
+
+
+## NOTICES
+
+### Snyk API usage policy
+
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the [terms & conditions](https://snyk.co/ucT6N)
+

--- a/help/commands-md/snyk.md
+++ b/help/commands-md/snyk.md
@@ -1,0 +1,357 @@
+# snyk(1) -- CLI and build-time tool to find & fix known vulnerabilities in open-source dependencies
+
+## SYNOPSIS
+
+`snyk` \[<COMMAND>] \[<SUBCOMMAND>] \[<OPTIONS>] \[<PACKAGE>] \[-- <COMPILER_OPTIONS>]
+
+## DESCRIPTION
+
+Snyk helps you find, fix and monitor known vulnerabilities in open source dependencies.<br />
+For more information see https://snyk.io
+
+### Not sure where to start?
+
+1. authenticate with `$ snyk auth`
+2. test your local project with `$ snyk test`
+3. get alerted for new vulnerabilities with `$ snyk monitor`
+
+## COMMANDS
+
+To see command-specific flags and usage, see `help` command, e.g. `snyk container --help`.
+Available top-level CLI commands:
+
+- `auth` \[<API_TOKEN>\]:
+  Authenticate Snyk CLI with a Snyk account.
+
+- `test`:
+  Test local project for vulnerabilities.
+
+- `monitor`:
+  Snapshot and continuously monitor your project.
+
+- `container`:
+  Test container images for vulnerabilities. See `snyk container --help` for full instructions.
+
+- `iac`:
+  Find security issues in your Infrastructure as Code files. See `snyk iac --help` for full instructions.
+
+- `config`:
+  Manage Snyk CLI configuration.
+
+- `protect`:
+  Applies the patches specified in your .snyk file to the local file system.
+
+- `policy`:
+  Display the .snyk policy for a package.
+
+- `ignore`:
+  Modifies the .snyk policy to ignore stated issues.
+
+- `wizard`:
+  Configure your policy file to update, auto patch and ignore vulnerabilities. Snyk wizard updates your .snyk file.
+
+
+## OPTIONS
+
+To see command-specific flags and usage, see `help` command, e.g. `snyk container --help`.
+For advanced usage, we offer language and context specific flags, listed further down this document.
+
+- `--all-projects`:
+  (only in `test` and `monitor` commands)
+  Auto-detect all projects in working directory
+
+- `--detection-depth`=<DEPTH>:
+  (only in `test` and `monitor` commands)
+  Use with --all-projects or --yarn-workspaces to indicate how many sub-directories to search. `DEPTH` must be a number.
+
+  Default: 4 (the current working directory and 3 sub-directories)
+
+- `--exclude`=<DIRECTORY>[,<DIRECTORY>]...>:
+  (only in `test` and `monitor` commands)
+  Can be used with --all-projects and --yarn-workspaces to indicate sub-directories and files to exclude. Must be comma separated.
+
+  If using with `--detection-depth` exclude ignores directories at any level deep.
+
+- `--prune-repeated-subdependencies`, `-p`:
+  (only in `test` and `monitor` commands)
+  Prune dependency trees, removing duplicate sub-dependencies.
+  Will still find all vulnerabilities, but potentially not all of the vulnerable paths.
+
+- `--print-deps`:
+  (only in `test` and `monitor` commands)
+  Print the dependency tree before sending it for analysis.
+
+- `--remote-repo-url`=<URL>:
+  Set or override the remote URL for the repository that you would like to monitor.
+
+- `--dev`:
+  Include development-only dependencies. Applicable only for some package managers. E.g. _devDependencies_ in npm or _:development_ dependencies in Gemfile.
+
+  Default: scan only production dependencies
+
+- `--org`=<ORG_NAME>:
+  Specify the <ORG_NAME> to run Snyk commands tied to a specific organization. This will influence where will new projects be created after running `monitor` command, some features availability and private tests limits.
+  If you have multiple organizations, you can set a default from the CLI using:
+
+  `$ snyk config set org`=<ORG_NAME>
+
+  Setting a default will ensure all newly monitored projects will be created
+  under your default organization. If you need to override the default, you can use the `--org`=<ORG_NAME> argument.
+
+  Default: uses <ORG_NAME> that sets as default in your [Account settings](https://app.snyk.io/account)
+
+- `--file`=<FILE>:
+  Sets a package file.
+
+  When testing locally or monitoring a project, you can specify the file that Snyk should inspect for package information. When ommitted Snyk will try to detect the appropriate file for your project.
+
+- `--ignore-policy`:
+  Ignores all set policies. The current policy in `.snyk` file, Org level ignores and the project policy on snyk.io.
+
+- `--trust-policies`:
+  Applies and uses ignore rules from your dependencies' Snyk policies, otherwise ignore policies are only shown as a suggestion.
+
+- `--show-vulnerable-paths`=none|some|all:
+  Display the dependency paths from the top level dependencies, down to the vulnerable packages. Doesn't affect output when using JSON `--json` output.
+
+  Default: <some> (a few example paths shown)
+  <false> is an alias for <none>.
+
+- `--project-name`=<PROJECT_NAME>:
+  Specify a custom Snyk project name.
+
+- `--policy-path`=<PATH_TO_POLICY_FILE>`:
+  Manually pass a path to a snyk policy file.
+
+- `--json`:
+  Prints results in JSON format.
+
+- `--json-file-output`=<OUTPUT_FILE_PATH>:
+  (only in `test` command)
+  Save test output in JSON format directly to the specified file, regardless of whether or not you use the `--json` option.
+  This is especially useful if you want to display the human-readable test output via stdout and at the same time save the JSON format output to a file.
+
+- `--sarif`:
+  Return results in SARIF format.
+
+- `--sarif-file-output`=<OUTPUT_FILE_PATH>:
+  (only in `test` command)
+  Save test output in SARIF format directly to the <OUTPUT_FILE_PATH> file, regardless of whether or not you use the `--sarif` option.
+  This is especially useful if you want to display the human-readable test output via stdout and at the same time save the SARIF format output to a file.
+
+- `--severity-threshold`=low|medium|high|critical:
+  Only report vulnerabilities of provided level or higher.
+
+- `--fail-on`=all|upgradable|patchable:
+  Only fail when there are vulnerabilities that can be fixed.
+
+  <all> fails when there is at least one vulnerability that can be either upgraded or patched.
+  <upgradable> fails when there is at least one vulnerability that can be upgraded.
+  <patchable> fails when there is at least one vulnerability that can be patched.
+
+  If vulnerabilities do not have a fix and this option is being used, tests will pass.
+
+- `--dry-run`:
+  (only in `protect` command)
+  Don't apply updates or patches during `protect` command run.
+
+- `--` \[<COMPILER_OPTIONS>\]:
+  Pass extra arguments directly to Gradle or Maven.
+  E.g. `snyk test -- --build-cache`
+
+Below are flags that are influencing CLI behavior for specific projects, languages and contexts:
+
+### Maven options
+
+- `--scan-all-unmanaged`:
+  Auto detects maven jars, aars, and wars in given directory. Individual testing can be done with `--file`=<JAR_FILE_NAME>
+
+- `--reachable`:
+  (only in `test` and `monitor` commands)
+  Analyze your source code to find which vulnerable
+  functions and packages are called.
+
+- `--reachable-timeout`=<TIMEOUT>:
+  The amount of time (in seconds) to wait for Snyk to gather reachability data. If it takes longer than <TIMEOUT>, Reachable Vulnerabilities are not reported. This does not affect regular test or monitor output.
+
+  Default: 300 (5 minutes).
+
+### Gradle options
+
+[More information about Gradle CLI options](https://snyk.co/ucT6P)
+
+- `--sub-project`=<NAME>, `--gradle-sub-project`=<NAME>:
+  For Gradle "multi project" configurations, test a specific sub-project.
+
+- `--all-sub-projects`:
+  For "multi project" configurations, test all sub-projects.
+
+- `--configuration-matching`=<CONFIGURATION_REGEX>:
+  Resolve dependencies using only configuration(s) that match the provided Java regular expression, e.g. `^releaseRuntimeClasspath$`.
+
+- `--configuration-attributes`=<ATTRIBUTE>[,<ATTRIBUTE>]...:
+  Select certain values of configuration attributes to resolve the dependencies. E.g. `buildtype:release,usage:java-runtime`
+
+- `--reachable`:
+  (only in `test` and `monitor` commands)
+  Analyze your source code to find which vulnerable
+  functions and packages are called.
+
+- `--reachable-timeout`=<TIMEOUT>:
+  The amount of time (in seconds) to wait for Snyk to gather reachability data. If it takes longer than <TIMEOUT>, Reachable Vulnerabilities are not reported. This does not affect regular test or monitor output.
+
+  Default: 300 (5 minutes).
+
+- `--init-script`=<FILE>
+  For projects that contain a gradle initialization script.
+
+### .Net & NuGet options
+
+- `--assets-project-name`:
+  When monitoring a .NET project using NuGet `PackageReference` use the project name in project.assets.json, if found.
+
+- `--packages-folder`:
+  Custom path to packages folder
+
+- `--project-name-prefix`=<PREFIX_STRING>:
+  When monitoring a .NET project, use this flag to add a custom prefix to the name of files inside a project along with any desired separators, e.g. `snyk monitor --file=my-project.sln --project-name-prefix=my-group/`. This is useful when you have multiple projects with the same name in other sln files.
+
+### npm options
+
+- `--strict-out-of-sync`=true|false:
+  Control testing out of sync lockfiles.
+
+  Default: true
+
+### Yarn options
+
+- `--strict-out-of-sync`=true|false:
+  Control testing out of sync lockfiles.
+
+  Default: true
+
+- `--yarn-workspaces`:
+  (only in `test` and `monitor` commands)
+  Detect and scan yarn workspaces. You can specify how many sub-directories to search using `--detection-depth` and exclude directories and files using `--exclude`.
+
+### CocoaPods options
+
+- `--strict-out-of-sync`=true|false:
+  Control testing out of sync lockfiles.
+
+  Default: false
+
+### Python options
+
+- `--command`=<COMMAND>:
+  Indicate which specific Python commands to use based on Python version. The default is `python` which executes your systems default python version. Run 'python -V' to find out what version is it. If you are using multiple Python versions, use this parameter to specify the correct Python command for execution.
+
+  Default: `python`
+  Example: `--command=python3`
+
+- `--skip-unresolved`=true|false:
+  Allow skipping packages that are not found in the environment.
+
+### Flags available accross all commands
+
+- `--insecure`:
+  Ignore unknown certificate authorities.
+
+- `-d`:
+  Output debug logs.
+
+- `--quiet`, `-q`:
+  Silence all output.
+
+- `--version`, `-v`:
+  Prints versions.
+
+- \[<COMMAND>\] `--help`, `--help` \[<COMMAND>\], `-h`:
+  Prints a help text. You may specify a <COMMAND> to get more details.
+
+
+## EXAMPLES
+
+- `Authenticate in your CI without user interaction`:
+  \$ snyk auth MY_API_TOKEN
+- `Test a project in current folder for known vulnerabilities`:
+  \$ snyk test
+- `Test a specific dependency for vulnerabilities`:
+  \$ snyk test ionic@1.6.5
+
+More examples:
+
+    $ snyk test --show-vulnerable-paths=false
+    $ snyk monitor --org=my-team
+    $ snyk monitor --project-name=my-project
+
+### Container scanning
+
+See `snyk container --help` for more details and examples:
+
+    $ snyk container test ubuntu:18.04 --org=my-team
+    $ snyk container test app:latest --file=Dockerfile --policy-path=path/to/.snyk
+
+### Infrastructure as Code (IAC) scanning
+
+See `snyk iac --help` for more details and examples:
+
+    $ snyk iac test /path/to/cloudformation_file.yaml
+    $ snyk iac test /path/to/kubernetes_file.yaml
+    $ snyk iac test /path/to/terraform_file.tf
+    $ snyk iac test /path/to/tf-plan.json
+
+
+## EXIT CODES
+
+Possible exit codes and their meaning:
+
+**0**: success, no vulns found<br />
+**1**: action_needed, vulns found<br />
+**2**: failure, try to re-run command<br />
+**3**: failure, no supported projects detected<br />
+
+
+## ENVIRONMENT
+
+You can set these environment variables to change CLI run settings.
+
+- `SNYK_TOKEN`:
+  Snyk authorization token. Setting this envvar will override the token that may be available in your `snyk config` settings.
+
+  [How to get your account token](https://snyk.co/ucT6J)<br />
+  [How to use Service Accounts](https://snyk.co/ucT6L)<br />
+
+- `SNYK_CFG_KEY`:
+  Allows you to override any key that's also available as `snyk config` option.
+
+  E.g. `SNYK_CFG_ORG`=myorg will override default org option in `config` with "myorg".
+
+- `SNYK_REGISTRY_USERNAME`:
+  Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+- `SNYK_REGISTRY_PASSWORD`:
+  Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+## Connecting to Snyk API
+
+By default Snyk CLI will connect to `https://snyk.io/api/v1`.
+
+- `SNYK_API`:
+  Sets API host to use for Snyk requests. Useful for on-premise instances and configuring proxies. If set with `http` protocol CLI will upgrade the requests to `https`. Unless `SNYK_HTTP_PROTOCOL_UPGRADE` is set to `0`.
+
+- `SNYK_HTTP_PROTOCOL_UPGRADE`=0:
+  If set to the value of `0`, API requests aimed at `http` URLs will not be upgraded to `https`. If not set, the default behavior will be to upgrade these requests from `http` to `https`. Useful e.g., for reverse proxies.
+
+- `HTTPS_PROXY` and `HTTP_PROXY`:
+  Allows you to specify a proxy to use for `https` and `http` calls. The `https` in the `HTTPS_PROXY` means that _requests using `https` protocol_ will use this proxy. The proxy itself doesn't need to use `https`.
+
+
+## NOTICES
+
+### Snyk API usage policy
+
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the [terms & conditions](https://snyk.co/ucT6N)
+

--- a/help/commands-txt/snyk-auth.txt
+++ b/help/commands-txt/snyk-auth.txt
@@ -1,0 +1,101 @@
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1ma[0m[1mu[0m[1mt[0m[1mh[0m - Authenticate Snyk CLI with a Snyk account
+
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1ma[0m[1mu[0m[1mt[0m[1mh[0m [[4mA[0m[4mP[0m[4mI[0m[1m_[0m[4mT[0m[4mO[0m[4mK[0m[4mE[0m[4mN[0m] [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
+
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
+       Authenticate  Snyk CLI with a Snyk account. Running [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1ma[0m[1mu[0m[1mt[0m[1mh[0m without
+       an [4mA[0m[4mP[0m[4mI[0m[1m_[0m[4mT[0m[4mO[0m[4mK[0m[4mE[0m[4mN[0m will open a browser window and asks you to login with Snyk
+       account  and  authorize.  When inputting an [4mA[0m[4mP[0m[4mI[0m[1m_[0m[4mT[0m[4mO[0m[4mK[0m[4mE[0m[4mN[0m, it will be vali-
+       dated with Snyk API.
+
+       When running in a CI environment [4mA[0m[4mP[0m[4mI[0m[1m_[0m[4mT[0m[4mO[0m[4mK[0m[4mE[0m[4mN[0m is required.
+
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       [[4mA[0m[4mP[0m[4mI[0m[1m_[0m[4mT[0m[4mO[0m[4mK[0m[4mE[0m[4mN[0m]
+              Your Snyk token. May be an user token or a service account.
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
+
+
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
+              Ignore unknown certificate authorities.
+
+       [1m-[0m[1md[0m     Output debug logs.
+
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
+              Silence all output.
+
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
+              Prints versions.
+
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints a help text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to  get  more  de-
+              tails.
+
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
+       Possible exit codes and their meaning:
+
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
+
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
+       You can set these environment variables to change CLI run settings.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
+              Snyk  authorization token. Setting this envvar will override the
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
+
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
+
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
+
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+              Specify a username to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
+              credentials when Docker is present.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
+              Specify  a  password  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
+              credentials when Docker is present.
+
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
+              Sets API host to use for Snyk requests.  Useful  for  on-premise
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
+              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
+              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
+              for reverse proxies.
+
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
+              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol will use this proxy. The proxy itself doesn't  need  to
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
+
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
+       age  or   otherwise,   is   subject   to   the   terms   &   conditions
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-config.txt
+++ b/help/commands-txt/snyk-config.txt
@@ -1,0 +1,114 @@
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m - Manage Snyk CLI configuration
+
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m [1mg[0m[1me[0m[1mt[0m[1m|[0m[1ms[0m[1me[0m[1mt[0m[1m|[0m[1mc[0m[1ml[0m[1me[0m[1ma[0m[1mr[0m [[4mK[0m[4mE[0m[4mY[0m[=[4mV[0m[4mA[0m[4mL[0m[4mU[0m[4mE[0m]] [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
+
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
+       Manage your local Snyk CLI config file.
+
+       This  command  does  not  manage  the  [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m  file  that's part of your
+       project. See [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m, [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m or [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mw[0m[1mi[0m[1mz[0m[1ma[0m[1mr[0m[1md[0m.
+
+[1mC[0m[1mO[0m[1mM[0m[1mM[0m[1mA[0m[1mN[0m[1mD[0m[1mS[0m
+       [1mg[0m[1me[0m[1mt[0m [4mK[0m[4mE[0m[4mY[0m
+              Print a config value.
+
+       [1ms[0m[1me[0m[1mt[0m [4mK[0m[4mE[0m[4mY[0m=[4mV[0m[4mA[0m[4mL[0m[4mU[0m[4mE[0m
+              Create a new config value.
+
+       [1mu[0m[1mn[0m[1ms[0m[1me[0m[1mt[0m [4mK[0m[4mE[0m[4mY[0m
+              Remove a config value.
+
+       [1mc[0m[1ml[0m[1me[0m[1ma[0m[1mr[0m  Remove all config values.
+
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+   [1mS[0m[1mu[0m[1mp[0m[1mp[0m[1mo[0m[1mr[0m[1mt[0m[1me[0m[1md[0m [1m<[0m[1mv[0m[1ma[0m[1mr[0m[1m>[0m[1mK[0m[1mE[0m[1mY[0m[1m<[0m[1m/[0m[1mv[0m[1ma[0m[1mr[0m[1m>[0m [1mv[0m[1ma[0m[1ml[0m[1mu[0m[1me[0m[1ms[0m
+       [1ma[0m[1mp[0m[1mi[0m    API token to use when calling Snyk API.
+
+       [1me[0m[1mn[0m[1md[0m[1mp[0m[1mo[0m[1mi[0m[1mn[0m[1mt[0m
+              Defines the API endpoint to use.
+
+       [1md[0m[1mi[0m[1ms[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1ma[0m[1mn[0m[1ma[0m[1ml[0m[1my[0m[1mt[0m[1mi[0m[1mc[0m[1ms[0m
+              Turns off analytics reporting.
+
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
+              Ignore unknown certificate authorities.
+
+       [1m-[0m[1md[0m     Output debug logs.
+
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
+              Silence all output.
+
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
+              Prints versions.
+
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints a help text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to  get  more  de-
+              tails.
+
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
+       Possible exit codes and their meaning:
+
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
+
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
+       You can set these environment variables to change CLI run settings.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
+              Snyk  authorization token. Setting this envvar will override the
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
+
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
+
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
+
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+              Specify a username to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
+              credentials when Docker is present.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
+              Specify  a  password  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
+              credentials when Docker is present.
+
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
+              Sets API host to use for Snyk requests.  Useful  for  on-premise
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
+              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
+              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
+              for reverse proxies.
+
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
+              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol will use this proxy. The proxy itself doesn't  need  to
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
+
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
+       age  or   otherwise,   is   subject   to   the   terms   &   conditions
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-container.txt
+++ b/help/commands-txt/snyk-container.txt
@@ -1,0 +1,150 @@
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mt[0m[1ma[0m[1mi[0m[1mn[0m[1me[0m[1mr[0m - Test container images for vulnerabilities
+
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mt[0m[1ma[0m[1mi[0m[1mn[0m[1me[0m[1mr[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m] [[4mI[0m[4mM[0m[4mA[0m[4mG[0m[4mE[0m]
+
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
+       Find vulnerabilities in your container images.
+
+[1mC[0m[1mO[0m[1mM[0m[1mM[0m[1mA[0m[1mN[0m[1mD[0m[1mS[0m
+       [1mt[0m[1me[0m[1ms[0m[1mt[0m   Test for any known vulnerabilities.
+
+       [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m
+              Record  the  state  of  dependencies  and any vulnerabilities on
+              snyk.io.
+
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m[1m-[0m[1mb[0m[1ma[0m[1ms[0m[1me[0m[1m-[0m[1mi[0m[1mm[0m[1ma[0m[1mg[0m[1me[0m[1m-[0m[1mv[0m[1mu[0m[1ml[0m[1mn[0m[1ms[0m
+              Exclude from display base image vulnerabilities.
+
+       [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              Include the path to the image's Dockerfile for more detailed ad-
+              vice.
+
+       [1m-[0m[1m-[0m[1mp[0m[1ml[0m[1ma[0m[1mt[0m[1mf[0m[1mo[0m[1mr[0m[1mm[0m=[4mP[0m[4mL[0m[4mA[0m[4mT[0m[4mF[0m[4mO[0m[4mR[0m[4mM[0m
+              For  multi-architecture  images,  specify  the platform to test.
+              [linux/amd64,   linux/arm64,    linux/riscv64,    linux/ppc64le,
+              linux/s390x, linux/386, linux/arm/v7 or linux/arm/v6]
+
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m Prints results in JSON format.
+
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format directly
+              to the specified file, regardless of whether or not you use  the
+              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m  option. This is especially useful if you want to display
+              the human-readable test output via stdout and at the  same  time
+              save the JSON format output to a file.
+
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m
+              Return results in SARIF format.
+
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in SARIF format directly
+              to the [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or  not  you
+              use the [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m option. This is especially useful if you want to
+              display the human-readable test output via  stdout  and  at  the
+              same time save the SARIF format output to a file.
+
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mi[0m[1mn[0m[1mt[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1ms[0m
+              Print the dependency tree before sending it for analysis.
+
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m=[4mP[0m[4mR[0m[4mO[0m[4mJ[0m[4mE[0m[4mC[0m[4mT[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+              Specify a custom Snyk project name.
+
+       [1m-[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m=[4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m
+              Manually pass a path to a snyk policy file.
+
+       [1m-[0m[1m-[0m[1ms[0m[1me[0m[1mv[0m[1me[0m[1mr[0m[1mi[0m[1mt[0m[1my[0m[1m-[0m[1mt[0m[1mh[0m[1mr[0m[1me[0m[1ms[0m[1mh[0m[1mo[0m[1ml[0m[1md[0m=low|medium|high|critical
+              Only report vulnerabilities of provided level or higher.
+
+       [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m=[4mC[0m[4mO[0m[4mN[0m[4mT[0m[4mA[0m[4mI[0m[4mN[0m[4mE[0m[4mR[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mI[0m[4mS[0m[4mT[0m[4mR[0m[4mY[0m[1m_[0m[4mU[0m[4mS[0m[4mE[0m[4mR[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+              Specify  a  username  to use when connecting to a container reg-
+              istry. This will be ignored in favour  of  local  Docker  binary
+              credentials when Docker is present.
+
+       [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m=[4mC[0m[4mO[0m[4mN[0m[4mT[0m[4mA[0m[4mI[0m[4mN[0m[4mE[0m[4mR[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mI[0m[4mS[0m[4mT[0m[4mR[0m[4mY[0m[1m_[0m[4mP[0m[4mA[0m[4mS[0m[4mS[0m[4mW[0m[4mO[0m[4mR[0m[4mD[0m
+              Specify  a  password  to use when connecting to a container reg-
+              istry. This will be ignored in favour  of  local  Docker  binary
+              credentials when Docker is present.
+
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
+              Ignore unknown certificate authorities.
+
+       [1m-[0m[1md[0m     Output debug logs.
+
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
+              Silence all output.
+
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
+              Prints versions.
+
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
+              tails.
+
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
+       Possible exit codes and their meaning:
+
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
+
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
+       You can set these environment variables to change CLI run settings.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
+              Snyk authorization token. Setting this envvar will override  the
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
+
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
+
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
+
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+              Specify  a  username  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
+              credentials when Docker is present.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
+              Specify a password to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
+              credentials when Docker is present.
+
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
+              Sets  API  host  to use for Snyk requests. Useful for on-premise
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
+              for reverse proxies.
+
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol  will  use this proxy. The proxy itself doesn't need to
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
+
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
+       age   or   otherwise,   is   subject   to   the   terms   &  conditions
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-help.txt
+++ b/help/commands-txt/snyk-help.txt
@@ -1,0 +1,90 @@
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m - Prints help topics
+
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mT[0m[4mO[0m[4mP[0m[4mI[0m[4mC[0m] [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
+
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
+       Prints help information. Pass in name of a command as [4mT[0m[4mO[0m[4mP[0m[4mI[0m[4mC[0m.
+
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
+              Ignore unknown certificate authorities.
+
+       [1m-[0m[1md[0m     Output debug logs.
+
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
+              Silence all output.
+
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
+              Prints versions.
+
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
+              tails.
+
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
+       Possible exit codes and their meaning:
+
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
+
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
+       You can set these environment variables to change CLI run settings.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
+              Snyk authorization token. Setting this envvar will override  the
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
+
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
+
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
+
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+              Specify  a  username  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
+              credentials when Docker is present.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
+              Specify a password to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
+              credentials when Docker is present.
+
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
+              Sets  API  host  to use for Snyk requests. Useful for on-premise
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
+              for reverse proxies.
+
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol  will  use this proxy. The proxy itself doesn't need to
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
+
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
+       age   or   otherwise,   is   subject   to   the   terms   &  conditions
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-iac.txt
+++ b/help/commands-txt/snyk-iac.txt
@@ -1,0 +1,169 @@
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mi[0m[1ma[0m[1mc[0m - Find security issues in your Infrastructure as Code files
+
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mi[0m[1ma[0m[1mc[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m] [4mP[0m[4mA[0m[4mT[0m[4mH[0m
+
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
+       Find security issues in your Infrastructure as Code files.
+
+       For more information see IaC help page [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mQ[0m
+
+[1mC[0m[1mO[0m[1mM[0m[1mM[0m[1mA[0m[1mN[0m[1mD[0m[1mS[0m
+       [1mt[0m[1me[0m[1ms[0m[1mt[0m   Test for any known issue.
+
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m=[4mD[0m[4mE[0m[4mP[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command)
+              Indicate  the  maximum depth of sub-directories to search. [4mD[0m[4mE[0m[4mP[0m[4mT[0m[4mH[0m
+              must be a number.
+
+              Default: No Limit
+              Example: [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m[1m=[0m[1m3[0m
+              Will limit search to provided directory (or current directory if
+              no [4mP[0m[4mA[0m[4mT[0m[4mH[0m provided) plus two levels of subdirectories.
+
+       [1m-[0m[1m-[0m[1ms[0m[1me[0m[1mv[0m[1me[0m[1mr[0m[1mi[0m[1mt[0m[1my[0m[1m-[0m[1mt[0m[1mh[0m[1mr[0m[1me[0m[1ms[0m[1mh[0m[1mo[0m[1ml[0m[1md[0m=low|medium|high
+              Only report vulnerabilities of provided level or higher.
+
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m Prints results in JSON format.
+
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format directly
+              to the specified file, regardless of whether or not you use  the
+              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m  option. This is especially useful if you want to display
+              the human-readable test output via stdout and at the  same  time
+              save the JSON format output to a file.
+
+       [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+              Specify the [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m to run Snyk commands tied to a specific or-
+              ganization. This will influence private  tests  limits.  If  you
+              have  multiple organizations, you can set a default from the CLI
+              using:
+
+              [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m [1ms[0m[1me[0m[1mt[0m [1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+
+              Setting a default will ensure all newly tested projects will  be
+              tested  under your default organization. If you need to override
+              the default, you can use the [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m  argument.  Default:
+              uses  [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m  that  sets  as  default in your Account settings
+              [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ma[0m[4mp[0m[4mp[0m[4m.[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mo[0m[4m/[0m[4ma[0m[4mc[0m[4mc[0m[4mo[0m[4mu[0m[4mn[0m[4mt[0m
+
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m
+              Return results in SARIF format.
+
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in SARIF format directly
+              to  the  [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or not you
+              use the [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m option. This is especially useful if you want to
+              display  the  human-readable  test  output via stdout and at the
+              same time save the SARIF format output to a file.
+
+       [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m=[0m[4mT[0m[4mE[0m[4mR[0m[4mR[0m[4mA[0m[4mF[0m[4mO[0m[4mR[0m[4mM[0m[1m_[0m[4mP[0m[4mL[0m[4mA[0m[4mN[0m[1m_[0m[4mS[0m[4mC[0m[4mA[0m[4mN[0m[1m_[0m[4mM[0m[4mO[0m[4mD[0m[4mE[0m
+              Dedicated flag for Terraform plan scanning modes.
+              It enables to control whether the scan should analyse  the  full
+              final  state (e.g. [1mp[0m[1ml[0m[1ma[0m[1mn[0m[1mn[0m[1me[0m[1md[0m[1m-[0m[1mv[0m[1ma[0m[1ml[0m[1mu[0m[1me[0m[1ms[0m), or the proposed changes only
+              (e.g. [1mr[0m[1me[0m[1ms[0m[1mo[0m[1mu[0m[1mr[0m[1mc[0m[1me[0m[1m-[0m[1mc[0m[1mh[0m[1ma[0m[1mn[0m[1mg[0m[1me[0m[1ms[0m).
+              Default: If the [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m flag is not provided it  would  scan  the
+              proposed changes only by default.
+              Example  #1: [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m=[0m[1mp[0m[1ml[0m[1ma[0m[1mn[0m[1mn[0m[1me[0m[1md[0m[1m-[0m[1mv[0m[1ma[0m[1ml[0m[1mu[0m[1me[0m[1ms[0m (full state scan) Example #2:
+              [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m=[0m[1mr[0m[1me[0m[1ms[0m[1mo[0m[1mu[0m[1mr[0m[1mc[0m[1me[0m[1m-[0m[1mc[0m[1mh[0m[1ma[0m[1mn[0m[1mg[0m[1me[0m[1ms[0m (proposed changes scan)
+
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
+              Ignore unknown certificate authorities.
+
+       [1m-[0m[1md[0m     Output debug logs.
+
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
+              Silence all output.
+
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
+              Prints versions.
+
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints a help text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to  get  more  de-
+              tails.
+
+[1mE[0m[1mX[0m[1mA[0m[1mM[0m[1mP[0m[1mL[0m[1mE[0m[1mS[0m
+       For more information see IaC help page [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mQ[0m
+
+       [1mT[0m[1me[0m[1ms[0m[1mt[0m [1mC[0m[1ml[0m[1mo[0m[1mu[0m[1md[0m[1mF[0m[1mo[0m[1mr[0m[1mm[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m [1mf[0m[1mi[0m[1ml[0m[1me[0m
+              $ snyk iac test /path/to/cloudformation_file.yaml
+
+       [1mT[0m[1me[0m[1ms[0m[1mt[0m [1mk[0m[1mu[0m[1mb[0m[1me[0m[1mr[0m[1mn[0m[1me[0m[1mt[0m[1me[0m[1ms[0m [1mf[0m[1mi[0m[1ml[0m[1me[0m
+              $ snyk iac test /path/to/kubernetes_file.yaml
+
+       [1mT[0m[1me[0m[1ms[0m[1mt[0m [1mt[0m[1me[0m[1mr[0m[1mr[0m[1ma[0m[1mf[0m[1mo[0m[1mr[0m[1mm[0m [1mf[0m[1mi[0m[1ml[0m[1me[0m
+              $ snyk iac test /path/to/terraform_file.tf
+
+       [1mT[0m[1me[0m[1ms[0m[1mt[0m [1mt[0m[1me[0m[1mr[0m[1mr[0m[1ma[0m[1mf[0m[1mo[0m[1mr[0m[1mm[0m [1mp[0m[1ml[0m[1ma[0m[1mn[0m [1mf[0m[1mi[0m[1ml[0m[1me[0m
+              $ snyk iac test /path/to/tf-plan.json
+
+       [1mT[0m[1me[0m[1ms[0m[1mt[0m [1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m [1mf[0m[1mi[0m[1ml[0m[1me[0m[1ms[0m [1mi[0m[1mn[0m [1ma[0m [1md[0m[1mi[0m[1mr[0m[1me[0m[1mc[0m[1mt[0m[1mo[0m[1mr[0m[1my[0m
+              $ snyk iac test /path/to/directory
+
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
+       Possible exit codes and their meaning:
+
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
+
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
+       You can set these environment variables to change CLI run settings.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
+              Snyk  authorization token. Setting this envvar will override the
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
+
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
+
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
+
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+              Specify a username to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
+              credentials when Docker is present.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
+              Specify  a  password  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
+              credentials when Docker is present.
+
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
+              Sets API host to use for Snyk requests.  Useful  for  on-premise
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
+              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
+              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
+              for reverse proxies.
+
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
+              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol will use this proxy. The proxy itself doesn't  need  to
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
+
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
+       age  or   otherwise,   is   subject   to   the   terms   &   conditions
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-ignore.txt
+++ b/help/commands-txt/snyk-ignore.txt
@@ -1,0 +1,108 @@
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m - Modifies the .snyk policy to ignore stated issues
+
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m [1m-[0m[1m-[0m[1mi[0m[1md[0m=[4mI[0m[4mS[0m[4mS[0m[4mU[0m[4mE[0m[1m_[0m[4mI[0m[4mD[0m [[1m-[0m[1m-[0m[1me[0m[1mx[0m[1mp[0m[1mi[0m[1mr[0m[1my[0m=[4mE[0m[4mX[0m[4mP[0m[4mI[0m[4mR[0m[4mY[0m] [[1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1ms[0m[1mo[0m[1mn[0m=[4mR[0m[4mE[0m[4mA[0m[4mS[0m[4mO[0m[4mN[0m] [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
+
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
+       Ignore  a  certain issue, according to its snyk ID for all occurrences.
+       This will update your local [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m to contain a similar block:
+
+       [1my[0m[1ma[0m[1mm[0m[1ml[0m [1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m[1m:[0m [1m'[0m[1m<[0m[1mI[0m[1mS[0m[1mS[0m[1mU[0m[1mE[0m[1m_[0m[1mI[0m[1mD[0m[1m>[0m[1m'[0m[1m:[0m [1m-[0m [1m'[0m[1m*[0m[1m'[0m[1m:[0m [1mr[0m[1me[0m[1ma[0m[1ms[0m[1mo[0m[1mn[0m[1m:[0m [1m<[0m[1mR[0m[1mE[0m[1mA[0m[1mS[0m[1mO[0m[1mN[0m[1m>[0m [1me[0m[1mx[0m[1mp[0m[1mi[0m[1mr[0m[1me[0m[1ms[0m[1m:[0m [1m<[0m[1mE[0m[1mX[0m[1mP[0m[1mI[0m[1mR[0m[1mY[0m[1m>[0m
+
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       [1m-[0m[1m-[0m[1mi[0m[1md[0m=[4mI[0m[4mS[0m[4mS[0m[4mU[0m[4mE[0m[1m_[0m[4mI[0m[4mD[0m
+              Snyk ID for the issue to ignore. Required.
+
+       [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mp[0m[1mi[0m[1mr[0m[1my[0m=[4mE[0m[4mX[0m[4mP[0m[4mI[0m[4mR[0m[4mY[0m
+              Expiry        date,         according         to         RFC2822
+              [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4mt[0m[4mo[0m[4mo[0m[4ml[0m[4ms[0m[4m.[0m[4mi[0m[4me[0m[4mt[0m[4mf[0m[4m.[0m[4mo[0m[4mr[0m[4mg[0m[4m/[0m[4mh[0m[4mt[0m[4mm[0m[4ml[0m[4m/[0m[4mr[0m[4mf[0m[4mc[0m[4m2[0m[4m8[0m[4m2[0m[4m2[0m
+
+       [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1ms[0m[1mo[0m[1mn[0m=[4mR[0m[4mE[0m[4mA[0m[4mS[0m[4mO[0m[4mN[0m
+              Human-readable [4mR[0m[4mE[0m[4mA[0m[4mS[0m[4mO[0m[4mN[0m to ignore this issue.
+
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
+              Ignore unknown certificate authorities.
+
+       [1m-[0m[1md[0m     Output debug logs.
+
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
+              Silence all output.
+
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
+              Prints versions.
+
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
+              tails.
+
+[1mE[0m[1mX[0m[1mA[0m[1mM[0m[1mP[0m[1mL[0m[1mE[0m[1mS[0m
+       [1mI[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m [1ma[0m [1ms[0m[1mp[0m[1me[0m[1mc[0m[1mi[0m[1mf[0m[1mi[0m[1mc[0m [1mv[0m[1mu[0m[1ml[0m[1mn[0m[1me[0m[1mr[0m[1ma[0m[1mb[0m[1mi[0m[1ml[0m[1mi[0m[1mt[0m[1my[0m
+              $  snyk  ignore   --id='npm:qs:20170213'   --expiry='2021-01-10'
+              --reason='Module not affected by this vuln'
+
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
+       Possible exit codes and their meaning:
+
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
+
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
+       You can set these environment variables to change CLI run settings.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
+              Snyk  authorization token. Setting this envvar will override the
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
+
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
+
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
+
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+              Specify a username to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
+              credentials when Docker is present.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
+              Specify  a  password  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
+              credentials when Docker is present.
+
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
+              Sets API host to use for Snyk requests.  Useful  for  on-premise
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
+              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
+              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
+              for reverse proxies.
+
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
+              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol will use this proxy. The proxy itself doesn't  need  to
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
+
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
+       age  or   otherwise,   is   subject   to   the   terms   &   conditions
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-monitor.txt
+++ b/help/commands-txt/snyk-monitor.txt
@@ -1,0 +1,326 @@
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m - Snapshot and continuously monitor your project
+
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
+
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
+       Create  a  project  on the Snyk website that will be continuously moni-
+       tored for new vulnerabilities. After running this command you will  see
+       it by logging in to the website and viewing Your projects.
+
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       To  see  command-specific  flags and usage, see [1mh[0m[1me[0m[1ml[0m[1mp[0m command, e.g. [1ms[0m[1mn[0m[1my[0m[1mk[0m
+       [1mc[0m[1mo[0m[1mn[0m[1mt[0m[1ma[0m[1mi[0m[1mn[0m[1me[0m[1mr[0m [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m. For advanced usage, we  offer  language  and  context
+       specific flags, listed further down this document.
+
+       [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Auto-detect all projects in
+              working directory
+
+       [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m=[4mD[0m[4mE[0m[4mP[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Use with  --all-projects  or
+              --yarn-workspaces   to  indicate  how  many  sub-directories  to
+              search. [1mD[0m[1mE[0m[1mP[0m[1mT[0m[1mH[0m must be a number.
+
+              Default: 4 (the current working directory and 3 sub-directories)
+
+       [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m=[4mD[0m[4mI[0m[4mR[0m[4mE[0m[4mC[0m[4mT[0m[4mO[0m[4mR[0m[4mY[0m[,[4mD[0m[4mI[0m[4mR[0m[4mE[0m[4mC[0m[4mT[0m[4mO[0m[4mR[0m[4mY[0m]...>
+              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Can   be   used   with
+              --all-projects and --yarn-workspaces to indicate sub-directories
+              and files to exclude. Must be comma separated.
+
+              If using with [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m exclude ignores  directories  at
+              any level deep.
+
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mu[0m[1mn[0m[1me[0m[1m-[0m[1mr[0m[1me[0m[1mp[0m[1me[0m[1ma[0m[1mt[0m[1me[0m[1md[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1md[0m[1me[0m[1mp[0m[1me[0m[1mn[0m[1md[0m[1me[0m[1mn[0m[1mc[0m[1mi[0m[1me[0m[1ms[0m, [1m-[0m[1mp[0m
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Prune dependency trees, re-
+              moving duplicate sub-dependencies. Will still find all  vulnera-
+              bilities, but potentially not all of the vulnerable paths.
+
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mi[0m[1mn[0m[1mt[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1ms[0m
+              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Print the dependency tree
+              before sending it for analysis.
+
+       [1m-[0m[1m-[0m[1mr[0m[1me[0m[1mm[0m[1mo[0m[1mt[0m[1me[0m[1m-[0m[1mr[0m[1me[0m[1mp[0m[1mo[0m[1m-[0m[1mu[0m[1mr[0m[1ml[0m=[4mU[0m[4mR[0m[4mL[0m
+              Set or override the remote URL for the repository that you would
+              like to monitor.
+
+       [1m-[0m[1m-[0m[1md[0m[1me[0m[1mv[0m  Include  development-only dependencies. Applicable only for some
+              package managers. E.g. [4md[0m[4me[0m[4mv[0m[4mD[0m[4me[0m[4mp[0m[4me[0m[4mn[0m[4md[0m[4me[0m[4mn[0m[4mc[0m[4mi[0m[4me[0m[4ms[0m in  npm  or  [4m:[0m[4md[0m[4me[0m[4mv[0m[4me[0m[4ml[0m[4mo[0m[4mp[0m[4mm[0m[4me[0m[4mn[0m[4mt[0m
+              dependencies in Gemfile.
+
+              Default: scan only production dependencies
+
+       [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+              Specify the [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m to run Snyk commands tied to a specific or-
+              ganization. This will influence where will new projects be  cre-
+              ated  after  running [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command, some features availability
+              and private tests limits. If you  have  multiple  organizations,
+              you can set a default from the CLI using:
+
+              [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m [1ms[0m[1me[0m[1mt[0m [1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+
+              Setting  a default will ensure all newly monitored projects will
+              be created under your default organization. If you need to over-
+              ride the default, you can use the [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m argument.
+
+              Default: uses [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m that sets as default in your Account set-
+              tings [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ma[0m[4mp[0m[4mp[0m[4m.[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mo[0m[4m/[0m[4ma[0m[4mc[0m[4mc[0m[4mo[0m[4mu[0m[4mn[0m[4mt[0m
+
+       [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m
+              Sets a package file.
+
+              When testing locally or monitoring a project,  you  can  specify
+              the  file that Snyk should inspect for package information. When
+              ommitted Snyk will try to detect the appropriate file  for  your
+              project.
+
+       [1m-[0m[1m-[0m[1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+              Ignores  all set policies. The current policy in [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m file, Org
+              level ignores and the project policy on snyk.io.
+
+       [1m-[0m[1m-[0m[1mt[0m[1mr[0m[1mu[0m[1ms[0m[1mt[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1mi[0m[1me[0m[1ms[0m
+              Applies and uses ignore rules from your dependencies' Snyk poli-
+              cies, otherwise ignore policies are only shown as a suggestion.
+
+       [1m-[0m[1m-[0m[1ms[0m[1mh[0m[1mo[0m[1mw[0m[1m-[0m[1mv[0m[1mu[0m[1ml[0m[1mn[0m[1me[0m[1mr[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1ms[0m=none|some|all
+              Display  the  dependency  paths from the top level dependencies,
+              down to the vulnerable packages. Doesn't affect output when  us-
+              ing JSON [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m output.
+
+              Default:  [4ms[0m[4mo[0m[4mm[0m[4me[0m (a few example paths shown) [4mf[0m[4ma[0m[4ml[0m[4ms[0m[4me[0m is an alias for
+              [4mn[0m[4mo[0m[4mn[0m[4me[0m.
+
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m=[4mP[0m[4mR[0m[4mO[0m[4mJ[0m[4mE[0m[4mC[0m[4mT[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+              Specify a custom Snyk project name.
+
+       [1m-[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m=[4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m`
+              Manually pass a path to a snyk policy file.
+
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m Prints results in JSON format.
+
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format  directly
+              to  the specified file, regardless of whether or not you use the
+              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m option. This is especially useful if you want to  display
+              the  human-readable  test output via stdout and at the same time
+              save the JSON format output to a file.
+
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m
+              Return results in SARIF format.
+
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in SARIF format directly
+              to  the  [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or not you
+              use the [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m option. This is especially useful if you want to
+              display  the  human-readable  test  output via stdout and at the
+              same time save the SARIF format output to a file.
+
+       [1m-[0m[1m-[0m[1ms[0m[1me[0m[1mv[0m[1me[0m[1mr[0m[1mi[0m[1mt[0m[1my[0m[1m-[0m[1mt[0m[1mh[0m[1mr[0m[1me[0m[1ms[0m[1mh[0m[1mo[0m[1ml[0m[1md[0m=low|medium|high|critical
+              Only report vulnerabilities of provided level or higher.
+
+       [1m-[0m[1m-[0m[1mf[0m[1ma[0m[1mi[0m[1ml[0m[1m-[0m[1mo[0m[1mn[0m=all|upgradable|patchable
+              Only fail when there are vulnerabilities that can be fixed.
+
+              [4ma[0m[4ml[0m[4ml[0m fails when there is at least one vulnerability that  can  be
+              either  upgraded  or  patched. [4mu[0m[4mp[0m[4mg[0m[4mr[0m[4ma[0m[4md[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails when there is at
+              least one vulnerability that can be  upgraded.  [4mp[0m[4ma[0m[4mt[0m[4mc[0m[4mh[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m  fails
+              when there is at least one vulnerability that can be patched.
+
+              If  vulnerabilities  do  not have a fix and this option is being
+              used, tests will pass.
+
+       [1m-[0m[1m-[0m[1md[0m[1mr[0m[1my[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m
+              (only in [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command) Don't apply updates or patches  during
+              [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command run.
+
+       [1m-[0m[1m-[0m [[4mC[0m[4mO[0m[4mM[0m[4mP[0m[4mI[0m[4mL[0m[4mE[0m[4mR[0m[1m_[0m[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
+              Pass extra arguments directly to Gradle or Maven. E.g. [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mt[0m[1me[0m[1ms[0m[1mt[0m
+              [1m-[0m[1m-[0m [1m-[0m[1m-[0m[1mb[0m[1mu[0m[1mi[0m[1ml[0m[1md[0m[1m-[0m[1mc[0m[1ma[0m[1mc[0m[1mh[0m[1me[0m
+
+       Below  are  flags  that  are  influencing  CLI  behavior  for  specific
+       projects, languages and contexts:
+
+   [1mM[0m[1ma[0m[1mv[0m[1me[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1mu[0m[1mn[0m[1mm[0m[1ma[0m[1mn[0m[1ma[0m[1mg[0m[1me[0m[1md[0m
+              Auto  detects maven jars, aars, and wars in given directory. In-
+              dividual testing can be done with [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mJ[0m[4mA[0m[4mR[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+
+       [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Analyze your source code  to
+              find which vulnerable functions and packages are called.
+
+       [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m
+              The  amount  of  time  (in  seconds)  to wait for Snyk to gather
+              reachability data. If it takes longer  than  [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m,  Reachable
+              Vulnerabilities  are  not reported. This does not affect regular
+              test or monitor output.
+
+              Default: 300 (5 minutes).
+
+   [1mG[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       More information about Gradle CLI options [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mP[0m
+
+       O   [1m-[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m, [1m-[0m[1m-[0m[1mg[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m:  For  Gradle  "multi
+           project" configurations, test a specific sub-project.
+
+       O   [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m:  For  "multi  project" configurations, test all
+           sub-projects.
+
+       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m=[4mC[0m[4mO[0m[4mN[0m[4mF[0m[4mI[0m[4mG[0m[4mU[0m[4mR[0m[4mA[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mE[0m[4mX[0m: Resolve  dependencies
+           using  only  configuration(s)  that match the provided Java regular
+           expression, e.g. [1m^[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1mR[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mC[0m[1ml[0m[1ma[0m[1ms[0m[1ms[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1m$[0m.
+
+       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1ma[0m[1mt[0m[1mt[0m[1mr[0m[1mi[0m[1mb[0m[1mu[0m[1mt[0m[1me[0m[1ms[0m=[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m[,[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m]...: Select certain
+           values  of  configuration  attributes  to resolve the dependencies.
+           E.g. [1mb[0m[1mu[0m[1mi[0m[1ml[0m[1md[0m[1mt[0m[1my[0m[1mp[0m[1me[0m[1m:[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1m,[0m[1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m[1m:[0m[1mj[0m[1ma[0m[1mv[0m[1ma[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m
+
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m: (only in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Analyze  your
+           source  code  to  find  which vulnerable functions and packages are
+           called.
+
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m: The amount of  time  (in  seconds)  to
+           wait  for Snyk to gather reachability data. If it takes longer than
+           [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m, Reachable Vulnerabilities are not reported. This does  not
+           affect regular test or monitor output.
+
+           Default: 300 (5 minutes).
+
+       O   [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1mi[0m[1mt[0m[1m-[0m[1ms[0m[1mc[0m[1mr[0m[1mi[0m[1mp[0m[1mt[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m  For  projects that contain a gradle initializa-
+           tion script.
+
+
+
+   [1m.[0m[1mN[0m[1me[0m[1mt[0m [1m&[0m [1mN[0m[1mu[0m[1mG[0m[1me[0m[1mt[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ma[0m[1ms[0m[1ms[0m[1me[0m[1mt[0m[1ms[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m
+              When monitoring a .NET project using NuGet [1mP[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1mR[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m  use
+              the project name in project.assets.json, if found.
+
+       [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1ms[0m[1m-[0m[1mf[0m[1mo[0m[1ml[0m[1md[0m[1me[0m[1mr[0m
+              Custom path to packages folder
+
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m=[4mP[0m[4mR[0m[4mE[0m[4mF[0m[4mI[0m[4mX[0m[1m_[0m[4mS[0m[4mT[0m[4mR[0m[4mI[0m[4mN[0m[4mG[0m
+              When  monitoring  a  .NET project, use this flag to add a custom
+              prefix to the name of files inside a project along with any  de-
+              sired   separators,   e.g.  [1ms[0m[1mn[0m[1my[0m[1mk[0m  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m.[0m[1ms[0m[1ml[0m[1mn[0m
+              [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mg[0m[1mr[0m[1mo[0m[1mu[0m[1mp[0m[1m/[0m. This is useful  when  you  have
+              multiple projects with the same name in other sln files.
+
+   [1mn[0m[1mp[0m[1mm[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mt[0m[1mr[0m[1mi[0m[1mc[0m[1mt[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1m-[0m[1mo[0m[1mf[0m[1m-[0m[1ms[0m[1my[0m[1mn[0m[1mc[0m=true|false
+              Control testing out of sync lockfiles.
+
+              Default: true
+
+   [1mY[0m[1ma[0m[1mr[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mt[0m[1mr[0m[1mi[0m[1mc[0m[1mt[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1m-[0m[1mo[0m[1mf[0m[1m-[0m[1ms[0m[1my[0m[1mn[0m[1mc[0m=true|false
+              Control testing out of sync lockfiles.
+
+              Default: true
+
+       [1m-[0m[1m-[0m[1my[0m[1ma[0m[1mr[0m[1mn[0m[1m-[0m[1mw[0m[1mo[0m[1mr[0m[1mk[0m[1ms[0m[1mp[0m[1ma[0m[1mc[0m[1me[0m[1ms[0m
+              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Detect  and  scan yarn
+              workspaces. You can specify how many sub-directories  to  search
+              using  [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m and exclude directories and files using
+              [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m.
+
+   [1mC[0m[1mo[0m[1mc[0m[1mo[0m[1ma[0m[1mP[0m[1mo[0m[1md[0m[1ms[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mt[0m[1mr[0m[1mi[0m[1mc[0m[1mt[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1m-[0m[1mo[0m[1mf[0m[1m-[0m[1ms[0m[1my[0m[1mn[0m[1mc[0m=true|false
+              Control testing out of sync lockfiles.
+
+              Default: false
+
+   [1mP[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m=[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m
+              Indicate which specific Python commands to use based  on  Python
+              version.  The  default is [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m which executes your systems de-
+              fault python version. Run 'python -V' to find out  what  version
+              is  it.  If you are using multiple Python versions, use this pa-
+              rameter to specify the correct Python command for execution.
+
+              Default: [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m Example: [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1m=[0m[1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m[1m3[0m
+
+       [1m-[0m[1m-[0m[1ms[0m[1mk[0m[1mi[0m[1mp[0m[1m-[0m[1mu[0m[1mn[0m[1mr[0m[1me[0m[1ms[0m[1mo[0m[1ml[0m[1mv[0m[1me[0m[1md[0m=true|false
+              Allow skipping packages that are not found in the environment.
+
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
+              Ignore unknown certificate authorities.
+
+       [1m-[0m[1md[0m     Output debug logs.
+
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
+              Silence all output.
+
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
+              Prints versions.
+
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints a help text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to  get  more  de-
+              tails.
+
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
+       Possible exit codes and their meaning:
+
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
+
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
+       You can set these environment variables to change CLI run settings.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
+              Snyk  authorization token. Setting this envvar will override the
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
+
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
+
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
+
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+              Specify a username to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
+              credentials when Docker is present.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
+              Specify  a  password  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
+              credentials when Docker is present.
+
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
+              Sets API host to use for Snyk requests.  Useful  for  on-premise
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
+              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
+              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
+              for reverse proxies.
+
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
+              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol will use this proxy. The proxy itself doesn't  need  to
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
+
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
+       age  or   otherwise,   is   subject   to   the   terms   &   conditions
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-policy.txt
+++ b/help/commands-txt/snyk-policy.txt
@@ -1,0 +1,93 @@
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m - Display the .snyk policy for a package
+
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m [[4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m] [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
+
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
+       Displays a [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m policy file.
+
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       [4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m
+              Manually pass a path to a snyk policy file.
+
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
+              Ignore unknown certificate authorities.
+
+       [1m-[0m[1md[0m     Output debug logs.
+
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
+              Silence all output.
+
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
+              Prints versions.
+
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
+              tails.
+
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
+       Possible exit codes and their meaning:
+
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
+
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
+       You can set these environment variables to change CLI run settings.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
+              Snyk authorization token. Setting this envvar will override  the
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
+
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
+
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
+
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+              Specify  a  username  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
+              credentials when Docker is present.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
+              Specify a password to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
+              credentials when Docker is present.
+
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
+              Sets  API  host  to use for Snyk requests. Useful for on-premise
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
+              for reverse proxies.
+
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol  will  use this proxy. The proxy itself doesn't need to
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
+
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
+       age   or   otherwise,   is   subject   to   the   terms   &  conditions
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-protect.txt
+++ b/help/commands-txt/snyk-protect.txt
@@ -1,0 +1,97 @@
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m  - Applies the patches specified in your .snyk file to the
+       local file system
+
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
+
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
+       [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m is used to apply patches to  your  vulnerable  dependen-
+       cies.  It's  useful  after  opening a fix pull request from our website
+       (GitHub only) or after running snyk wizard on  the  CLI.  snyk  protect
+       reads a .snyk policy file to determine what patches to apply.
+
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       [1m-[0m[1m-[0m[1md[0m[1mr[0m[1my[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m
+              Don't apply updates or patches when running.
+
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
+              Ignore unknown certificate authorities.
+
+       [1m-[0m[1md[0m     Output debug logs.
+
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
+              Silence all output.
+
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
+              Prints versions.
+
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
+              tails.
+
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
+       Possible exit codes and their meaning:
+
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
+
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
+       You can set these environment variables to change CLI run settings.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
+              Snyk authorization token. Setting this envvar will override  the
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
+
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
+
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
+
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+              Specify  a  username  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
+              credentials when Docker is present.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
+              Specify a password to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
+              credentials when Docker is present.
+
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
+              Sets  API  host  to use for Snyk requests. Useful for on-premise
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
+              for reverse proxies.
+
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol  will  use this proxy. The proxy itself doesn't need to
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
+
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
+       age   or   otherwise,   is   subject   to   the   terms   &  conditions
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-test.txt
+++ b/help/commands-txt/snyk-test.txt
@@ -1,0 +1,326 @@
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mt[0m[1me[0m[1ms[0m[1mt[0m - test local project for vulnerabilities
+
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mt[0m[1me[0m[1ms[0m[1mt[0m [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
+
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
+       Test  command checks locally installed projects for vulnerabilities. It
+       tries to autodetect supported manifest files with dependencies and test
+       those.
+
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       To  see  command-specific  flags and usage, see [1mh[0m[1me[0m[1ml[0m[1mp[0m command, e.g. [1ms[0m[1mn[0m[1my[0m[1mk[0m
+       [1mc[0m[1mo[0m[1mn[0m[1mt[0m[1ma[0m[1mi[0m[1mn[0m[1me[0m[1mr[0m [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m. For advanced usage, we  offer  language  and  context
+       specific flags, listed further down this document.
+
+       [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Auto-detect all projects in
+              working directory
+
+       [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m=[4mD[0m[4mE[0m[4mP[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Use with  --all-projects  or
+              --yarn-workspaces   to  indicate  how  many  sub-directories  to
+              search. [1mD[0m[1mE[0m[1mP[0m[1mT[0m[1mH[0m must be a number.
+
+              Default: 4 (the current working directory and 3 sub-directories)
+
+       [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m=[4mD[0m[4mI[0m[4mR[0m[4mE[0m[4mC[0m[4mT[0m[4mO[0m[4mR[0m[4mY[0m[,[4mD[0m[4mI[0m[4mR[0m[4mE[0m[4mC[0m[4mT[0m[4mO[0m[4mR[0m[4mY[0m]...>
+              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Can   be   used   with
+              --all-projects and --yarn-workspaces to indicate sub-directories
+              and files to exclude. Must be comma separated.
+
+              If using with [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m exclude ignores  directories  at
+              any level deep.
+
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mu[0m[1mn[0m[1me[0m[1m-[0m[1mr[0m[1me[0m[1mp[0m[1me[0m[1ma[0m[1mt[0m[1me[0m[1md[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1md[0m[1me[0m[1mp[0m[1me[0m[1mn[0m[1md[0m[1me[0m[1mn[0m[1mc[0m[1mi[0m[1me[0m[1ms[0m, [1m-[0m[1mp[0m
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Prune dependency trees, re-
+              moving duplicate sub-dependencies. Will still find all  vulnera-
+              bilities, but potentially not all of the vulnerable paths.
+
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mi[0m[1mn[0m[1mt[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1ms[0m
+              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Print the dependency tree
+              before sending it for analysis.
+
+       [1m-[0m[1m-[0m[1mr[0m[1me[0m[1mm[0m[1mo[0m[1mt[0m[1me[0m[1m-[0m[1mr[0m[1me[0m[1mp[0m[1mo[0m[1m-[0m[1mu[0m[1mr[0m[1ml[0m=[4mU[0m[4mR[0m[4mL[0m
+              Set or override the remote URL for the repository that you would
+              like to monitor.
+
+       [1m-[0m[1m-[0m[1md[0m[1me[0m[1mv[0m  Include  development-only dependencies. Applicable only for some
+              package managers. E.g. [4md[0m[4me[0m[4mv[0m[4mD[0m[4me[0m[4mp[0m[4me[0m[4mn[0m[4md[0m[4me[0m[4mn[0m[4mc[0m[4mi[0m[4me[0m[4ms[0m in  npm  or  [4m:[0m[4md[0m[4me[0m[4mv[0m[4me[0m[4ml[0m[4mo[0m[4mp[0m[4mm[0m[4me[0m[4mn[0m[4mt[0m
+              dependencies in Gemfile.
+
+              Default: scan only production dependencies
+
+       [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+              Specify the [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m to run Snyk commands tied to a specific or-
+              ganization. This will influence where will new projects be  cre-
+              ated  after  running [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command, some features availability
+              and private tests limits. If you  have  multiple  organizations,
+              you can set a default from the CLI using:
+
+              [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m [1ms[0m[1me[0m[1mt[0m [1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+
+              Setting  a default will ensure all newly monitored projects will
+              be created under your default organization. If you need to over-
+              ride the default, you can use the [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m argument.
+
+              Default: uses [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m that sets as default in your Account set-
+              tings [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ma[0m[4mp[0m[4mp[0m[4m.[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mo[0m[4m/[0m[4ma[0m[4mc[0m[4mc[0m[4mo[0m[4mu[0m[4mn[0m[4mt[0m
+
+       [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m
+              Sets a package file.
+
+              When testing locally or monitoring a project,  you  can  specify
+              the  file that Snyk should inspect for package information. When
+              ommitted Snyk will try to detect the appropriate file  for  your
+              project.
+
+       [1m-[0m[1m-[0m[1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+              Ignores  all set policies. The current policy in [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m file, Org
+              level ignores and the project policy on snyk.io.
+
+       [1m-[0m[1m-[0m[1mt[0m[1mr[0m[1mu[0m[1ms[0m[1mt[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1mi[0m[1me[0m[1ms[0m
+              Applies and uses ignore rules from your dependencies' Snyk poli-
+              cies, otherwise ignore policies are only shown as a suggestion.
+
+       [1m-[0m[1m-[0m[1ms[0m[1mh[0m[1mo[0m[1mw[0m[1m-[0m[1mv[0m[1mu[0m[1ml[0m[1mn[0m[1me[0m[1mr[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1ms[0m=none|some|all
+              Display  the  dependency  paths from the top level dependencies,
+              down to the vulnerable packages. Doesn't affect output when  us-
+              ing JSON [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m output.
+
+              Default:  [4ms[0m[4mo[0m[4mm[0m[4me[0m (a few example paths shown) [4mf[0m[4ma[0m[4ml[0m[4ms[0m[4me[0m is an alias for
+              [4mn[0m[4mo[0m[4mn[0m[4me[0m.
+
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m=[4mP[0m[4mR[0m[4mO[0m[4mJ[0m[4mE[0m[4mC[0m[4mT[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+              Specify a custom Snyk project name.
+
+       [1m-[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m=[4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m`
+              Manually pass a path to a snyk policy file.
+
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m Prints results in JSON format.
+
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format  directly
+              to  the specified file, regardless of whether or not you use the
+              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m option. This is especially useful if you want to  display
+              the  human-readable  test output via stdout and at the same time
+              save the JSON format output to a file.
+
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m
+              Return results in SARIF format.
+
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in SARIF format directly
+              to  the  [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or not you
+              use the [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m option. This is especially useful if you want to
+              display  the  human-readable  test  output via stdout and at the
+              same time save the SARIF format output to a file.
+
+       [1m-[0m[1m-[0m[1ms[0m[1me[0m[1mv[0m[1me[0m[1mr[0m[1mi[0m[1mt[0m[1my[0m[1m-[0m[1mt[0m[1mh[0m[1mr[0m[1me[0m[1ms[0m[1mh[0m[1mo[0m[1ml[0m[1md[0m=low|medium|high|critical
+              Only report vulnerabilities of provided level or higher.
+
+       [1m-[0m[1m-[0m[1mf[0m[1ma[0m[1mi[0m[1ml[0m[1m-[0m[1mo[0m[1mn[0m=all|upgradable|patchable
+              Only fail when there are vulnerabilities that can be fixed.
+
+              [4ma[0m[4ml[0m[4ml[0m fails when there is at least one vulnerability that  can  be
+              either  upgraded  or  patched. [4mu[0m[4mp[0m[4mg[0m[4mr[0m[4ma[0m[4md[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails when there is at
+              least one vulnerability that can be  upgraded.  [4mp[0m[4ma[0m[4mt[0m[4mc[0m[4mh[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m  fails
+              when there is at least one vulnerability that can be patched.
+
+              If  vulnerabilities  do  not have a fix and this option is being
+              used, tests will pass.
+
+       [1m-[0m[1m-[0m[1md[0m[1mr[0m[1my[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m
+              (only in [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command) Don't apply updates or patches  during
+              [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command run.
+
+       [1m-[0m[1m-[0m [[4mC[0m[4mO[0m[4mM[0m[4mP[0m[4mI[0m[4mL[0m[4mE[0m[4mR[0m[1m_[0m[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
+              Pass extra arguments directly to Gradle or Maven. E.g. [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mt[0m[1me[0m[1ms[0m[1mt[0m
+              [1m-[0m[1m-[0m [1m-[0m[1m-[0m[1mb[0m[1mu[0m[1mi[0m[1ml[0m[1md[0m[1m-[0m[1mc[0m[1ma[0m[1mc[0m[1mh[0m[1me[0m
+
+       Below  are  flags  that  are  influencing  CLI  behavior  for  specific
+       projects, languages and contexts:
+
+   [1mM[0m[1ma[0m[1mv[0m[1me[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1mu[0m[1mn[0m[1mm[0m[1ma[0m[1mn[0m[1ma[0m[1mg[0m[1me[0m[1md[0m
+              Auto  detects maven jars, aars, and wars in given directory. In-
+              dividual testing can be done with [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mJ[0m[4mA[0m[4mR[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+
+       [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Analyze your source code  to
+              find which vulnerable functions and packages are called.
+
+       [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m
+              The  amount  of  time  (in  seconds)  to wait for Snyk to gather
+              reachability data. If it takes longer  than  [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m,  Reachable
+              Vulnerabilities  are  not reported. This does not affect regular
+              test or monitor output.
+
+              Default: 300 (5 minutes).
+
+   [1mG[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       More information about Gradle CLI options [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mP[0m
+
+       O   [1m-[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m, [1m-[0m[1m-[0m[1mg[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m:  For  Gradle  "multi
+           project" configurations, test a specific sub-project.
+
+       O   [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m:  For  "multi  project" configurations, test all
+           sub-projects.
+
+       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m=[4mC[0m[4mO[0m[4mN[0m[4mF[0m[4mI[0m[4mG[0m[4mU[0m[4mR[0m[4mA[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mE[0m[4mX[0m: Resolve  dependencies
+           using  only  configuration(s)  that match the provided Java regular
+           expression, e.g. [1m^[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1mR[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mC[0m[1ml[0m[1ma[0m[1ms[0m[1ms[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1m$[0m.
+
+       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1ma[0m[1mt[0m[1mt[0m[1mr[0m[1mi[0m[1mb[0m[1mu[0m[1mt[0m[1me[0m[1ms[0m=[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m[,[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m]...: Select certain
+           values  of  configuration  attributes  to resolve the dependencies.
+           E.g. [1mb[0m[1mu[0m[1mi[0m[1ml[0m[1md[0m[1mt[0m[1my[0m[1mp[0m[1me[0m[1m:[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1m,[0m[1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m[1m:[0m[1mj[0m[1ma[0m[1mv[0m[1ma[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m
+
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m: (only in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Analyze  your
+           source  code  to  find  which vulnerable functions and packages are
+           called.
+
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m: The amount of  time  (in  seconds)  to
+           wait  for Snyk to gather reachability data. If it takes longer than
+           [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m, Reachable Vulnerabilities are not reported. This does  not
+           affect regular test or monitor output.
+
+           Default: 300 (5 minutes).
+
+       O   [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1mi[0m[1mt[0m[1m-[0m[1ms[0m[1mc[0m[1mr[0m[1mi[0m[1mp[0m[1mt[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m  For  projects that contain a gradle initializa-
+           tion script.
+
+
+
+   [1m.[0m[1mN[0m[1me[0m[1mt[0m [1m&[0m [1mN[0m[1mu[0m[1mG[0m[1me[0m[1mt[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ma[0m[1ms[0m[1ms[0m[1me[0m[1mt[0m[1ms[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m
+              When monitoring a .NET project using NuGet [1mP[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1mR[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m  use
+              the project name in project.assets.json, if found.
+
+       [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1ms[0m[1m-[0m[1mf[0m[1mo[0m[1ml[0m[1md[0m[1me[0m[1mr[0m
+              Custom path to packages folder
+
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m=[4mP[0m[4mR[0m[4mE[0m[4mF[0m[4mI[0m[4mX[0m[1m_[0m[4mS[0m[4mT[0m[4mR[0m[4mI[0m[4mN[0m[4mG[0m
+              When  monitoring  a  .NET project, use this flag to add a custom
+              prefix to the name of files inside a project along with any  de-
+              sired   separators,   e.g.  [1ms[0m[1mn[0m[1my[0m[1mk[0m  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m.[0m[1ms[0m[1ml[0m[1mn[0m
+              [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mg[0m[1mr[0m[1mo[0m[1mu[0m[1mp[0m[1m/[0m. This is useful  when  you  have
+              multiple projects with the same name in other sln files.
+
+   [1mn[0m[1mp[0m[1mm[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mt[0m[1mr[0m[1mi[0m[1mc[0m[1mt[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1m-[0m[1mo[0m[1mf[0m[1m-[0m[1ms[0m[1my[0m[1mn[0m[1mc[0m=true|false
+              Control testing out of sync lockfiles.
+
+              Default: true
+
+   [1mY[0m[1ma[0m[1mr[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mt[0m[1mr[0m[1mi[0m[1mc[0m[1mt[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1m-[0m[1mo[0m[1mf[0m[1m-[0m[1ms[0m[1my[0m[1mn[0m[1mc[0m=true|false
+              Control testing out of sync lockfiles.
+
+              Default: true
+
+       [1m-[0m[1m-[0m[1my[0m[1ma[0m[1mr[0m[1mn[0m[1m-[0m[1mw[0m[1mo[0m[1mr[0m[1mk[0m[1ms[0m[1mp[0m[1ma[0m[1mc[0m[1me[0m[1ms[0m
+              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Detect  and  scan yarn
+              workspaces. You can specify how many sub-directories  to  search
+              using  [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m and exclude directories and files using
+              [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m.
+
+   [1mC[0m[1mo[0m[1mc[0m[1mo[0m[1ma[0m[1mP[0m[1mo[0m[1md[0m[1ms[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mt[0m[1mr[0m[1mi[0m[1mc[0m[1mt[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1m-[0m[1mo[0m[1mf[0m[1m-[0m[1ms[0m[1my[0m[1mn[0m[1mc[0m=true|false
+              Control testing out of sync lockfiles.
+
+              Default: false
+
+   [1mP[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m=[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m
+              Indicate which specific Python commands to use based  on  Python
+              version.  The  default is [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m which executes your systems de-
+              fault python version. Run 'python -V' to find out  what  version
+              is  it.  If you are using multiple Python versions, use this pa-
+              rameter to specify the correct Python command for execution.
+
+              Default: [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m Example: [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1m=[0m[1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m[1m3[0m
+
+       [1m-[0m[1m-[0m[1ms[0m[1mk[0m[1mi[0m[1mp[0m[1m-[0m[1mu[0m[1mn[0m[1mr[0m[1me[0m[1ms[0m[1mo[0m[1ml[0m[1mv[0m[1me[0m[1md[0m=true|false
+              Allow skipping packages that are not found in the environment.
+
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
+              Ignore unknown certificate authorities.
+
+       [1m-[0m[1md[0m     Output debug logs.
+
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
+              Silence all output.
+
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
+              Prints versions.
+
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints a help text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to  get  more  de-
+              tails.
+
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
+       Possible exit codes and their meaning:
+
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
+
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
+       You can set these environment variables to change CLI run settings.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
+              Snyk  authorization token. Setting this envvar will override the
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
+
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
+
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
+
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+              Specify a username to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
+              credentials when Docker is present.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
+              Specify  a  password  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
+              credentials when Docker is present.
+
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
+              Sets API host to use for Snyk requests.  Useful  for  on-premise
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
+              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
+              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
+              for reverse proxies.
+
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
+              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol will use this proxy. The proxy itself doesn't  need  to
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
+
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
+       age  or   otherwise,   is   subject   to   the   terms   &   conditions
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-wizard.txt
+++ b/help/commands-txt/snyk-wizard.txt
@@ -1,0 +1,104 @@
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mw[0m[1mi[0m[1mz[0m[1ma[0m[1mr[0m[1md[0m  - Configure your policy file to update, auto patch and ig-
+       nore vulnerabilities
+
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mw[0m[1mi[0m[1mz[0m[1ma[0m[1mr[0m[1md[0m [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
+
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
+       Snyk's wizard will:
+
+       O   Enumerate your local dependencies and query Snyk's servers for vul-
+           nerabilities
+
+       O   Guide you through fixing found vulnerabilities
+
+       O   Create  a .snyk policy file to guide snyk commands such as [1mt[0m[1me[0m[1ms[0m[1mt[0m and
+           [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m
+
+       O   Remember your dependencies to alert you  when  new  vulnerabilities
+           are disclosed
+
+
+
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
+              Ignore unknown certificate authorities.
+
+       [1m-[0m[1md[0m     Output debug logs.
+
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
+              Silence all output.
+
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
+              Prints versions.
+
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
+              tails.
+
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
+       Possible exit codes and their meaning:
+
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
+
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
+       You can set these environment variables to change CLI run settings.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
+              Snyk authorization token. Setting this envvar will override  the
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
+
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
+
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
+
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+              Specify  a  username  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
+              credentials when Docker is present.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
+              Specify a password to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
+              credentials when Docker is present.
+
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
+              Sets  API  host  to use for Snyk requests. Useful for on-premise
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
+              for reverse proxies.
+
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol  will  use this proxy. The proxy itself doesn't need to
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
+
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
+       age   or   otherwise,   is   subject   to   the   terms   &  conditions
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-woof.txt
+++ b/help/commands-txt/snyk-woof.txt
@@ -1,0 +1,94 @@
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mw[0m[1mo[0m[1mo[0m[1mf[0m - W00f
+
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mw[0m[1mo[0m[1mo[0m[1mf[0m [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
+
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
+       Easter egg that prints a Patch ascii art.
+
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       [1m-[0m[1m-[0m[1ml[0m[1ma[0m[1mn[0m[1mg[0m[1mu[0m[1ma[0m[1mg[0m[1me[0m=[4mL[0m[4mA[0m[4mN[0m[4mG[0m[4mU[0m[4mA[0m[4mG[0m[4mE[0m
+              Woof  in  a  specific  language.  [4mL[0m[4mA[0m[4mN[0m[4mG[0m[4mU[0m[4mA[0m[4mG[0m[4mE[0m should be a ISO 639-1
+              code.
+
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
+              Ignore unknown certificate authorities.
+
+       [1m-[0m[1md[0m     Output debug logs.
+
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
+              Silence all output.
+
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
+              Prints versions.
+
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints a help text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to  get  more  de-
+              tails.
+
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
+       Possible exit codes and their meaning:
+
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
+
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
+       You can set these environment variables to change CLI run settings.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
+              Snyk  authorization token. Setting this envvar will override the
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
+
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
+
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
+
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+              Specify a username to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
+              credentials when Docker is present.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
+              Specify  a  password  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
+              credentials when Docker is present.
+
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
+              Sets API host to use for Snyk requests.  Useful  for  on-premise
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
+              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
+              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
+              for reverse proxies.
+
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
+              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol will use this proxy. The proxy itself doesn't  need  to
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
+
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
+       age  or   otherwise,   is   subject   to   the   terms   &   conditions
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk.txt
+++ b/help/commands-txt/snyk.txt
@@ -1,0 +1,407 @@
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m  -  CLI and build-time tool to find & fix known vulnerabilities in
+       open-source dependencies
+
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [[4mS[0m[4mU[0m[4mB[0m[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m] [[4mP[0m[4mA[0m[4mC[0m[4mK[0m[4mA[0m[4mG[0m[4mE[0m] [-- [4mC[0m[4mO[0m[4mM[0m[4mP[0m[4mI[0m[4mL[0m[4mE[0m[4mR[0m[1m_[0m[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
+
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
+       Snyk helps you find, fix and  monitor  known  vulnerabilities  in  open
+       source dependencies.
+       For more information see https://snyk.io
+
+   [1mN[0m[1mo[0m[1mt[0m [1ms[0m[1mu[0m[1mr[0m[1me[0m [1mw[0m[1mh[0m[1me[0m[1mr[0m[1me[0m [1mt[0m[1mo[0m [1ms[0m[1mt[0m[1ma[0m[1mr[0m[1mt[0m[1m?[0m
+       1.  authenticate with [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1ma[0m[1mu[0m[1mt[0m[1mh[0m
+
+       2.  test your local project with [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mt[0m[1me[0m[1ms[0m[1mt[0m
+
+       3.  get alerted for new vulnerabilities with [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m
+
+
+
+[1mC[0m[1mO[0m[1mM[0m[1mM[0m[1mA[0m[1mN[0m[1mD[0m[1mS[0m
+       To  see  command-specific  flags and usage, see [1mh[0m[1me[0m[1ml[0m[1mp[0m command, e.g. [1ms[0m[1mn[0m[1my[0m[1mk[0m
+       [1mc[0m[1mo[0m[1mn[0m[1mt[0m[1ma[0m[1mi[0m[1mn[0m[1me[0m[1mr[0m [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m. Available top-level CLI commands:
+
+       [1ma[0m[1mu[0m[1mt[0m[1mh[0m [[4mA[0m[4mP[0m[4mI[0m[1m_[0m[4mT[0m[4mO[0m[4mK[0m[4mE[0m[4mN[0m]
+              Authenticate Snyk CLI with a Snyk account.
+
+       [1mt[0m[1me[0m[1ms[0m[1mt[0m   Test local project for vulnerabilities.
+
+       [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m
+              Snapshot and continuously monitor your project.
+
+       [1mc[0m[1mo[0m[1mn[0m[1mt[0m[1ma[0m[1mi[0m[1mn[0m[1me[0m[1mr[0m
+              Test container images for vulnerabilities.  See  [1ms[0m[1mn[0m[1my[0m[1mk[0m  [1mc[0m[1mo[0m[1mn[0m[1mt[0m[1ma[0m[1mi[0m[1mn[0m[1me[0m[1mr[0m
+              [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m for full instructions.
+
+       [1mi[0m[1ma[0m[1mc[0m    Find  security  issues in your Infrastructure as Code files. See
+              [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mi[0m[1ma[0m[1mc[0m [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m for full instructions.
+
+       [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m Manage Snyk CLI configuration.
+
+       [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m
+              Applies the patches specified in your .snyk file  to  the  local
+              file system.
+
+       [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m Display the .snyk policy for a package.
+
+       [1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m Modifies the .snyk policy to ignore stated issues.
+
+       [1mw[0m[1mi[0m[1mz[0m[1ma[0m[1mr[0m[1md[0m Configure your policy file to update, auto patch and ignore vul-
+              nerabilities. Snyk wizard updates your .snyk file.
+
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       To see command-specific flags and usage, see [1mh[0m[1me[0m[1ml[0m[1mp[0m  command,  e.g.  [1ms[0m[1mn[0m[1my[0m[1mk[0m
+       [1mc[0m[1mo[0m[1mn[0m[1mt[0m[1ma[0m[1mi[0m[1mn[0m[1me[0m[1mr[0m  [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m.  For  advanced  usage, we offer language and context
+       specific flags, listed further down this document.
+
+       [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Auto-detect all projects  in
+              working directory
+
+       [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m=[4mD[0m[4mE[0m[4mP[0m[4mT[0m[4mH[0m
+              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Use with --all-projects or
+              --yarn-workspaces  to  indicate  how  many  sub-directories   to
+              search. [1mD[0m[1mE[0m[1mP[0m[1mT[0m[1mH[0m must be a number.
+
+              Default: 4 (the current working directory and 3 sub-directories)
+
+       [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m=[4mD[0m[4mI[0m[4mR[0m[4mE[0m[4mC[0m[4mT[0m[4mO[0m[4mR[0m[4mY[0m[,[4mD[0m[4mI[0m[4mR[0m[4mE[0m[4mC[0m[4mT[0m[4mO[0m[4mR[0m[4mY[0m]...>
+              (only   in   [1mt[0m[1me[0m[1ms[0m[1mt[0m   and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Can  be  used  with
+              --all-projects and --yarn-workspaces to indicate sub-directories
+              and files to exclude. Must be comma separated.
+
+              If  using  with [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m exclude ignores directories at
+              any level deep.
+
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mu[0m[1mn[0m[1me[0m[1m-[0m[1mr[0m[1me[0m[1mp[0m[1me[0m[1ma[0m[1mt[0m[1me[0m[1md[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1md[0m[1me[0m[1mp[0m[1me[0m[1mn[0m[1md[0m[1me[0m[1mn[0m[1mc[0m[1mi[0m[1me[0m[1ms[0m, [1m-[0m[1mp[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Prune dependency trees,  re-
+              moving  duplicate sub-dependencies. Will still find all vulnera-
+              bilities, but potentially not all of the vulnerable paths.
+
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mi[0m[1mn[0m[1mt[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1ms[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Print  the  dependency  tree
+              before sending it for analysis.
+
+       [1m-[0m[1m-[0m[1mr[0m[1me[0m[1mm[0m[1mo[0m[1mt[0m[1me[0m[1m-[0m[1mr[0m[1me[0m[1mp[0m[1mo[0m[1m-[0m[1mu[0m[1mr[0m[1ml[0m=[4mU[0m[4mR[0m[4mL[0m
+              Set or override the remote URL for the repository that you would
+              like to monitor.
+
+       [1m-[0m[1m-[0m[1md[0m[1me[0m[1mv[0m  Include development-only dependencies. Applicable only for  some
+              package  managers.  E.g.  [4md[0m[4me[0m[4mv[0m[4mD[0m[4me[0m[4mp[0m[4me[0m[4mn[0m[4md[0m[4me[0m[4mn[0m[4mc[0m[4mi[0m[4me[0m[4ms[0m in npm or [4m:[0m[4md[0m[4me[0m[4mv[0m[4me[0m[4ml[0m[4mo[0m[4mp[0m[4mm[0m[4me[0m[4mn[0m[4mt[0m
+              dependencies in Gemfile.
+
+              Default: scan only production dependencies
+
+       [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+              Specify the [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m to run Snyk commands tied to a specific or-
+              ganization.  This will influence where will new projects be cre-
+              ated after running [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command, some  features  availability
+              and  private  tests  limits. If you have multiple organizations,
+              you can set a default from the CLI using:
+
+              [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m [1ms[0m[1me[0m[1mt[0m [1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+
+              Setting a default will ensure all newly monitored projects  will
+              be created under your default organization. If you need to over-
+              ride the default, you can use the [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m argument.
+
+              Default: uses [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m that sets as default in your Account set-
+              tings [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ma[0m[4mp[0m[4mp[0m[4m.[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mo[0m[4m/[0m[4ma[0m[4mc[0m[4mc[0m[4mo[0m[4mu[0m[4mn[0m[4mt[0m
+
+       [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m
+              Sets a package file.
+
+              When  testing  locally  or monitoring a project, you can specify
+              the file that Snyk should inspect for package information.  When
+              ommitted  Snyk  will try to detect the appropriate file for your
+              project.
+
+       [1m-[0m[1m-[0m[1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+              Ignores all set policies. The current policy in [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m file,  Org
+              level ignores and the project policy on snyk.io.
+
+       [1m-[0m[1m-[0m[1mt[0m[1mr[0m[1mu[0m[1ms[0m[1mt[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1mi[0m[1me[0m[1ms[0m
+              Applies and uses ignore rules from your dependencies' Snyk poli-
+              cies, otherwise ignore policies are only shown as a suggestion.
+
+       [1m-[0m[1m-[0m[1ms[0m[1mh[0m[1mo[0m[1mw[0m[1m-[0m[1mv[0m[1mu[0m[1ml[0m[1mn[0m[1me[0m[1mr[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1ms[0m=none|some|all
+              Display the dependency paths from the  top  level  dependencies,
+              down  to the vulnerable packages. Doesn't affect output when us-
+              ing JSON [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m output.
+
+              Default: [4ms[0m[4mo[0m[4mm[0m[4me[0m (a few example paths shown) [4mf[0m[4ma[0m[4ml[0m[4ms[0m[4me[0m is an alias  for
+              [4mn[0m[4mo[0m[4mn[0m[4me[0m.
+
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m=[4mP[0m[4mR[0m[4mO[0m[4mJ[0m[4mE[0m[4mC[0m[4mT[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+              Specify a custom Snyk project name.
+
+       [1m-[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m=[4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m`
+              Manually pass a path to a snyk policy file.
+
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m Prints results in JSON format.
+
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format directly
+              to the specified file, regardless of whether or not you use  the
+              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m  option. This is especially useful if you want to display
+              the human-readable test output via stdout and at the  same  time
+              save the JSON format output to a file.
+
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m
+              Return results in SARIF format.
+
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in SARIF format directly
+              to the [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or  not  you
+              use the [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m option. This is especially useful if you want to
+              display the human-readable test output via  stdout  and  at  the
+              same time save the SARIF format output to a file.
+
+       [1m-[0m[1m-[0m[1ms[0m[1me[0m[1mv[0m[1me[0m[1mr[0m[1mi[0m[1mt[0m[1my[0m[1m-[0m[1mt[0m[1mh[0m[1mr[0m[1me[0m[1ms[0m[1mh[0m[1mo[0m[1ml[0m[1md[0m=low|medium|high|critical
+              Only report vulnerabilities of provided level or higher.
+
+       [1m-[0m[1m-[0m[1mf[0m[1ma[0m[1mi[0m[1ml[0m[1m-[0m[1mo[0m[1mn[0m=all|upgradable|patchable
+              Only fail when there are vulnerabilities that can be fixed.
+
+              [4ma[0m[4ml[0m[4ml[0m  fails  when there is at least one vulnerability that can be
+              either upgraded or patched. [4mu[0m[4mp[0m[4mg[0m[4mr[0m[4ma[0m[4md[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails when  there  is  at
+              least  one  vulnerability  that can be upgraded. [4mp[0m[4ma[0m[4mt[0m[4mc[0m[4mh[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails
+              when there is at least one vulnerability that can be patched.
+
+              If vulnerabilities do not have a fix and this  option  is  being
+              used, tests will pass.
+
+       [1m-[0m[1m-[0m[1md[0m[1mr[0m[1my[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m
+              (only  in [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command) Don't apply updates or patches during
+              [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command run.
+
+       [1m-[0m[1m-[0m [[4mC[0m[4mO[0m[4mM[0m[4mP[0m[4mI[0m[4mL[0m[4mE[0m[4mR[0m[1m_[0m[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
+              Pass extra arguments directly to Gradle or Maven. E.g. [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mt[0m[1me[0m[1ms[0m[1mt[0m
+              [1m-[0m[1m-[0m [1m-[0m[1m-[0m[1mb[0m[1mu[0m[1mi[0m[1ml[0m[1md[0m[1m-[0m[1mc[0m[1ma[0m[1mc[0m[1mh[0m[1me[0m
+
+       Below  are  flags  that  are  influencing  CLI  behavior  for  specific
+       projects, languages and contexts:
+
+   [1mM[0m[1ma[0m[1mv[0m[1me[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1mu[0m[1mn[0m[1mm[0m[1ma[0m[1mn[0m[1ma[0m[1mg[0m[1me[0m[1md[0m
+              Auto detects maven jars, aars, and wars in given directory.  In-
+              dividual testing can be done with [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mJ[0m[4mA[0m[4mR[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+
+       [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Analyze your source code to
+              find which vulnerable functions and packages are called.
+
+       [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m
+              The amount of time (in seconds)  to  wait  for  Snyk  to  gather
+              reachability  data.  If  it takes longer than [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m, Reachable
+              Vulnerabilities are not reported. This does not  affect  regular
+              test or monitor output.
+
+              Default: 300 (5 minutes).
+
+   [1mG[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       More information about Gradle CLI options [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mP[0m
+
+       O   [1m-[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m,  [1m-[0m[1m-[0m[1mg[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m:  For  Gradle "multi
+           project" configurations, test a specific sub-project.
+
+       O   [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m: For "multi project"  configurations,  test  all
+           sub-projects.
+
+       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m=[4mC[0m[4mO[0m[4mN[0m[4mF[0m[4mI[0m[4mG[0m[4mU[0m[4mR[0m[4mA[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mE[0m[4mX[0m:  Resolve dependencies
+           using only configuration(s) that match the  provided  Java  regular
+           expression, e.g. [1m^[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1mR[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mC[0m[1ml[0m[1ma[0m[1ms[0m[1ms[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1m$[0m.
+
+       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1ma[0m[1mt[0m[1mt[0m[1mr[0m[1mi[0m[1mb[0m[1mu[0m[1mt[0m[1me[0m[1ms[0m=[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m[,[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m]...: Select certain
+           values of configuration attributes  to  resolve  the  dependencies.
+           E.g. [1mb[0m[1mu[0m[1mi[0m[1ml[0m[1md[0m[1mt[0m[1my[0m[1mp[0m[1me[0m[1m:[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1m,[0m[1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m[1m:[0m[1mj[0m[1ma[0m[1mv[0m[1ma[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m
+
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m:  (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands) Analyze your
+           source code to find which vulnerable  functions  and  packages  are
+           called.
+
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m:  The  amount  of  time (in seconds) to
+           wait for Snyk to gather reachability data. If it takes longer  than
+           [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m,  Reachable Vulnerabilities are not reported. This does not
+           affect regular test or monitor output.
+
+           Default: 300 (5 minutes).
+
+       O   [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1mi[0m[1mt[0m[1m-[0m[1ms[0m[1mc[0m[1mr[0m[1mi[0m[1mp[0m[1mt[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m For projects that contain a  gradle  initializa-
+           tion script.
+
+
+
+   [1m.[0m[1mN[0m[1me[0m[1mt[0m [1m&[0m [1mN[0m[1mu[0m[1mG[0m[1me[0m[1mt[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ma[0m[1ms[0m[1ms[0m[1me[0m[1mt[0m[1ms[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m
+              When  monitoring a .NET project using NuGet [1mP[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1mR[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m use
+              the project name in project.assets.json, if found.
+
+       [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1ms[0m[1m-[0m[1mf[0m[1mo[0m[1ml[0m[1md[0m[1me[0m[1mr[0m
+              Custom path to packages folder
+
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m=[4mP[0m[4mR[0m[4mE[0m[4mF[0m[4mI[0m[4mX[0m[1m_[0m[4mS[0m[4mT[0m[4mR[0m[4mI[0m[4mN[0m[4mG[0m
+              When monitoring a .NET project, use this flag to  add  a  custom
+              prefix  to the name of files inside a project along with any de-
+              sired  separators,  e.g.  [1ms[0m[1mn[0m[1my[0m[1mk[0m   [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m   [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m.[0m[1ms[0m[1ml[0m[1mn[0m
+              [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mg[0m[1mr[0m[1mo[0m[1mu[0m[1mp[0m[1m/[0m.  This  is  useful when you have
+              multiple projects with the same name in other sln files.
+
+   [1mn[0m[1mp[0m[1mm[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mt[0m[1mr[0m[1mi[0m[1mc[0m[1mt[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1m-[0m[1mo[0m[1mf[0m[1m-[0m[1ms[0m[1my[0m[1mn[0m[1mc[0m=true|false
+              Control testing out of sync lockfiles.
+
+              Default: true
+
+   [1mY[0m[1ma[0m[1mr[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mt[0m[1mr[0m[1mi[0m[1mc[0m[1mt[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1m-[0m[1mo[0m[1mf[0m[1m-[0m[1ms[0m[1my[0m[1mn[0m[1mc[0m=true|false
+              Control testing out of sync lockfiles.
+
+              Default: true
+
+       [1m-[0m[1m-[0m[1my[0m[1ma[0m[1mr[0m[1mn[0m[1m-[0m[1mw[0m[1mo[0m[1mr[0m[1mk[0m[1ms[0m[1mp[0m[1ma[0m[1mc[0m[1me[0m[1ms[0m
+              (only in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Detect  and  scan  yarn
+              workspaces.  You  can specify how many sub-directories to search
+              using [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m and exclude directories and files  using
+              [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m.
+
+   [1mC[0m[1mo[0m[1mc[0m[1mo[0m[1ma[0m[1mP[0m[1mo[0m[1md[0m[1ms[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mt[0m[1mr[0m[1mi[0m[1mc[0m[1mt[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1m-[0m[1mo[0m[1mf[0m[1m-[0m[1ms[0m[1my[0m[1mn[0m[1mc[0m=true|false
+              Control testing out of sync lockfiles.
+
+              Default: false
+
+   [1mP[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m=[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m
+              Indicate  which  specific Python commands to use based on Python
+              version. The default is [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m which executes your  systems  de-
+              fault  python  version. Run 'python -V' to find out what version
+              is it. If you are using multiple Python versions, use  this  pa-
+              rameter to specify the correct Python command for execution.
+
+              Default: [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m Example: [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1m=[0m[1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m[1m3[0m
+
+       [1m-[0m[1m-[0m[1ms[0m[1mk[0m[1mi[0m[1mp[0m[1m-[0m[1mu[0m[1mn[0m[1mr[0m[1me[0m[1ms[0m[1mo[0m[1ml[0m[1mv[0m[1me[0m[1md[0m=true|false
+              Allow skipping packages that are not found in the environment.
+
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
+              Ignore unknown certificate authorities.
+
+       [1m-[0m[1md[0m     Output debug logs.
+
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
+              Silence all output.
+
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
+              Prints versions.
+
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
+              tails.
+
+[1mE[0m[1mX[0m[1mA[0m[1mM[0m[1mP[0m[1mL[0m[1mE[0m[1mS[0m
+       [1mA[0m[1mu[0m[1mt[0m[1mh[0m[1me[0m[1mn[0m[1mt[0m[1mi[0m[1mc[0m[1ma[0m[1mt[0m[1me[0m [1mi[0m[1mn[0m [1my[0m[1mo[0m[1mu[0m[1mr[0m [1mC[0m[1mI[0m [1mw[0m[1mi[0m[1mt[0m[1mh[0m[1mo[0m[1mu[0m[1mt[0m [1mu[0m[1ms[0m[1me[0m[1mr[0m [1mi[0m[1mn[0m[1mt[0m[1me[0m[1mr[0m[1ma[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m
+              $ snyk auth MY_API_TOKEN
+
+       [1mT[0m[1me[0m[1ms[0m[1mt[0m [1ma[0m [1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m [1mi[0m[1mn[0m [1mc[0m[1mu[0m[1mr[0m[1mr[0m[1me[0m[1mn[0m[1mt[0m [1mf[0m[1mo[0m[1ml[0m[1md[0m[1me[0m[1mr[0m [1mf[0m[1mo[0m[1mr[0m [1mk[0m[1mn[0m[1mo[0m[1mw[0m[1mn[0m [1mv[0m[1mu[0m[1ml[0m[1mn[0m[1me[0m[1mr[0m[1ma[0m[1mb[0m[1mi[0m[1ml[0m[1mi[0m[1mt[0m[1mi[0m[1me[0m[1ms[0m
+              $ snyk test
+
+       [1mT[0m[1me[0m[1ms[0m[1mt[0m [1ma[0m [1ms[0m[1mp[0m[1me[0m[1mc[0m[1mi[0m[1mf[0m[1mi[0m[1mc[0m [1md[0m[1me[0m[1mp[0m[1me[0m[1mn[0m[1md[0m[1me[0m[1mn[0m[1mc[0m[1my[0m [1mf[0m[1mo[0m[1mr[0m [1mv[0m[1mu[0m[1ml[0m[1mn[0m[1me[0m[1mr[0m[1ma[0m[1mb[0m[1mi[0m[1ml[0m[1mi[0m[1mt[0m[1mi[0m[1me[0m[1ms[0m
+              $ snyk test ionic@1.6.5
+
+       More examples:
+
+
+           $ snyk test --show-vulnerable-paths=false
+           $ snyk monitor --org=my-team
+           $ snyk monitor --project-name=my-project
+
+
+
+   [1mC[0m[1mo[0m[1mn[0m[1mt[0m[1ma[0m[1mi[0m[1mn[0m[1me[0m[1mr[0m [1ms[0m[1mc[0m[1ma[0m[1mn[0m[1mn[0m[1mi[0m[1mn[0m[1mg[0m
+       See [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mt[0m[1ma[0m[1mi[0m[1mn[0m[1me[0m[1mr[0m [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m for more details and examples:
+
+
+           $ snyk container test ubuntu:18.04 --org=my-team
+           $ snyk container test app:latest --file=Dockerfile --policy-path=path/to/.snyk
+
+
+
+   [1mI[0m[1mn[0m[1mf[0m[1mr[0m[1ma[0m[1ms[0m[1mt[0m[1mr[0m[1mu[0m[1mc[0m[1mt[0m[1mu[0m[1mr[0m[1me[0m [1ma[0m[1ms[0m [1mC[0m[1mo[0m[1md[0m[1me[0m [1m([0m[1mI[0m[1mA[0m[1mC[0m[1m)[0m [1ms[0m[1mc[0m[1ma[0m[1mn[0m[1mn[0m[1mi[0m[1mn[0m[1mg[0m
+       See [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mi[0m[1ma[0m[1mc[0m [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m for more details and examples:
+
+
+           $ snyk iac test /path/to/cloudformation_file.yaml
+           $ snyk iac test /path/to/kubernetes_file.yaml
+           $ snyk iac test /path/to/terraform_file.tf
+           $ snyk iac test /path/to/tf-plan.json
+
+
+
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
+       Possible exit codes and their meaning:
+
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
+
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
+       You can set these environment variables to change CLI run settings.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
+              Snyk authorization token. Setting this envvar will override  the
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
+
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
+
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
+
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+              Specify  a  username  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
+              credentials when Docker is present.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
+              Specify a password to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
+              credentials when Docker is present.
+
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
+              Sets  API  host  to use for Snyk requests. Useful for on-premise
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
+              for reverse proxies.
+
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol  will  use this proxy. The proxy itself doesn't need to
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
+
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
+       age   or   otherwise,   is   subject   to   the   terms   &  conditions
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m


### PR DESCRIPTION
<img width="940" alt="Screen Shot 2021-07-26 at 16 01 43" src="https://user-images.githubusercontent.com/1788727/127002385-b5046dc0-496f-40cd-9f30-b7d11a417699.png">

Embedds the help files statically in the repository. This should make it easier to review future changes. It will also simplify local setup and speeds up CI runs