### PR TITLE
chore: skip Yarn Smoke Tests on Node 10

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -29,6 +29,8 @@ jobs:
             node_version: 12
           - snyk_install_method: binary
             node_version: 15
+          - snyk_install_method: yarn # yarn doesn't support Node v10 anymore
+            node_version: 10
         include:
           - snyk_install_method: binary
             os: ubuntu

--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,4 @@
 @snyk:registry=https://registry.npmjs.org
-engine-strict=true
 package-lock=false
 audit=false
 fund=false


### PR DESCRIPTION
Resolve a failing Smoke Test after Yarn dropping Node v10 support

```
error @yarnpkg/json-proxy@2.1.1: The engine "node" is incompatible with this module. Expected version ">=12 <14 || 14.2 - 14.9 || >14.10.0". Got "10.24.1"
error Found incompatible module.
```