### PR TITLE
Use named export in request module

### DIFF
--- a/src/cli/commands/auth/index.ts
+++ b/src/cli/commands/auth/index.ts
@@ -9,7 +9,7 @@ import { isCI } from '../../../lib/is-ci';
 import { isDocker } from '../../../lib/is-docker';
 import { args as argsLib } from '../../args';
 import * as config from '../../../lib/config';
-import request = require('../../../lib/request');
+import { makeRequest } from '../../../lib/request';
 import { CustomError } from '../../../lib/errors';
 import { AuthFailedError } from '../../../lib/errors';
 import { TokenExpiredError } from '../../../lib/errors/token-expired-error';
@@ -94,7 +94,7 @@ async function testAuthComplete(
 
   return new Promise((resolve, reject) => {
     debug(payload);
-    request(payload, (error, res, body) => {
+    makeRequest(payload, (error, res, body) => {
       debug(error, (res || {}).statusCode, body);
       if (error) {
         return reject(error);
@@ -175,7 +175,7 @@ async function getIpFamily(): Promise<6 | undefined> {
   const family = 6;
   try {
     // Dispatch a FORCED IPv6 request to test client's ISP and network capability
-    await request({
+    await makeRequest({
       url: config.API + '/verify/callback',
       family, // family param forces the handler to dispatch a request using IP at "family" version
       method: 'post',

--- a/src/cli/commands/auth/is-authed.ts
+++ b/src/cli/commands/auth/is-authed.ts
@@ -1,6 +1,6 @@
 import * as snyk from '../../../lib';
 import * as config from '../../../lib/config';
-import request = require('../../../lib/request');
+import { makeRequest } from '../../../lib/request';
 
 export function isAuthed() {
   const token = snyk.config.get('api');
@@ -20,7 +20,7 @@ export function verifyAPI(api) {
   };
 
   return new Promise((resolve, reject) => {
-    request(payload, (error, res, body) => {
+    makeRequest(payload, (error, res, body) => {
       if (error) {
         return reject(error);
       }

--- a/src/cli/commands/test/iac-local-execution/org-settings/get-iac-org-settings.ts
+++ b/src/cli/commands/test/iac-local-execution/org-settings/get-iac-org-settings.ts
@@ -3,7 +3,7 @@ import { Payload } from '../../../../../lib/snyk-test/types';
 import * as config from '../../../../../lib/config';
 import { isCI } from '../../../../../lib/is-ci';
 import { api } from '../../../../../lib/api-token';
-import request = require('../../../../../lib/request');
+import { makeRequest } from '../../../../../lib/request';
 import { CustomError } from '../../../../../lib/errors';
 import { getErrorStringCode } from '../error-utils';
 
@@ -22,7 +22,7 @@ export function getIacOrgSettings(
   };
 
   return new Promise((resolve, reject) => {
-    request(payload, (error, res) => {
+    makeRequest(payload, (error, res) => {
       if (error) {
         return reject(error);
       }

--- a/src/cli/commands/test/iac-local-execution/usage-tracking.ts
+++ b/src/cli/commands/test/iac-local-execution/usage-tracking.ts
@@ -1,4 +1,4 @@
-import request = require('../../../../lib/request');
+import { makeRequest } from '../../../../lib/request';
 import config = require('../../../../lib/config');
 import { api as getApiToken } from '../../../../lib/api-token';
 import { CustomError } from '../../../../lib/errors';
@@ -12,7 +12,7 @@ export async function trackUsage(
       issuesPrevented: res.result.cloudConfigResults.length,
     };
   });
-  const trackingResponse = await request({
+  const trackingResponse = await makeRequest({
     method: 'POST',
     headers: {
       Authorization: `token ${getApiToken()}`,

--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 const snyk = require('../../lib');
 const config = require('../config');
 const version = require('../version');
-const request = require('../request');
+import { makeRequest } from '../request';
 const {
   getIntegrationName,
   getIntegrationVersion,
@@ -123,7 +123,7 @@ export async function postAnalytics(
     const queryString =
       Object.keys(queryStringParams).length > 0 ? queryStringParams : undefined;
 
-    return request({
+    return makeRequest({
       body: {
         data: data,
       },

--- a/src/lib/authorization.ts
+++ b/src/lib/authorization.ts
@@ -1,5 +1,5 @@
 import * as snyk from './';
-import request = require('./request');
+import { makeRequest } from './request';
 import * as config from './config';
 
 export async function actionAllowed(
@@ -9,7 +9,7 @@ export async function actionAllowed(
   const org = options.org || config.org || null;
 
   try {
-    const res = await request({
+    const res = await makeRequest({
       method: 'GET',
       url: config.API + '/authorization/' + action,
       json: true,

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,4 +1,4 @@
-import request = require('./request');
+import { makeRequest } from './request';
 import { api as getApiToken } from './api-token';
 import * as config from './config';
 import { assembleQueryString } from './snyk-test/common';
@@ -14,7 +14,7 @@ export async function isFeatureFlagSupportedForOrg(
   featureFlag: string,
   org,
 ): Promise<OrgFeatureFlagResponse> {
-  const response = await request({
+  const response = await makeRequest({
     method: 'GET',
     headers: {
       Authorization: `token ${getApiToken()}`,

--- a/src/lib/iac/iac-parser.ts
+++ b/src/lib/iac/iac-parser.ts
@@ -6,7 +6,7 @@ import {
   MissingApiTokenError,
   NotSupportedIacFileErrorMsg,
 } from '../errors';
-import request = require('../request');
+import { makeRequest } from '../request';
 import { api as getApiToken } from '../api-token';
 import * as config from './../config';
 import {
@@ -93,7 +93,7 @@ export function validateK8sFile(
 export async function makeValidateTerraformRequest(
   terraformFileContent: string,
 ): Promise<IacValidationResponse> {
-  const response = await request({
+  const response = await makeRequest({
     body: {
       contentBase64: Buffer.from(terraformFileContent).toString('base64'),
     },

--- a/src/lib/monitor/index.ts
+++ b/src/lib/monitor/index.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as depGraphLib from '@snyk/dep-graph';
 import * as snyk from '..';
 import { apiOrOAuthTokenExists, getAuthHeader } from '../api-token';
-import request = require('../request');
+import { makeRequest } from '../request';
 import * as config from '../config';
 import * as os from 'os';
 const get = require('lodash.get');
@@ -270,7 +270,7 @@ async function monitorDepTree(
         ),
       );
     }
-    request(
+    makeRequest(
       {
         body: {
           meta: {
@@ -439,7 +439,7 @@ export async function monitorDepGraph(
         ),
       );
     }
-    request(
+    makeRequest(
       {
         body: {
           meta: {
@@ -584,7 +584,7 @@ async function experimentalMonitorDepGraphFromDepTree(
         ),
       );
     }
-    request(
+    makeRequest(
       {
         body: {
           meta: {

--- a/src/lib/plugins/sast/checks.ts
+++ b/src/lib/plugins/sast/checks.ts
@@ -1,4 +1,5 @@
-import request = require('../../request');
+import { makeRequest } from '../../request';
+
 import { api as getApiToken } from '../../api-token';
 import * as config from '../../config';
 import { assembleQueryString } from '../../snyk-test/common';
@@ -15,7 +16,7 @@ interface TrackUsageResponse {
 }
 
 export async function getSastSettingsForOrg(org): Promise<SastSettings> {
-  const response = await request({
+  const response = await makeRequest({
     method: 'GET',
     headers: {
       Authorization: `token ${getApiToken()}`,
@@ -30,7 +31,7 @@ export async function getSastSettingsForOrg(org): Promise<SastSettings> {
 }
 
 export async function trackUsage(org): Promise<TrackUsageResponse> {
-  const response = await request({
+  const response = await makeRequest({
     method: 'POST',
     headers: {
       Authorization: `token ${getApiToken()}`,

--- a/src/lib/protect/fetch-patch.ts
+++ b/src/lib/protect/fetch-patch.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as analytics from '../analytics';
 import * as debugModule from 'debug';
-import request = require('../request');
+import { makeRequest } from '../request';
 
 const debug = debugModule('snyk:fetch-patch');
 
@@ -10,7 +10,7 @@ async function getPatchFile(
   patchFilename: string,
 ): Promise<string> {
   try {
-    const response = await request({ url: patchUrl });
+    const response = await makeRequest({ url: patchUrl });
     if (
       !response ||
       !response.res ||

--- a/src/lib/request/index.ts
+++ b/src/lib/request/index.ts
@@ -1,24 +1,24 @@
-import request = require('./request');
+import { makeRequest } from './request';
 import alerts = require('../alerts');
 import { MetricsCollector } from '../metrics';
 import * as needle from 'needle';
 
 // A hybrid async function: both returns a promise and takes a callback
-async function requestWrapper(
+async function makeRequestWrapper(
   payload: any,
 ): Promise<{ res: needle.NeedleResponse; body: any }>;
-async function requestWrapper(
+async function makeRequestWrapper(
   payload: any,
   callback: (err: Error | null, res?, body?) => void,
 ): Promise<void>;
-async function requestWrapper(
+async function makeRequestWrapper(
   payload: any,
   callback?: (err: Error | null, res?, body?) => void,
 ): Promise<void | { res: needle.NeedleResponse; body: any }> {
   const totalNetworkTimeTimer = MetricsCollector.NETWORK_TIME.createInstance();
   totalNetworkTimeTimer.start();
   try {
-    const result = await request(payload);
+    const result = await makeRequest(payload);
     if (result.body.alerts) {
       alerts.registerAlerts(result.body.alerts);
     }
@@ -37,4 +37,4 @@ async function requestWrapper(
   }
 }
 
-export = requestWrapper;
+export { makeRequestWrapper as makeRequest };

--- a/src/lib/request/promise.ts
+++ b/src/lib/request/promise.ts
@@ -1,8 +1,8 @@
-import request = require('./index');
+import * as request from './index';
 
 export async function makeRequest<T>(payload: any): Promise<T> {
   return new Promise((resolve, reject) => {
-    request(payload, (error, res, body) => {
+    request.makeRequest(payload, (error, res, body) => {
       if (error) {
         return reject(error);
       }

--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -17,7 +17,7 @@ const snykDebug = debugModule('snyk');
 
 declare const global: Global;
 
-export = function makeRequest(
+export async function makeRequest(
   payload: Payload,
 ): Promise<{ res: needle.NeedleResponse; body: any }> {
   // This ensures we support lowercase http(s)_proxy values as well
@@ -30,121 +30,119 @@ export = function makeRequest(
       process.env.HTTPS_PROXY || process.env.https_proxy;
   }
 
-  return getVersion().then(
-    (versionNumber) =>
-      new Promise((resolve, reject) => {
-        const body = payload.body;
-        let data;
+  const versionNumber = await getVersion();
+  const body = payload.body;
+  let data;
 
-        delete payload.body;
+  delete payload.body;
 
-        if (!payload.headers) {
-          payload.headers = {};
-        }
+  if (!payload.headers) {
+    payload.headers = {};
+  }
 
-        payload.headers['x-snyk-cli-version'] = versionNumber;
+  payload.headers['x-snyk-cli-version'] = versionNumber;
 
-        if (body) {
-          const json = JSON.stringify(body);
-          if (json.length < 1e4) {
-            debug(JSON.stringify(body, null, 2));
-          }
+  if (body) {
+    const json = JSON.stringify(body);
+    if (json.length < 1e4) {
+      debug(JSON.stringify(body, null, 2));
+    }
 
-          // always compress going upstream
-          data = zlib.gzipSync(json, { level: 9 });
+    // always compress going upstream
+    data = zlib.gzipSync(json, { level: 9 });
 
-          snykDebug('sending request to:', payload.url);
-          snykDebug('request body size:', json.length);
-          snykDebug('gzipped request body size:', data.length);
+    snykDebug('sending request to:', payload.url);
+    snykDebug('request body size:', json.length);
+    snykDebug('gzipped request body size:', data.length);
 
-          let callGraphLength: number | null = null;
-          if (body.callGraph) {
-            callGraphLength = JSON.stringify(body.callGraph).length;
-            snykDebug('call graph size:', callGraphLength);
-          }
+    let callGraphLength: number | null = null;
+    if (body.callGraph) {
+      callGraphLength = JSON.stringify(body.callGraph).length;
+      snykDebug('call graph size:', callGraphLength);
+    }
 
-          payload.headers['content-encoding'] = 'gzip';
-          payload.headers['content-length'] = data.length;
-        }
+    payload.headers['content-encoding'] = 'gzip';
+    payload.headers['content-length'] = data.length;
+  }
 
-        const parsedUrl = parse(payload.url);
+  const parsedUrl = parse(payload.url);
 
-        if (
-          parsedUrl.protocol === 'http:' &&
-          parsedUrl.hostname !== 'localhost' &&
-          process.env.SNYK_HTTP_PROTOCOL_UPGRADE !== '0'
-        ) {
-          debug('forcing api request to https');
-          parsedUrl.protocol = 'https:';
-          payload.url = format(parsedUrl);
-        }
+  if (
+    parsedUrl.protocol === 'http:' &&
+    parsedUrl.hostname !== 'localhost' &&
+    process.env.SNYK_HTTP_PROTOCOL_UPGRADE !== '0'
+  ) {
+    debug('forcing api request to https');
+    parsedUrl.protocol = 'https:';
+    payload.url = format(parsedUrl);
+  }
 
-        // prefer config timeout unless payload specified
-        if (!payload.hasOwnProperty('timeout')) {
-          payload.timeout = config.timeout * 1000; // s -> ms
-        }
+  // prefer config timeout unless payload specified
+  if (!payload.hasOwnProperty('timeout')) {
+    payload.timeout = config.timeout * 1000; // s -> ms
+  }
 
-        try {
-          debug('request payload: ', JSON.stringify(payload));
-        } catch (e) {
-          debug('request payload is too big to log', e);
-        }
+  try {
+    debug('request payload: ', JSON.stringify(payload));
+  } catch (e) {
+    debug('request payload is too big to log', e);
+  }
 
-        const method = (
-          payload.method || 'get'
-        ).toLowerCase() as needle.NeedleHttpVerbs;
-        let url = payload.url;
+  const method = (
+    payload.method || 'get'
+  ).toLowerCase() as needle.NeedleHttpVerbs;
+  let url = payload.url;
 
-        if (payload.qs) {
-          // Parse the URL and append the search part - this will take care of adding the '/?' part if it's missing
-          const urlObject = new URL(url);
-          urlObject.search = querystring.stringify(payload.qs);
-          url = urlObject.toString();
-          delete payload.qs;
-        }
+  if (payload.qs) {
+    // Parse the URL and append the search part - this will take care of adding the '/?' part if it's missing
+    const urlObject = new URL(url);
+    urlObject.search = querystring.stringify(payload.qs);
+    url = urlObject.toString();
+    delete payload.qs;
+  }
 
-        const agent =
-          parsedUrl.protocol === 'http:'
-            ? new http.Agent({ keepAlive: true })
-            : new https.Agent({ keepAlive: true });
-        const options: needle.NeedleOptions = {
-          json: payload.json,
-          headers: payload.headers,
-          timeout: payload.timeout,
-          // eslint-disable-next-line @typescript-eslint/camelcase
-          follow_max: 5,
-          family: payload.family,
-          agent,
-        };
+  const agent =
+    parsedUrl.protocol === 'http:'
+      ? new http.Agent({ keepAlive: true })
+      : new https.Agent({ keepAlive: true });
+  const options: needle.NeedleOptions = {
+    json: payload.json,
+    headers: payload.headers,
+    timeout: payload.timeout,
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    follow_max: 5,
+    family: payload.family,
+    agent,
+  };
 
-        const proxyUri = getProxyForUrl(url);
-        if (proxyUri) {
-          snykDebug('using proxy:', proxyUri);
-          bootstrap({
-            environmentVariableNamespace: '',
-          });
-        } else {
-          snykDebug('not using proxy');
-        }
+  const proxyUri = getProxyForUrl(url);
+  if (proxyUri) {
+    snykDebug('using proxy:', proxyUri);
+    bootstrap({
+      environmentVariableNamespace: '',
+    });
+  } else {
+    snykDebug('not using proxy');
+  }
 
-        if (global.ignoreUnknownCA) {
-          debug('Using insecure mode (ignore unknown certificate authority)');
-          options.rejectUnauthorized = false;
-        }
+  if (global.ignoreUnknownCA) {
+    debug('Using insecure mode (ignore unknown certificate authority)');
+    options.rejectUnauthorized = false;
+  }
 
-        needle.request(method, url, data, options, (err, res, respBody) => {
-          debug(err);
-          debug(
-            'response (%s): ',
-            (res || {}).statusCode,
-            JSON.stringify(respBody),
-          );
-          if (err) {
-            return reject(err);
-          }
+  return new Promise((resolve, reject) => {
+    needle.request(method, url, data, options, (err, res, respBody) => {
+      debug(err);
+      debug(
+        'response (%s): ',
+        (res || {}).statusCode,
+        JSON.stringify(respBody),
+      );
+      if (err) {
+        return reject(err);
+      }
 
-          resolve({ res, body: respBody });
-        });
-      }),
-  );
-};
+      resolve({ res, body: respBody });
+    });
+  });
+}

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -72,7 +72,7 @@ import { getAuthHeader } from '../api-token';
 import { getEcosystem } from '../ecosystems';
 import { Issue } from '../ecosystems/types';
 import { assembleEcosystemPayloads } from './assemble-payloads';
-import request = require('../request');
+import { makeRequest } from '../request';
 import spinner = require('../spinner');
 
 const debug = debugModule('snyk:run-test');
@@ -470,7 +470,7 @@ function sendTestPayload(
   const filesystemPolicy =
     payload.body && !!(payloadBody?.policy || payloadBody?.scanResult?.policy);
   return new Promise((resolve, reject) => {
-    request(payload, (error, res, body) => {
+    makeRequest(payload, (error, res, body) => {
       if (error) {
         return reject(error);
       }

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -41,7 +41,9 @@ test('analytics disabled', (t) => {
   const spy = sinon.spy();
   snyk.config.set('disable-analytics', '1');
   const analytics = proxyquire('../src/lib/analytics', {
-    '../request': spy,
+    '../request': {
+      makeRequest: spy,
+    },
   });
 
   return analytics.addDataAndSend().then(() => {
@@ -52,7 +54,9 @@ test('analytics disabled', (t) => {
 test('analytics', (t) => {
   const spy = sinon.spy();
   const analytics = proxyquire('../src/lib/analytics', {
-    '../request': spy,
+    '../request': {
+      makeRequest: spy,
+    },
   });
 
   analytics.add('foo', 'bar');
@@ -100,7 +104,9 @@ test('analytics', (t) => {
 test('analytics with args', (t) => {
   const spy = sinon.spy();
   const analytics = proxyquire('../src/lib/analytics', {
-    '../request': spy,
+    '../request': {
+      makeRequest: spy,
+    },
   });
 
   analytics.add('foo', 'bar');
@@ -143,7 +149,9 @@ test('analytics with args', (t) => {
 test('analytics with args and org', (t) => {
   const spy = sinon.spy();
   const analytics = proxyquire('../src/lib/analytics', {
-    '../request': spy,
+    '../request': {
+      makeRequest: spy,
+    },
   });
 
   analytics.add('foo', 'bar');
@@ -192,7 +200,9 @@ test('analytics with args and org', (t) => {
 test('analytics npm version capture', (t) => {
   const spy = sinon.spy();
   const analytics = proxyquire('../src/lib/analytics', {
-    '../request': spy,
+    '../request': {
+      makeRequest: spy,
+    },
   });
 
   analytics.add('foo', 'bar');
@@ -223,7 +233,9 @@ test('bad command', (t) => {
   process.argv = ['node', 'script.js', 'random command', '-q'];
   const cli = proxyquire('../src/cli', {
     '../lib/analytics': proxyquire('../src/lib/analytics', {
-      '../request': spy,
+      '../request': {
+        makeRequest: spy,
+      },
     }),
   });
 
@@ -252,7 +264,9 @@ test('bad command with string error', (t) => {
   error.code = 'CODE';
   const cli = proxyquire('../src/cli', {
     '../lib/analytics': proxyquire('../src/lib/analytics', {
-      '../request': spy,
+      '../request': {
+        makeRequest: spy,
+      },
     }),
 
     './args': proxyquire('../src/cli/args', {
@@ -287,7 +301,9 @@ test('vulns found (thrown as an error)', (t) => {
   error.code = 'VULNS';
   const cli = proxyquire('../src/cli', {
     '../lib/analytics': proxyquire('../src/lib/analytics', {
-      '../request': spy,
+      '../request': {
+        makeRequest: spy,
+      },
     }),
 
     './args': proxyquire('../src/cli/args', {
@@ -323,7 +339,9 @@ test('analytics was called', (t) => {
   const spy = sinon.spy();
   const cli = proxyquire('../src/cli', {
     '../lib/analytics': proxyquire('../src/lib/analytics', {
-      '../request': spy,
+      '../request': {
+        makeRequest: spy,
+      },
     }),
   });
 

--- a/test/jest/system/snyk-test/python/snyk-test-pyproject.spec.ts
+++ b/test/jest/system/snyk-test/python/snyk-test-pyproject.spec.ts
@@ -4,7 +4,7 @@ import { NeedleResponse } from 'needle';
 import { test } from '../../../../../src/cli/commands';
 import { loadPlugin } from '../../../../../src/lib/plugins/index';
 import { CommandResult } from '../../../../../src/cli/commands/types';
-import makeRequest = require('../../../../../src/lib/request/request');
+import { makeRequest } from '../../../../../src/lib/request/request';
 
 jest.mock('../../../../../src/lib/plugins/index');
 jest.mock('../../../../../src/lib/request/request');

--- a/test/jest/unit/iac-unit-tests/usage-tracking.spec.ts
+++ b/test/jest/unit/iac-unit-tests/usage-tracking.spec.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../src/cli/commands/test/iac-local-execution/usage-tracking';
 import { mocked } from 'ts-jest/utils';
 import { NeedleResponse } from 'needle';
-import makeRequest = require('../../../../src/lib/request/request');
+import { makeRequest } from '../../../../src/lib/request/request';
 import { CustomError } from '../../../../src/lib/errors';
 
 jest.mock('../../../../src/lib/request/request');

--- a/test/patch-fetch-fail.test.ts
+++ b/test/patch-fetch-fail.test.ts
@@ -4,13 +4,15 @@ import * as proxyquire from 'proxyquire';
 let analytics;
 
 const proxyFetchPatch = proxyquire('../src/lib/protect/fetch-patch', {
-  '../request': () => {
-    return Promise.resolve({
-      res: {
-        statusCode: 200,
-      },
-      body: 'patch content',
-    });
+  '../request': {
+    makeRequest: () => {
+      return Promise.resolve({
+        res: {
+          statusCode: 200,
+        },
+        body: 'patch content',
+      });
+    },
   },
   fs: {
     writeFileSync() {
@@ -25,13 +27,15 @@ const proxyFetchPatch = proxyquire('../src/lib/protect/fetch-patch', {
 });
 
 const proxyFetchPatchNotFound = proxyquire('../src/lib/protect/fetch-patch', {
-  '../request': () => {
-    return Promise.resolve({
-      res: {
-        statusCode: 404,
-      },
-      body: 'not found',
-    });
+  '../request': {
+    makeRequest: () => {
+      return Promise.resolve({
+        res: {
+          statusCode: 404,
+        },
+        body: 'not found',
+      });
+    },
   },
   '../analytics': {
     add(type, data) {
@@ -43,13 +47,15 @@ const proxyFetchPatchNotFound = proxyquire('../src/lib/protect/fetch-patch', {
 const proxyFetchPatchErrorWriting = proxyquire(
   '../src/lib/protect/fetch-patch',
   {
-    '../request': () => {
-      return Promise.resolve({
-        res: {
-          statusCode: 200,
-        },
-        body: 'patch content',
-      });
+    '../request': {
+      makeRequest: () => {
+        return Promise.resolve({
+          res: {
+            statusCode: 200,
+          },
+          body: 'patch content',
+        });
+      },
     },
     fs: {
       writeFileSync() {

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -3,7 +3,7 @@ const test = tap.test;
 const url = require('url');
 const http = require('http');
 const nock = require('nock');
-const request = require('../src/lib/request');
+import { makeRequest } from '../src/lib/request';
 
 const proxyPort = 4242;
 const httpRequestHost = 'http://localhost:8000';
@@ -22,7 +22,7 @@ test('request respects proxy environment variables', function(t) {
     const nockClient = nock(httpRequestHost)
       .post(requestPath)
       .reply(200, {});
-    return request({ method: 'post', url: httpRequestHost + requestPath })
+    return makeRequest({ method: 'post', url: httpRequestHost + requestPath })
       .then(function() {
         t.ok(nockClient.isDone(), 'direct call without a proxy');
         nock.cleanAll();
@@ -34,7 +34,7 @@ test('request respects proxy environment variables', function(t) {
     const nockClient = nock(httpsRequestHost)
       .post(requestPath)
       .reply(200, {});
-    return request({ method: 'post', url: httpsRequestHost + requestPath })
+    return makeRequest({ method: 'post', url: httpsRequestHost + requestPath })
       .then(function() {
         t.ok(nockClient.isDone(), 'direct call without a proxy');
         nock.cleanAll();
@@ -63,7 +63,7 @@ test('request respects proxy environment variables', function(t) {
     });
     proxy.listen(proxyPort);
     // http is only supported for localhost
-    return request({ method: 'post', url: httpRequestHost + requestPath })
+    return makeRequest({ method: 'post', url: httpRequestHost + requestPath })
       .catch((err) => t.fail(err.message))
       .then(() => {
         t.equal(process.env.http_proxy, process.env.HTTP_PROXY);
@@ -90,7 +90,7 @@ test('request respects proxy environment variables', function(t) {
     });
     proxy.listen(proxyPort);
     // http is only supported for localhost
-    return request({ method: 'post', url: httpRequestHost + requestPath })
+    return makeRequest({ method: 'post', url: httpRequestHost + requestPath })
       .catch((err) => t.fail(err.message))
       .then(() => {
         proxy.close();
@@ -137,7 +137,7 @@ test('request respects proxy environment variables', function(t) {
     });
 
     proxy.listen(proxyPort);
-    return request({ method: 'post', url: httpsRequestHost + requestPath })
+    return makeRequest({ method: 'post', url: httpsRequestHost + requestPath })
       .catch(() => {}) // client socket being closed generates an error here
       .then(() => {
         t.equal(process.env.https_proxy, process.env.HTTPS_PROXY);
@@ -183,7 +183,7 @@ test('request respects proxy environment variables', function(t) {
     });
 
     proxy.listen(proxyPort);
-    return request({ method: 'post', url: httpsRequestHost + requestPath })
+    return makeRequest({ method: 'post', url: httpsRequestHost + requestPath })
       .catch(() => {}) // client socket being closed generates an error here
       .then(() => {
         proxy.close();

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -30,7 +30,8 @@ test('request calls needle as expected and returns status code and body', (t) =>
   const payload = {
     url: 'http://test.stub',
   };
-  return request(payload)
+  return request
+    .makeRequest(payload)
     .then((response) => {
       t.deepEquals(
         response,
@@ -67,7 +68,8 @@ test('request to localhost calls needle as expected', (t) => {
   const payload = {
     url: 'http://localhost',
   };
-  return request(payload)
+  return request
+    .makeRequest(payload)
     .then((response) => {
       t.deepEquals(
         response,
@@ -105,7 +107,8 @@ test('request with timeout calls needle as expected', (t) => {
     url: 'http://test.stub',
     timeout: 100000,
   };
-  return request(payload)
+  return request
+    .makeRequest(payload)
     .then((response) => {
       t.deepEquals(
         response,
@@ -146,7 +149,8 @@ test('request with query string calls needle as expected', (t) => {
       test: ['multi', 'value'],
     },
   };
-  return request(payload)
+  return request
+    .makeRequest(payload)
     .then((response) => {
       t.deepEquals(
         response,
@@ -184,7 +188,8 @@ test('request with json calls needle as expected', (t) => {
     url: 'http://test.stub',
     json: false,
   };
-  return request(payload)
+  return request
+    .makeRequest(payload)
     .then((response) => {
       t.deepEquals(
         response,
@@ -224,7 +229,8 @@ test('request with custom header calls needle as expected', (t) => {
       custom: 'header',
     },
   };
-  return request(payload)
+  return request
+    .makeRequest(payload)
     .then((response) => {
       t.deepEquals(
         response,
@@ -263,7 +269,8 @@ test('request with https proxy calls needle as expected', (t) => {
   const payload = {
     url: 'http://test.stub',
   };
-  return request(payload)
+  return request
+    .makeRequest(payload)
     .then((response) => {
       t.deepEquals(
         response,
@@ -311,7 +318,8 @@ test('request with http proxy calls needle as expected', (t) => {
   const payload = {
     url: 'http://localhost',
   };
-  return request(payload)
+  return request
+    .makeRequest(payload)
     .then((response) => {
       t.deepEquals(
         response,
@@ -350,7 +358,8 @@ test('request with no proxy calls needle as expected', (t) => {
   const payload = {
     url: 'http://localhost',
   };
-  return request(payload)
+  return request
+    .makeRequest(payload)
     .then((response) => {
       t.deepEquals(
         response,
@@ -388,7 +397,8 @@ test('request with insecure calls needle as expected', (t) => {
   const payload = {
     url: 'http://test.stub',
   };
-  return request(payload)
+  return request
+    .makeRequest(payload)
     .then((response) => {
       t.deepEquals(
         response,
@@ -429,7 +439,8 @@ test('request rejects if needle fails', (t) => {
   const payload = {
     url: 'http://test.stub',
   };
-  return request(payload)
+  return request
+    .makeRequest(payload)
     .then(() => t.fail('should have failed'))
     .catch((e) => {
       t.equals(e, 'Unexpected Error', 'rejects error');
@@ -442,7 +453,8 @@ test('request calls needle as expected and will not update HTTP to HTTPS if envv
   const payload = {
     url: 'http://test.stub',
   };
-  return request(payload)
+  return request
+    .makeRequest(payload)
     .then((response) => {
       process.env.SNYK_HTTP_PROTOCOL_UPGRADE = '1';
       t.deepEquals(


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Use a named export in the request module rather than a default exported function.
This should help with modernizing the analytics module and with being able to spy on the request module in tests.
