### PR TITLE
fix: IaC path parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "open": "^7.0.3",
     "ora": "5.4.0",
     "os-name": "^3.0.0",
+    "pegjs": "^0.10.0",
     "promise-queue": "^2.2.5",
     "proxy-from-env": "^1.0.0",
     "rimraf": "^2.6.3",

--- a/src/cli/commands/test/iac-local-execution/parsers/path.ts
+++ b/src/cli/commands/test/iac-local-execution/parsers/path.ts
@@ -1,0 +1,35 @@
+import * as peg from 'pegjs';
+
+const grammar = `
+start
+  = element+
+
+element
+  = component:component "."? { return component; }
+
+component
+  = $(identifier index?)
+
+identifier
+  = $([^'"\\[\\]\\.]+)
+
+index
+  = $("[" ['"]? [^'"\\]]+ ['"]? "]")
+`;
+
+export const parsePath = createPathParser();
+
+function createPathParser(): (expr: string) => string[] {
+  const parser = peg.generate(grammar);
+  return (expr: string) => {
+    try {
+      return parser.parse(expr);
+    } catch (e) {
+      // I haven't actually been able to write a testcase that triggers this
+      // code path, but I've included it anyway as a fallback to allow users to
+      // keep using the CLI even if this does occur. Their paths might look
+      // strange, but that's better than nothing.
+      return expr.split('.');
+    }
+  };
+}

--- a/src/cli/commands/test/iac-local-execution/results-formatter.ts
+++ b/src/cli/commands/test/iac-local-execution/results-formatter.ts
@@ -7,6 +7,7 @@ import {
   PolicyMetadata,
   TestMeta,
 } from './types';
+import { parsePath } from './parsers/path';
 import * as path from 'path';
 import { SEVERITY } from '../../../../lib/snyk-test/common';
 import { IacProjectType } from '../../../../lib/iac/constants';
@@ -55,7 +56,7 @@ function formatScanResult(
   const formattedIssues = scanResult.violatedPolicies.map((policy) => {
     const cloudConfigPath =
       scanResult.docId !== undefined
-        ? [`[DocId: ${scanResult.docId}]`].concat(policy.msg.split('.'))
+        ? [`[DocId: ${scanResult.docId}]`].concat(parsePath(policy.msg))
         : policy.msg.split('.');
 
     const flagsRequiringLineNumber = [

--- a/test/jest/unit/iac-unit-tests/path-parser.spec.ts
+++ b/test/jest/unit/iac-unit-tests/path-parser.spec.ts
@@ -1,0 +1,19 @@
+import { parsePath } from '../../../../src/cli/commands/test/iac-local-execution/parsers/path';
+
+describe('parsing cloudConfigPath', () => {
+  it.each([
+    ['foo', ['foo']],
+    ['foo.bar.baz', ['foo', 'bar', 'baz']],
+    ['foo_1._bar2.baz3_', ['foo_1', '_bar2', 'baz3_']],
+    ['foo.bar[abc].baz', ['foo', 'bar[abc]', 'baz']],
+    ['foo.bar[abc.def].baz', ['foo', 'bar[abc.def]', 'baz']],
+    ["foo.bar['abc.def'].baz", ['foo', "bar['abc.def']", 'baz']],
+    ['foo.bar["abc.def"].baz', ['foo', 'bar["abc.def"]', 'baz']],
+    ["foo.bar['abc/def'].baz", ['foo', "bar['abc/def']", 'baz']],
+    ["foo.bar['abcdef'].baz", ['foo', "bar['abcdef']", 'baz']],
+    ["bar['abc.def']", ["bar['abc.def']"]],
+    ["fo%o.bar['ab$c/def'].baz", ['fo%o', "bar['ab$c/def']", 'baz']],
+  ])('%s', (input, expected) => {
+    expect(parsePath(input)).toEqual(expected);
+  });
+});


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Fix a bug in which IaC resource paths (more context below) was naively
split by dot, without distinguishing between separator dots and dots
inside string literals.

For example: "foo.bar.baz" was split into 3 words correctly, but
"metadata.annotations['container.apparmor.security.beta.kubernetes.io/web']"
was not.

The "path" / "cloud config path" is a sort of address used to identify
locations in files where vulnerabilities reside. It is very similar to a
jsonpath. The user receives it as an array of components, which in the
future can be useful for building tooling around, e.g. the upcoming CLI
ignores.

The code that evaluates policies against source files is also
responsible for returning a representation of this path, which it does
as a dot-separated string.

#### Where should the reviewer start?

Implementation note: with PEGjs, if we want to we can pre-compile the grammar into a javascript file, which could offer some small performance improvements. I didn't do this to preserve simplicity of iteration, because realistically the other operations of the CLI, including network calls, take orders of magnitude longer than compiling this parser.

#### How should this be manually tested?

`snyk iac test deployment.yaml` against https://github.com/snyk/infrastructure-as-code-goof/blob/master/k8s/PrivilegedPod/web/deployment.yaml returns vulnerabilities including:

```
  ✗ Container is running without AppArmor profile [Low Severity] [SNYK-CC-K8S-32] in Deployment
    introduced by metadata > annotations['container > apparmor > security > beta > kubernetes > io/web']
```

You can see the mangled path there above. With this code, the same output is:

```
  ✗ Container is running without AppArmor profile [Low Severity] [SNYK-CC-K8S-32] in Deployment
    introduced by metadata > annotations['container.apparmor.security.beta.kubernetes.io/web']
```

The `--json` output shows the fix similarly.

#### Any background context you want to provide?

IaC CLI scans are "local execution" by default, and do no processing on registry. For IaC SCM imported projects, registry contains its own logic for parsing paths: https://github.com/snyk/registry/blob/96aebaf2e16f14bac9c939f9b0717caa09fcce4f/src/lib/snapshots/cloud-config-issues.ts#L155-L164

As you can see, it achieves the same aims as this PR but only for "annotations", a Kubernetes special case.

Ideally, we'll align on the same code in here and registry (maybe in https://github.com/snyk/cloud-config-parser) in order to minimise differences in path handling, which will help us avoid bugs in an upcoming feature to have registry respect `.snyk` ignores for IaC imported projects.

#### What are the relevant tickets?

Tangentially related to https://snyksec.atlassian.net/browse/CC-990. In order to deliver CLI ignores, we want the user to copy-paste resource paths from the CLI's output into the `.snyk` file. If the resource paths are mangled this will be confusing!

#### Screenshots


#### Additional questions
