### PR TITLE
chore: execute snyk and snyk-protect using bin file

### DIFF
--- a/bin/snyk
+++ b/bin/snyk
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../dist/cli/index.js');

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "files": [
     "help",
     "dist",
+    "bin",
     "config.default.json",
     "SECURITY.md",
     "LICENSE",
@@ -18,7 +19,7 @@
     "doc": "help/commands-help"
   },
   "bin": {
-    "snyk": "dist/cli/index.js"
+    "snyk": "bin/snyk"
   },
   "engines": {
     "node": ">=10"
@@ -186,7 +187,8 @@
   },
   "pkg": {
     "scripts": [
-      "dist/**/*.js"
+      "dist/**/*.js",
+      "bin/snyk"
     ],
     "assets": [
       "config.default.json",

--- a/packages/snyk-fix/package.json
+++ b/packages/snyk-fix/package.json
@@ -15,9 +15,6 @@
     "lib": "src",
     "test": "test"
   },
-  "bin": {
-    "snyk-fix": "dist/index.js"
-  },
   "engines": {
     "node": ">=10"
   },

--- a/packages/snyk-protect/bin/snyk-protect
+++ b/packages/snyk-protect/bin/snyk-protect
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../dist/index.js').protect();

--- a/packages/snyk-protect/package.json
+++ b/packages/snyk-protect/package.json
@@ -7,6 +7,7 @@
   "files": [
     "help",
     "dist",
+    "bin",
     "SECURITY.md",
     "LICENSE",
     "README.md"
@@ -16,7 +17,7 @@
     "test": "test"
   },
   "bin": {
-    "snyk-protect": "dist/index.js"
+    "snyk-protect": "bin/snyk-protect"
   },
   "engines": {
     "node": ">=10"

--- a/packages/snyk-protect/src/index.ts
+++ b/packages/snyk-protect/src/index.ts
@@ -1,12 +1,6 @@
-#!/usr/bin/env node
+import protectLib from './lib';
 
-import protect from './lib';
-
-async function main() {
+export async function protect() {
   const projectPath = process.cwd();
-  await protect(projectPath);
-}
-
-if (require.main === module) {
-  main();
+  await protectLib(projectPath);
 }

--- a/packages/snyk-protect/test/acceptance/protect.spec.ts
+++ b/packages/snyk-protect/test/acceptance/protect.spec.ts
@@ -247,7 +247,7 @@ describe('@snyk/protect', () => {
 
       const { code, stdout } = await runCommand(
         'node',
-        [path.resolve(__dirname, '../../dist/index.js'), '--help'],
+        [path.resolve(__dirname, '../../bin/snyk-protect'), '--help'],
         {
           cwd: project.path(),
         },
@@ -264,7 +264,7 @@ describe('@snyk/protect', () => {
 
       const { code, stdout } = await runCommand(
         'node',
-        [path.resolve(__dirname, '../../dist/index.js'), '--version'],
+        [path.resolve(__dirname, '../../bin/snyk-protect'), '--version'],
         {
           cwd: project.path(),
         },

--- a/scripts/run-smoke-tests-locally.sh
+++ b/scripts/run-smoke-tests-locally.sh
@@ -38,4 +38,4 @@ fi
 echo "Installing fixture project with npm install"
 npm install --silent --prefix test/fixtures/basic-npm
 
-SNYK_COMMAND="node ${PWD}/dist/cli" REGRESSION_TEST=1 SMOKE_TESTS_SKIP_TEST_THAT_OPENS_BROWSER=1 SMOKE_TESTS_SNYK_TOKEN=$SNYK_API_TOKEN shellspec --chdir test/smoke test/smoke/spec/snyk_auth_spec.sh -f d
+SNYK_COMMAND="node ${PWD}/bin/snyk" REGRESSION_TEST=1 SMOKE_TESTS_SKIP_TEST_THAT_OPENS_BROWSER=1 SMOKE_TESTS_SNYK_TOKEN=$SNYK_API_TOKEN shellspec --chdir test/smoke test/smoke/spec/snyk_auth_spec.sh -f d

--- a/test/acceptance/cli-protect.test.ts
+++ b/test/acceptance/cli-protect.test.ts
@@ -51,7 +51,7 @@ before('prime config', async (t) => {
   t.pass('endpoint removed');
   t.end();
 });
-const main = './dist/cli/index.js'.replace(/\//g, sep);
+const main = './bin/snyk'.replace(/\//g, sep);
 
 test('`protect` should not fail for unauthorized users', (t) => {
   t.plan(1);

--- a/test/jest/acceptance/cli-json-file-output.spec.ts
+++ b/test/jest/acceptance/cli-json-file-output.spec.ts
@@ -5,7 +5,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { fakeServer } from '../../acceptance/fake-server';
 import cli = require('../../../src/cli/commands');
 
-const main = './dist/cli/index.js'.replace(/\//g, sep);
+const main = './bin/snyk'.replace(/\//g, sep);
 const testTimeout = 50000;
 
 describe('test --json-file-output ', () => {

--- a/test/jest/acceptance/iac/helpers.ts
+++ b/test/jest/acceptance/iac/helpers.ts
@@ -50,7 +50,7 @@ export async function run(
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   return new Promise((resolve, reject) => {
     const root = join(__dirname, '../../../../');
-    const main = join(root, 'dist/cli/index.js');
+    const main = join(root, 'bin/snyk');
     const child = exec(
       cmd.trim().replace(/^snyk/, `node ${main}`),
       {

--- a/test/jest/acceptance/proxy-behavior.spec.ts
+++ b/test/jest/acceptance/proxy-behavior.spec.ts
@@ -1,6 +1,6 @@
 import { exec } from 'child_process';
 import { sep } from 'path';
-const main = './dist/cli/index.js'.replace(/\//g, sep);
+const main = './bin/snyk'.replace(/\//g, sep);
 
 const SNYK_API_HTTPS = 'https://snyk.io/api/v1';
 const SNYK_API_HTTP = 'http://snyk.io/api/v1';

--- a/test/jest/system/lib/commands/fix/fix.spec.ts
+++ b/test/jest/system/lib/commands/fix/fix.spec.ts
@@ -5,7 +5,7 @@ import stripAnsi from 'strip-ansi';
 import { fakeServer } from '../../../../../acceptance/fake-server';
 import cli = require('../../../../../../src/cli/commands');
 
-const main = './dist/cli/index.js'.replace(/\//g, pathLib.sep);
+const main = './bin/snyk'.replace(/\//g, pathLib.sep);
 const testTimeout = 50000;
 describe('snyk fix (system tests)', () => {
   let oldkey;

--- a/test/jest/util/runSnykCLI.ts
+++ b/test/jest/util/runSnykCLI.ts
@@ -7,7 +7,7 @@ const runSnykCLI = async (
   argsString: string,
   options?: RunCommandOptions,
 ): Promise<RunCommandResult> => {
-  const cliPath = path.resolve(cwd, './dist/cli/index.js');
+  const cliPath = path.resolve(cwd, './bin/snyk');
   const args = argsString.split(' ').filter((v) => !!v);
   return await runCommand('node', [cliPath, ...args], options);
 };

--- a/test/smoke/setup-alias-for-snyk.sh
+++ b/test/smoke/setup-alias-for-snyk.sh
@@ -2,5 +2,5 @@
 set -e
 
 # Force CI to have this built Snyk version available in shell used
-echo "node ${PWD}/dist/cli/index.js \"\$@\"" > /usr/local/bin/snyk
+echo "node ${PWD}/bin/snyk \"\$@\"" > /usr/local/bin/snyk
 chmod +x /usr/local/bin/snyk

--- a/test/smoke/spec/spec_helper.sh
+++ b/test/smoke/spec/spec_helper.sh
@@ -62,7 +62,7 @@ spec_helper_configure() {
   echo "Using this 'snyk' executable:"
   echo "${SNYK_COMMAND:=$ORIGINAL_SNYK_EXECUTABLE}"
   echo " "
-  echo "You may override it with envvar SNYK_COMMAND - e.g. SNYK_COMMAND=\"node ./dist/cli\" to test a local build"
+  echo "You may override it with envvar SNYK_COMMAND - e.g. SNYK_COMMAND=\"node ./bin/snyk\" to test a local build"
   echo " "
 
   snyk() {


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Execute `bin/snyk` and `packages/snyk-protect/bin/snyk-protect` instead of the respective `index.js` files.
This solves this bug: https://github.com/npm/cli/issues/2632 and makes running snyk more predictable and clear.