### PR TITLE
feat: IaC ignore support

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "snyk-nodejs-lockfile-parser": "1.35.0",
     "snyk-nuget-plugin": "1.22.0",
     "snyk-php-plugin": "1.9.2",
-    "snyk-policy": "1.19.0",
+    "snyk-policy": "1.22.0",
     "snyk-python-plugin": "1.19.11",
     "snyk-resolve": "1.1.0",
     "snyk-resolve-deps": "4.7.2",

--- a/packages/snyk-protect/test/fixtures/fix-pr/.snyk
+++ b/packages/snyk-protect/test/fixtures/fix-pr/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.19.0
+version: v1.22.0
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 patch:

--- a/packages/snyk-protect/test/fixtures/multiple-matching-paths/.snyk
+++ b/packages/snyk-protect/test/fixtures/multiple-matching-paths/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.19.0
+version: v1.22.0
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 patch:
@@ -22,4 +22,3 @@ patch:
         patched: '2021-02-17T13:43:51.857Z'
     - tap > nyc > istanbul-lib-instrument > babel-template > babel-traverse > babel-types > lodash:
         patched: '2021-02-17T13:43:51.857Z'
-

--- a/packages/snyk-protect/test/fixtures/no-matching-paths/.snyk
+++ b/packages/snyk-protect/test/fixtures/no-matching-paths/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.19.0
+version: v1.22.0
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 patch:
@@ -22,4 +22,3 @@ patch:
         patched: '2021-02-17T13:43:51.857Z'
     - tap > nyc > istanbul-lib-instrument > babel-template > babel-traverse > babel-types > lodash:
         patched: '2021-02-17T13:43:51.857Z'
-

--- a/packages/snyk-protect/test/fixtures/single-patchable-module/.snyk
+++ b/packages/snyk-protect/test/fixtures/single-patchable-module/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.19.0
+version: v1.22.0
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 patch:
@@ -22,4 +22,3 @@ patch:
         patched: '2021-02-17T13:43:51.857Z'
     - 'tap > nyc > istanbul-lib-instrument > babel-template > babel-traverse > babel-types > lodash':
         patched: '2021-02-17T13:43:51.857Z'
-

--- a/packages/snyk-protect/test/fixtures/target-module-exists-but-no-patches-for-version/.snyk
+++ b/packages/snyk-protect/test/fixtures/target-module-exists-but-no-patches-for-version/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.19.0
+version: v1.22.0
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 patch:
@@ -22,4 +22,3 @@ patch:
         patched: '2021-02-17T13:43:51.857Z'
     - tap > nyc > istanbul-lib-instrument > babel-template > babel-traverse > babel-types > lodash:
         patched: '2021-02-17T13:43:51.857Z'
-

--- a/src/cli/commands/test/iac-local-execution/analytics.ts
+++ b/src/cli/commands/test/iac-local-execution/analytics.ts
@@ -1,7 +1,11 @@
 import { FormattedResult } from './types';
 import * as analytics from '../../../../lib/analytics';
 
-export function addIacAnalytics(formattedResults: FormattedResult[]) {
+export function addIacAnalytics(
+  formattedResults: FormattedResult[],
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  ignoredIssuesCount: number,
+) {
   let totalIssuesCount = 0;
   const issuesByType: Record<string, object> = {};
   const packageManagers = Array<string>();
@@ -22,6 +26,8 @@ export function addIacAnalytics(formattedResults: FormattedResult[]) {
 
   analytics.add('packageManager', Array.from(new Set(packageManagers)));
   analytics.add('iac-issues-count', totalIssuesCount);
+  // TODO enable once we have support for it in registry
+  // analytics.add('iac-ignored-issues-count', ignoredIssuesCount);
   analytics.add('iac-type', issuesByType);
   analytics.add('iac-metrics', performanceAnalyticsObject);
   analytics.add('iac-test-count', formattedResults.length);

--- a/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
+++ b/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
@@ -22,6 +22,10 @@ const keys: (keyof IaCTestFlags)[] = [
   'quiet',
   'scan',
   'legacy',
+
+  // PolicyOptions
+  'ignore-policy',
+  'policy-path',
 ];
 const allowed = new Set<string>(keys);
 

--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -69,10 +69,13 @@ export async function test(
       iacOrgSettings.meta,
     );
 
-    const filteredResults = filterIgnoredIssues(policy, formattedResults);
+    const { filteredIssues, ignoreCount } = filterIgnoredIssues(
+      policy,
+      formattedResults,
+    );
 
     try {
-      await trackUsage(filteredResults);
+      await trackUsage(filteredIssues);
     } catch (e) {
       if (e instanceof TestLimitReachedError) {
         throw e;
@@ -81,11 +84,11 @@ export async function test(
       // run their tests by squashing the error.
     }
 
-    addIacAnalytics(filteredResults);
+    addIacAnalytics(filteredIssues, ignoreCount);
 
     // TODO: add support for proper typing of old TestResult interface.
     return {
-      results: (filteredResults as unknown) as TestResult[],
+      results: (filteredIssues as unknown) as TestResult[],
       // NOTE: No file or parsed file data should leave this function.
       failures: isLocalFolder(pathToScan)
         ? failedFiles.map(removeFileContent)

--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -9,6 +9,7 @@ import {
 } from './types';
 import { addIacAnalytics } from './analytics';
 import { TestLimitReachedError } from './usage-tracking';
+import { filterIgnoredIssues } from './policy';
 import { TestResult } from '../../../../lib/snyk-test/legacy';
 import {
   initLocalCache,
@@ -24,6 +25,7 @@ import {
 import { isFeatureFlagSupportedForOrg } from '../../../../lib/feature-flags';
 import { FlagError } from './assert-iac-options-flag';
 import config = require('../../../../lib/config');
+import { findAndLoadPolicy } from '../../../../lib/policy/find-and-load-policy';
 
 // this method executes the local processing engine and then formats the results to adapt with the CLI output.
 // this flow is the default GA flow for IAC scanning.
@@ -37,6 +39,8 @@ export async function test(
     const customRulesPath = await customRulesPathForOrg(options.rules, org);
 
     await initLocalCache({ customRulesPath });
+
+    const policy = await findAndLoadPolicy(pathToScan, 'iac', options);
 
     const filesToParse = await loadFiles(pathToScan, options);
     const { parsedFiles, failedFiles } = await parseFiles(
@@ -65,8 +69,10 @@ export async function test(
       iacOrgSettings.meta,
     );
 
+    const filteredResults = filterIgnoredIssues(policy, formattedResults);
+
     try {
-      await trackUsage(formattedResults);
+      await trackUsage(filteredResults);
     } catch (e) {
       if (e instanceof TestLimitReachedError) {
         throw e;
@@ -75,11 +81,11 @@ export async function test(
       // run their tests by squashing the error.
     }
 
-    addIacAnalytics(formattedResults);
+    addIacAnalytics(filteredResults);
 
     // TODO: add support for proper typing of old TestResult interface.
     return {
-      results: (formattedResults as unknown) as TestResult[],
+      results: (filteredResults as unknown) as TestResult[],
       // NOTE: No file or parsed file data should leave this function.
       failures: isLocalFolder(pathToScan)
         ? failedFiles.map(removeFileContent)

--- a/src/cli/commands/test/iac-local-execution/policy.ts
+++ b/src/cli/commands/test/iac-local-execution/policy.ts
@@ -8,7 +8,9 @@ export function filterIgnoredIssues(
   if (!policy) {
     return { filteredIssues: results, ignoreCount: 0 };
   }
-  const vulns = results.map((res) => policy.filter(toIaCVulnAdapter(res)));
+  const vulns = results.map((res) =>
+    policy.filter(toIaCVulnAdapter(res), undefined, 'exact'),
+  );
   const ignoreCount: number = vulns.reduce(
     (totalIgnored, vuln) => totalIgnored + vuln.filtered.ignore.length,
     0,
@@ -44,10 +46,8 @@ function toIaCVulnAdapter(result: FormattedResult): IacVulnAdapter {
         // splice.
         // Insert the targetFile into the path so that it is taken into account
         // when determining whether an ignore rule should be applied.
-        // Insert garbage into the first element because the policy library
-        // ignores it.
         const path = [...annotatedResult.cloudConfigPath];
-        path.splice(0, 0, 'GARBAGE', result.targetFile);
+        path.splice(0, 0, result.targetFile);
 
         return {
           id: cloudConfigResult.id,
@@ -73,7 +73,7 @@ function toFormattedResult(adapter: IacVulnAdapter): FormattedResult {
         // including target file context. As that logic changes, so must this.
         const annotatedResult = res as AnnotatedResult;
         const significantPath = [...annotatedResult.cloudConfigPath];
-        significantPath.splice(0, 0, 'GARBAGE', original.targetFile);
+        significantPath.splice(0, 0, original.targetFile);
 
         if (vuln.from.length !== significantPath.length) {
           return false;

--- a/src/cli/commands/test/iac-local-execution/policy.ts
+++ b/src/cli/commands/test/iac-local-execution/policy.ts
@@ -4,13 +4,17 @@ import { Policy } from '../../../../lib/policy/find-and-load-policy';
 export function filterIgnoredIssues(
   policy: Policy | undefined,
   results: FormattedResult[],
-): FormattedResult[] {
+) {
   if (!policy) {
-    return results;
+    return { filteredIssues: results, ignoreCount: 0 };
   }
-  return results
-    .map((res) => policy.filter(toIaCVulnAdapter(res)))
-    .map((vuln) => toFormattedResult(vuln));
+  const vulns = results.map((res) => policy.filter(toIaCVulnAdapter(res)));
+  const ignoreCount: number = vulns.reduce(
+    (totalIgnored, vuln) => totalIgnored + vuln.filtered.ignore.length,
+    0,
+  );
+  const filteredIssues = vulns.map((vuln) => toFormattedResult(vuln));
+  return { filteredIssues, ignoreCount };
 }
 
 type IacVulnAdapter = {
@@ -19,6 +23,7 @@ type IacVulnAdapter = {
     from: string[];
   }[];
   originalResult: FormattedResult;
+  filtered?: { ignore: any[] };
 };
 
 // This is a total cop-out. The type I really want is AnnotatedIacIssue from

--- a/src/cli/commands/test/iac-local-execution/policy.ts
+++ b/src/cli/commands/test/iac-local-execution/policy.ts
@@ -1,0 +1,87 @@
+import { FormattedResult, PolicyMetadata } from './types';
+import { Policy } from '../../../../lib/policy/find-and-load-policy';
+
+export function filterIgnoredIssues(
+  policy: Policy | undefined,
+  results: FormattedResult[],
+): FormattedResult[] {
+  if (!policy) {
+    return results;
+  }
+  return results
+    .map((res) => policy.filter(toIaCVulnAdapter(res)))
+    .map((vuln) => toFormattedResult(vuln));
+}
+
+type IacVulnAdapter = {
+  vulnerabilities: {
+    id: string;
+    from: string[];
+  }[];
+  originalResult: FormattedResult;
+};
+
+// This is a total cop-out. The type I really want is AnnotatedIacIssue from
+// src/lib/snyk-test/iac-test-result.ts, but that appears to only be used in the
+// legacy flow and I gave up on adapting it to work in both flows. By the time
+// this code is called, cloudConfigPath is present on the result object.
+type AnnotatedResult = PolicyMetadata & {
+  cloudConfigPath: string[];
+};
+
+function toIaCVulnAdapter(result: FormattedResult): IacVulnAdapter {
+  return {
+    vulnerabilities: result.result.cloudConfigResults.map(
+      (cloudConfigResult) => {
+        const annotatedResult = cloudConfigResult as AnnotatedResult;
+
+        // Copy the cloudConfigPath array to avoid modifying the original with
+        // splice.
+        // Insert the targetFile into the path so that it is taken into account
+        // when determining whether an ignore rule should be applied.
+        // Insert garbage into the first element because the policy library
+        // ignores it.
+        const path = [...annotatedResult.cloudConfigPath];
+        path.splice(0, 0, 'GARBAGE', result.targetFile);
+
+        return {
+          id: cloudConfigResult.id,
+          from: path,
+        };
+      },
+    ),
+    originalResult: result,
+  };
+}
+
+function toFormattedResult(adapter: IacVulnAdapter): FormattedResult {
+  const original = adapter.originalResult;
+  const filteredCloudConfigResults = original.result.cloudConfigResults.filter(
+    (res) => {
+      return adapter.vulnerabilities.some((vuln) => {
+        if (vuln.id !== res.id) {
+          return false;
+        }
+
+        // Unfortunately we are forced to duplicate the logic in
+        // toIaCVulnAdapter so that we're comparing path components properly,
+        // including target file context. As that logic changes, so must this.
+        const annotatedResult = res as AnnotatedResult;
+        const significantPath = [...annotatedResult.cloudConfigPath];
+        significantPath.splice(0, 0, 'GARBAGE', original.targetFile);
+
+        if (vuln.from.length !== significantPath.length) {
+          return false;
+        }
+        for (let i = 0; i < vuln.from.length; i++) {
+          if (vuln.from[i] !== significantPath[i]) {
+            return false;
+          }
+        }
+        return true;
+      });
+    },
+  );
+  original.result.cloudConfigResults = filteredCloudConfigResults;
+  return original;
+}

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -9,6 +9,7 @@ import {
   IacFileInDirectory,
   Options,
   TestOptions,
+  PolicyOptions,
 } from '../../../../lib/types';
 
 export interface IacFileData extends IacFileInDirectory {
@@ -117,7 +118,7 @@ export interface PolicyMetadata {
 // Collection of all options supported by `iac test` command.
 // TODO: Needs to be fixed at the args module level.
 export type IaCTestFlags = Pick<
-  Options & TestOptions,
+  Options & TestOptions & PolicyOptions,
   | 'org'
   | 'insecure'
   | 'debug'
@@ -126,6 +127,10 @@ export type IaCTestFlags = Pick<
   | 'severityThreshold'
   | 'json'
   | 'sarif'
+
+  // PolicyOptions
+  | 'ignore-policy'
+  | 'policy-path'
 > & {
   // Supported flags not yet covered by Options or TestOptions
   'json-file-output'?: string;

--- a/src/lib/formatters/iac-output.ts
+++ b/src/lib/formatters/iac-output.ts
@@ -30,7 +30,7 @@ function formatIacIssue(
   let introducedBy = '';
   if (path) {
     // In this mode, we show only one path by default, for compactness
-    const pathStr = printPath(path);
+    const pathStr = printPath(path, 0);
     introducedBy = `\n    introduced by ${pathStr}`;
   }
 

--- a/src/lib/formatters/remediation-based-format-issues.ts
+++ b/src/lib/formatters/remediation-based-format-issues.ts
@@ -417,8 +417,8 @@ function constructUnfixableText(
   return unfixableIssuesTextArray;
 }
 
-export function printPath(path: string[]) {
-  return path.slice(1).join(PATH_SEPARATOR);
+export function printPath(path: string[], slice = 1) {
+  return path.slice(slice).join(PATH_SEPARATOR);
 }
 
 export function formatIssue(

--- a/src/lib/formatters/test/display-result.ts
+++ b/src/lib/formatters/test/display-result.ts
@@ -1,4 +1,3 @@
-import * as pathLib from 'path';
 import chalk from 'chalk';
 import { icon, color } from '../../theme';
 import { isCI } from '../../../lib/is-ci';
@@ -39,7 +38,7 @@ export function displayResult(
   const localPackageTest = isLocalFolder(options.path);
   let testingPath = options.path;
   if (options.iac && res.targetFile) {
-    testingPath = pathLib.basename(res.targetFile);
+    testingPath = res.targetFile;
   }
   const prefix = chalk.bold.white('\nTesting ' + testingPath + '...\n\n');
 
@@ -57,7 +56,7 @@ export function displayResult(
   if (res.dependencyCount) {
     pathOrDepsText += res.dependencyCount + ' dependencies';
   } else if (options.iac && res.targetFile) {
-    pathOrDepsText += pathLib.basename(res.targetFile);
+    pathOrDepsText += res.targetFile;
   } else {
     pathOrDepsText += options.path;
   }

--- a/src/lib/policy/find-and-load-policy.ts
+++ b/src/lib/policy/find-and-load-policy.ts
@@ -51,5 +51,5 @@ export async function findAndLoadPolicy(
 }
 
 export interface Policy {
-  filter(vulns: any): any;
+  filter(vulns: any, root?: string, matchStrategy?: string): any;
 }

--- a/src/lib/policy/find-and-load-policy.ts
+++ b/src/lib/policy/find-and-load-policy.ts
@@ -11,11 +11,11 @@ const debug = debugModule('snyk');
 
 export async function findAndLoadPolicy(
   root: string,
-  scanType: SupportedPackageManagers | 'docker',
+  scanType: SupportedPackageManagers | 'docker' | 'iac',
   options: PolicyOptions,
   pkg?: PackageExpanded,
   scannedProjectFolder?: string,
-): Promise<string | undefined> {
+): Promise<Policy | undefined> {
   const isDocker = scanType === 'docker';
   const isNodeProject = ['npm', 'yarn'].includes(scanType);
   // monitor
@@ -43,9 +43,13 @@ export async function findAndLoadPolicy(
   } catch (err) {
     // note: inline catch, to handle error from .load
     // if the .snyk file wasn't found, it is fine
-    if (err.code !== 'ENOENT') {
+    if (err.code !== 'ENOENT' && err.code !== 'ENOTDIR') {
       throw err;
     }
   }
   return policy;
+}
+
+export interface Policy {
+  filter(vulns: any): any;
 }

--- a/test/acceptance/workspaces/npm-package-policy/.snyk
+++ b/test/acceptance/workspaces/npm-package-policy/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.19.0
+version: v1.22.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   'npm:marked:20170907':

--- a/test/acceptance/workspaces/npm-package-policy/custom-location/.snyk
+++ b/test/acceptance/workspaces/npm-package-policy/custom-location/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.19.0
+version: v1.22.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   'npm:marked:20170907':

--- a/test/acceptance/workspaces/npm-with-dep-missing-policy/.snyk
+++ b/test/acceptance/workspaces/npm-with-dep-missing-policy/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.19.0
+version: v1.22.0
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 patch:

--- a/test/fixtures/protect-lodash-skip/.snyk
+++ b/test/fixtures/protect-lodash-skip/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.19.0
+version: v1.22.0
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 

--- a/test/fixtures/protect-semver/.snyk
+++ b/test/fixtures/protect-semver/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.19.0
+version: v1.22.0
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 patch:

--- a/test/jest/acceptance/iac/custom-rules.spec.ts
+++ b/test/jest/acceptance/iac/custom-rules.spec.ts
@@ -22,12 +22,12 @@ describe('iac test --rules', () => {
     );
     expect(exitCode).toBe(1);
 
-    expect(stdout).toContain('Testing sg_open_ssh.tf');
+    expect(stdout).toContain('Testing ./iac/terraform/sg_open_ssh.tf');
     expect(stdout).toContain('Infrastructure as code issues:');
     expect(stdout).toContain('Missing tags');
     expect(stdout).toContain('CUSTOM-123');
     expect(stdout).toContain(
-      'introduced by resource > aws_security_group[allow_ssh] > tags',
+      'introduced by input > resource > aws_security_group[allow_ssh] > tags',
     );
   });
 

--- a/test/jest/unit/iac-unit-tests/fixtures/formatted-results.json
+++ b/test/jest/unit/iac-unit-tests/fixtures/formatted-results.json
@@ -1,0 +1,827 @@
+[
+  {
+    "result": {
+      "cloudConfigResults": [
+        {
+          "severity": "low",
+          "resolve": "Set `disable_api_termination` attribute  with value `true`",
+          "id": "SNYK-CC-AWS-426",
+          "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+          "msg": "resource.aws_instance[denied].disable_api_termination",
+          "remediation": {
+            "cloudformation": "Set `DisableApiTermination` attribute with value `true`",
+            "terraform": "Set `disable_api_termination` attribute  with value `true`"
+          },
+          "subType": "EC2",
+          "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+          "publicId": "SNYK-CC-AWS-426",
+          "title": "EC2 API termination protection is not enabled",
+          "references": [
+            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+          ],
+          "name": "EC2 API termination protection is not enabled",
+          "cloudConfigPath": [
+            "resource",
+            "aws_instance[denied]",
+            "disable_api_termination"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+            "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+            "resolve": "Set `disable_api_termination` attribute  with value `true`"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
+        },
+        {
+          "severity": "high",
+          "resolve": "Remove secret value from `user_data` attribute",
+          "id": "SNYK-CC-TF-123",
+          "impact": "Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+          "msg": "resource.aws_instance[denied_2].user_data_base64[aws_access_key_id]",
+          "remediation": {
+            "cloudformation": "Remove secret value from `Properties.UserData` attribute",
+            "terraform": "Remove secret value from `user_data` attribute"
+          },
+          "subType": "EC2",
+          "issue": "Secret keys have been hardcoded in user_data script",
+          "publicId": "SNYK-CC-TF-123",
+          "title": "Hard coded secrets in EC2 metadata",
+          "references": [
+            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html"
+          ],
+          "name": "Hard coded secrets in EC2 metadata",
+          "cloudConfigPath": [
+            "resource",
+            "aws_instance[denied_2]",
+            "user_data_base64[aws_access_key_id]"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "Secret keys have been hardcoded in user_data script",
+            "impact": "Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+            "resolve": "Remove secret value from `user_data` attribute"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-123"
+        },
+        {
+          "severity": "low",
+          "resolve": "Set `disable_api_termination` attribute  with value `true`",
+          "id": "SNYK-CC-AWS-426",
+          "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+          "msg": "resource.aws_instance[denied_3].disable_api_termination",
+          "remediation": {
+            "cloudformation": "Set `DisableApiTermination` attribute with value `true`",
+            "terraform": "Set `disable_api_termination` attribute  with value `true`"
+          },
+          "subType": "EC2",
+          "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+          "publicId": "SNYK-CC-AWS-426",
+          "title": "EC2 API termination protection is not enabled",
+          "references": [
+            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+          ],
+          "name": "EC2 API termination protection is not enabled",
+          "cloudConfigPath": [
+            "resource",
+            "aws_instance[denied_3]",
+            "disable_api_termination"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+            "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+            "resolve": "Set `disable_api_termination` attribute  with value `true`"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
+        },
+        {
+          "severity": "high",
+          "resolve": "Remove secret value from `user_data` attribute",
+          "id": "SNYK-CC-TF-123",
+          "impact": "Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+          "msg": "resource.aws_instance[denied_3].user_data[aws_secret_access_key]",
+          "remediation": {
+            "cloudformation": "Remove secret value from `Properties.UserData` attribute",
+            "terraform": "Remove secret value from `user_data` attribute"
+          },
+          "subType": "EC2",
+          "issue": "Secret keys have been hardcoded in user_data script",
+          "publicId": "SNYK-CC-TF-123",
+          "title": "Hard coded secrets in EC2 metadata",
+          "references": [
+            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html"
+          ],
+          "name": "Hard coded secrets in EC2 metadata",
+          "cloudConfigPath": [
+            "resource",
+            "aws_instance[denied_3]",
+            "user_data[aws_secret_access_key]"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "Secret keys have been hardcoded in user_data script",
+            "impact": "Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+            "resolve": "Remove secret value from `user_data` attribute"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-123"
+        },
+        {
+          "severity": "low",
+          "resolve": "Set `disable_api_termination` attribute  with value `true`",
+          "id": "SNYK-CC-AWS-426",
+          "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+          "msg": "resource.aws_instance[allowed_3].disable_api_termination",
+          "remediation": {
+            "cloudformation": "Set `DisableApiTermination` attribute with value `true`",
+            "terraform": "Set `disable_api_termination` attribute  with value `true`"
+          },
+          "subType": "EC2",
+          "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+          "publicId": "SNYK-CC-AWS-426",
+          "title": "EC2 API termination protection is not enabled",
+          "references": [
+            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+          ],
+          "name": "EC2 API termination protection is not enabled",
+          "cloudConfigPath": [
+            "resource",
+            "aws_instance[allowed_3]",
+            "disable_api_termination"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+            "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+            "resolve": "Set `disable_api_termination` attribute  with value `true`"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
+        },
+        {
+          "severity": "high",
+          "resolve": "Remove secret value from `user_data` attribute",
+          "id": "SNYK-CC-TF-123",
+          "impact": "Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+          "msg": "resource.aws_instance[denied].user_data[aws_access_key_id]",
+          "remediation": {
+            "cloudformation": "Remove secret value from `Properties.UserData` attribute",
+            "terraform": "Remove secret value from `user_data` attribute"
+          },
+          "subType": "EC2",
+          "issue": "Secret keys have been hardcoded in user_data script",
+          "publicId": "SNYK-CC-TF-123",
+          "title": "Hard coded secrets in EC2 metadata",
+          "references": [
+            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html"
+          ],
+          "name": "Hard coded secrets in EC2 metadata",
+          "cloudConfigPath": [
+            "resource",
+            "aws_instance[denied]",
+            "user_data[aws_access_key_id]"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "Secret keys have been hardcoded in user_data script",
+            "impact": "Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+            "resolve": "Remove secret value from `user_data` attribute"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-123"
+        },
+        {
+          "severity": "high",
+          "resolve": "Remove secret value from `user_data` attribute",
+          "id": "SNYK-CC-TF-123",
+          "impact": "Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+          "msg": "resource.aws_instance[denied_2].user_data_base64[aws_secret_access_key]",
+          "remediation": {
+            "cloudformation": "Remove secret value from `Properties.UserData` attribute",
+            "terraform": "Remove secret value from `user_data` attribute"
+          },
+          "subType": "EC2",
+          "issue": "Secret keys have been hardcoded in user_data script",
+          "publicId": "SNYK-CC-TF-123",
+          "title": "Hard coded secrets in EC2 metadata",
+          "references": [
+            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html"
+          ],
+          "name": "Hard coded secrets in EC2 metadata",
+          "cloudConfigPath": [
+            "resource",
+            "aws_instance[denied_2]",
+            "user_data_base64[aws_secret_access_key]"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "Secret keys have been hardcoded in user_data script",
+            "impact": "Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+            "resolve": "Remove secret value from `user_data` attribute"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-123"
+        },
+        {
+          "severity": "low",
+          "resolve": "Set `disable_api_termination` attribute  with value `true`",
+          "id": "SNYK-CC-AWS-426",
+          "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+          "msg": "resource.aws_instance[allowed].disable_api_termination",
+          "remediation": {
+            "cloudformation": "Set `DisableApiTermination` attribute with value `true`",
+            "terraform": "Set `disable_api_termination` attribute  with value `true`"
+          },
+          "subType": "EC2",
+          "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+          "publicId": "SNYK-CC-AWS-426",
+          "title": "EC2 API termination protection is not enabled",
+          "references": [
+            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+          ],
+          "name": "EC2 API termination protection is not enabled",
+          "cloudConfigPath": [
+            "resource",
+            "aws_instance[allowed]",
+            "disable_api_termination"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+            "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+            "resolve": "Set `disable_api_termination` attribute  with value `true`"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
+        },
+        {
+          "severity": "low",
+          "resolve": "Set `disable_api_termination` attribute  with value `true`",
+          "id": "SNYK-CC-AWS-426",
+          "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+          "msg": "resource.aws_instance[denied_2].disable_api_termination",
+          "remediation": {
+            "cloudformation": "Set `DisableApiTermination` attribute with value `true`",
+            "terraform": "Set `disable_api_termination` attribute  with value `true`"
+          },
+          "subType": "EC2",
+          "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+          "publicId": "SNYK-CC-AWS-426",
+          "title": "EC2 API termination protection is not enabled",
+          "references": [
+            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+          ],
+          "name": "EC2 API termination protection is not enabled",
+          "cloudConfigPath": [
+            "resource",
+            "aws_instance[denied_2]",
+            "disable_api_termination"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+            "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+            "resolve": "Set `disable_api_termination` attribute  with value `true`"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
+        },
+        {
+          "severity": "low",
+          "resolve": "Set `disable_api_termination` attribute  with value `true`",
+          "id": "SNYK-CC-AWS-426",
+          "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+          "msg": "resource.aws_instance[allowed_2].disable_api_termination",
+          "remediation": {
+            "cloudformation": "Set `DisableApiTermination` attribute with value `true`",
+            "terraform": "Set `disable_api_termination` attribute  with value `true`"
+          },
+          "subType": "EC2",
+          "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+          "publicId": "SNYK-CC-AWS-426",
+          "title": "EC2 API termination protection is not enabled",
+          "references": [
+            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+          ],
+          "name": "EC2 API termination protection is not enabled",
+          "cloudConfigPath": [
+            "resource",
+            "aws_instance[allowed_2]",
+            "disable_api_termination"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+            "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+            "resolve": "Set `disable_api_termination` attribute  with value `true`"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
+        }
+      ],
+      "projectType": "terraformconfig"
+    },
+    "meta": {
+      "isPrivate": true,
+      "isLicensesEnabled": false,
+      "ignoreSettings": null,
+      "org": "craig.furman",
+      "projectId": "",
+      "policy": ""
+    },
+    "filesystemPolicy": false,
+    "vulnerabilities": [],
+    "dependencyCount": 0,
+    "licensesPolicy": null,
+    "ignoreSettings": null,
+    "targetFile": "aws_ec2_metadata_secrets.tf",
+    "projectName": "policies",
+    "org": "craig.furman",
+    "policy": "",
+    "isPrivate": true,
+    "targetFilePath": "/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/aws_ec2_metadata_secrets.tf",
+    "packageManager": "terraformconfig"
+  },
+  {
+    "result": {
+      "cloudConfigResults": [
+        {
+          "severity": "low",
+          "resolve": "Set `DisableApiTermination` attribute with value `true`",
+          "id": "SNYK-CC-AWS-426",
+          "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+          "msg": "Resources[BastionHost].Properties.DisableApiTermination",
+          "remediation": {
+            "cloudformation": "Set `DisableApiTermination` attribute with value `true`",
+            "terraform": "Set `disable_api_termination` attribute  with value `true`"
+          },
+          "subType": "EC2",
+          "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+          "publicId": "SNYK-CC-AWS-426",
+          "title": "EC2 API termination protection is not enabled",
+          "references": [
+            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+          ],
+          "name": "EC2 API termination protection is not enabled",
+          "cloudConfigPath": [
+            "[DocId: 0]",
+            "Resources[BastionHost]",
+            "Properties",
+            "DisableApiTermination"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+            "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+            "resolve": "Set `DisableApiTermination` attribute with value `true`"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
+        },
+        {
+          "severity": "medium",
+          "resolve": "Set `BlockDeviceMappings.Encrypted` attribute of root device to `true`",
+          "id": "SNYK-CC-TF-53",
+          "impact": "That should someone gain unauthorized access to the data they would be able to read the contents.",
+          "msg": "Resources.BastionHost.Properties.BlockDeviceMappings",
+          "remediation": {
+            "cloudformation": "Set `BlockDeviceMappings.Encrypted` attribute of root device to `true`",
+            "terraform": "Set `root_block_device.encrypted` attribute to `true`"
+          },
+          "subType": "EC2",
+          "issue": "The root block device for ec2 instance is not encrypted",
+          "publicId": "SNYK-CC-TF-53",
+          "title": "Non-Encrypted root block device",
+          "references": [
+            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/RootDeviceStorage.html",
+            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html",
+            "https://aws.amazon.com/premiumsupport/knowledge-center/cloudformation-root-volume-property/",
+            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html"
+          ],
+          "name": "Non-Encrypted root block device",
+          "cloudConfigPath": [
+            "[DocId: 0]",
+            "Resources",
+            "BastionHost",
+            "Properties",
+            "BlockDeviceMappings"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "The root block device for ec2 instance is not encrypted",
+            "impact": "That should someone gain unauthorized access to the data they would be able to read the contents.",
+            "resolve": "Set `BlockDeviceMappings.Encrypted` attribute of root device to `true`"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53"
+        },
+        {
+          "severity": "low",
+          "resolve": "Set `Properties.KmsKeyId` attribute with customer managed key id",
+          "id": "SNYK-CC-AWS-415",
+          "impact": "Scope of use of the key cannot be controlled via KMS/IAM policies",
+          "msg": "Resources[BastionSecureLogGroup].Properties.KmsKeyId",
+          "remediation": {
+            "cloudformation": "Set `Properties.KmsKeyId` attribute with customer managed key id",
+            "terraform": "Set `kms_key_id` attribute with customer managed key id"
+          },
+          "subType": "CloudWatch",
+          "issue": "Log group is not encrypted with customer managed key",
+          "publicId": "SNYK-CC-AWS-415",
+          "title": "CloudWatch log group not encrypted with managed key",
+          "references": [
+            "https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html",
+            "https://docs.aws.amazon.com/whitepapers/latest/kms-best-practices/aws-managed-and-customer-managed-cmks.html"
+          ],
+          "name": "CloudWatch log group not encrypted with managed key",
+          "cloudConfigPath": [
+            "[DocId: 0]",
+            "Resources[BastionSecureLogGroup]",
+            "Properties",
+            "KmsKeyId"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "Log group is not encrypted with customer managed key",
+            "impact": "Scope of use of the key cannot be controlled via KMS/IAM policies",
+            "resolve": "Set `Properties.KmsKeyId` attribute with customer managed key id"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-415"
+        }
+      ],
+      "projectType": "cloudformationconfig"
+    },
+    "meta": {
+      "isPrivate": true,
+      "isLicensesEnabled": false,
+      "ignoreSettings": null,
+      "org": "craig.furman",
+      "projectId": "",
+      "policy": ""
+    },
+    "filesystemPolicy": false,
+    "vulnerabilities": [],
+    "dependencyCount": 0,
+    "licensesPolicy": null,
+    "ignoreSettings": null,
+    "targetFile": "bastion.yml",
+    "projectName": "policies",
+    "org": "craig.furman",
+    "policy": "",
+    "isPrivate": true,
+    "targetFilePath": "/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/bastion.yml",
+    "packageManager": "cloudformationconfig"
+  },
+  {
+    "result": {
+      "cloudConfigResults": [
+        {
+          "severity": "medium",
+          "description": "",
+          "resolve": "Set `securityContext.runAsNonRoot` to `true`",
+          "id": "SNYK-CC-K8S-10",
+          "impact": "Container could be running with full administrative privileges",
+          "msg": "input.spec.template.spec.containers[web].securityContext.runAsNonRoot",
+          "subType": "Deployment",
+          "issue": "Container is running without root user control",
+          "publicId": "SNYK-CC-K8S-10",
+          "title": "Container is running without root user control",
+          "references": [
+            "CIS Docker Benchmark 1.2.0 - 5.5 Ensure sensitive host system directories are not mounted on containers",
+            "https://kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups",
+            "https://kubernetes.io/blog/2016/08/security-best-practices-kubernetes-deployment/"
+          ],
+          "name": "Container is running without root user control",
+          "cloudConfigPath": [
+            "[DocId: 0]",
+            "input",
+            "spec",
+            "template",
+            "spec",
+            "containers[web]",
+            "securityContext",
+            "runAsNonRoot"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "Container is running without root user control",
+            "impact": "Container could be running with full administrative privileges",
+            "resolve": "Set `securityContext.runAsNonRoot` to `true`"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10"
+        },
+        {
+          "severity": "low",
+          "description": "",
+          "resolve": "Set `imagePullPolicy` attribute to `Always`",
+          "id": "SNYK-CC-K8S-42",
+          "impact": "The container may run with outdated or unauthorized image",
+          "msg": "spec.template.spec.containers[web].imagePullPolicy",
+          "subType": "Deployment",
+          "issue": "The image policy does not prevent image reuse",
+          "publicId": "SNYK-CC-K8S-42",
+          "title": "Container could be running with outdated image",
+          "references": [
+            "5.27 Ensure that Docker commands always make use of the latest version of their image",
+            "https://kubernetes.io/docs/concepts/containers/images/",
+            "https://kubernetes.io/docs/concepts/configuration/overview/#container-images"
+          ],
+          "name": "Container could be running with outdated image",
+          "cloudConfigPath": [
+            "[DocId: 0]",
+            "spec",
+            "template",
+            "spec",
+            "containers[web]",
+            "imagePullPolicy"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "The image policy does not prevent image reuse",
+            "impact": "The container may run with outdated or unauthorized image",
+            "resolve": "Set `imagePullPolicy` attribute to `Always`"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42"
+        },
+        {
+          "severity": "medium",
+          "description": "",
+          "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`",
+          "id": "SNYK-CC-K8S-6",
+          "impact": "Containers are running with potentially unnecessary privileges",
+          "msg": "input.spec.template.spec.containers[web].securityContext.capabilities.drop",
+          "subType": "Deployment",
+          "issue": "All default capabilities are not explicitly dropped",
+          "publicId": "SNYK-CC-K8S-6",
+          "title": "Container does not drop all default capabilities",
+          "references": [
+            "https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+            "https://linux-audit.com/linux-capabilities-hardening-linux-binaries-by-removing-setuid/"
+          ],
+          "name": "Container does not drop all default capabilities",
+          "cloudConfigPath": [
+            "[DocId: 0]",
+            "input",
+            "spec",
+            "template",
+            "spec",
+            "containers[web]",
+            "securityContext",
+            "capabilities",
+            "drop"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "All default capabilities are not explicitly dropped",
+            "impact": "Containers are running with potentially unnecessary privileges",
+            "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6"
+        },
+        {
+          "severity": "low",
+          "description": "",
+          "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`",
+          "id": "SNYK-CC-K8S-8",
+          "impact": "Compromised process could abuse writable root filesystem to elevate privileges",
+          "msg": "input.spec.template.spec.containers[web].securityContext.readOnlyRootFilesystem",
+          "subType": "Deployment",
+          "issue": "`readOnlyRootFilesystem` attribute is not set to `true`",
+          "publicId": "SNYK-CC-K8S-8",
+          "title": "Container is running with writable root filesystem",
+          "references": [
+            "CIS Docker Benchmark 1.2.0 - Ensure that the container's root filesystem is mounted as read only",
+            "https://kubernetes.io/docs/concepts/policy/pod-security-policy/#volumes-and-file-systems",
+            "https://kubernetes.io/blog/2016/08/security-best-practices-kubernetes-deployment/"
+          ],
+          "name": "Container is running with writable root filesystem",
+          "cloudConfigPath": [
+            "[DocId: 0]",
+            "input",
+            "spec",
+            "template",
+            "spec",
+            "containers[web]",
+            "securityContext",
+            "readOnlyRootFilesystem"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "`readOnlyRootFilesystem` attribute is not set to `true`",
+            "impact": "Compromised process could abuse writable root filesystem to elevate privileges",
+            "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8"
+        },
+        {
+          "severity": "medium",
+          "description": "",
+          "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`",
+          "id": "SNYK-CC-K8S-9",
+          "impact": "Processes could elevate current privileges via known vectors, for example SUID binaries",
+          "msg": "input.spec.template.spec.containers[web].securityContext.allowPrivilegeEscalation",
+          "subType": "Deployment",
+          "issue": "`allowPrivilegeEscalation` attribute is not set to `false`",
+          "publicId": "SNYK-CC-K8S-9",
+          "title": "Container is running without privilege escalation control",
+          "references": [
+            "CIS Docker Benchmark 1.2.0 - 5.25 Ensure that the container is restricted from acquiring additional privileges",
+            "https://kubernetes.io/docs/concepts/policy/pod-security-policy/#privilege-escalation",
+            "https://www.kernel.org/doc/html/latest/userspace-api/no_new_privs.html"
+          ],
+          "name": "Container is running without privilege escalation control",
+          "cloudConfigPath": [
+            "[DocId: 0]",
+            "input",
+            "spec",
+            "template",
+            "spec",
+            "containers[web]",
+            "securityContext",
+            "allowPrivilegeEscalation"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "`allowPrivilegeEscalation` attribute is not set to `false`",
+            "impact": "Processes could elevate current privileges via known vectors, for example SUID binaries",
+            "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9"
+        },
+        {
+          "severity": "low",
+          "description": "",
+          "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`",
+          "id": "SNYK-CC-K8S-32",
+          "impact": "AppArmor will not enforce mandatory access control, which can increase the attack vectors.",
+          "msg": "metadata.annotations['container.apparmor.security.beta.kubernetes.io/web']",
+          "subType": "Deployment",
+          "issue": "The AppArmor profile is not set correctly",
+          "publicId": "SNYK-CC-K8S-32",
+          "title": "Container is running without AppArmor profile",
+          "references": [
+            "CIS Docker Benchmark 1.2.0 - 5.1 Ensure that, if applicable, an AppArmor Profile is enabled",
+            "https://kubernetes.io/docs/tutorials/clusters/apparmor/",
+            "https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor"
+          ],
+          "name": "Container is running without AppArmor profile",
+          "cloudConfigPath": [
+            "[DocId: 0]",
+            "metadata",
+            "annotations['container.apparmor.security.beta.kubernetes.io/web']"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "The AppArmor profile is not set correctly",
+            "impact": "AppArmor will not enforce mandatory access control, which can increase the attack vectors.",
+            "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32"
+        },
+        {
+          "severity": "low",
+          "description": "",
+          "resolve": "Set `resources.limits.memory` value",
+          "id": "SNYK-CC-K8S-4",
+          "impact": "Containers without memory limits are more likely to be terminated when the node runs out of memory",
+          "msg": "input.spec.template.spec.containers[web].resources.limits.memory",
+          "subType": "Deployment",
+          "issue": "Memory limit is not defined",
+          "publicId": "SNYK-CC-K8S-4",
+          "title": "Container is running without memory limit",
+          "references": [
+            "CIS Docker Benchmark 1.2.0 - 5.10 Ensure that the memory usage for containers is limited",
+            "https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource/",
+            "https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/"
+          ],
+          "name": "Container is running without memory limit",
+          "cloudConfigPath": [
+            "[DocId: 0]",
+            "input",
+            "spec",
+            "template",
+            "spec",
+            "containers[web]",
+            "resources",
+            "limits",
+            "memory"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "Memory limit is not defined",
+            "impact": "Containers without memory limits are more likely to be terminated when the node runs out of memory",
+            "resolve": "Set `resources.limits.memory` value"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4"
+        },
+        {
+          "severity": "low",
+          "description": "",
+          "resolve": "Add `resources.limits.cpu` field with required CPU limit value",
+          "id": "SNYK-CC-K8S-5",
+          "impact": "Containers without limits can exceed the capacity of the node, and affect availability/performance of the host and other containers.",
+          "msg": "input.spec.template.spec.containers[web].resources.limits.cpu",
+          "subType": "Deployment",
+          "issue": "CPU limit is not defined",
+          "publicId": "SNYK-CC-K8S-5",
+          "title": "Container is running without cpu limit",
+          "references": [
+            "CIS Docker Benchmark 1.2.0 - 5.11 Ensure that CPU priority is set appropriately on containers",
+            "https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/",
+            "https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+            "https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace/"
+          ],
+          "name": "Container is running without cpu limit",
+          "cloudConfigPath": [
+            "[DocId: 0]",
+            "input",
+            "spec",
+            "template",
+            "spec",
+            "containers[web]",
+            "resources",
+            "limits",
+            "cpu"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "CPU limit is not defined",
+            "impact": "Containers without limits can exceed the capacity of the node, and affect availability/performance of the host and other containers.",
+            "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5"
+        },
+        {
+          "severity": "high",
+          "description": "",
+          "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`",
+          "id": "SNYK-CC-K8S-1",
+          "impact": "Compromised container could potentially modify the underlying host’s kernel by loading unauthorized modules (i.e. drivers).",
+          "msg": "input.spec.template.spec.containers[web].securityContext.privileged",
+          "subType": "Deployment",
+          "issue": "Container is running in privileged mode",
+          "publicId": "SNYK-CC-K8S-1",
+          "title": "Container is running in privileged mode",
+          "references": [
+            "CIS Kubernetes Benchmark 1.6.0 - 5.2.1 Minimize the admission of privileged containers",
+            "https://kubernetes.io/docs/concepts/policy/pod-security-policy/#privileged",
+            "https://kubernetes.io/blog/2016/08/security-best-practices-kubernetes-deployment/"
+          ],
+          "name": "Container is running in privileged mode",
+          "cloudConfigPath": [
+            "[DocId: 0]",
+            "input",
+            "spec",
+            "template",
+            "spec",
+            "containers[web]",
+            "securityContext",
+            "privileged"
+          ],
+          "isIgnored": false,
+          "iacDescription": {
+            "issue": "Container is running in privileged mode",
+            "impact": "Compromised container could potentially modify the underlying host’s kernel by loading unauthorized modules (i.e. drivers).",
+            "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
+          },
+          "lineNumber": -1,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1"
+        }
+      ],
+      "projectType": "k8sconfig"
+    },
+    "meta": {
+      "isPrivate": true,
+      "isLicensesEnabled": false,
+      "ignoreSettings": null,
+      "org": "craig.furman",
+      "projectId": "",
+      "policy": ""
+    },
+    "filesystemPolicy": false,
+    "vulnerabilities": [],
+    "dependencyCount": 0,
+    "licensesPolicy": null,
+    "ignoreSettings": null,
+    "targetFile": "k8s.yaml",
+    "projectName": "policies",
+    "org": "craig.furman",
+    "policy": "",
+    "isPrivate": true,
+    "targetFilePath": "/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/k8s.yaml",
+    "packageManager": "k8sconfig"
+  }
+]

--- a/test/jest/unit/iac-unit-tests/fixtures/policy-ignore-file-path-non-matching.yml
+++ b/test/jest/unit/iac-unit-tests/fixtures/policy-ignore-file-path-non-matching.yml
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-CC-K8S-1:
+    - 'wrong.yaml':
+        reason: None Given
+        created: 2021-07-26T13:09:08.459Z
+patch: {}

--- a/test/jest/unit/iac-unit-tests/fixtures/policy-ignore-file-path-non-matching.yml
+++ b/test/jest/unit/iac-unit-tests/fixtures/policy-ignore-file-path-non-matching.yml
@@ -3,7 +3,7 @@ version: v1.19.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-CC-K8S-1:
-    - 'wrong.yaml':
+    - 'wrong.yaml > *':
         reason: None Given
         created: 2021-07-26T13:09:08.459Z
 patch: {}

--- a/test/jest/unit/iac-unit-tests/fixtures/policy-ignore-file-path-wrong-dir.yml
+++ b/test/jest/unit/iac-unit-tests/fixtures/policy-ignore-file-path-wrong-dir.yml
@@ -3,7 +3,7 @@ version: v1.19.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-CC-K8S-1:
-    - 'k8s.yaml > *':
+    - 'wrong/k8s.yaml > [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > privileged':
         reason: None Given
         created: 2021-07-26T13:09:08.459Z
 patch: {}

--- a/test/jest/unit/iac-unit-tests/fixtures/policy-ignore-file-path.yml
+++ b/test/jest/unit/iac-unit-tests/fixtures/policy-ignore-file-path.yml
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-CC-K8S-1:
+    - 'k8s.yaml':
+        reason: None Given
+        created: 2021-07-26T13:09:08.459Z
+patch: {}

--- a/test/jest/unit/iac-unit-tests/fixtures/policy-ignore-non-matching-file-matching-resource.yml
+++ b/test/jest/unit/iac-unit-tests/fixtures/policy-ignore-non-matching-file-matching-resource.yml
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-CC-K8S-1:
+    - 'wrong.yaml > [DocId:0] > input > spec > template > spec > containers[web] > securityContext > privileged':
+        reason: None Given
+        created: 2021-07-26T13:09:08.459Z
+patch: {}

--- a/test/jest/unit/iac-unit-tests/fixtures/policy-ignore-resource-path-cloudformation.yml
+++ b/test/jest/unit/iac-unit-tests/fixtures/policy-ignore-resource-path-cloudformation.yml
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-CC-TF-53:
+    - 'bastion.yml > [DocId: 0] > Resources > BastionHost > Properties > BlockDeviceMappings':
+        reason: None Given
+        created: 2021-07-26T13:09:08.459Z
+patch: {}

--- a/test/jest/unit/iac-unit-tests/fixtures/policy-ignore-resource-path-kubernetes.yml
+++ b/test/jest/unit/iac-unit-tests/fixtures/policy-ignore-resource-path-kubernetes.yml
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-CC-K8S-1:
+    - 'k8s.yaml > [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > privileged':
+        reason: None Given
+        created: 2021-07-26T13:09:08.459Z
+patch: {}

--- a/test/jest/unit/iac-unit-tests/fixtures/policy-ignore-resource-path-non-matching.yml
+++ b/test/jest/unit/iac-unit-tests/fixtures/policy-ignore-resource-path-non-matching.yml
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-CC-K8S-1:
+    - 'k8s.yaml > [DocId:0] > input > spec > template > spec > containers[wrong] > securityContext > privileged':
+        reason: None Given
+        created: 2021-07-26T13:09:08.459Z
+patch: {}

--- a/test/jest/unit/iac-unit-tests/fixtures/policy-ignore-resource-path-terraform.yml
+++ b/test/jest/unit/iac-unit-tests/fixtures/policy-ignore-resource-path-terraform.yml
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-CC-TF-123:
+    - 'aws_ec2_metadata_secrets.tf > resource > aws_instance[denied_2] > user_data_base64[aws_access_key_id]':
+        reason: None Given
+        created: 2021-07-26T13:09:08.459Z
+patch: {}

--- a/test/jest/unit/iac-unit-tests/fixtures/policy-ignore-star.yml
+++ b/test/jest/unit/iac-unit-tests/fixtures/policy-ignore-star.yml
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-CC-K8S-1:
+    - '*':
+        reason: None Given
+        created: 2021-07-26T13:09:08.459Z
+patch: {}

--- a/test/jest/unit/iac-unit-tests/policy.spec.ts
+++ b/test/jest/unit/iac-unit-tests/policy.spec.ts
@@ -1,0 +1,118 @@
+import { filterIgnoredIssues } from '../../../../src/cli/commands/test/iac-local-execution/policy';
+import { FormattedResult } from '../../../../src/cli/commands/test/iac-local-execution/types';
+import fs = require('fs');
+import * as path from 'path';
+import * as snykPolicy from 'snyk-policy';
+const cloneDeep = require('lodash.clonedeep');
+
+async function filterFixture(policyName: string) {
+  const policy = await loadPolicy(policyName);
+
+  const fixtureContent = fs.readFileSync(
+    path.join(__dirname, 'fixtures', 'formatted-results.json'),
+    'utf-8',
+  );
+  const fixture: FormattedResult[] = JSON.parse(fixtureContent);
+
+  // The policy library modifies its input. In order to write meaningful
+  // assertions, deep-clone the original fixture.
+  const filtered = filterIgnoredIssues(policy, cloneDeep(fixture));
+
+  return { fixture: fixture, filtered: filtered };
+}
+
+async function loadPolicy(policyName: string) {
+  if (policyName === '') {
+    return null;
+  }
+  const policyPath = path.join(__dirname, 'fixtures', policyName);
+  const policyText = fs.readFileSync(policyPath, 'utf-8');
+  return await snykPolicy.loadFromText(policyText);
+}
+
+function assertK8sPolicyPruned(
+  fixture: FormattedResult[],
+  filtered: FormattedResult[],
+) {
+  expect(filtered[0]).toEqual(fixture[0]);
+  expect(filtered[1]).toEqual(fixture[1]);
+  const k8sFixture = fixture[2].result.cloudConfigResults;
+  const k8sResults = filtered[2].result.cloudConfigResults;
+  expect(k8sResults).toHaveLength(k8sFixture.length - 1);
+  expect(k8sResults.some((e) => e.id === 'SNYK-CC-K8S-1')).toEqual(false);
+}
+
+describe('filtering ignored issues', () => {
+  it('returns the original issues when policy is not loaded', async () => {
+    const { fixture, filtered } = await filterFixture('');
+    expect(filtered).toEqual(fixture);
+  });
+
+  it('filters ignored issues when path=*', async () => {
+    const { fixture, filtered } = await filterFixture('policy-ignore-star.yml');
+    assertK8sPolicyPruned(fixture, filtered);
+  });
+
+  // This might seem paranoid, but given that our handling of resource paths is
+  // in a state of flux, e.g. to support multi-doc YAML properly, having some
+  // regression tests around each currently supported config type might be wise.
+  describe('filtering ignored issues by resource path', () => {
+    it('filters ignored issues when path is resource path (Kubernetes)', async () => {
+      const { fixture, filtered } = await filterFixture(
+        'policy-ignore-resource-path-kubernetes.yml',
+      );
+      assertK8sPolicyPruned(fixture, filtered);
+    });
+
+    it('filters ignored issues when path is resource path (CloudFormation)', async () => {
+      const { fixture, filtered } = await filterFixture(
+        'policy-ignore-resource-path-cloudformation.yml',
+      );
+      expect(filtered[0]).toEqual(fixture[0]);
+      expect(filtered[2]).toEqual(fixture[2]);
+      const cfFixture = fixture[1].result.cloudConfigResults;
+      const cfResults = filtered[1].result.cloudConfigResults;
+      expect(cfResults).toHaveLength(cfFixture.length - 1);
+      expect(cfResults.some((e) => e.id === 'SNYK-CC-TF-53')).toEqual(false);
+    });
+
+    it('filters ignored issues when path is resource path (Terraform)', async () => {
+      const { fixture, filtered } = await filterFixture(
+        'policy-ignore-resource-path-terraform.yml',
+      );
+      expect(filtered[1]).toEqual(fixture[1]);
+      expect(filtered[2]).toEqual(fixture[2]);
+      const tfFixture = fixture[0].result.cloudConfigResults;
+      const tfResults = filtered[0].result.cloudConfigResults;
+      expect(tfResults).toHaveLength(tfFixture.length - 1);
+    });
+  });
+
+  it('filters no issues when path is non-matching resource path', async () => {
+    const { fixture, filtered } = await filterFixture(
+      'policy-ignore-resource-path-non-matching.yml',
+    );
+    expect(filtered).toEqual(fixture);
+  });
+
+  it('filters ignored issues when path is file path', async () => {
+    const { fixture, filtered } = await filterFixture(
+      'policy-ignore-file-path.yml',
+    );
+    assertK8sPolicyPruned(fixture, filtered);
+  });
+
+  it('filters no issues when path is non-matching file path', async () => {
+    const { fixture, filtered } = await filterFixture(
+      'policy-ignore-file-path-non-matching.yml',
+    );
+    expect(filtered).toEqual(fixture);
+  });
+
+  it('filters no issues when path is non-matching file path but matching resource path', async () => {
+    const { fixture, filtered } = await filterFixture(
+      'policy-ignore-non-matching-file-matching-resource.yml',
+    );
+    expect(filtered).toEqual(fixture);
+  });
+});

--- a/test/jest/unit/iac-unit-tests/policy.spec.ts
+++ b/test/jest/unit/iac-unit-tests/policy.spec.ts
@@ -115,6 +115,14 @@ describe('filtering ignored issues', () => {
     expect(ignoreCount).toEqual(1);
   });
 
+  it('filters no issues when path is file path in the wrong directory', async () => {
+    const { fixture, filtered, ignoreCount } = await filterFixture(
+      'policy-ignore-file-path-wrong-dir.yml',
+    );
+    expect(filtered).toEqual(fixture);
+    expect(ignoreCount).toEqual(0);
+  });
+
   it('filters no issues when path is non-matching file path', async () => {
     const { fixture, filtered, ignoreCount } = await filterFixture(
       'policy-ignore-file-path-non-matching.yml',

--- a/test/smoke/spec/iac/snyk_test_k8s_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_k8s_spec.sh
@@ -9,7 +9,7 @@ Describe "Snyk iac test command"
     It "finds issues in k8s file"
       When run snyk iac test ../fixtures/iac/kubernetes/pod-privileged.yaml --legacy
       The status should be failure # issues found
-      The output should include "Testing pod-privileged.yaml..."
+      The output should include "Testing ../fixtures/iac/kubernetes/pod-privileged.yaml..."
 
       # Outputs issues
       The output should include "Infrastructure as code issues:"
@@ -23,13 +23,13 @@ Describe "Snyk iac test command"
       The output should include "Project name:      kubernetes"
       The output should include "Open source:       no"
       The output should include "Project path:      ../fixtures/iac/kubernetes/pod-privileged.yaml"
-      The output should include "Tested pod-privileged.yaml for known issues, found"
+      The output should include "Tested ../fixtures/iac/kubernetes/pod-privileged.yaml for known issues, found"
     End
 
     It "filters out issues when using severity threshold"
       When run snyk iac test ../fixtures/iac/kubernetes/pod-privileged.yaml --severity-threshold=high --legacy
       The status should be failure # one issue found
-      The output should include "Testing pod-privileged.yaml..."
+      The output should include "Testing ../fixtures/iac/kubernetes/pod-privileged.yaml..."
 
       The output should include "Infrastructure as code issues:"
       The output should include "✗ "
@@ -41,7 +41,7 @@ Describe "Snyk iac test command"
       The output should include "Project name:      kubernetes"
       The output should include "Open source:       no"
       The output should include "Project path:      ../fixtures/iac/kubernetes/pod-privileged.yaml"
-      The output should include "Tested pod-privileged.yaml for known issues, found"
+      The output should include "Tested ../fixtures/iac/kubernetes/pod-privileged.yaml for known issues, found"
     End
 
     It "outputs an error for files with no valid k8s objects"

--- a/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
@@ -30,7 +30,7 @@ Describe "Snyk iac local test command"
     It "finds issues in k8s YAML file"
       When run snyk iac test ../fixtures/iac/kubernetes/pod-privileged.yaml
       The status should equal 1 # issues found
-      The output should include "Testing pod-privileged.yaml..."
+      The output should include "Testing ../fixtures/iac/kubernetes/pod-privileged.yaml..."
 
       # Outputs issues
       The output should include "Infrastructure as code issues:"
@@ -41,7 +41,7 @@ Describe "Snyk iac local test command"
     It "finds issues in k8s JSON file"
           When run snyk iac test ../fixtures/iac/kubernetes/pod-valid.json
           The status should equal 1 # issues found
-          The output should include "Testing pod-valid.json..."
+          The output should include "Testing ../fixtures/iac/kubernetes/pod-valid.json..."
 
           # Outputs issues
           The output should include "Infrastructure as code issues:"
@@ -52,7 +52,7 @@ Describe "Snyk iac local test command"
     It "filters out issues when using severity threshold"
       When run snyk iac test ../fixtures/iac/kubernetes/pod-privileged.yaml  --severity-threshold=high
       The status should equal 1 # one issue found
-      The output should include "Testing pod-privileged.yaml..."
+      The output should include "Testing ../fixtures/iac/kubernetes/pod-privileged.yaml..."
 
       The output should include "Infrastructure as code issues:"
       The output should include "✗ "
@@ -94,7 +94,7 @@ Describe "Snyk iac local test command"
       It "finds issues in CloudFormation YAML file"
         When run snyk iac test ../fixtures/iac/cloudformation/aurora-valid.yml
         The status should equal 1 # issues found
-        The output should include "Testing aurora-valid.yml..."
+        The output should include "Testing ../fixtures/iac/cloudformation/aurora-valid.yml..."
 
         # Outputs issues
         The output should include "Infrastructure as code issues:"
@@ -105,7 +105,7 @@ Describe "Snyk iac local test command"
       It "finds issues in CloudFormation JSON file"
               When run snyk iac test ../fixtures/iac/cloudformation/fargate-valid.json
               The status should equal 1 # issues found
-              The output should include "Testing fargate-valid.json..."
+              The output should include "Testing ../fixtures/iac/cloudformation/fargate-valid.json..."
 
               # Outputs issues
               The output should include "Infrastructure as code issues:"
@@ -116,10 +116,10 @@ Describe "Snyk iac local test command"
       It "filters out issues when using severity threshold"
         When run snyk iac test ../fixtures/iac/cloudformation/aurora-valid.yml  --severity-threshold=high
         The status should equal 0 # no issues found
-        The output should include "Testing aurora-valid.yml..."
+        The output should include "Testing ../fixtures/iac/cloudformation/aurora-valid.yml..."
 
         The output should include "Infrastructure as code issues:"
-        The output should include "Tested aurora-valid.yml for known issues, found"
+        The output should include "Tested ../fixtures/iac/cloudformation/aurora-valid.yml for known issues, found"
       End
 
       It "outputs an error for files with no valid YAML"
@@ -149,7 +149,7 @@ Describe "Snyk iac local test command"
     It "finds issues in terraform file"
       When run snyk iac test ../fixtures/iac/terraform/sg_open_ssh.tf
       The status should equal 1 # issues found
-      The output should include "Testing sg_open_ssh.tf..."
+      The output should include "Testing ../fixtures/iac/terraform/sg_open_ssh.tf..."
 
       # Outputs issues
       The output should include "Infrastructure as code issues:"
@@ -160,10 +160,10 @@ Describe "Snyk iac local test command"
     It "filters out issues when using severity threshold"
       When run snyk iac test ../fixtures/iac/terraform/sg_open_ssh.tf  --severity-threshold=high
       The status should equal 0 # no issues found
-      The output should include "Testing sg_open_ssh.tf..."
+      The output should include "Testing ../fixtures/iac/terraform/sg_open_ssh.tf..."
 
       The output should include "Infrastructure as code issues:"
-      The output should include "Tested sg_open_ssh.tf for known issues, found"
+      The output should include "Tested ../fixtures/iac/terraform/sg_open_ssh.tf for known issues, found"
     End
 
     # TODO: currently skipped because the parser we're using doesn't fail on invalid terraform
@@ -236,9 +236,9 @@ Describe "Snyk iac local test command"
       When run snyk iac test ../fixtures/iac/depth_detection/  --detection-depth=2
       The status should equal 1 #  issues found
       # Only File
-      The output should include "Testing one.tf..."
+      The output should include "Testing one/one.tf..."
       The output should include "Infrastructure as code issues:"
-      The output should include "Tested one.tf for known issues, found"
+      The output should include "Tested one/one.tf for known issues, found"
 
       # Second File
       The output should include "Testing root.tf..."
@@ -310,7 +310,7 @@ Describe "Snyk iac local test command"
     It "finds issues in a Terraform plan file - full scan flag"
       When run snyk iac test ../fixtures/iac/terraform-plan/tf-plan-create.json  --scan=planned-values
       The status should equal 1 # issues found
-      The output should include "Testing tf-plan-create.json"
+      The output should include "Testing ../fixtures/iac/terraform-plan/tf-plan-create.json"
 
       # Outputs issues
       The output should include "Infrastructure as code issues:"
@@ -324,7 +324,7 @@ Describe "Snyk iac local test command"
     It "finds issues in a Terraform plan file - explicit delta scan with flag"
       When run snyk iac test ../fixtures/iac/terraform-plan/tf-plan-create.json  --scan=resource-changes
       The status should equal 1 # issues found
-      The output should include "Testing tf-plan-create.json"
+      The output should include "Testing ../fixtures/iac/terraform-plan/tf-plan-create.json"
 
       # Outputs issues
       The output should include "Infrastructure as code issues:"

--- a/test/smoke/spec/iac/snyk_test_terraform_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_terraform_spec.sh
@@ -9,7 +9,7 @@ Describe "Snyk iac test command"
     It "finds issues in terraform file"
       When run snyk iac test ../fixtures/iac/terraform/sg_open_ssh.tf --legacy
       The status should be failure # issues found
-      The output should include "Testing sg_open_ssh.tf..."
+      The output should include "Testing ../fixtures/iac/terraform/sg_open_ssh.tf..."
       # Outputs issues   
       The output should include "Infrastructure as code issues:"
       The output should include "✗ "
@@ -22,13 +22,13 @@ Describe "Snyk iac test command"
       The output should include "Project name:      terraform"
       The output should include "Open source:       no"
       The output should include "Project path:      ../fixtures/iac/terraform/sg_open_ssh.tf"
-      The output should include "Tested sg_open_ssh.tf for known issues, found"
+      The output should include "Tested ../fixtures/iac/terraform/sg_open_ssh.tf for known issues, found"
     End
 
     It "filters out issues when using severity threshold"
       When run snyk iac test ../fixtures/iac/terraform/sg_open_ssh.tf --severity-threshold=high --legacy
       The status should be success # no issues found
-      The output should include "Testing sg_open_ssh.tf..."
+      The output should include "Testing ../fixtures/iac/terraform/sg_open_ssh.tf..."
       # Outputs issues   
       The output should include "Infrastructure as code issues:"
 
@@ -39,7 +39,7 @@ Describe "Snyk iac test command"
       The output should include "Project name:      terraform"
       The output should include "Open source:       no"
       The output should include "Project path:      ../fixtures/iac/terraform/sg_open_ssh.tf"
-      The output should include "Tested sg_open_ssh.tf for known issues, found"
+      The output should include "Tested ../fixtures/iac/terraform/sg_open_ssh.tf for known issues, found"
     End
 
     It "outputs an error for invalid hcl2 tf files"


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

- Non-JSON output includes full targetFile pathname, not just the basename. These are paths relative to the root of the scan, which might be needed by users in order to write path-scoped ignore rules (more below).
- Support for IaC ignores with 3 levels of specificity: all instances of an issue, all instances in a file, and one specific instance by resource path.
- Add some scaffolding for an ignored-issues analytics counter. We can't turn this on until we ensure there is backend support for it (https://snyksec.atlassian.net/browse/CC-995).

All the usual policy flags from the CLI are supported, including `--policy-path` to pass in an out-of-tree `.snyk`. The logic used to load the policy is the same as used by other CLI subsystems (open-source, container).

Without `--policy-path`, `.snyk` files will be searched for in each directory passed to `snyk iac test` (default is the CWD). In this way you can use multiple, directory-scoped `.snyk`s. File paths in file-scoped ignore rules must be relative to the directory under test. Note that there is a 1:1 correspondence between .snyk policy files and root directories under test. If you only test 1 directory, recursively, you must use only one `.snyk` file. This is a limitation of the current policy file framework, not a new limitation introduced by this PR.

When using `--policy-path`, you can pass it either a directory in which it will look for a file named `.snyk`, or a file path - but the file must be named `.snyk`. This is a bit unexpected, but is a limitation of the current policy file framework, not a new limitation introduced by this PR. If we want to fix it, we can do that separarately.

All of this affects only `snyk iac test`, not `snyk test`. Ignore support has not been added to the `snyk iac test test --legacy` flow either (but the output formatting does affect this flow).

#### Where should the reviewer start?

I'd recommend going commit-by-commit. The middle commit that actually adds the ignore support is a little chunky admittedly, but I couldn't really break it down much.

#### How should this be manually tested?

First, a developer can run snyk ignore --id=SNYK-CC-K8S-1 , which will generate a .snyk policy file with the following content if it doesn’t already exist. If it does exist, that command will append the relevant policy stanza:

```yaml
version: v1.19.0
ignore:
  SNYK-CC-K8S-1:
    - '*':
        reason: None Given
        expires: 2021-08-26T08:40:35.249Z
        created: 2021-07-27T08:40:35.251Z
```

You can also handwrite this file, or copy-paste a template from our docs.

Now, snyk iac test (with an optional --policy-path=/path/to/policy-file if you don’t want to keep .snyk in the root of a repository) will ignore all instances of that particular issue.

If you want to scope the ignore down to a single file, you can edit that * to instead be the relative path to the file in question. For example:

```yaml
version: v1.19.0
ignore:
  SNYK-CC-K8S-1:
    - 'staging/deployment.yaml':
        reason: None Given
        expires: 2021-08-26T08:40:35.249Z
        created: 2021-07-27T08:40:35.251Z
```


Finally, in order to scope the ignore down to one particular instance, you can append the `>`-separated “resource path” to the filename, which you can copy-paste from the CLI’s output. For example:

```yaml
version: v1.19.0
ignore:
  SNYK-CC-K8S-1:
    - 'k8s.yaml > [DocId:1] > spec > template > spec > containers[web] > securityContext > privileged':
        reason: None Given
        expires: 2021-08-26T08:40:35.249Z
        created: 2021-07-27T08:40:35.251Z
```

#### Any background context you want to provide?

- I haven't written documentation for this new feature yet, but that's next on my list.
- formatted-results.json was captured by console.logging a `FormattedResult[]` from an actual scan. It has some metadata about my org and computer in there, but I don't see any security risks. Perhaps double check that.]
- Because I changed the smoke tests, I pushed a `smoke/feat/iac-ignores` branch to the same HEAD. You can see the resultant github checks in the regular checks area below.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/CC-990

#### Screenshots


#### Additional questions
