### PR TITLE
Fix/cli code 0 exclude base image vulns

### DIFF
--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -390,7 +390,7 @@ async function parseRes(
       (res as any) as TestDepGraphResponse, // Double "as" required by Typescript for dodgy assertions
       depGraph,
       pkgManager,
-      options.severityThreshold,
+      options,
     );
     // For Node.js: inject additional information (for remediation etc.) into the response.
     if (payload.modules) {
@@ -446,11 +446,6 @@ async function parseRes(
       (vuln as DockerIssue).dockerBaseImage = res.docker!.baseImage;
       return vuln;
     });
-  }
-  if (options.docker && options.file && options['exclude-base-image-vulns']) {
-    res.vulnerabilities = res.vulnerabilities.filter(
-      (vuln) => (vuln as DockerIssue).dockerfileInstruction,
-    );
   }
 
   res.uniqueCount = countUniqueVulns(res.vulnerabilities);

--- a/test/acceptance/fixtures/docker/Dockerfile.alpine-3.12.0
+++ b/test/acceptance/fixtures/docker/Dockerfile.alpine-3.12.0
@@ -1,0 +1,1 @@
+FROM alpine:3.12.0

--- a/test/jest/acceptance/cli-args.spec.ts
+++ b/test/jest/acceptance/cli-args.spec.ts
@@ -10,6 +10,11 @@ const createOutputDirectory = (): string => {
   return outputPath;
 };
 
+const isWindows =
+  require('os-name')()
+    .toLowerCase()
+    .indexOf('windows') === 0;
+
 jest.setTimeout(1000 * 60 * 5);
 
 test('snyk test command should fail when --file is not specified correctly', async () => {
@@ -333,17 +338,20 @@ test('container test --sarif-file-output can be used at the same time as --json'
   expect(code).toEqual(0);
 });
 
-test('bug: container test --file=Dockerfile --exclude-base-image-vulns returns exit code 2', async () => {
-  const dockerfilePath = path.normalize(
-    'test/acceptance/fixtures/docker/Dockerfile.alpine-3.12.0',
-  );
+if (!isWindows) {
+  // Previously we used to have a bug where --exclude-base-image-vulns returned exit code 2.
+  // This test asserts that the bug no longer exists.
+  test('container test --file=Dockerfile --exclude-base-image-vulns returns exit code 0', async () => {
+    const dockerfilePath = path.normalize(
+      'test/acceptance/fixtures/docker/Dockerfile.alpine-3.12.0',
+    );
 
-  const { code, stdout } = await runSnykCLI(
-    `container test alpine:3.12.0 --json --file=${dockerfilePath} --exclude-base-image-vulns`,
-  );
-  const jsonOutput = JSON.parse(stdout);
+    const { code, stdout } = await runSnykCLI(
+      `container test alpine:3.12.0 --json --file=${dockerfilePath} --exclude-base-image-vulns`,
+    );
+    const jsonOutput = JSON.parse(stdout);
 
-  // BUG: it should return ok: true and exit code 0 when all vulns are excluded
-  expect(jsonOutput.ok).toEqual(false);
-  expect(code).toEqual(2);
-});
+    expect(jsonOutput.ok).toEqual(true);
+    expect(code).toEqual(0);
+  });
+}

--- a/test/jest/acceptance/cli-args.spec.ts
+++ b/test/jest/acceptance/cli-args.spec.ts
@@ -332,3 +332,18 @@ test('container test --sarif-file-output can be used at the same time as --json'
   expect(sarifOutput.version).toMatch('2.1.0');
   expect(code).toEqual(0);
 });
+
+test('bug: container test --file=Dockerfile --exclude-base-image-vulns returns exit code 2', async () => {
+  const dockerfilePath = path.normalize(
+    'test/acceptance/fixtures/docker/Dockerfile.alpine-3.12.0',
+  );
+
+  const { code, stdout } = await runSnykCLI(
+    `container test alpine:3.12.0 --json --file=${dockerfilePath} --exclude-base-image-vulns`,
+  );
+  const jsonOutput = JSON.parse(stdout);
+
+  // BUG: it should return ok: true and exit code 0 when all vulns are excluded
+  expect(jsonOutput.ok).toEqual(false);
+  expect(code).toEqual(2);
+});


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

We now filter the vulnerabilities when using the --exclude-base-image-vulns flag before we decide if the test response was successful. Previously this was incorrectly returning exit code 2.

#### What are the relevant tickets?

https://snyk.zendesk.com/agent/tickets/12631

#### Screenshots

|Before|After|
|--|--|
|$ snyk container test alpine:3.12.0 --json --exclude-base-image-vulns --file=project/Dockerfile 2>&1 > /dev/null<br />$ echo $?<br />**2**|$ node dist/cli/index.js container test alpine:3.12.0 --json --exclude-base-image-vulns --file=project/Dockerfile 2>&1 > /dev/null<br />$ echo $?<br />**0**|
