### PR TITLE
chore: add prebuild step

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   ],
   "scripts": {
     "clean": "rimraf dist tsconfig.tsbuildinfo",
+    "prebuild": "npm run clean",
     "build": "tsc --build",
     "build-watch": "tsc -w",
     "find-circular": "npm run build && madge --circular ./dist",


### PR DESCRIPTION
The `./dist` folder doesn't seem to get deleted when we run `npm run build`, so if we have run it before and have any old files left behind, they will stay in the `./dist` folder.

We noticed this by running `snyk-dev iac test <IaC file> --debug` and getting an error from a file that doesn't exist in our latest pull from `master`:
![Screenshot 2021-08-09 at 17 37 30](https://user-images.githubusercontent.com/81559517/128741867-23b1282f-ebd3-4bc5-8f62-81e26fc036d0.png)

If we add the `prebuild` step, the `./dist` folder gets re-created from scratch, without leftover files.