### PR TITLE
fix: help docs to include iac ignores

### DIFF
--- a/help/commands-docs/iac.md
+++ b/help/commands-docs/iac.md
@@ -28,6 +28,9 @@ Find security issues in your Infrastructure as Code files.
 - `--severity-threshold`=low|medium|high:
   Only report vulnerabilities of provided level or higher.
 
+- `--ignore-policy`:
+  Ignores all set policies. The current policy in `.snyk` file, Org level ignores and the project policy on snyk.io.
+
 - `--json`:
   Prints results in JSON format.
 
@@ -45,6 +48,9 @@ Find security issues in your Infrastructure as Code files.
   Setting a default will ensure all newly tested projects will be tested
   under your default organization. If you need to override the default, you can use the `--org`=<ORG_NAME> argument.
   Default: uses <ORG_NAME> that sets as default in your [Account settings](https://app.snyk.io/account)
+
+- `--policy-path`=<PATH_TO_POLICY_FILE>`:
+  Manually pass a path to a snyk policy file.
 
 - `--sarif`:
   Return results in SARIF format.

--- a/help/commands-man/snyk-auth.1
+++ b/help/commands-man/snyk-auth.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-AUTH" "1" "July 2021" "Snyk.io"
+.TH "SNYK\-AUTH" "1" "August 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-auth\fR \- Authenticate Snyk CLI with a Snyk account
 .SH "SYNOPSIS"

--- a/help/commands-man/snyk-config.1
+++ b/help/commands-man/snyk-config.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-CONFIG" "1" "July 2021" "Snyk.io"
+.TH "SNYK\-CONFIG" "1" "August 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-config\fR \- Manage Snyk CLI configuration
 .SH "SYNOPSIS"

--- a/help/commands-man/snyk-container.1
+++ b/help/commands-man/snyk-container.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-CONTAINER" "1" "July 2021" "Snyk.io"
+.TH "SNYK\-CONTAINER" "1" "August 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-container\fR \- Test container images for vulnerabilities
 .SH "SYNOPSIS"

--- a/help/commands-man/snyk-help.1
+++ b/help/commands-man/snyk-help.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-HELP" "1" "July 2021" "Snyk.io"
+.TH "SNYK\-HELP" "1" "August 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-help\fR \- Prints help topics
 .SH "SYNOPSIS"

--- a/help/commands-man/snyk-iac.1
+++ b/help/commands-man/snyk-iac.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-IAC" "1" "July 2021" "Snyk.io"
+.TH "SNYK\-IAC" "1" "August 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-iac\fR \- Find security issues in your Infrastructure as Code files
 .SH "SYNOPSIS"
@@ -29,6 +29,9 @@ Will limit search to provided directory (or current directory if no \fIPATH\fR p
 \fB\-\-severity\-threshold\fR=low|medium|high
 Only report vulnerabilities of provided level or higher\.
 .TP
+\fB\-\-ignore\-policy\fR
+Ignores all set policies\. The current policy in \fB\.snyk\fR file, Org level ignores and the project policy on snyk\.io\.
+.TP
 \fB\-\-json\fR
 Prints results in JSON format\.
 .TP
@@ -41,6 +44,9 @@ Specify the \fIORG_NAME\fR to run Snyk commands tied to a specific organization\
 \fB$ snyk config set org\fR=\fIORG_NAME\fR
 .IP
 Setting a default will ensure all newly tested projects will be tested under your default organization\. If you need to override the default, you can use the \fB\-\-org\fR=\fIORG_NAME\fR argument\. Default: uses \fIORG_NAME\fR that sets as default in your Account settings \fIhttps://app\.snyk\.io/account\fR
+.TP
+\fB\-\-policy\-path\fR=\fIPATH_TO_POLICY_FILE\fR`
+Manually pass a path to a snyk policy file\.
 .TP
 \fB\-\-sarif\fR
 Return results in SARIF format\.

--- a/help/commands-man/snyk-ignore.1
+++ b/help/commands-man/snyk-ignore.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-IGNORE" "1" "July 2021" "Snyk.io"
+.TH "SNYK\-IGNORE" "1" "August 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-ignore\fR \- Modifies the \.snyk policy to ignore stated issues
 .SH "SYNOPSIS"

--- a/help/commands-man/snyk-monitor.1
+++ b/help/commands-man/snyk-monitor.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-MONITOR" "1" "July 2021" "Snyk.io"
+.TH "SNYK\-MONITOR" "1" "August 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-monitor\fR \- Snapshot and continuously monitor your project
 .SH "SYNOPSIS"

--- a/help/commands-man/snyk-policy.1
+++ b/help/commands-man/snyk-policy.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-POLICY" "1" "July 2021" "Snyk.io"
+.TH "SNYK\-POLICY" "1" "August 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-policy\fR \- Display the \.snyk policy for a package
 .SH "SYNOPSIS"

--- a/help/commands-man/snyk-protect.1
+++ b/help/commands-man/snyk-protect.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-PROTECT" "1" "July 2021" "Snyk.io"
+.TH "SNYK\-PROTECT" "1" "August 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-protect\fR \- Applies the patches specified in your \.snyk file to the local file system
 .SH "SYNOPSIS"

--- a/help/commands-man/snyk-test.1
+++ b/help/commands-man/snyk-test.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-TEST" "1" "July 2021" "Snyk.io"
+.TH "SNYK\-TEST" "1" "August 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-test\fR \- test local project for vulnerabilities
 .SH "SYNOPSIS"

--- a/help/commands-man/snyk-wizard.1
+++ b/help/commands-man/snyk-wizard.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-WIZARD" "1" "July 2021" "Snyk.io"
+.TH "SNYK\-WIZARD" "1" "August 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-wizard\fR \- Configure your policy file to update, auto patch and ignore vulnerabilities
 .SH "SYNOPSIS"

--- a/help/commands-man/snyk-woof.1
+++ b/help/commands-man/snyk-woof.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-WOOF" "1" "July 2021" "Snyk.io"
+.TH "SNYK\-WOOF" "1" "August 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-woof\fR \- W00f
 .SH "SYNOPSIS"

--- a/help/commands-man/snyk.1
+++ b/help/commands-man/snyk.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK" "1" "July 2021" "Snyk.io"
+.TH "SNYK" "1" "August 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\fR \- CLI and build\-time tool to find & fix known vulnerabilities in open\-source dependencies
 .SH "SYNOPSIS"

--- a/help/commands-md/snyk-iac.md
+++ b/help/commands-md/snyk-iac.md
@@ -28,6 +28,9 @@ Find security issues in your Infrastructure as Code files.
 - `--severity-threshold`=low|medium|high:
   Only report vulnerabilities of provided level or higher.
 
+- `--ignore-policy`:
+  Ignores all set policies. The current policy in `.snyk` file, Org level ignores and the project policy on snyk.io.
+
 - `--json`:
   Prints results in JSON format.
 
@@ -46,6 +49,9 @@ Find security issues in your Infrastructure as Code files.
   under your default organization. If you need to override the default, you can use the `--org`=<ORG_NAME> argument.
   Default: uses <ORG_NAME> that sets as default in your [Account settings](https://app.snyk.io/account)
 
+- `--policy-path`=<PATH_TO_POLICY_FILE>`:
+  Manually pass a path to a snyk policy file.
+  
 - `--sarif`:
   Return results in SARIF format.
 

--- a/help/commands-txt/snyk-iac.txt
+++ b/help/commands-txt/snyk-iac.txt
@@ -26,47 +26,54 @@
        [1m-[0m[1m-[0m[1ms[0m[1me[0m[1mv[0m[1me[0m[1mr[0m[1mi[0m[1mt[0m[1my[0m[1m-[0m[1mt[0m[1mh[0m[1mr[0m[1me[0m[1ms[0m[1mh[0m[1mo[0m[1ml[0m[1md[0m=low|medium|high
               Only report vulnerabilities of provided level or higher.
 
+       [1m-[0m[1m-[0m[1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+              Ignores  all set policies. The current policy in [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m file, Org
+              level ignores and the project policy on snyk.io.
+
        [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m Prints results in JSON format.
 
        [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
-              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format directly
-              to the specified file, regardless of whether or not you use  the
-              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m  option. This is especially useful if you want to display
-              the human-readable test output via stdout and at the  same  time
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format  directly
+              to  the specified file, regardless of whether or not you use the
+              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m option. This is especially useful if you want to  display
+              the  human-readable  test output via stdout and at the same time
               save the JSON format output to a file.
 
        [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
               Specify the [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m to run Snyk commands tied to a specific or-
-              ganization. This will influence private  tests  limits.  If  you
-              have  multiple organizations, you can set a default from the CLI
+              ganization.  This  will  influence  private tests limits. If you
+              have multiple organizations, you can set a default from the  CLI
               using:
 
               [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m [1ms[0m[1me[0m[1mt[0m [1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
 
-              Setting a default will ensure all newly tested projects will  be
-              tested  under your default organization. If you need to override
-              the default, you can use the [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m  argument.  Default:
-              uses  [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m  that  sets  as  default in your Account settings
+              Setting  a default will ensure all newly tested projects will be
+              tested under your default organization. If you need to  override
+              the  default,  you can use the [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m argument. Default:
+              uses [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m that sets as  default  in  your  Account  settings
               [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ma[0m[4mp[0m[4mp[0m[4m.[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mo[0m[4m/[0m[4ma[0m[4mc[0m[4mc[0m[4mo[0m[4mu[0m[4mn[0m[4mt[0m
+
+       [1m-[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m=[4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m`
+              Manually pass a path to a snyk policy file.
 
        [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m
               Return results in SARIF format.
 
        [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
               (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in SARIF format directly
-              to  the  [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or not you
+              to the [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or  not  you
               use the [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m option. This is especially useful if you want to
-              display  the  human-readable  test  output via stdout and at the
+              display the human-readable test output via  stdout  and  at  the
               same time save the SARIF format output to a file.
 
        [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m=[0m[4mT[0m[4mE[0m[4mR[0m[4mR[0m[4mA[0m[4mF[0m[4mO[0m[4mR[0m[4mM[0m[1m_[0m[4mP[0m[4mL[0m[4mA[0m[4mN[0m[1m_[0m[4mS[0m[4mC[0m[4mA[0m[4mN[0m[1m_[0m[4mM[0m[4mO[0m[4mD[0m[4mE[0m
               Dedicated flag for Terraform plan scanning modes.
-              It enables to control whether the scan should analyse  the  full
-              final  state (e.g. [1mp[0m[1ml[0m[1ma[0m[1mn[0m[1mn[0m[1me[0m[1md[0m[1m-[0m[1mv[0m[1ma[0m[1ml[0m[1mu[0m[1me[0m[1ms[0m), or the proposed changes only
+              It  enables  to control whether the scan should analyse the full
+              final state (e.g. [1mp[0m[1ml[0m[1ma[0m[1mn[0m[1mn[0m[1me[0m[1md[0m[1m-[0m[1mv[0m[1ma[0m[1ml[0m[1mu[0m[1me[0m[1ms[0m), or the proposed changes  only
               (e.g. [1mr[0m[1me[0m[1ms[0m[1mo[0m[1mu[0m[1mr[0m[1mc[0m[1me[0m[1m-[0m[1mc[0m[1mh[0m[1ma[0m[1mn[0m[1mg[0m[1me[0m[1ms[0m).
-              Default: If the [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m flag is not provided it  would  scan  the
+              Default:  If  the  [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m flag is not provided it would scan the
               proposed changes only by default.
-              Example  #1: [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m=[0m[1mp[0m[1ml[0m[1ma[0m[1mn[0m[1mn[0m[1me[0m[1md[0m[1m-[0m[1mv[0m[1ma[0m[1ml[0m[1mu[0m[1me[0m[1ms[0m (full state scan) Example #2:
+              Example #1: [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m=[0m[1mp[0m[1ml[0m[1ma[0m[1mn[0m[1mn[0m[1me[0m[1md[0m[1m-[0m[1mv[0m[1ma[0m[1ml[0m[1mu[0m[1me[0m[1ms[0m (full state scan) Example  #2:
               [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m=[0m[1mr[0m[1me[0m[1ms[0m[1mo[0m[1mu[0m[1mr[0m[1mc[0m[1me[0m[1m-[0m[1mc[0m[1mh[0m[1ma[0m[1mn[0m[1mg[0m[1me[0m[1ms[0m (proposed changes scan)
 
    [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
@@ -82,7 +89,7 @@
               Prints versions.
 
        [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
-              Prints a help text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to  get  more  de-
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
               tails.
 
 [1mE[0m[1mX[0m[1mA[0m[1mM[0m[1mP[0m[1mL[0m[1mE[0m[1mS[0m
@@ -115,7 +122,7 @@
        You can set these environment variables to change CLI run settings.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
-              Snyk  authorization token. Setting this envvar will override the
+              Snyk authorization token. Setting this envvar will override  the
               token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
               How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
@@ -123,47 +130,47 @@
 
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
-              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
               [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
               E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
               [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
-              Specify a username to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
-              value. This will be ignored in favour  of  local  Docker  binary
+              Specify  a  username  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
-              Specify  a  password  to use when connecting to a container reg-
-              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
-              value.  This  will  be  ignored in favour of local Docker binary
+              Specify a password to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
 [1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
        By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
-              Sets API host to use for Snyk requests.  Useful  for  on-premise
+              Sets  API  host  to use for Snyk requests. Useful for on-premise
               instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
-              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
               [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
-              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
-              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
-              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
               for reverse proxies.
 
        [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
-              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
-              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
-              protocol will use this proxy. The proxy itself doesn't  need  to
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol  will  use this proxy. The proxy itself doesn't need to
               use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
 [1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
    [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
-       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
-       age  or   otherwise,   is   subject   to   the   terms   &   conditions
+       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
+       age   or   otherwise,   is   subject   to   the   terms   &  conditions
        [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m


### PR DESCRIPTION
#### What does this PR do?

Updates the `--help` docs for iac to include the new flags: 
- `--policy-path`
- `--ignore-policy`

#### Where should the reviewer start?
Build locally and run 
`snyk iac --help` to see the iac section include the 2 flags above under OPTIONS

#### Any background context you want to provide?
 
The functionality for IaC ignores is released on version 1.677.0

#### Screenshots
```
 snyk-dev iac --help
NAME
       snyk-iac - Find security issues in your Infrastructure as Code files

SYNOPSIS
       snyk iac [COMMAND] [OPTIONS] PATH

DESCRIPTION
       Find security issues in your Infrastructure as Code files.

       For more information see IaC help page https://snyk.co/ucT6Q

COMMANDS
       test   Test for any known issue.

OPTIONS
       --detection-depth=DEPTH
              (only in test command)
              Indicate  the  maximum depth of sub-directories to search. DEPTH
              must be a number.

              Default: No Limit
              Example: --detection-depth=3
              Will limit search to provided directory (or current directory if
              no PATH provided) plus two levels of subdirectories.

       --severity-threshold=low|medium|high
              Only report vulnerabilities of provided level or higher.

       --ignore-policy
              Ignores  all set policies. The current policy in .snyk file, Org
              level ignores and the project policy on snyk.io.

       --json Prints results in JSON format.

       --json-file-output=OUTPUT_FILE_PATH
              (only in test command) Save test output in JSON format  directly
              to  the specified file, regardless of whether or not you use the
              --json option. This is especially useful if you want to  display
              the  human-readable  test output via stdout and at the same time
              save the JSON format output to a file.

       --org=ORG_NAME
              Specify the ORG_NAME to run Snyk commands tied to a specific or-
              ganization.  This  will  influence  private tests limits. If you
              have multiple organizations, you can set a default from the  CLI
              using:

              $ snyk config set org=ORG_NAME

              Setting  a default will ensure all newly tested projects will be
              tested under your default organization. If you need to  override
              the  default,  you can use the --org=ORG_NAME argument. Default:
              uses ORG_NAME that sets as  default  in  your  Account  settings
              https://app.snyk.io/account

       --policy-path=PATH_TO_POLICY_FILE`
              Manually pass a path to a snyk policy file.

       --sarif
              Return results in SARIF format.

       --sarif-file-output=OUTPUT_FILE_PATH
              (only in test command) Save test output in SARIF format directly
              to the OUTPUT_FILE_PATH file, regardless of whether or  not  you
              use the --sarif option. This is especially useful if you want to
              display the human-readable test output via  stdout  and  at  the
              same time save the SARIF format output to a file.

       --scan=TERRAFORM_PLAN_SCAN_MODE
              Dedicated flag for Terraform plan scanning modes.
              It  enables  to control whether the scan should analyse the full
              final state (e.g. planned-values), or the proposed changes  only
              (e.g. resource-changes).
              Default:  If  the  --scan flag is not provided it would scan the
              proposed changes only by default.
              Example #1: --scan=planned-values (full state scan) Example  #2:
              --scan=resource-changes (proposed changes scan)
```