### PR TITLE
chore: update release to use local lerna installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,9 +212,6 @@ jobs:
       - run: npm install -g npm@7
       - show_node_version
       - run:
-          name: Setup Lerna
-          command: npm install -g lerna@3.22.1
-      - run:
           name: Update local .npmrc file (Windows)
           command: echo "//registry.npmjs.org/:_authToken=$env:NPM_TOKEN" >> .npmrc
       - run:
@@ -464,7 +461,7 @@ jobs:
       - run:
           name: Lerna Publish
           command: |
-            lerna publish minor --yes --no-push --no-git-tag-version --exact
+            npx lerna publish minor --yes --no-push --no-git-tag-version --exact
       - run:
           name: Install osslsigncode
           command: sudo apt-get install -y osslsigncode


### PR DESCRIPTION
Fixes broken release step because lerna is no longer a global command