### PR TITLE
feat: bump snyk-docker-plugin to 4.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.2.1",
-    "snyk-docker-plugin": "4.22.1",
+    "snyk-docker-plugin": "4.23.0",
     "snyk-go-plugin": "1.17.0",
     "snyk-gradle-plugin": "3.16.1",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
Bumps Snyk-docker-plugin version to 4.23, to bring in Dockerfile name parsing fix


