### PR TITLE
fix: upgrade snyk-nuget-plugin 1.22.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.26.2",
     "snyk-nodejs-lockfile-parser": "1.35.0",
-    "snyk-nuget-plugin": "1.22.0",
+    "snyk-nuget-plugin": "1.22.1",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "1.22.0",
     "snyk-python-plugin": "1.19.11",


### PR DESCRIPTION
Bump snyk-nuget-plugin, includes fix to be able to scan target framework from any PropoertyGroup from project file not only first PropertyGroup https://github.com/snyk/snyk-nuget-plugin/pull/102