### PR TITLE
fix: support quoted keys in inline tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "snyk-nuget-plugin": "1.22.1",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "1.22.0",
-    "snyk-python-plugin": "1.19.11",
+    "snyk-python-plugin": "1.20.1",
     "snyk-resolve": "1.1.0",
     "snyk-resolve-deps": "4.7.2",
     "snyk-sbt-plugin": "2.11.3",


### PR DESCRIPTION
updates the plugin to include changes in
https://github.com/snyk/snyk-poetry-lockfile-parser/pull/15
https://github.com/snyk/snyk-python-plugin/pull/160