### PR TITLE
refactor: replace cc parser with split functions [CC-1021]

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "dependencies": {
     "@open-policy-agent/opa-wasm": "^1.2.0",
     "@snyk/cli-interface": "2.11.0",
-    "@snyk/cloud-config-parser": "^1.9.2",
+    "@snyk/cloud-config-parser": "^1.10.2",
     "@snyk/code-client": "4.0.0",
     "@snyk/dep-graph": "^1.27.1",
     "@snyk/fix": "1.650.0",
@@ -147,7 +147,7 @@
   "devDependencies": {
     "@types/cross-spawn": "^6.0.2",
     "@types/fs-extra": "^9.0.11",
-    "@types/jest": "^26.0.20",
+    "@types/jest": "^27.0.1",
     "@types/lodash": "^4.14.161",
     "@types/needle": "^2.0.4",
     "@types/node": "^14.14.31",

--- a/src/cli/commands/test/iac-local-execution/extract-line-number.ts
+++ b/src/cli/commands/test/iac-local-execution/extract-line-number.ts
@@ -2,7 +2,8 @@ import { IaCErrorCodes } from './types';
 import { CustomError } from '../../../../lib/errors';
 import {
   CloudConfigFileTypes,
-  issuesToLineNumbers,
+  MapsDocIdToTree,
+  getLineNumber,
 } from '@snyk/cloud-config-parser';
 import { UnsupportedFileTypeError } from './file-parser';
 import * as analytics from '../../../../lib/analytics';
@@ -10,7 +11,7 @@ import * as Debug from 'debug';
 import { getErrorStringCode } from './error-utils';
 const debug = Debug('iac-extract-line-number');
 
-function getFileTypeForLineNumber(fileType: string): CloudConfigFileTypes {
+export function getFileTypeForParser(fileType: string): CloudConfigFileTypes {
   switch (fileType) {
     case 'yaml':
     case 'yml':
@@ -25,16 +26,12 @@ function getFileTypeForLineNumber(fileType: string): CloudConfigFileTypes {
 }
 
 export function extractLineNumber(
-  fileContent: string,
-  fileType: string,
   cloudConfigPath: string[],
+  fileType: CloudConfigFileTypes,
+  treeByDocId: MapsDocIdToTree,
 ): number {
   try {
-    return issuesToLineNumbers(
-      fileContent,
-      getFileTypeForLineNumber(fileType),
-      cloudConfigPath,
-    );
+    return getLineNumber(cloudConfigPath, fileType, treeByDocId);
   } catch {
     const err = new FailedToExtractLineNumberError();
     analytics.add('error-code', err.code);


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR updates the version of the `cloud-config-parser` dependency to use a newer version that takes care of a performance issue.
Instead of calculating the treeMap for each line in the file, we are calculating the treeMap once for each file, and sending it to the parser to get the correct line number.
Therefore, for a file that has multiple issues, we only calculate the treeMap once.

#### Where should the reviewer start?


#### How should this be manually tested?
1. Download the new branch and install dependencies
2. Run `snyk iac test` with `--json` or `--sarif` flags.
3. See the line number returns in the response

#### What are the relevant tickets?
Jira Ticket [CC-1021](https://snyksec.atlassian.net/browse/CC-1021)

#### Snapshots
<img width="1070" alt="Screen Shot 2021-08-16 at 11 37 49" src="https://user-images.githubusercontent.com/1466549/129535667-bd1e1baa-8b52-4abd-9a4e-f23ea7dc94cf.png">


