### PR TITLE
fix: missing no supported sast files strategy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,6 +23,7 @@ test/jest/unit/iac-unit-tests/ @snyk/cloudconfig
 test/jest/acceptance/iac/ @snyk/cloudconfig
 src/lib/errors/invalid-iac-file.ts @snyk/cloudconfig
 src/lib/errors/unsupported-options-iac-error.ts @snyk/cloudconfig
+src/lib/errors/no-supported-sast-files-found.ts @snyk/sast-team
 help/commands-docs/iac-examples.md @snyk/cloudconfig
 help/commands-docs/iac.md @snyk/cloudconfig
 packages/snyk-fix/ @snyk/tech-services

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,6 +30,7 @@ import {
   UnsupportedOptionCombinationError,
   ExcludeFlagBadInputError,
   CustomError,
+  NoSupportedSastFiles,
 } from '../lib/errors';
 import stripAnsi from 'strip-ansi';
 import { ExcludeFlagInvalidInputError } from '../lib/errors/exclude-flag-invalid-input';
@@ -50,7 +51,7 @@ const debug = Debug('snyk');
 const EXIT_CODES = {
   VULNS_FOUND: 1,
   ERROR: 2,
-  NO_SUPPORTED_MANIFESTS_FOUND: 3,
+  NO_SUPPORTED_PROJECTS_DETECTED: 3,
 };
 
 async function runCommand(args: Args) {
@@ -92,12 +93,16 @@ async function handleError(args, error) {
   spinner.clearAll();
   let command = 'bad-command';
   let exitCode = EXIT_CODES.ERROR;
+
   const noSupportedManifestsFound = error.message?.includes(
     'Could not detect supported target files in',
   );
+  const noSupportedSastFiles = error instanceof NoSupportedSastFiles;
+  const noSupportedProjectsDetected =
+    noSupportedManifestsFound || noSupportedSastFiles;
 
-  if (noSupportedManifestsFound) {
-    exitCode = EXIT_CODES.NO_SUPPORTED_MANIFESTS_FOUND;
+  if (noSupportedProjectsDetected) {
+    exitCode = EXIT_CODES.NO_SUPPORTED_PROJECTS_DETECTED;
   }
 
   const vulnsFound = error.code === 'VULNS';

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -2,6 +2,7 @@ export { MissingApiTokenError } from './missing-api-token';
 export { FileFlagBadInputError } from './file-flag-bad-input';
 export { MissingTargetFileError } from './missing-targetfile-error';
 export { NoSupportedManifestsFoundError } from './no-supported-manifests-found';
+export { NoSupportedSastFiles } from './no-supported-sast-files-found';
 export { CustomError } from './custom-error';
 export { MonitorError } from './monitor-error';
 export { ConnectionTimeoutError } from './connection-timeout-error';

--- a/src/lib/errors/no-supported-sast-files-found.ts
+++ b/src/lib/errors/no-supported-sast-files-found.ts
@@ -1,0 +1,17 @@
+import chalk from 'chalk';
+import { CustomError } from './custom-error';
+
+export class NoSupportedSastFiles extends CustomError {
+  private static ERROR_MESSAGE =
+    'We found 0 supported files ' +
+    '\nPlease see our documentation for Snyk Code language and framework support\n' +
+    chalk.underline(
+      'https://support.snyk.io/hc/en-us/articles/360016973477-Snyk-Code-language-support',
+    );
+
+  constructor() {
+    super(NoSupportedSastFiles.ERROR_MESSAGE);
+    this.code = 422;
+    this.userMessage = NoSupportedSastFiles.ERROR_MESSAGE;
+  }
+}

--- a/src/lib/plugins/sast/analysis.ts
+++ b/src/lib/plugins/sast/analysis.ts
@@ -13,7 +13,7 @@ import { bootstrap } from 'global-agent';
 export async function getCodeAnalysisAndParseResults(
   root: string,
   options: Options,
-): Promise<Log> {
+): Promise<Log | null> {
   const currentLabel = '';
   await spinner.clearAll();
   analysisProgressUpdate(currentLabel);
@@ -71,8 +71,12 @@ function severityToAnalysisSeverity(severity: SEVERITY): AnalysisSeverity {
   return severityLevel[severity];
 }
 
-function parseSecurityResults(codeAnalysis: Log): Log {
+function parseSecurityResults(codeAnalysis: Log | null): Log | null {
   let securityRulesMap;
+
+  if (!codeAnalysis) {
+    return codeAnalysis;
+  }
 
   const rules = codeAnalysis.runs[0].tool.driver.rules;
   const results = codeAnalysis.runs[0].results;

--- a/src/lib/plugins/sast/index.ts
+++ b/src/lib/plugins/sast/index.ts
@@ -8,7 +8,7 @@ import {
   getMeta,
 } from './format/output-format';
 import { EcosystemPlugin } from '../../ecosystems/types';
-import { FailedToRunTestError } from '../../errors/failed-to-run-test-error';
+import { FailedToRunTestError, NoSupportedSastFiles } from '../../errors';
 import { jsonStringifyLargeObject } from '../../json';
 import * as analytics from '../../analytics';
 
@@ -34,7 +34,10 @@ export const codePlugin: EcosystemPlugin = {
         options,
       );
 
-      const numOfIssues = sarifTypedResult.runs?.[0].results?.length || 0;
+      if (!sarifTypedResult) {
+        throw new NoSupportedSastFiles();
+      }
+      const numOfIssues = sarifTypedResult!.runs?.[0].results?.length || 0;
       analytics.add('sast-issues-found', numOfIssues);
 
       if (options.sarif || options.json) {
@@ -46,7 +49,7 @@ export const codePlugin: EcosystemPlugin = {
       const meta = getMeta(options, path);
       const prefix = getPrefix(path);
       const readableResult = getCodeDisplayedOutput(
-        sarifTypedResult,
+        sarifTypedResult!,
         meta,
         prefix,
       );

--- a/test/jest/unit/snyk-code/snyk-code-test.spec.ts
+++ b/test/jest/unit/snyk-code/snyk-code-test.spec.ts
@@ -92,6 +92,34 @@ describe('Test snyk code', () => {
     );
   });
 
+  it('should fail - when we do not support files ', async () => {
+    const options: Options & TestOptions = {
+      path: '',
+      traverseNodeModules: false,
+      showVulnPaths: 'none',
+      code: true,
+    };
+
+    analyzeFoldersMock.mockResolvedValue(null);
+    isFeatureFlagSupportedForOrgSpy.mockResolvedValue({
+      ok: true,
+    });
+    isSastEnabledForOrgSpy.mockResolvedValueOnce({
+      sastEnabled: true,
+    });
+    trackUsageSpy.mockResolvedValue({});
+
+    expect.hasAssertions();
+    try {
+      await ecosystems.testEcosystem('code', ['some/path'], options);
+    } catch (error) {
+      const errMessage = stripAscii(stripAnsi(error.message.trim()));
+
+      expect(error.code).toBe(422);
+      expect(errMessage).toContain('We found 0 supported files');
+    }
+  });
+
   it('succeed testing - with correct exit code', async () => {
     const options: Options & TestOptions = {
       path: '',
@@ -167,6 +195,7 @@ describe('Test snyk code', () => {
       expect(error).toEqual(expected);
     }
   });
+
   it('should throw error correctly from outside of ecosystem flow when response code is not 200', async () => {
     const error = { code: 401, message: 'Invalid auth token' };
     isSastEnabledForOrgSpy.mockRejectedValue(error);


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This Pr adds an appropriate message when we do not support files for `snyk code` scanning

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots
![image](https://user-images.githubusercontent.com/42909729/130412286-6e341cd9-b0e6-4d82-9ad3-e591363f5000.png)


#### Additional questions
