### PR TITLE
feat: support critical severities in IaC

### DIFF
--- a/help/commands-docs/iac.md
+++ b/help/commands-docs/iac.md
@@ -25,8 +25,8 @@ Find security issues in your Infrastructure as Code files.
   Example: `--detection-depth=3`  
   Will limit search to provided directory (or current directory if no <PATH> provided) plus two levels of subdirectories.
 
-- `--severity-threshold`=low|medium|high:
-  Only report vulnerabilities of provided level or higher.
+- `--severity-threshold`=low|medium|high|critical:
+  Only report configuration issues with the provided severity level or higher. Please note that the Snyk Infrastructure as Code configuration issues do not currently use the `critical` severity level.
 
 - `--ignore-policy`:
   Ignores all set policies. The current policy in `.snyk` file, Org level ignores and the project policy on snyk.io.

--- a/help/commands-man/snyk-iac.1
+++ b/help/commands-man/snyk-iac.1
@@ -26,8 +26,8 @@ Example: \fB\-\-detection\-depth=3\fR
 .br
 Will limit search to provided directory (or current directory if no \fIPATH\fR provided) plus two levels of subdirectories\.
 .TP
-\fB\-\-severity\-threshold\fR=low|medium|high
-Only report vulnerabilities of provided level or higher\.
+\fB\-\-severity\-threshold\fR=low|medium|high|critical
+Only report configuration issues with the provided severity level or higher\. Please note that the Snyk Infrastructure as Code configuration issues do not currently use the \fBcritical\fR severity level\.
 .TP
 \fB\-\-ignore\-policy\fR
 Ignores all set policies\. The current policy in \fB\.snyk\fR file, Org level ignores and the project policy on snyk\.io\.

--- a/help/commands-md/snyk-iac.md
+++ b/help/commands-md/snyk-iac.md
@@ -25,8 +25,8 @@ Find security issues in your Infrastructure as Code files.
   Example: `--detection-depth=3`  
   Will limit search to provided directory (or current directory if no <PATH> provided) plus two levels of subdirectories.
 
-- `--severity-threshold`=low|medium|high:
-  Only report vulnerabilities of provided level or higher.
+- `--severity-threshold`=low|medium|high|critical:
+  Only report configuration issues with the provided severity level or higher. Please note that the Snyk Infrastructure as Code configuration issues do not currently use the `critical` severity level.
 
 - `--ignore-policy`:
   Ignores all set policies. The current policy in `.snyk` file, Org level ignores and the project policy on snyk.io.
@@ -51,7 +51,7 @@ Find security issues in your Infrastructure as Code files.
 
 - `--policy-path`=<PATH_TO_POLICY_FILE>`:
   Manually pass a path to a snyk policy file.
-  
+
 - `--sarif`:
   Return results in SARIF format.
 

--- a/help/commands-txt/snyk-iac.txt
+++ b/help/commands-txt/snyk-iac.txt
@@ -23,34 +23,37 @@
               Will limit search to provided directory (or current directory if
               no [4mP[0m[4mA[0m[4mT[0m[4mH[0m provided) plus two levels of subdirectories.
 
-       [1m-[0m[1m-[0m[1ms[0m[1me[0m[1mv[0m[1me[0m[1mr[0m[1mi[0m[1mt[0m[1my[0m[1m-[0m[1mt[0m[1mh[0m[1mr[0m[1me[0m[1ms[0m[1mh[0m[1mo[0m[1ml[0m[1md[0m=low|medium|high
-              Only report vulnerabilities of provided level or higher.
+       [1m-[0m[1m-[0m[1ms[0m[1me[0m[1mv[0m[1me[0m[1mr[0m[1mi[0m[1mt[0m[1my[0m[1m-[0m[1mt[0m[1mh[0m[1mr[0m[1me[0m[1ms[0m[1mh[0m[1mo[0m[1ml[0m[1md[0m=low|medium|high|critical
+              Only  report  configuration  issues  with  the provided severity
+              level or higher. Please note that  the  Snyk  Infrastructure  as
+              Code  configuration  issues  do  not  currently use the [1mc[0m[1mr[0m[1mi[0m[1mt[0m[1mi[0m[1mc[0m[1ma[0m[1ml[0m
+              severity level.
 
        [1m-[0m[1m-[0m[1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
-              Ignores  all set policies. The current policy in [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m file, Org
+              Ignores all set policies. The current policy in [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m file,  Org
               level ignores and the project policy on snyk.io.
 
        [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m Prints results in JSON format.
 
        [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
-              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format  directly
-              to  the specified file, regardless of whether or not you use the
-              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m option. This is especially useful if you want to  display
-              the  human-readable  test output via stdout and at the same time
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format directly
+              to the specified file, regardless of whether or not you use  the
+              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m  option. This is especially useful if you want to display
+              the human-readable test output via stdout and at the  same  time
               save the JSON format output to a file.
 
        [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
               Specify the [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m to run Snyk commands tied to a specific or-
-              ganization.  This  will  influence  private tests limits. If you
-              have multiple organizations, you can set a default from the  CLI
+              ganization. This will influence private  tests  limits.  If  you
+              have  multiple organizations, you can set a default from the CLI
               using:
 
               [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m [1ms[0m[1me[0m[1mt[0m [1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
 
-              Setting  a default will ensure all newly tested projects will be
-              tested under your default organization. If you need to  override
-              the  default,  you can use the [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m argument. Default:
-              uses [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m that sets as  default  in  your  Account  settings
+              Setting a default will ensure all newly tested projects will  be
+              tested  under your default organization. If you need to override
+              the default, you can use the [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m  argument.  Default:
+              uses  [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m  that  sets  as  default in your Account settings
               [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ma[0m[4mp[0m[4mp[0m[4m.[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mo[0m[4m/[0m[4ma[0m[4mc[0m[4mc[0m[4mo[0m[4mu[0m[4mn[0m[4mt[0m
 
        [1m-[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m=[4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m`
@@ -61,19 +64,19 @@
 
        [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
               (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in SARIF format directly
-              to the [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or  not  you
+              to  the  [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or not you
               use the [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m option. This is especially useful if you want to
-              display the human-readable test output via  stdout  and  at  the
+              display  the  human-readable  test  output via stdout and at the
               same time save the SARIF format output to a file.
 
        [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m=[0m[4mT[0m[4mE[0m[4mR[0m[4mR[0m[4mA[0m[4mF[0m[4mO[0m[4mR[0m[4mM[0m[1m_[0m[4mP[0m[4mL[0m[4mA[0m[4mN[0m[1m_[0m[4mS[0m[4mC[0m[4mA[0m[4mN[0m[1m_[0m[4mM[0m[4mO[0m[4mD[0m[4mE[0m
               Dedicated flag for Terraform plan scanning modes.
-              It  enables  to control whether the scan should analyse the full
-              final state (e.g. [1mp[0m[1ml[0m[1ma[0m[1mn[0m[1mn[0m[1me[0m[1md[0m[1m-[0m[1mv[0m[1ma[0m[1ml[0m[1mu[0m[1me[0m[1ms[0m), or the proposed changes  only
+              It enables to control whether the scan should analyse  the  full
+              final  state (e.g. [1mp[0m[1ml[0m[1ma[0m[1mn[0m[1mn[0m[1me[0m[1md[0m[1m-[0m[1mv[0m[1ma[0m[1ml[0m[1mu[0m[1me[0m[1ms[0m), or the proposed changes only
               (e.g. [1mr[0m[1me[0m[1ms[0m[1mo[0m[1mu[0m[1mr[0m[1mc[0m[1me[0m[1m-[0m[1mc[0m[1mh[0m[1ma[0m[1mn[0m[1mg[0m[1me[0m[1ms[0m).
-              Default:  If  the  [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m flag is not provided it would scan the
+              Default: If the [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m flag is not provided it  would  scan  the
               proposed changes only by default.
-              Example #1: [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m=[0m[1mp[0m[1ml[0m[1ma[0m[1mn[0m[1mn[0m[1me[0m[1md[0m[1m-[0m[1mv[0m[1ma[0m[1ml[0m[1mu[0m[1me[0m[1ms[0m (full state scan) Example  #2:
+              Example  #1: [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m=[0m[1mp[0m[1ml[0m[1ma[0m[1mn[0m[1mn[0m[1me[0m[1md[0m[1m-[0m[1mv[0m[1ma[0m[1ml[0m[1mu[0m[1me[0m[1ms[0m (full state scan) Example #2:
               [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m=[0m[1mr[0m[1me[0m[1ms[0m[1mo[0m[1mu[0m[1mr[0m[1mc[0m[1me[0m[1m-[0m[1mc[0m[1mh[0m[1ma[0m[1mn[0m[1mg[0m[1me[0m[1ms[0m (proposed changes scan)
 
    [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
@@ -89,7 +92,7 @@
               Prints versions.
 
        [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
-              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
+              Prints a help text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to  get  more  de-
               tails.
 
 [1mE[0m[1mX[0m[1mA[0m[1mM[0m[1mP[0m[1mL[0m[1mE[0m[1mS[0m
@@ -122,7 +125,7 @@
        You can set these environment variables to change CLI run settings.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
-              Snyk authorization token. Setting this envvar will override  the
+              Snyk  authorization token. Setting this envvar will override the
               token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
               How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
@@ -130,47 +133,47 @@
 
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
-              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
               [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
               E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
               [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
-              Specify  a  username  to use when connecting to a container reg-
-              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
-              value.  This  will  be  ignored in favour of local Docker binary
+              Specify a username to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
-              Specify a password to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
-              value. This will be ignored in favour  of  local  Docker  binary
+              Specify  a  password  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
 [1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
        By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
-              Sets  API  host  to use for Snyk requests. Useful for on-premise
+              Sets API host to use for Snyk requests.  Useful  for  on-premise
               instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
-              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
               [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
-              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
-              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
-              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
+              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
+              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
+              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
               for reverse proxies.
 
        [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
-              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
-              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
-              protocol  will  use this proxy. The proxy itself doesn't need to
+              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
+              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol will use this proxy. The proxy itself doesn't  need  to
               use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
 [1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
    [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
-       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
-       age   or   otherwise,   is   subject   to   the   terms   &  conditions
+       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
+       age  or   otherwise,   is   subject   to   the   terms   &   conditions
        [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/src/cli/commands/test/iac-local-execution/results-formatter.ts
+++ b/src/cli/commands/test/iac-local-execution/results-formatter.ts
@@ -9,7 +9,7 @@ import {
 } from './types';
 import { parsePath } from './parsers/path';
 import * as path from 'path';
-import { SEVERITY } from '../../../../lib/snyk-test/common';
+import { SEVERITY, SEVERITIES } from '../../../../lib/snyk-test/common';
 import { IacProjectType } from '../../../../lib/iac/constants';
 import { CustomError } from '../../../../lib/errors';
 import { extractLineNumber, getFileTypeForParser } from './extract-line-number';
@@ -17,7 +17,7 @@ import { getErrorStringCode } from './error-utils';
 import { isLocalFolder } from '../../../../lib/detect';
 import { MapsDocIdToTree, getTrees } from '@snyk/cloud-config-parser';
 
-const SEVERITIES = [SEVERITY.LOW, SEVERITY.MEDIUM, SEVERITY.HIGH];
+const severitiesArray = SEVERITIES.map((s) => s.verboseName);
 
 export function formatScanResults(
   scanResults: IacFileScanResult[],
@@ -165,8 +165,8 @@ export function filterPoliciesBySeverity(
     });
   }
 
-  const severitiesToInclude = SEVERITIES.slice(
-    SEVERITIES.indexOf(severityThreshold),
+  const severitiesToInclude = severitiesArray.slice(
+    severitiesArray.indexOf(severityThreshold),
   );
   return violatedPolicies.filter((policy) => {
     return (


### PR DESCRIPTION
#### What does this PR do?

This PR adds support for critical severities to IaC vulnerabilities. We don't use `critical` when defining our own rules, but we will soon support custom rules. It may be confusing to customers if they see that our other tools support all severities and we don't.

#### How should this be manually tested?
1. Build with `npm run build`
2. Run the custom rules example at https://github.com/snyk/snyk-iac-custom-rules-beta/blob/main/writing.md
3. Run without a severity threshold: `snyk-dev iac test --rules=custom.tar.gz <path to file>`
4. Run with a severity threshold: `snyk-dev iac test --rules=custom.tar.gz <path to file> --severity-threshold=medium`

#### Screenshots
![Screenshot 2021-08-23 at 14 55 28](https://user-images.githubusercontent.com/81559517/130460819-7938f6bf-e280-4048-99e0-07bc33f5b14e.png)

![Screenshot 2021-08-23 at 14 55 41](https://user-images.githubusercontent.com/81559517/130460814-8b928d53-78ca-4c65-b7f1-1946b11c6365.png)

