### PR TITLE
feat: use depGraph for pip projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "snyk-nuget-plugin": "1.22.1",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.22.1",
-    "snyk-python-plugin": "1.20.1",
+    "snyk-python-plugin": "1.21.0",
     "snyk-resolve": "1.1.0",
     "snyk-resolve-deps": "4.7.3",
     "snyk-sbt-plugin": "2.11.3",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Upgrades `snyk-python-plugin` to a version that returns a DepGraph

includes https://github.com/snyk/snyk-python-plugin/pull/159