### PR TITLE
fix: support oauth tokens for feature flags

### DIFF
--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,5 +1,5 @@
 import { makeRequest } from './request';
-import { api as getApiToken } from './api-token';
+import { getAuthHeader } from './api-token';
 import * as config from './config';
 import { assembleQueryString } from './snyk-test/common';
 
@@ -17,7 +17,7 @@ export async function isFeatureFlagSupportedForOrg(
   const response = await makeRequest({
     method: 'GET',
     headers: {
-      Authorization: `token ${getApiToken()}`,
+      Authorization: getAuthHeader(),
     },
     qs: assembleQueryString({ org }),
     url: `${config.API}/cli-config/feature-flags/${featureFlag}`,

--- a/test/acceptance/cli-monitor/cli-monitor.all-projects.spec.ts
+++ b/test/acceptance/cli-monitor/cli-monitor.all-projects.spec.ts
@@ -205,7 +205,7 @@ export const AllProjectsTests: AcceptanceTests = {
         'all left requests are feature flag requests',
       );
       t.equal(
-        params.server._reqLog.length,
+        params.server.requests.length,
         0,
         'no other requests sent (yarn error ignored)',
       );
@@ -409,9 +409,9 @@ export const AllProjectsTests: AcceptanceTests = {
         );
         t.equal(requests.length, 9, 'sends expected # requests'); // extra feature-flags request
         t.equal(
-          params.server._reqLog.length,
+          params.server.requests.length,
           0,
-          `${params.server._reqLog.length} pending requests`,
+          `${params.server.requests.length} pending requests`,
         );
 
         const jsonResponse = JSON.parse(response);

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -1,7 +1,7 @@
 import * as restify from 'restify';
 
 interface FakeServer extends restify.Server {
-  _reqLog: restify.Request[];
+  requests: restify.Request[];
   _nextResponse?: restify.Response;
   _nextStatusCode?: number;
   popRequest: () => restify.Request;
@@ -16,21 +16,21 @@ export function fakeServer(root, apikey) {
     name: 'snyk-mock-server',
     version: '1.0.0',
   }) as FakeServer;
-  server._reqLog = [];
+  server.requests = [];
   server.popRequest = () => {
-    return server._reqLog.pop()!;
+    return server.requests.pop()!;
   };
   server.popRequests = (num: number) => {
-    return server._reqLog.splice(server._reqLog.length - num, num);
+    return server.requests.splice(server.requests.length - num, num);
   };
   server.clearRequests = () => {
-    server._reqLog = [];
+    server.requests = [];
   };
   server.use(restify.plugins.acceptParser(server.acceptable));
   server.use(restify.plugins.queryParser({ mapParams: true }));
   server.use(restify.plugins.bodyParser({ mapParams: true }));
   server.use(function logRequest(req, res, next) {
-    server._reqLog.push(req);
+    server.requests.push(req);
     next();
   });
 

--- a/test/jest/acceptance/oauth-token.spec.ts
+++ b/test/jest/acceptance/oauth-token.spec.ts
@@ -12,14 +12,17 @@ describe('test using OAuth token', () => {
     const apiPath = '/api/v1';
     const apiPort = process.env.PORT || process.env.SNYK_PORT || '12345';
     env = {
-      ...process.env,
+      PATH: process.env.PATH || '',
       SNYK_API: 'http://localhost:' + apiPort + apiPath,
-      SNYK_TOKEN: '123456789',
       SNYK_OAUTH_TOKEN: 'oauth-jwt-token',
     };
 
     server = fakeServer(apiPath, env.SNYK_TOKEN);
     server.listen(apiPort, () => done());
+  });
+
+  afterEach(() => {
+    server.clearRequests();
   });
 
   afterAll((done) => {
@@ -56,5 +59,29 @@ describe('test using OAuth token', () => {
     const requests = server.popRequests(2);
     expect(requests[0].headers.authorization).toBe('Bearer oauth-jwt-token');
     expect(requests[0].method).toBe('PUT');
+  });
+
+  it('uses oauth token when fetching feature flags', async () => {
+    const project = await createProjectFromWorkspace('fail-on/no-vulns');
+    const jsonObj = JSON.parse(await project.read('vulns-result.json'));
+    server.setNextResponse(jsonObj);
+
+    const expectedUrl =
+      '/api/v1/cli-config/feature-flags/experimentalDepGraph?org=test-org';
+
+    /**
+     * The --experimental-dep-graph isn't actually needed for triggering the
+     * experimentalDepGraph feature flag check. Which might be a bug. I've put
+     * it here to show intent despite us not really needing it.
+     */
+    await runSnykCLI(`monitor --experimental-dep-graph --org=test-org`, {
+      cwd: project.path(),
+      env,
+    });
+
+    expect(server.requests.map((r) => r.url)).toContain(expectedUrl);
+
+    const request = server.requests.filter((r) => r.url === expectedUrl)[0];
+    expect(request.headers.authorization).toBe('Bearer oauth-jwt-token');
   });
 });

--- a/test/jest/acceptance/oauth-token.spec.ts
+++ b/test/jest/acceptance/oauth-token.spec.ts
@@ -4,7 +4,7 @@ import { runSnykCLI } from '../util/runSnykCLI';
 
 jest.setTimeout(1000 * 60);
 
-describe('test using OAuth token', () => {
+describe('OAuth Token', () => {
   let server: ReturnType<typeof fakeServer>;
   let env: Record<string, string>;
 
@@ -29,7 +29,7 @@ describe('test using OAuth token', () => {
     server.close(() => done());
   });
 
-  it('successfully tests a project with an OAuth env variable set', async () => {
+  it('uses oauth token when testing projects', async () => {
     const project = await createProjectFromWorkspace('fail-on/no-vulns');
     const jsonObj = JSON.parse(await project.read('vulns-result.json'));
     server.setNextResponse(jsonObj);
@@ -45,7 +45,7 @@ describe('test using OAuth token', () => {
     expect(requests[0].method).toBe('POST');
   });
 
-  it('successfully monitors a project with an OAuth env variable set', async () => {
+  it('uses oauth token when monitoring projects', async () => {
     const project = await createProjectFromWorkspace('fail-on/no-vulns');
     const jsonObj = JSON.parse(await project.read('vulns-result.json'));
     server.setNextResponse(jsonObj);


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Utilized the newer `getAuthHeader` function. This function returns the OAuth token when set. Typical use cases include Snyk Plugin in AWS CodePipelines.

#### Where should the reviewer start?


#### How should this be manually tested?

Set/export environmental variable `SNYK_OAUTH_TOKEN` and the run `snyk monitor` for a package manager that calls the experimental dep graph API endpoint which is behind a feature flag.

#### Any background context you want to provide?

We at Team Moose are implementing the monitor functionality in AWS CodePipeline. We found that for package managers such as `yarn` or `npm` it calls experimental dep graph API endpoint. Since the dep graph API endpoint in the `dev` environment is behind a feature flag. The call to check if the org had a feature flag was failing because of `Authorization: token undefined` header.
