### PR TITLE
Update Jest acceptance tests

### DIFF
--- a/test/jest/acceptance/cli-args.spec.ts
+++ b/test/jest/acceptance/cli-args.spec.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { UnsupportedOptionCombinationError } from '../../../src/lib/errors/unsupported-option-combination-error';
 import { runSnykCLI } from '../util/runSnykCLI';
+import { fakeServer } from '../../acceptance/fake-server';
 
 const createOutputDirectory = (): string => {
   const outputPath = path.normalize(`test-output/${uuidv4()}`);
@@ -17,341 +18,440 @@ const isWindows =
 
 jest.setTimeout(1000 * 60 * 5);
 
-test('snyk test command should fail when --file is not specified correctly', async () => {
-  const { code, stdout } = await runSnykCLI(`test --file package-lock.json`);
-  expect(stdout).toMatch(
-    'Empty --file argument. Did you mean --file=path/to/file ?',
-  );
-  expect(code).toEqual(2);
-});
+describe('cli args', () => {
+  let server;
+  let env: Record<string, string>;
 
-test('snyk version command should show cli version', async () => {
-  const { code, stdout } = await runSnykCLI(`--version`);
-  expect(stdout).toMatch(/[0-9]+\.[0-9]+\.[0-9]+/);
-  expect(code).toEqual(0);
-});
+  beforeAll((done) => {
+    const port = process.env.PORT || process.env.SNYK_PORT || '12345';
+    const baseApi = '/api/v1';
+    env = {
+      ...process.env,
+      SNYK_API: 'http://localhost:' + port + baseApi,
+      SNYK_HOST: 'http://localhost:' + port,
+      SNYK_TOKEN: '123456789',
+      SNYK_DISABLE_ANALYTICS: '1',
+    };
+    server = fakeServer(baseApi, env.SNYK_TOKEN);
+    server.listen(port, () => {
+      done();
+    });
+  });
 
-test('snyk test command should fail when --packageManager is not specified correctly', async () => {
-  const { code, stdout } = await runSnykCLI(`test --packageManager=hello`);
-  expect(stdout).toMatch('Unsupported package manager');
-  expect(code).toEqual(2);
-});
+  afterEach(() => {
+    server.restore();
+  });
 
-test('snyk test command should fail when iac --file is specified', async () => {
-  const { code, stdout } = await runSnykCLI(
-    `iac test --file=./test/acceptance/workspaces/iac-kubernetes/multi-file.yaml`,
-  );
+  afterAll((done) => {
+    server.close(() => {
+      done();
+    });
+  });
 
-  expect(stdout).toMatch('Unsupported flag');
-  expect(code).toEqual(2);
-});
+  test('snyk test command should fail when --file is not specified correctly', async () => {
+    const { code, stdout } = await runSnykCLI(`test --file package-lock.json`, {
+      env,
+    });
+    expect(stdout).toMatch(
+      'Empty --file argument. Did you mean --file=path/to/file ?',
+    );
+    expect(code).toEqual(2);
+  });
 
-test('snyk test command should fail when iac file is not supported', async () => {
-  const { code, stdout } = await runSnykCLI(
-    `iac test ./test/acceptance/workspaces/empty/readme.md --legacy`,
-  );
+  test('snyk version command should show cli version', async () => {
+    const { code, stdout } = await runSnykCLI(`--version`, {
+      env,
+    });
+    expect(stdout).toMatch(/[0-9]+\.[0-9]+\.[0-9]+/);
+    expect(code).toEqual(0);
+  });
 
-  expect(stdout).toMatch('Illegal infrastructure as code target file');
-  expect(code).toEqual(2);
-});
+  test('snyk test command should fail when --packageManager is not specified correctly', async () => {
+    const { code, stdout } = await runSnykCLI(`test --packageManager=hello`, {
+      env,
+    });
+    expect(stdout).toMatch('Unsupported package manager');
+    expect(code).toEqual(2);
+  });
 
-test('snyk test command should fail when iac file is not supported', async () => {
-  const { code, stdout } = await runSnykCLI(
-    `iac test ./test/acceptance/workspaces/helmconfig/Chart.yaml --legacy`,
-  );
-
-  expect(stdout).toMatch(
-    'Not supported infrastructure as code target files in',
-  );
-  expect(code).toEqual(2);
-});
-
-test('test multiple paths with --project-name=NAME', async () => {
-  const { code, stdout } = await runSnykCLI(
-    `test pathA pathB --project-name=NAME`,
-  );
-  expect(stdout).toMatch(
-    'The following option combination is not currently supported: multiple paths + project-name',
-  );
-  expect(code).toEqual(2);
-});
-
-test('test --file=file.sln --project-name=NAME', async () => {
-  const { code, stdout } = await runSnykCLI(
-    `test --file=file.sln --project-name=NAME`,
-  );
-
-  expect(stdout).toMatch(
-    'The following option combination is not currently supported: file=*.sln + project-name',
-  );
-  expect(code).toEqual(2);
-});
-
-test('test --file=blah --scan-all-unmanaged', async () => {
-  const { code, stdout } = await runSnykCLI(
-    `test --file=blah --scan-all-unmanaged`,
-  );
-  expect(stdout).toMatch(
-    'The following option combination is not currently supported: file + scan-all-unmanaged',
-  );
-  expect(code).toEqual(2);
-});
-
-[
-  'file',
-  'package-manager',
-  'project-name',
-  'docker',
-  'all-sub-projects',
-].forEach((arg) => {
-  test(`test using --${arg} and --yarn-workspaces displays error message`, async () => {
+  test('snyk test command should fail when iac --file is specified', async () => {
     const { code, stdout } = await runSnykCLI(
-      `test --${arg} --yarn-workspaces`,
+      `iac test --file=./test/acceptance/workspaces/iac-kubernetes/multi-file.yaml`,
+      {
+        env,
+      },
     );
-    expect(stdout).toMatch(
-      `The following option combination is not currently supported: ${arg} + yarn-workspaces`,
-    );
+
+    expect(stdout).toMatch('Unsupported flag');
     expect(code).toEqual(2);
   });
 
-  test(`monitor using --${arg} and --yarn-workspaces displays error message`, async () => {
+  test('snyk test command should fail when iac file is not supported', async () => {
     const { code, stdout } = await runSnykCLI(
-      `monitor --${arg} --yarn-workspaces`,
+      `iac test ./test/acceptance/workspaces/empty/readme.md --legacy`,
+      {
+        env,
+      },
     );
-    expect(stdout).toMatch(
-      `The following option combination is not currently supported: ${arg} + yarn-workspaces`,
-    );
-    expect(code).toEqual(2);
-  });
-});
 
-[
-  'file',
-  'package-manager',
-  'project-name',
-  'docker',
-  'all-sub-projects',
-  'yarn-workspaces',
-].forEach((arg) => {
-  test(`test using --${arg} and --all-projects displays error message`, async () => {
-    const { code, stdout } = await runSnykCLI(`test --${arg} --all-projects`);
-    expect(stdout).toMatch(
-      `The following option combination is not currently supported: ${arg} + all-projects`,
-    );
+    expect(stdout).toMatch('Illegal infrastructure as code target file');
     expect(code).toEqual(2);
   });
 
-  test(`monitor using --${arg} and --all-projects displays error message`, async () => {
+  test('snyk test command should fail when iac file is not supported', async () => {
     const { code, stdout } = await runSnykCLI(
-      `monitor --${arg} --all-projects`,
+      `iac test ./test/acceptance/workspaces/helmconfig/Chart.yaml --legacy`,
+      {
+        env,
+      },
     );
+
     expect(stdout).toMatch(
-      `The following option combination is not currently supported: ${arg} + all-projects`,
+      'Not supported infrastructure as code target files in',
     );
     expect(code).toEqual(2);
   });
-});
 
-test('test --exclude without --all-project displays error message', async () => {
-  const { code, stdout } = await runSnykCLI(`test --exclude=test`);
-  expect(stdout).toMatch(
-    'The --exclude option can only be use in combination with --all-projects or --yarn-workspaces.',
-  );
-  expect(code).toEqual(2);
-});
-
-test('test --exclude without any value displays error message', async () => {
-  const { code, stdout } = await runSnykCLI(`test --all-projects --exclude`);
-  expect(stdout).toMatch(
-    'Empty --exclude argument. Did you mean --exclude=subdirectory ?',
-  );
-  expect(code).toEqual(2);
-});
-
-test('test --exclude=path/to/dir displays error message', async () => {
-  const exclude = path.normalize('path/to/dir');
-  const { code, stdout } = await runSnykCLI(
-    `test --all-projects --exclude=${exclude}`,
-  );
-
-  expect(stdout).toMatch(
-    'The --exclude argument must be a comma separated list of directory or file names and cannot contain a path.',
-  );
-  expect(code).toEqual(2);
-});
-
-[
-  'auth',
-  'config',
-  'help',
-  'ignore',
-  'modules',
-  'monitor',
-  'policy',
-  'protect',
-  'version',
-  'wizard',
-  'woof',
-].forEach((command) => {
-  test(`${command} not allowed with --json-file-output`, async () => {
-    const { code, stdout } = await runSnykCLI(`${command} --json-file-output`);
+  test('test multiple paths with --project-name=NAME', async () => {
+    const { code, stdout } = await runSnykCLI(
+      `test pathA pathB --project-name=NAME`,
+      {
+        env,
+      },
+    );
     expect(stdout).toMatch(
-      `The following option combination is not currently supported: ${command} + json-file-output`,
+      'The following option combination is not currently supported: multiple paths + project-name',
     );
     expect(code).toEqual(2);
   });
-});
 
-const optionsToTest = [
-  '--json-file-output',
-  '--json-file-output=',
-  '--json-file-output=""',
-  "--json-file-output=''",
-];
+  test('test --file=file.sln --project-name=NAME', async () => {
+    const { code, stdout } = await runSnykCLI(
+      `test --file=file.sln --project-name=NAME`,
+      {
+        env,
+      },
+    );
 
-optionsToTest.forEach((option) => {
-  test('test --json-file-output no value produces error message', async () => {
-    const { code, stdout } = await runSnykCLI(`test ${option}`);
     expect(stdout).toMatch(
-      'Empty --json-file-output argument. Did you mean --file=path/to/output-file.json ?',
+      'The following option combination is not currently supported: file=*.sln + project-name',
     );
     expect(code).toEqual(2);
   });
-});
 
-test('iac test with flags not allowed with --sarif', async () => {
-  const { code, stdout } = await runSnykCLI(`test iac --sarif --json`);
-  expect(stdout).toMatch(
-    new UnsupportedOptionCombinationError(['test', 'sarif', 'json'])
-      .userMessage,
-  );
-  expect(stdout.trim().split('\n')).toHaveLength(1);
-  expect(code).toEqual(2);
-});
-
-test('iac container with flags not allowed with --sarif', async () => {
-  const { code, stdout } = await runSnykCLI(`test container --sarif --json`);
-  expect(stdout).toMatch(
-    new UnsupportedOptionCombinationError(['test', 'sarif', 'json'])
-      .userMessage,
-  );
-  expect(stdout.trim().split('\n')).toHaveLength(1);
-  expect(code).toEqual(2);
-});
-
-[
-  '--sarif-file-output',
-  '--sarif-file-output=',
-  '--sarif-file-output=""',
-  "--sarif-file-output=''",
-].forEach((option) => {
-  test('test --sarif-file-output no value produces error message', async () => {
-    const { code, stdout } = await runSnykCLI(`test ${option}`);
+  test('test --file=blah --scan-all-unmanaged', async () => {
+    const { code, stdout } = await runSnykCLI(
+      `test --file=blah --scan-all-unmanaged`,
+      {
+        env,
+      },
+    );
     expect(stdout).toMatch(
-      'Empty --sarif-file-output argument. Did you mean --file=path/to/output-file.json ?',
+      'The following option combination is not currently supported: file + scan-all-unmanaged',
     );
     expect(code).toEqual(2);
   });
-});
 
-test('container test --json-file-output can be used at the same time as --sarif-file-output', async () => {
-  const outputDir = createOutputDirectory();
-  const jsonPath = path.normalize(
-    `${outputDir}/snyk-direct-json-test-output.json`,
-  );
-  const sarifPath = path.normalize(
-    `${outputDir}/snyk-direct-sarif-test-output.json`,
-  );
-  const dockerfilePath = path.normalize(
-    'test/acceptance/fixtures/docker/Dockerfile',
-  );
+  [
+    'file',
+    'package-manager',
+    'project-name',
+    'docker',
+    'all-sub-projects',
+  ].forEach((arg) => {
+    test(`test using --${arg} and --yarn-workspaces displays error message`, async () => {
+      const { code, stdout } = await runSnykCLI(
+        `test --${arg} --yarn-workspaces`,
+        {
+          env,
+        },
+      );
+      expect(stdout).toMatch(
+        `The following option combination is not currently supported: ${arg} + yarn-workspaces`,
+      );
+      expect(code).toEqual(2);
+    });
 
-  const { code, stdout } = await runSnykCLI(
-    `container test hello-world --file=${dockerfilePath} --sarif-file-output=${sarifPath} --json-file-output=${jsonPath}`,
-  );
+    test(`monitor using --${arg} and --yarn-workspaces displays error message`, async () => {
+      const { code, stdout } = await runSnykCLI(
+        `monitor --${arg} --yarn-workspaces`,
+        {
+          env,
+        },
+      );
+      expect(stdout).toMatch(
+        `The following option combination is not currently supported: ${arg} + yarn-workspaces`,
+      );
+      expect(code).toEqual(2);
+    });
+  });
 
-  const sarifOutput = JSON.parse(await fse.readFile(sarifPath, 'utf-8'));
-  const jsonOutput = JSON.parse(await fse.readFile(jsonPath, 'utf-8'));
+  [
+    'file',
+    'package-manager',
+    'project-name',
+    'docker',
+    'all-sub-projects',
+    'yarn-workspaces',
+  ].forEach((arg) => {
+    test(`test using --${arg} and --all-projects displays error message`, async () => {
+      const { code, stdout } = await runSnykCLI(`test --${arg} --all-projects`);
+      expect(stdout).toMatch(
+        `The following option combination is not currently supported: ${arg} + all-projects`,
+      );
+      expect(code).toEqual(2);
+    });
 
-  expect(stdout).toMatch('Organization:');
-  expect(jsonOutput.ok).toEqual(true);
-  expect(sarifOutput.version).toMatch('2.1.0');
-  expect(code).toEqual(0);
-});
+    test(`monitor using --${arg} and --all-projects displays error message`, async () => {
+      const { code, stdout } = await runSnykCLI(
+        `monitor --${arg} --all-projects`,
+        {
+          env,
+        },
+      );
+      expect(stdout).toMatch(
+        `The following option combination is not currently supported: ${arg} + all-projects`,
+      );
+      expect(code).toEqual(2);
+    });
+  });
 
-test('container test --sarif-file-output can be used at the same time as --sarif', async () => {
-  const outputDir = createOutputDirectory();
-  const sarifPath = path.normalize(
-    `${outputDir}/snyk-direct-sarif-test-output.json`,
-  );
-  const dockerfilePath = path.normalize(
-    'test/acceptance/fixtures/docker/Dockerfile',
-  );
+  test('test --exclude without --all-project displays error message', async () => {
+    const { code, stdout } = await runSnykCLI(`test --exclude=test`, {
+      env,
+    });
+    expect(stdout).toMatch(
+      'The --exclude option can only be use in combination with --all-projects or --yarn-workspaces.',
+    );
+    expect(code).toEqual(2);
+  });
 
-  const { code, stdout } = await runSnykCLI(
-    `container test hello-world --sarif --file=${dockerfilePath} --sarif-file-output=${sarifPath}`,
-  );
+  test('test --exclude without any value displays error message', async () => {
+    const { code, stdout } = await runSnykCLI(`test --all-projects --exclude`, {
+      env,
+    });
+    expect(stdout).toMatch(
+      'Empty --exclude argument. Did you mean --exclude=subdirectory ?',
+    );
+    expect(code).toEqual(2);
+  });
 
-  const sarifOutput = JSON.parse(await fse.readFile(sarifPath, 'utf-8'));
+  test('test --exclude=path/to/dir displays error message', async () => {
+    const exclude = path.normalize('path/to/dir');
+    const { code, stdout } = await runSnykCLI(
+      `test --all-projects --exclude=${exclude}`,
+      {
+        env,
+      },
+    );
 
-  expect(stdout).toMatch('rules');
-  expect(sarifOutput.version).toMatch('2.1.0');
-  expect(code).toEqual(0);
-});
+    expect(stdout).toMatch(
+      'The --exclude argument must be a comma separated list of directory or file names and cannot contain a path.',
+    );
+    expect(code).toEqual(2);
+  });
 
-test('container test --sarif-file-output without vulns', async () => {
-  const outputDir = createOutputDirectory();
-  const sarifPath = path.normalize(
-    `${outputDir}/snyk-direct-sarif-test-output.json`,
-  );
-  const dockerfilePath = path.normalize(
-    'test/acceptance/fixtures/docker/Dockerfile',
-  );
+  [
+    'auth',
+    'config',
+    'help',
+    'ignore',
+    'modules',
+    'monitor',
+    'policy',
+    'protect',
+    'version',
+    'wizard',
+    'woof',
+  ].forEach((command) => {
+    test(`${command} not allowed with --json-file-output`, async () => {
+      const { code, stdout } = await runSnykCLI(
+        `${command} --json-file-output`,
+        {
+          env,
+        },
+      );
+      expect(stdout).toMatch(
+        `The following option combination is not currently supported: ${command} + json-file-output`,
+      );
+      expect(code).toEqual(2);
+    });
+  });
 
-  const { code } = await runSnykCLI(
-    `container test hello-world --file=${dockerfilePath} --sarif-file-output=${sarifPath}`,
-  );
+  const optionsToTest = [
+    '--json-file-output',
+    '--json-file-output=',
+    '--json-file-output=""',
+    "--json-file-output=''",
+  ];
 
-  const sarifOutput = JSON.parse(await fse.readFile(sarifPath, 'utf-8'));
-  expect(sarifOutput.version).toMatch('2.1.0');
-  expect(code).toEqual(0);
-});
+  optionsToTest.forEach((option) => {
+    test('test --json-file-output no value produces error message', async () => {
+      const { code, stdout } = await runSnykCLI(`test ${option}`, {
+        env,
+      });
+      expect(stdout).toMatch(
+        'Empty --json-file-output argument. Did you mean --file=path/to/output-file.json ?',
+      );
+      expect(code).toEqual(2);
+    });
+  });
 
-test('container test --sarif-file-output can be used at the same time as --json', async () => {
-  const outputDir = createOutputDirectory();
-  const sarifPath = path.normalize(
-    `${outputDir}/snyk-direct-sarif-test-output.json`,
-  );
-  const dockerfilePath = path.normalize(
-    'test/acceptance/fixtures/docker/Dockerfile',
-  );
+  test('iac test with flags not allowed with --sarif', async () => {
+    const { code, stdout } = await runSnykCLI(`test iac --sarif --json`, {
+      env,
+    });
+    expect(stdout).toMatch(
+      new UnsupportedOptionCombinationError(['test', 'sarif', 'json'])
+        .userMessage,
+    );
+    expect(stdout.trim().split('\n')).toHaveLength(1);
+    expect(code).toEqual(2);
+  });
 
-  const { code, stdout } = await runSnykCLI(
-    `container test hello-world --json --file=${dockerfilePath} --sarif-file-output=${sarifPath}`,
-  );
+  test('iac container with flags not allowed with --sarif', async () => {
+    const { code, stdout } = await runSnykCLI(`test container --sarif --json`, {
+      env,
+    });
+    expect(stdout).toMatch(
+      new UnsupportedOptionCombinationError(['test', 'sarif', 'json'])
+        .userMessage,
+    );
+    expect(stdout.trim().split('\n')).toHaveLength(1);
+    expect(code).toEqual(2);
+  });
 
-  const sarifOutput = JSON.parse(await fse.readFile(sarifPath, 'utf-8'));
-  const jsonOutput = JSON.parse(stdout);
+  [
+    '--sarif-file-output',
+    '--sarif-file-output=',
+    '--sarif-file-output=""',
+    "--sarif-file-output=''",
+  ].forEach((option) => {
+    test('test --sarif-file-output no value produces error message', async () => {
+      const { code, stdout } = await runSnykCLI(`test ${option}`, {
+        env,
+      });
+      expect(stdout).toMatch(
+        'Empty --sarif-file-output argument. Did you mean --file=path/to/output-file.json ?',
+      );
+      expect(code).toEqual(2);
+    });
+  });
 
-  expect(jsonOutput.ok).toEqual(true);
-  expect(sarifOutput.version).toMatch('2.1.0');
-  expect(code).toEqual(0);
-});
-
-if (!isWindows) {
-  // Previously we used to have a bug where --exclude-base-image-vulns returned exit code 2.
-  // This test asserts that the bug no longer exists.
-  test('container test --file=Dockerfile --exclude-base-image-vulns returns exit code 0', async () => {
+  test('container test --json-file-output can be used at the same time as --sarif-file-output', async () => {
+    const outputDir = createOutputDirectory();
+    const jsonPath = path.normalize(
+      `${outputDir}/snyk-direct-json-test-output.json`,
+    );
+    const sarifPath = path.normalize(
+      `${outputDir}/snyk-direct-sarif-test-output.json`,
+    );
     const dockerfilePath = path.normalize(
-      'test/acceptance/fixtures/docker/Dockerfile.alpine-3.12.0',
+      'test/acceptance/fixtures/docker/Dockerfile',
     );
 
     const { code, stdout } = await runSnykCLI(
-      `container test alpine:3.12.0 --json --file=${dockerfilePath} --exclude-base-image-vulns`,
+      `container test hello-world --file=${dockerfilePath} --sarif-file-output=${sarifPath} --json-file-output=${jsonPath}`,
+      {
+        env,
+      },
     );
+
+    const sarifOutput = JSON.parse(await fse.readFile(sarifPath, 'utf-8'));
+    const jsonOutput = JSON.parse(await fse.readFile(jsonPath, 'utf-8'));
+
+    expect(stdout).toMatch('Organization:');
+    expect(jsonOutput.ok).toEqual(true);
+    expect(sarifOutput.version).toMatch('2.1.0');
+    expect(code).toEqual(0);
+  });
+
+  test('container test --sarif-file-output can be used at the same time as --sarif', async () => {
+    const outputDir = createOutputDirectory();
+    const sarifPath = path.normalize(
+      `${outputDir}/snyk-direct-sarif-test-output.json`,
+    );
+    const dockerfilePath = path.normalize(
+      'test/acceptance/fixtures/docker/Dockerfile',
+    );
+
+    const { code, stdout } = await runSnykCLI(
+      `container test hello-world --sarif --file=${dockerfilePath} --sarif-file-output=${sarifPath}`,
+      {
+        env,
+      },
+    );
+
+    const sarifOutput = JSON.parse(await fse.readFile(sarifPath, 'utf-8'));
+
+    expect(stdout).toMatch('rules');
+    expect(sarifOutput.version).toMatch('2.1.0');
+    expect(code).toEqual(0);
+  });
+
+  test('container test --sarif-file-output without vulns', async () => {
+    const outputDir = createOutputDirectory();
+    const sarifPath = path.normalize(
+      `${outputDir}/snyk-direct-sarif-test-output.json`,
+    );
+    const dockerfilePath = path.normalize(
+      'test/acceptance/fixtures/docker/Dockerfile',
+    );
+
+    const { code } = await runSnykCLI(
+      `container test hello-world --file=${dockerfilePath} --sarif-file-output=${sarifPath}`,
+      {
+        env,
+      },
+    );
+
+    const sarifOutput = JSON.parse(await fse.readFile(sarifPath, 'utf-8'));
+    expect(sarifOutput.version).toMatch('2.1.0');
+    expect(code).toEqual(0);
+  });
+
+  test('container test --sarif-file-output can be used at the same time as --json', async () => {
+    const outputDir = createOutputDirectory();
+    const sarifPath = path.normalize(
+      `${outputDir}/snyk-direct-sarif-test-output.json`,
+    );
+    const dockerfilePath = path.normalize(
+      'test/acceptance/fixtures/docker/Dockerfile',
+    );
+
+    const { code, stdout } = await runSnykCLI(
+      `container test hello-world --json --file=${dockerfilePath} --sarif-file-output=${sarifPath}`,
+      {
+        env,
+      },
+    );
+
+    const sarifOutput = JSON.parse(await fse.readFile(sarifPath, 'utf-8'));
     const jsonOutput = JSON.parse(stdout);
 
     expect(jsonOutput.ok).toEqual(true);
+    expect(sarifOutput.version).toMatch('2.1.0');
     expect(code).toEqual(0);
   });
-}
+
+  if (!isWindows) {
+    // Previously we used to have a bug where --exclude-base-image-vulns returned exit code 2.
+    // This test asserts that the bug no longer exists.
+    test('container test --file=Dockerfile --exclude-base-image-vulns returns exit code 0', async () => {
+      const dockerfilePath = path.normalize(
+        'test/acceptance/fixtures/docker/Dockerfile.alpine-3.12.0',
+      );
+
+      const { code, stdout } = await runSnykCLI(
+        `container test alpine:3.12.0 --json --file=${dockerfilePath} --exclude-base-image-vulns`,
+        {
+          env,
+        },
+      );
+      const jsonOutput = JSON.parse(stdout);
+
+      expect(jsonOutput.ok).toEqual(true);
+      expect(code).toEqual(0);
+    });
+  }
+});

--- a/test/jest/acceptance/cli-json-file-output.spec.ts
+++ b/test/jest/acceptance/cli-json-file-output.spec.ts
@@ -15,6 +15,7 @@ describe('test --json-file-output ', () => {
       ...process.env,
       SNYK_API: 'http://localhost:' + apiPort + apiPath,
       SNYK_TOKEN: '123456789',
+      SNYK_DISABLE_ANALYTICS: '1',
     };
 
     server = fakeServer(apiPath, env.SNYK_TOKEN);

--- a/test/jest/acceptance/oauth-token.spec.ts
+++ b/test/jest/acceptance/oauth-token.spec.ts
@@ -15,6 +15,7 @@ describe('OAuth Token', () => {
       PATH: process.env.PATH || '',
       SNYK_API: 'http://localhost:' + apiPort + apiPath,
       SNYK_OAUTH_TOKEN: 'oauth-jwt-token',
+      SNYK_DISABLE_ANALYTICS: '1',
     };
 
     server = fakeServer(apiPath, env.SNYK_TOKEN);
@@ -40,9 +41,13 @@ describe('OAuth Token', () => {
     });
 
     expect(code).toEqual(0);
-    const requests = server.popRequests(2);
-    expect(requests[0].headers.authorization).toBe('Bearer oauth-jwt-token');
-    expect(requests[0].method).toBe('POST');
+    server.requests.forEach((r) => {
+      expect(r).toMatchObject({
+        headers: {
+          authorization: 'Bearer oauth-jwt-token',
+        },
+      });
+    });
   });
 
   it('uses oauth token when monitoring projects', async () => {
@@ -56,9 +61,13 @@ describe('OAuth Token', () => {
     });
 
     expect(code).toEqual(0);
-    const requests = server.popRequests(2);
-    expect(requests[0].headers.authorization).toBe('Bearer oauth-jwt-token');
-    expect(requests[0].method).toBe('PUT');
+    server.requests.forEach((r) => {
+      expect(r).toMatchObject({
+        headers: {
+          authorization: 'Bearer oauth-jwt-token',
+        },
+      });
+    });
   });
 
   it('uses oauth token when fetching feature flags', async () => {

--- a/test/jest/acceptance/snyk-test-all-projects-exit-codes.spec.ts
+++ b/test/jest/acceptance/snyk-test-all-projects-exit-codes.spec.ts
@@ -16,6 +16,7 @@ describe('snyk test --all-projects with one project that has errors', () => {
       SNYK_API: 'http://localhost:' + port + baseApi,
       SNYK_HOST: 'http://localhost:' + port,
       SNYK_TOKEN: '123456789',
+      SNYK_DISABLE_ANALYTICS: '1',
     };
     server = fakeServer(baseApi, env.SNYK_TOKEN);
     server.listen(port, () => {

--- a/test/jest/acceptance/snyk-test/fail-on.spec.ts
+++ b/test/jest/acceptance/snyk-test/fail-on.spec.ts
@@ -15,6 +15,7 @@ describe('snyk test --fail-on', () => {
       ...process.env,
       SNYK_API: 'http://localhost:' + apiPort + apiPath,
       SNYK_TOKEN: '123456789',
+      SNYK_DISABLE_ANALYTICS: '1',
     };
 
     server = fakeServer(apiPath, env.SNYK_TOKEN);

--- a/test/jest/acceptance/snyk-test/missing-node-modules.spec.ts
+++ b/test/jest/acceptance/snyk-test/missing-node-modules.spec.ts
@@ -24,6 +24,7 @@ describe('snyk test with missing node_modules', () => {
       SNYK_API: 'http://localhost:' + port + BASE_API,
       SNYK_HOST: 'http://localhost:' + port,
       SNYK_TOKEN: requireSnykToken(),
+      SNYK_DISABLE_ANALYTICS: '1',
     };
 
     const apiKey = '123456789';

--- a/test/jest/acceptance/snyk-test/package-no-name.spec.ts
+++ b/test/jest/acceptance/snyk-test/package-no-name.spec.ts
@@ -4,26 +4,28 @@ import { runSnykCLI } from '../../util/runSnykCLI';
 
 jest.setTimeout(1000 * 60);
 
-test('packages with no name read dir', async () => {
-  const project = await createProject('package-sans-name');
-  const { code } = await runSnykCLI('test', {
-    cwd: project.path(),
-    env: {
-      ...process.env,
-      SNYK_TOKEN: requireSnykToken(),
-    },
-  });
-  expect(code).toEqual(1);
-});
+describe('packages with no name', () => {
+  const env = {
+    ...process.env,
+    SNYK_TOKEN: requireSnykToken(),
+    SNYK_DISABLE_ANALYTICS: '1',
+  };
 
-test('packages with no name read dir with a lockfile', async () => {
-  const project = await createProject('package-sans-name-lockfile');
-  const { code } = await runSnykCLI('test', {
-    cwd: project.path(),
-    env: {
-      ...process.env,
-      SNYK_TOKEN: requireSnykToken(),
-    },
+  test('packages with no name read dir', async () => {
+    const project = await createProject('package-sans-name');
+    const { code } = await runSnykCLI('test', {
+      cwd: project.path(),
+      env,
+    });
+    expect(code).toEqual(1);
   });
-  expect(code).toEqual(1);
+
+  test('packages with no name read dir with a lockfile', async () => {
+    const project = await createProject('package-sans-name-lockfile');
+    const { code } = await runSnykCLI('test', {
+      cwd: project.path(),
+      env,
+    });
+    expect(code).toEqual(1);
+  });
 });

--- a/test/jest/acceptance/snyk-test/trust-policies.spec.ts
+++ b/test/jest/acceptance/snyk-test/trust-policies.spec.ts
@@ -4,38 +4,40 @@ import { runSnykCLI } from '../../util/runSnykCLI';
 
 jest.setTimeout(1000 * 60);
 
-test('`snyk test` detects suggested ignore policies', async () => {
-  const project = await createProject('qs-package');
-  const { code, stdout } = await runSnykCLI('test', {
-    cwd: project.path(),
-    env: {
-      ...process.env,
-      SNYK_TOKEN: requireSnykToken(),
-    },
+describe('trust policies', () => {
+  const env = {
+    ...process.env,
+    SNYK_TOKEN: requireSnykToken(),
+    SNYK_DISABLE_ANALYTICS: '1',
+  };
+
+  test('`snyk test` detects suggested ignore policies', async () => {
+    const project = await createProject('qs-package');
+    const { code, stdout } = await runSnykCLI('test', {
+      cwd: project.path(),
+      env,
+    });
+
+    expect(code).toEqual(1);
+    expect(stdout).toMatch(
+      'suggests ignoring this issue, with reason: test trust policies',
+    );
+    expect(stdout).toMatch('npm:hawk:20160119');
+    expect(stdout).toMatch('npm:request:20160119');
   });
 
-  expect(code).toEqual(1);
-  expect(stdout).toMatch(
-    'suggests ignoring this issue, with reason: test trust policies',
-  );
-  expect(stdout).toMatch('npm:hawk:20160119');
-  expect(stdout).toMatch('npm:request:20160119');
-});
+  test('`snyk test --trust-policies` applies suggested ignore policies', async () => {
+    const project = await createProject('qs-package');
+    const { code, stdout } = await runSnykCLI('test --trust-policies', {
+      cwd: project.path(),
+      env,
+    });
 
-test('`snyk test --trust-policies` applies suggested ignore policies', async () => {
-  const project = await createProject('qs-package');
-  const { code, stdout } = await runSnykCLI('test --trust-policies', {
-    cwd: project.path(),
-    env: {
-      ...process.env,
-      SNYK_TOKEN: requireSnykToken(),
-    },
+    expect(code).toEqual(1);
+    expect(stdout).not.toMatch(
+      'suggests ignoring this issue, with reason: test trust policies',
+    );
+    expect(stdout).not.toMatch('npm:hawk:20160119');
+    expect(stdout).not.toMatch('npm:request:20160119');
   });
-
-  expect(code).toEqual(1);
-  expect(stdout).not.toMatch(
-    'suggests ignoring this issue, with reason: test trust policies',
-  );
-  expect(stdout).not.toMatch('npm:hawk:20160119');
-  expect(stdout).not.toMatch('npm:request:20160119');
 });


### PR DESCRIPTION
#### What does this PR do?

- Use fake-server for the `test/jest/acceptance/cli-args.spec.ts` acceptance tests which are quite long-running.
- Update the acceptance tests to not send analytics
