### PR TITLE
chore: always use local @snyk/fix package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@snyk/cloud-config-parser": "^1.10.2",
         "@snyk/code-client": "4.0.0",
         "@snyk/dep-graph": "^1.27.1",
-        "@snyk/fix": "1.650.0",
+        "@snyk/fix": "file:packages/snyk-fix",
         "@snyk/gemfile": "1.2.0",
         "@snyk/graphlib": "^2.1.9-patch.3",
         "@snyk/inquirer": "^7.3.3-patch",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@snyk/cloud-config-parser": "^1.10.2",
     "@snyk/code-client": "4.0.0",
     "@snyk/dep-graph": "^1.27.1",
-    "@snyk/fix": "1.650.0",
+    "@snyk/fix": "file:packages/snyk-fix",
     "@snyk/gemfile": "1.2.0",
     "@snyk/graphlib": "^2.1.9-patch.3",
     "@snyk/inquirer": "^7.3.3-patch",


### PR DESCRIPTION
This makes sure that we are using and releasing the @snyk/fix that is in the repository

npm workspaces and package-lock are able to resolve it correctly. With CLI Bundling, @snyk/fix included in the repository will always be the latest.

**Which begs the question:** should we stop releasing @snyk/fix on the npm? I'd say we don't have a reason, unless we are using @snyk/fix in some other context than the CLI?

<img width="434" alt="Screen Shot 2021-08-27 at 13 49 42" src="https://user-images.githubusercontent.com/1788727/131122950-19887498-1d8c-407c-81d7-16b79b057416.png">
