### PR TITLE
feat: support yarn workspaces with transitives that are also workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "snyk",
       "version": "1.0.0-monorepo",
       "license": "Apache-2.0",
       "workspaces": [
@@ -62,12 +61,12 @@
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.2.1",
-        "snyk-docker-plugin": "4.23.0",
+        "snyk-docker-plugin": "4.24.0",
         "snyk-go-plugin": "1.17.0",
         "snyk-gradle-plugin": "3.16.1",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.26.2",
-        "snyk-nodejs-lockfile-parser": "1.35.0",
+        "snyk-nodejs-lockfile-parser": "1.37.0",
         "snyk-nuget-plugin": "1.22.1",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.22.1",
@@ -6890,6 +6889,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.5.tgz",
+      "integrity": "sha512-IWwXKnCbirdbyXSfUDvCCrmYrOHANRZcc8NcRrvTlIApdl7PwE9oGcsYvNeJPAVY1M+70b4PxXGKIf8AEuiQ6w==",
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/agent-base": {
@@ -19219,6 +19226,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
       "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -21693,13 +21701,14 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.23.0.tgz",
-      "integrity": "sha512-hcQnDH6kN+Q9FU5/ulqfS/zmrM3YYM5cuCBjU9SZlDE/U3kpqDFePqHPmDdUBuQCdT0/3Os5A3qyg9Y7iNz8fg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.24.0.tgz",
+      "integrity": "sha512-BmTZaRy1l0S05dWqqenBP6sSBWBIaNvbKvV0Y2yowV4JkDRFiLeS/KNs1mp/u6kvAfec8mslY5fAtxu6bqQdkw==",
       "dependencies": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/rpm-parser": "^2.0.0",
         "@snyk/snyk-docker-pull": "^3.6.3",
+        "adm-zip": "^0.5.5",
         "chalk": "^2.4.2",
         "debug": "^4.1.1",
         "docker-modem": "2.1.3",
@@ -22053,22 +22062,22 @@
       "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
     },
     "node_modules/snyk-nodejs-lockfile-parser": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.35.0.tgz",
-      "integrity": "sha512-fSjer9Ic8cdA2HvInUmhwbAhoLFXIokAzGB1PeGKwr0zzyfo3dSX3ReTMEbkhrEg+h0eES13px/KiiJ0EKRKMg==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.0.tgz",
+      "integrity": "sha512-UZr6AjLlskbUkMBImthlajpSRS629RPis7gqDbd0BzuCLhhg66kIdybpSh087/t/6NjYIhuJAYEMv+1vpAPIog==",
       "dependencies": {
+        "@snyk/dep-graph": "^1.28.0",
         "@snyk/graphlib": "2.1.9-patch.3",
         "@yarnpkg/core": "^2.4.0",
         "@yarnpkg/lockfile": "^1.1.0",
         "event-loop-spinner": "^2.0.0",
-        "got": "11.8.2",
         "js-yaml": "^4.1.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.flatmap": "^4.5.0",
         "lodash.isempty": "^4.4.0",
         "lodash.set": "^4.3.2",
         "lodash.topairs": "^4.3.0",
-        "p-map": "2.1.0",
+        "semver": "^7.3.5",
         "snyk-config": "^4.0.0-rc.2",
         "tslib": "^1.9.3",
         "uuid": "^8.3.0"
@@ -22095,6 +22104,36 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/snyk-nodejs-lockfile-parser/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/snyk-nodejs-lockfile-parser/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/snyk-nodejs-lockfile-parser/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-nuget-plugin": {
       "version": "1.22.1",
@@ -31488,6 +31527,11 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
+    },
+    "adm-zip": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.5.tgz",
+      "integrity": "sha512-IWwXKnCbirdbyXSfUDvCCrmYrOHANRZcc8NcRrvTlIApdl7PwE9oGcsYvNeJPAVY1M+70b4PxXGKIf8AEuiQ6w=="
     },
     "agent-base": {
       "version": "4.3.0",
@@ -41204,7 +41248,8 @@
     "p-map": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "dev": true
     },
     "p-map-series": {
       "version": "1.0.0",
@@ -43133,12 +43178,12 @@
         "snyk": "file:",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.2.1",
-        "snyk-docker-plugin": "4.23.0",
+        "snyk-docker-plugin": "4.24.0",
         "snyk-go-plugin": "1.17.0",
         "snyk-gradle-plugin": "3.16.1",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.26.2",
-        "snyk-nodejs-lockfile-parser": "1.35.0",
+        "snyk-nodejs-lockfile-parser": "1.37.0",
         "snyk-nuget-plugin": "1.22.1",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.22.1",
@@ -48772,6 +48817,11 @@
           "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
           "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
           "dev": true
+        },
+        "adm-zip": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.5.tgz",
+          "integrity": "sha512-IWwXKnCbirdbyXSfUDvCCrmYrOHANRZcc8NcRrvTlIApdl7PwE9oGcsYvNeJPAVY1M+70b4PxXGKIf8AEuiQ6w=="
         },
         "agent-base": {
           "version": "4.3.0",
@@ -58488,7 +58538,8 @@
         "p-map": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+          "dev": true
         },
         "p-map-series": {
           "version": "1.0.0",
@@ -60427,13 +60478,14 @@
           }
         },
         "snyk-docker-plugin": {
-          "version": "4.23.0",
-          "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.23.0.tgz",
-          "integrity": "sha512-hcQnDH6kN+Q9FU5/ulqfS/zmrM3YYM5cuCBjU9SZlDE/U3kpqDFePqHPmDdUBuQCdT0/3Os5A3qyg9Y7iNz8fg==",
+          "version": "4.24.0",
+          "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.24.0.tgz",
+          "integrity": "sha512-BmTZaRy1l0S05dWqqenBP6sSBWBIaNvbKvV0Y2yowV4JkDRFiLeS/KNs1mp/u6kvAfec8mslY5fAtxu6bqQdkw==",
           "requires": {
             "@snyk/dep-graph": "^1.28.0",
             "@snyk/rpm-parser": "^2.0.0",
             "@snyk/snyk-docker-pull": "^3.6.3",
+            "adm-zip": "^0.5.5",
             "chalk": "^2.4.2",
             "debug": "^4.1.1",
             "docker-modem": "2.1.3",
@@ -60713,22 +60765,22 @@
           }
         },
         "snyk-nodejs-lockfile-parser": {
-          "version": "1.35.0",
-          "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.35.0.tgz",
-          "integrity": "sha512-fSjer9Ic8cdA2HvInUmhwbAhoLFXIokAzGB1PeGKwr0zzyfo3dSX3ReTMEbkhrEg+h0eES13px/KiiJ0EKRKMg==",
+          "version": "1.37.0",
+          "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.0.tgz",
+          "integrity": "sha512-UZr6AjLlskbUkMBImthlajpSRS629RPis7gqDbd0BzuCLhhg66kIdybpSh087/t/6NjYIhuJAYEMv+1vpAPIog==",
           "requires": {
+            "@snyk/dep-graph": "^1.28.0",
             "@snyk/graphlib": "2.1.9-patch.3",
             "@yarnpkg/core": "^2.4.0",
             "@yarnpkg/lockfile": "^1.1.0",
             "event-loop-spinner": "^2.0.0",
-            "got": "11.8.2",
             "js-yaml": "^4.1.0",
             "lodash.clonedeep": "^4.5.0",
             "lodash.flatmap": "^4.5.0",
             "lodash.isempty": "^4.4.0",
             "lodash.set": "^4.3.2",
             "lodash.topairs": "^4.3.0",
-            "p-map": "2.1.0",
+            "semver": "^7.3.5",
             "snyk-config": "^4.0.0-rc.2",
             "tslib": "^1.9.3",
             "uuid": "^8.3.0"
@@ -60746,6 +60798,27 @@
               "requires": {
                 "argparse": "^2.0.1"
               }
+            },
+            "lru-cache": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+              "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            },
+            "semver": {
+              "version": "7.3.5",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+              "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+              "requires": {
+                "lru-cache": "^6.0.0"
+              }
+            },
+            "yallist": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
             }
           }
         },
@@ -63728,13 +63801,14 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.23.0.tgz",
-      "integrity": "sha512-hcQnDH6kN+Q9FU5/ulqfS/zmrM3YYM5cuCBjU9SZlDE/U3kpqDFePqHPmDdUBuQCdT0/3Os5A3qyg9Y7iNz8fg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.24.0.tgz",
+      "integrity": "sha512-BmTZaRy1l0S05dWqqenBP6sSBWBIaNvbKvV0Y2yowV4JkDRFiLeS/KNs1mp/u6kvAfec8mslY5fAtxu6bqQdkw==",
       "requires": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/rpm-parser": "^2.0.0",
         "@snyk/snyk-docker-pull": "^3.6.3",
+        "adm-zip": "^0.5.5",
         "chalk": "^2.4.2",
         "debug": "^4.1.1",
         "docker-modem": "2.1.3",
@@ -64014,22 +64088,22 @@
       }
     },
     "snyk-nodejs-lockfile-parser": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.35.0.tgz",
-      "integrity": "sha512-fSjer9Ic8cdA2HvInUmhwbAhoLFXIokAzGB1PeGKwr0zzyfo3dSX3ReTMEbkhrEg+h0eES13px/KiiJ0EKRKMg==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.0.tgz",
+      "integrity": "sha512-UZr6AjLlskbUkMBImthlajpSRS629RPis7gqDbd0BzuCLhhg66kIdybpSh087/t/6NjYIhuJAYEMv+1vpAPIog==",
       "requires": {
+        "@snyk/dep-graph": "^1.28.0",
         "@snyk/graphlib": "2.1.9-patch.3",
         "@yarnpkg/core": "^2.4.0",
         "@yarnpkg/lockfile": "^1.1.0",
         "event-loop-spinner": "^2.0.0",
-        "got": "11.8.2",
         "js-yaml": "^4.1.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.flatmap": "^4.5.0",
         "lodash.isempty": "^4.4.0",
         "lodash.set": "^4.3.2",
         "lodash.topairs": "^4.3.0",
-        "p-map": "2.1.0",
+        "semver": "^7.3.5",
         "snyk-config": "^4.0.0-rc.2",
         "tslib": "^1.9.3",
         "uuid": "^8.3.0"
@@ -64047,6 +64121,27 @@
           "requires": {
             "argparse": "^2.0.1"
           }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "snyk-gradle-plugin": "3.16.1",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.26.2",
-    "snyk-nodejs-lockfile-parser": "1.35.0",
+    "snyk-nodejs-lockfile-parser": "1.37.0",
     "snyk-nuget-plugin": "1.22.1",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.22.1",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Yarn workspaces introduces complexity where local packages
are mentioned as required dependency but are not present on the lockfile
this means that the lockfile is considered deeply out of sync by the plugin.

Allow to skip the check if user is calling with StrictOutOfSync=false not just
for top level dependencies but also the transitives as a package can rely on another local workspace which lists a workspace as a dep.

https://github.com/snyk/nodejs-lockfile-parser/pull/119


#### Where should the reviewer start?
https://github.com/snyk/nodejs-lockfile-parser/pull/119


#### How should this be manually tested?

Scan https://github.com/backstage/backstage

#### Any background context you want to provide?
https://github.com/snyk/snyk/issues/2126

#### What are the relevant tickets?
https://github.com/snyk/snyk/issues/2126

