### PR TITLE
fix: sbt plugin check global plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "snyk-python-plugin": "1.20.1",
         "snyk-resolve": "1.1.0",
         "snyk-resolve-deps": "4.7.3",
-        "snyk-sbt-plugin": "2.11.3",
+        "snyk-sbt-plugin": "^2.11.4",
         "snyk-try-require": "^2.0.2",
         "strip-ansi": "^5.2.0",
         "tar": "^6.1.2",
@@ -22378,9 +22378,9 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "node_modules/snyk-sbt-plugin": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.11.3.tgz",
-      "integrity": "sha512-xcZAYENuEx+SG51AuLLL59jpN/qerJdSdznTANoyNM7bJjVhTvLTjEfoOxbeogZwKmFDKKUfc6Vw+EdEy8VZug==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.11.4.tgz",
+      "integrity": "sha512-Y0qeSzXokFqFJQgG/h5jzpbYNPQQNNbM9xYz+swZFlY/7hlfzUnHFO05VNf7mQNERxyiXH8XLDQUEr7WkVIK3Q==",
       "dependencies": {
         "debug": "^4.1.1",
         "semver": "^6.1.2",
@@ -43190,7 +43190,7 @@
         "snyk-python-plugin": "1.20.1",
         "snyk-resolve": "1.1.0",
         "snyk-resolve-deps": "4.7.3",
-        "snyk-sbt-plugin": "2.11.3",
+        "snyk-sbt-plugin": "2.11.4",
         "snyk-try-require": "^2.0.2",
         "strip-ansi": "^5.2.0",
         "tap": "^12.6.1",
@@ -61044,9 +61044,9 @@
           }
         },
         "snyk-sbt-plugin": {
-          "version": "2.11.3",
-          "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.11.3.tgz",
-          "integrity": "sha512-xcZAYENuEx+SG51AuLLL59jpN/qerJdSdznTANoyNM7bJjVhTvLTjEfoOxbeogZwKmFDKKUfc6Vw+EdEy8VZug==",
+          "version": "2.11.4",
+          "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.11.4.tgz",
+          "integrity": "sha512-Y0qeSzXokFqFJQgG/h5jzpbYNPQQNNbM9xYz+swZFlY/7hlfzUnHFO05VNf7mQNERxyiXH8XLDQUEr7WkVIK3Q==",
           "requires": {
             "debug": "^4.1.1",
             "semver": "^6.1.2",
@@ -64367,9 +64367,9 @@
       }
     },
     "snyk-sbt-plugin": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.11.3.tgz",
-      "integrity": "sha512-xcZAYENuEx+SG51AuLLL59jpN/qerJdSdznTANoyNM7bJjVhTvLTjEfoOxbeogZwKmFDKKUfc6Vw+EdEy8VZug==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.11.4.tgz",
+      "integrity": "sha512-Y0qeSzXokFqFJQgG/h5jzpbYNPQQNNbM9xYz+swZFlY/7hlfzUnHFO05VNf7mQNERxyiXH8XLDQUEr7WkVIK3Q==",
       "requires": {
         "debug": "^4.1.1",
         "semver": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "snyk-python-plugin": "1.20.1",
     "snyk-resolve": "1.1.0",
     "snyk-resolve-deps": "4.7.3",
-    "snyk-sbt-plugin": "2.11.3",
+    "snyk-sbt-plugin": "2.11.4",
     "snyk-try-require": "^2.0.2",
     "strip-ansi": "^5.2.0",
     "tar": "^6.1.2",


### PR DESCRIPTION
Fix snyk-sbt-plugin to check global sbt directories for sbt plugins.

See https://github.com/snyk/snyk-sbt-plugin/pull/101
