### PR TITLE
fix: exclude-base-image-vulns to work with autodetected base image

### DIFF
--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -430,7 +430,11 @@ function convertTestDepGraphResultToLegacy(
       ? undefined
       : options.severityThreshold;
 
-  if (options.docker && options.file && options['exclude-base-image-vulns']) {
+  if (
+    options.docker &&
+    dockerRes?.baseImage &&
+    options['exclude-base-image-vulns']
+  ) {
     vulns = vulns.filter((vuln) => (vuln as DockerIssue).dockerfileInstruction);
   }
 

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -240,6 +240,44 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
       return;
     }
 
+    let dockerResults = {};
+    // To check --exclude-base-image-vulns
+    if (req.body.scanResult.target.image === 'docker-image|alpine') {
+      dockerResults = {
+        baseImage: 'something:0.0.1',
+        baseImageRemediation: {
+          advice: [],
+          code: 'REMEDIATION_AVAILABLE',
+        },
+        binariesVulns: {
+          affectedPkgs: {
+            'node/5.10.1': {
+              pkg: {
+                version: '5.10.1',
+                name: 'node',
+              },
+              issues: {
+                'SNYK-UPSTREAM-BZIP2-106947': {
+                  issueId: 'SNYK-UPSTREAM-BZIP2-106947',
+                  fixInfo: {
+                    upgradePaths: [],
+                    isPatchable: false,
+                    nearestFixedInVersion: '5.13.1',
+                  },
+                },
+              },
+            },
+          },
+          issuesData: {
+            'SNYK-UPSTREAM-BZIP2-106947': {
+              id: 'SNYK-UPSTREAM-NODE-72359',
+              severity: 'high',
+            },
+          },
+        },
+      };
+    }
+
     res.send({
       result: {
         issues: [],
@@ -270,6 +308,7 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
             ],
           },
         },
+        docker: dockerResults,
       },
       meta: {
         org: 'test-org',


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Fixes an issue where `--exclude-base-image-vulns` does not work properly when the base image is auto detected, without using `--file`


#### How should this be manually tested?

`snyk container test alpine:3.10` with/without `--exclude-base-image-vulns`

