### PR TITLE
Cleanup some Jest tests

### DIFF
--- a/test/fixtures/qs-package/test-dep-graph-result-trust-policies.json
+++ b/test/fixtures/qs-package/test-dep-graph-result-trust-policies.json
@@ -1,0 +1,12325 @@
+{
+  "result": {
+    "affectedPkgs": {
+      "bl@0.9.5": {
+        "pkg": {
+          "name": "bl",
+          "version": "0.9.5"
+        },
+        "issues": {
+          "SNYK-JS-BL-608877": {
+            "issueId": "SNYK-JS-BL-608877",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "bl@1.1.2": {
+        "pkg": {
+          "name": "bl",
+          "version": "1.1.2"
+        },
+        "issues": {
+          "SNYK-JS-BL-608877": {
+            "issueId": "SNYK-JS-BL-608877",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.76.0"
+                    },
+                    {
+                      "name": "bl",
+                      "version": "1.1.2",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "dot-prop@2.4.0": {
+        "pkg": {
+          "name": "dot-prop",
+          "version": "2.4.0"
+        },
+        "issues": {
+          "SNYK-JS-DOTPROP-543489": {
+            "issueId": "SNYK-JS-DOTPROP-543489",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "hosted-git-info@2.1.5": {
+        "pkg": {
+          "name": "hosted-git-info",
+          "version": "2.1.5"
+        },
+        "issues": {
+          "SNYK-JS-HOSTEDGITINFO-1088355": {
+            "issueId": "SNYK-JS-HOSTEDGITINFO-1088355",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-module",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "hosted-git-info",
+                      "version": "2.1.5",
+                      "newVersion": "2.8.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-policy",
+                      "version": "1.5.2",
+                      "newVersion": "1.5.2"
+                    },
+                    {
+                      "name": "snyk-module",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "hosted-git-info",
+                      "version": "2.1.5",
+                      "newVersion": "2.8.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "snyk-module",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "hosted-git-info",
+                      "version": "2.1.5",
+                      "newVersion": "2.8.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "yargs",
+                      "version": "4.8.1",
+                      "newVersion": "4.8.1"
+                    },
+                    {
+                      "name": "read-pkg-up",
+                      "version": "1.0.1",
+                      "newVersion": "1.0.1"
+                    },
+                    {
+                      "name": "read-pkg",
+                      "version": "1.1.0",
+                      "newVersion": "1.1.0"
+                    },
+                    {
+                      "name": "normalize-package-data",
+                      "version": "2.3.5",
+                      "newVersion": "2.3.5"
+                    },
+                    {
+                      "name": "hosted-git-info",
+                      "version": "2.1.5",
+                      "newVersion": "2.8.9"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "ini@1.3.4": {
+        "pkg": {
+          "name": "ini",
+          "version": "1.3.4"
+        },
+        "issues": {
+          "SNYK-JS-INI-1048974": {
+            "issueId": "SNYK-JS-INI-1048974",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-config",
+                      "version": "1.0.1",
+                      "newVersion": "1.0.1"
+                    },
+                    {
+                      "name": "nconf",
+                      "version": "0.7.2",
+                      "newVersion": "0.7.2"
+                    },
+                    {
+                      "name": "ini",
+                      "version": "1.3.4",
+                      "newVersion": "1.3.6"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.5.0",
+                      "newVersion": "0.5.0"
+                    },
+                    {
+                      "name": "latest-version",
+                      "version": "1.0.1",
+                      "newVersion": "1.0.1"
+                    },
+                    {
+                      "name": "package-json",
+                      "version": "1.2.0",
+                      "newVersion": "1.2.0"
+                    },
+                    {
+                      "name": "registry-url",
+                      "version": "3.1.0",
+                      "newVersion": "3.1.0"
+                    },
+                    {
+                      "name": "rc",
+                      "version": "1.1.6",
+                      "newVersion": "1.1.6"
+                    },
+                    {
+                      "name": "ini",
+                      "version": "1.3.4",
+                      "newVersion": "1.3.6"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.6.3",
+                      "newVersion": "0.6.3"
+                    },
+                    {
+                      "name": "latest-version",
+                      "version": "2.0.0",
+                      "newVersion": "2.0.0"
+                    },
+                    {
+                      "name": "package-json",
+                      "version": "2.3.3",
+                      "newVersion": "2.3.3"
+                    },
+                    {
+                      "name": "rc",
+                      "version": "1.1.6",
+                      "newVersion": "1.1.6"
+                    },
+                    {
+                      "name": "ini",
+                      "version": "1.3.4",
+                      "newVersion": "1.3.6"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.6.3",
+                      "newVersion": "0.6.3"
+                    },
+                    {
+                      "name": "latest-version",
+                      "version": "2.0.0",
+                      "newVersion": "2.0.0"
+                    },
+                    {
+                      "name": "package-json",
+                      "version": "2.3.3",
+                      "newVersion": "2.3.3"
+                    },
+                    {
+                      "name": "registry-url",
+                      "version": "3.1.0",
+                      "newVersion": "3.1.0"
+                    },
+                    {
+                      "name": "rc",
+                      "version": "1.1.6",
+                      "newVersion": "1.1.6"
+                    },
+                    {
+                      "name": "ini",
+                      "version": "1.3.4",
+                      "newVersion": "1.3.6"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "is-my-json-valid@2.13.1": {
+        "pkg": {
+          "name": "is-my-json-valid",
+          "version": "2.13.1"
+        },
+        "issues": {
+          "SNYK-JS-ISMYJSONVALID-597165": {
+            "issueId": "SNYK-JS-ISMYJSONVALID-597165",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.57.0",
+                      "newVersion": "2.57.0"
+                    },
+                    {
+                      "name": "har-validator",
+                      "version": "1.8.0",
+                      "newVersion": "1.8.0"
+                    },
+                    {
+                      "name": "is-my-json-valid",
+                      "version": "2.13.1",
+                      "newVersion": "2.20.2"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.74.0"
+                    },
+                    {
+                      "name": "har-validator",
+                      "version": "2.0.6",
+                      "newVersion": "2.0.6"
+                    },
+                    {
+                      "name": "is-my-json-valid",
+                      "version": "2.13.1",
+                      "newVersion": "2.20.2"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-ISMYJSONVALID-597167": {
+            "issueId": "SNYK-JS-ISMYJSONVALID-597167",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.57.0",
+                      "newVersion": "2.57.0"
+                    },
+                    {
+                      "name": "har-validator",
+                      "version": "1.8.0",
+                      "newVersion": "1.8.0"
+                    },
+                    {
+                      "name": "is-my-json-valid",
+                      "version": "2.13.1",
+                      "newVersion": "2.20.3"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.74.0"
+                    },
+                    {
+                      "name": "har-validator",
+                      "version": "2.0.6",
+                      "newVersion": "2.0.6"
+                    },
+                    {
+                      "name": "is-my-json-valid",
+                      "version": "2.13.1",
+                      "newVersion": "2.20.3"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "npm:is-my-json-valid:20180214": {
+            "issueId": "npm:is-my-json-valid:20180214",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.57.0",
+                      "newVersion": "2.57.0"
+                    },
+                    {
+                      "name": "har-validator",
+                      "version": "1.8.0",
+                      "newVersion": "1.8.0"
+                    },
+                    {
+                      "name": "is-my-json-valid",
+                      "version": "2.13.1",
+                      "newVersion": "2.17.2"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.74.0"
+                    },
+                    {
+                      "name": "har-validator",
+                      "version": "2.0.6",
+                      "newVersion": "2.0.6"
+                    },
+                    {
+                      "name": "is-my-json-valid",
+                      "version": "2.13.1",
+                      "newVersion": "2.17.2"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "jsonpointer@2.0.0": {
+        "pkg": {
+          "name": "jsonpointer",
+          "version": "2.0.0"
+        },
+        "issues": {
+          "SNYK-JS-JSONPOINTER-598804": {
+            "issueId": "SNYK-JS-JSONPOINTER-598804",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.57.0",
+                      "newVersion": "2.57.0"
+                    },
+                    {
+                      "name": "har-validator",
+                      "version": "1.8.0",
+                      "newVersion": "1.8.0"
+                    },
+                    {
+                      "name": "is-my-json-valid",
+                      "version": "2.13.1",
+                      "newVersion": "2.15.0"
+                    },
+                    {
+                      "name": "jsonpointer",
+                      "version": "2.0.0",
+                      "newVersion": "4.1.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.74.0"
+                    },
+                    {
+                      "name": "har-validator",
+                      "version": "2.0.6",
+                      "newVersion": "2.0.6"
+                    },
+                    {
+                      "name": "is-my-json-valid",
+                      "version": "2.13.1",
+                      "newVersion": "2.15.0"
+                    },
+                    {
+                      "name": "jsonpointer",
+                      "version": "2.0.0",
+                      "newVersion": "4.1.0"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "js-yaml@3.6.1": {
+        "pkg": {
+          "name": "js-yaml",
+          "version": "3.6.1"
+        },
+        "issues": {
+          "SNYK-JS-JSYAML-173999": {
+            "issueId": "SNYK-JS-JSYAML-173999",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-policy",
+                      "version": "1.5.2",
+                      "newVersion": "1.5.2"
+                    },
+                    {
+                      "name": "js-yaml",
+                      "version": "3.6.1",
+                      "newVersion": "3.13.0"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-JSYAML-174129": {
+            "issueId": "SNYK-JS-JSYAML-174129",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-policy",
+                      "version": "1.5.2",
+                      "newVersion": "1.5.2"
+                    },
+                    {
+                      "name": "js-yaml",
+                      "version": "3.6.1",
+                      "newVersion": "3.13.1"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "lodash@4.14.0": {
+        "pkg": {
+          "name": "lodash",
+          "version": "4.14.0"
+        },
+        "issues": {
+          "SNYK-JS-LODASH-1018905": {
+            "issueId": "SNYK-JS-LODASH-1018905",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "inquirer",
+                      "version": "1.0.3",
+                      "newVersion": "1.0.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.21"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.21"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-1040724": {
+            "issueId": "SNYK-JS-LODASH-1040724",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "inquirer",
+                      "version": "1.0.3",
+                      "newVersion": "1.0.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.21"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.21"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-450202": {
+            "issueId": "SNYK-JS-LODASH-450202",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "inquirer",
+                      "version": "1.0.3",
+                      "newVersion": "1.0.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.12"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.12"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-567746": {
+            "issueId": "SNYK-JS-LODASH-567746",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "inquirer",
+                      "version": "1.0.3",
+                      "newVersion": "1.0.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.16"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.16"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-590103": {
+            "issueId": "SNYK-JS-LODASH-590103",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "inquirer",
+                      "version": "1.0.3",
+                      "newVersion": "1.0.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.20"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.20"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-608086": {
+            "issueId": "SNYK-JS-LODASH-608086",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "inquirer",
+                      "version": "1.0.3",
+                      "newVersion": "1.0.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.17"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.17"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-73638": {
+            "issueId": "SNYK-JS-LODASH-73638",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "inquirer",
+                      "version": "1.0.3",
+                      "newVersion": "1.0.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.11"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.11"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-73639": {
+            "issueId": "SNYK-JS-LODASH-73639",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "inquirer",
+                      "version": "1.0.3",
+                      "newVersion": "1.0.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.11"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.11"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "npm:lodash:20180130": {
+            "issueId": "npm:lodash:20180130",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "inquirer",
+                      "version": "1.0.3",
+                      "newVersion": "1.0.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.5"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.5"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "lodash@3.10.1": {
+        "pkg": {
+          "name": "lodash",
+          "version": "3.10.1"
+        },
+        "issues": {
+          "SNYK-JS-LODASH-1018905": {
+            "issueId": "SNYK-JS-LODASH-1018905",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.19.1"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "3.10.1",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-1040724": {
+            "issueId": "SNYK-JS-LODASH-1040724",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.19.1"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "3.10.1",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-450202": {
+            "issueId": "SNYK-JS-LODASH-450202",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.19.1"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "3.10.1",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-567746": {
+            "issueId": "SNYK-JS-LODASH-567746",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.19.1"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "3.10.1",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-590103": {
+            "issueId": "SNYK-JS-LODASH-590103",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.19.1"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "3.10.1",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-608086": {
+            "issueId": "SNYK-JS-LODASH-608086",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.19.1"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "3.10.1",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-73638": {
+            "issueId": "SNYK-JS-LODASH-73638",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.19.1"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "3.10.1",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-73639": {
+            "issueId": "SNYK-JS-LODASH-73639",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.19.1"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "3.10.1",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "npm:lodash:20180130": {
+            "issueId": "npm:lodash:20180130",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.19.1"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "3.10.1",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "lodash.defaultsdeep@4.5.0": {
+        "pkg": {
+          "name": "lodash.defaultsdeep",
+          "version": "4.5.0"
+        },
+        "issues": {
+          "SNYK-JS-LODASHDEFAULTSDEEP-450198": {
+            "issueId": "SNYK-JS-LODASHDEFAULTSDEEP-450198",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "lodash.defaultsdeep",
+                      "version": "4.5.0",
+                      "newVersion": "4.6.1"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASHDEFAULTSDEEP-450199": {
+            "issueId": "SNYK-JS-LODASHDEFAULTSDEEP-450199",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "lodash.defaultsdeep",
+                      "version": "4.5.0",
+                      "newVersion": "4.6.1"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "lodash.mergewith@4.5.0": {
+        "pkg": {
+          "name": "lodash.mergewith",
+          "version": "4.5.0"
+        },
+        "issues": {
+          "SNYK-JS-LODASHMERGEWITH-174136": {
+            "issueId": "SNYK-JS-LODASHMERGEWITH-174136",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "lodash.mergewith",
+                      "version": "4.5.0",
+                      "newVersion": "4.6.2"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASHMERGEWITH-174137": {
+            "issueId": "SNYK-JS-LODASHMERGEWITH-174137",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "lodash.mergewith",
+                      "version": "4.5.0",
+                      "newVersion": "4.6.1"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "minimist@0.0.8": {
+        "pkg": {
+          "name": "minimist",
+          "version": "0.0.8"
+        },
+        "issues": {
+          "SNYK-JS-MINIMIST-559764": {
+            "issueId": "SNYK-JS-MINIMIST-559764",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "configstore",
+                      "version": "1.4.0",
+                      "newVersion": "1.4.0"
+                    },
+                    {
+                      "name": "mkdirp",
+                      "version": "0.5.1",
+                      "newVersion": "0.5.2"
+                    },
+                    {
+                      "name": "minimist",
+                      "version": "0.0.8",
+                      "newVersion": "1.2.5"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.5.0",
+                      "newVersion": "0.5.0"
+                    },
+                    {
+                      "name": "configstore",
+                      "version": "1.4.0",
+                      "newVersion": "1.4.0"
+                    },
+                    {
+                      "name": "mkdirp",
+                      "version": "0.5.1",
+                      "newVersion": "0.5.2"
+                    },
+                    {
+                      "name": "minimist",
+                      "version": "0.0.8",
+                      "newVersion": "1.2.5"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.6.3",
+                      "newVersion": "0.6.3"
+                    },
+                    {
+                      "name": "configstore",
+                      "version": "2.0.0",
+                      "newVersion": "2.0.0"
+                    },
+                    {
+                      "name": "mkdirp",
+                      "version": "0.5.1",
+                      "newVersion": "0.5.2"
+                    },
+                    {
+                      "name": "minimist",
+                      "version": "0.0.8",
+                      "newVersion": "1.2.5"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "minimist@1.2.0": {
+        "pkg": {
+          "name": "minimist",
+          "version": "1.2.0"
+        },
+        "issues": {
+          "SNYK-JS-MINIMIST-559764": {
+            "issueId": "SNYK-JS-MINIMIST-559764",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "minimist",
+                      "version": "1.2.0",
+                      "newVersion": "1.2.3"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "os-name",
+                      "version": "1.0.3",
+                      "newVersion": "1.0.3"
+                    },
+                    {
+                      "name": "osx-release",
+                      "version": "1.1.0",
+                      "newVersion": "1.1.0"
+                    },
+                    {
+                      "name": "minimist",
+                      "version": "1.2.0",
+                      "newVersion": "1.2.3"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.5.0",
+                      "newVersion": "0.5.0"
+                    },
+                    {
+                      "name": "latest-version",
+                      "version": "1.0.1",
+                      "newVersion": "1.0.1"
+                    },
+                    {
+                      "name": "package-json",
+                      "version": "1.2.0",
+                      "newVersion": "1.2.0"
+                    },
+                    {
+                      "name": "registry-url",
+                      "version": "3.1.0",
+                      "newVersion": "3.1.0"
+                    },
+                    {
+                      "name": "rc",
+                      "version": "1.1.6",
+                      "newVersion": "1.1.6"
+                    },
+                    {
+                      "name": "minimist",
+                      "version": "1.2.0",
+                      "newVersion": "1.2.3"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.6.3",
+                      "newVersion": "0.6.3"
+                    },
+                    {
+                      "name": "latest-version",
+                      "version": "2.0.0",
+                      "newVersion": "2.0.0"
+                    },
+                    {
+                      "name": "package-json",
+                      "version": "2.3.3",
+                      "newVersion": "2.3.3"
+                    },
+                    {
+                      "name": "rc",
+                      "version": "1.1.6",
+                      "newVersion": "1.1.6"
+                    },
+                    {
+                      "name": "minimist",
+                      "version": "1.2.0",
+                      "newVersion": "1.2.3"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.6.3",
+                      "newVersion": "0.6.3"
+                    },
+                    {
+                      "name": "latest-version",
+                      "version": "2.0.0",
+                      "newVersion": "2.0.0"
+                    },
+                    {
+                      "name": "package-json",
+                      "version": "2.3.3",
+                      "newVersion": "2.3.3"
+                    },
+                    {
+                      "name": "registry-url",
+                      "version": "3.1.0",
+                      "newVersion": "3.1.0"
+                    },
+                    {
+                      "name": "rc",
+                      "version": "1.1.6",
+                      "newVersion": "1.1.6"
+                    },
+                    {
+                      "name": "minimist",
+                      "version": "1.2.0",
+                      "newVersion": "1.2.3"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "open@0.0.5": {
+        "pkg": {
+          "name": "open",
+          "version": "0.0.5"
+        },
+        "issues": {
+          "SNYK-JS-OPEN-174041": {
+            "issueId": "SNYK-JS-OPEN-174041",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.76.0"
+                    },
+                    {
+                      "name": "open",
+                      "version": "0.0.5",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "npm:open:20180512": {
+            "issueId": "npm:open:20180512",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.76.0"
+                    },
+                    {
+                      "name": "open",
+                      "version": "0.0.5",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "request@2.57.0": {
+        "pkg": {
+          "name": "request",
+          "version": "2.57.0"
+        },
+        "issues": {
+          "SNYK-JS-REQUEST-1314897": {
+            "issueId": "SNYK-JS-REQUEST-1314897",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [],
+              "isPinnable": false
+            }
+          },
+          "npm:request:20160119": {
+            "issueId": "npm:request:20160119",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "request@2.74.0": {
+        "pkg": {
+          "name": "request",
+          "version": "2.74.0"
+        },
+        "issues": {
+          "SNYK-JS-REQUEST-1314897": {
+            "issueId": "SNYK-JS-REQUEST-1314897",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "undefsafe@0.0.3": {
+        "pkg": {
+          "name": "undefsafe",
+          "version": "0.0.3"
+        },
+        "issues": {
+          "SNYK-JS-UNDEFSAFE-548940": {
+            "issueId": "SNYK-JS-UNDEFSAFE-548940",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.78.0"
+                    },
+                    {
+                      "name": "undefsafe",
+                      "version": "0.0.3",
+                      "newVersion": "2.0.3"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "y18n@3.2.1": {
+        "pkg": {
+          "name": "y18n",
+          "version": "3.2.1"
+        },
+        "issues": {
+          "SNYK-JS-Y18N-1021887": {
+            "issueId": "SNYK-JS-Y18N-1021887",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "yargs",
+                      "version": "4.8.1",
+                      "newVersion": "4.8.1"
+                    },
+                    {
+                      "name": "y18n",
+                      "version": "3.2.1",
+                      "newVersion": "3.2.2"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "brace-expansion@1.1.6": {
+        "pkg": {
+          "name": "brace-expansion",
+          "version": "1.1.6"
+        },
+        "issues": {
+          "npm:brace-expansion:20170302": {
+            "issueId": "npm:brace-expansion:20170302",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-recursive-readdir",
+                      "version": "2.0.0",
+                      "newVersion": "2.0.0"
+                    },
+                    {
+                      "name": "minimatch",
+                      "version": "3.0.2",
+                      "newVersion": "3.0.2"
+                    },
+                    {
+                      "name": "brace-expansion",
+                      "version": "1.1.6",
+                      "newVersion": "1.1.7"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "debug@2.2.0": {
+        "pkg": {
+          "name": "debug",
+          "version": "2.2.0"
+        },
+        "issues": {
+          "npm:debug:20170905": {
+            "issueId": "npm:debug:20170905",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-config",
+                      "version": "1.0.1",
+                      "newVersion": "1.0.1"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-module",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-try-require",
+                      "version": "1.1.1",
+                      "newVersion": "1.1.1"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-policy",
+                      "version": "1.5.2",
+                      "newVersion": "1.5.2"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-policy",
+                      "version": "1.5.2",
+                      "newVersion": "1.5.2"
+                    },
+                    {
+                      "name": "snyk-module",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "snyk-module",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-policy",
+                      "version": "1.5.2",
+                      "newVersion": "1.5.2"
+                    },
+                    {
+                      "name": "snyk-try-require",
+                      "version": "1.1.1",
+                      "newVersion": "1.1.1"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "snyk-try-require",
+                      "version": "1.1.1",
+                      "newVersion": "1.1.1"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "deep-extend@0.4.1": {
+        "pkg": {
+          "name": "deep-extend",
+          "version": "0.4.1"
+        },
+        "issues": {
+          "npm:deep-extend:20180409": {
+            "issueId": "npm:deep-extend:20180409",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.5.0",
+                      "newVersion": "0.5.0"
+                    },
+                    {
+                      "name": "latest-version",
+                      "version": "1.0.1",
+                      "newVersion": "1.0.1"
+                    },
+                    {
+                      "name": "package-json",
+                      "version": "1.2.0",
+                      "newVersion": "1.2.0"
+                    },
+                    {
+                      "name": "registry-url",
+                      "version": "3.1.0",
+                      "newVersion": "3.1.0"
+                    },
+                    {
+                      "name": "rc",
+                      "version": "1.1.6",
+                      "newVersion": "1.2.7"
+                    },
+                    {
+                      "name": "deep-extend",
+                      "version": "0.4.1",
+                      "newVersion": "0.5.1"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.6.3",
+                      "newVersion": "0.6.3"
+                    },
+                    {
+                      "name": "latest-version",
+                      "version": "2.0.0",
+                      "newVersion": "2.0.0"
+                    },
+                    {
+                      "name": "package-json",
+                      "version": "2.3.3",
+                      "newVersion": "2.3.3"
+                    },
+                    {
+                      "name": "rc",
+                      "version": "1.1.6",
+                      "newVersion": "1.2.7"
+                    },
+                    {
+                      "name": "deep-extend",
+                      "version": "0.4.1",
+                      "newVersion": "0.5.1"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.6.3",
+                      "newVersion": "0.6.3"
+                    },
+                    {
+                      "name": "latest-version",
+                      "version": "2.0.0",
+                      "newVersion": "2.0.0"
+                    },
+                    {
+                      "name": "package-json",
+                      "version": "2.3.3",
+                      "newVersion": "2.3.3"
+                    },
+                    {
+                      "name": "registry-url",
+                      "version": "3.1.0",
+                      "newVersion": "3.1.0"
+                    },
+                    {
+                      "name": "rc",
+                      "version": "1.1.6",
+                      "newVersion": "1.2.7"
+                    },
+                    {
+                      "name": "deep-extend",
+                      "version": "0.4.1",
+                      "newVersion": "0.5.1"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "extend@3.0.0": {
+        "pkg": {
+          "name": "extend",
+          "version": "3.0.0"
+        },
+        "issues": {
+          "npm:extend:20180424": {
+            "issueId": "npm:extend:20180424",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.74.0"
+                    },
+                    {
+                      "name": "extend",
+                      "version": "3.0.0",
+                      "newVersion": "3.0.2"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "hawk@2.3.1": {
+        "pkg": {
+          "name": "hawk",
+          "version": "2.3.1"
+        },
+        "issues": {
+          "npm:hawk:20160119": {
+            "issueId": "npm:hawk:20160119",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "hoek@2.16.3": {
+        "pkg": {
+          "name": "hoek",
+          "version": "2.16.3"
+        },
+        "issues": {
+          "npm:hoek:20180212": {
+            "issueId": "npm:hoek:20180212",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.82.0"
+                    },
+                    {
+                      "name": "hawk",
+                      "version": "3.1.3",
+                      "newVersion": "6.0.2"
+                    },
+                    {
+                      "name": "hoek",
+                      "version": "2.16.3",
+                      "newVersion": "4.2.1"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.82.0"
+                    },
+                    {
+                      "name": "hawk",
+                      "version": "3.1.3",
+                      "newVersion": "6.0.2"
+                    },
+                    {
+                      "name": "boom",
+                      "version": "2.10.1",
+                      "newVersion": "4.0.0"
+                    },
+                    {
+                      "name": "hoek",
+                      "version": "2.16.3",
+                      "newVersion": "4.2.1"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.82.0"
+                    },
+                    {
+                      "name": "hawk",
+                      "version": "3.1.3",
+                      "newVersion": "6.0.2"
+                    },
+                    {
+                      "name": "sntp",
+                      "version": "1.0.9",
+                      "newVersion": "2.0.1"
+                    },
+                    {
+                      "name": "hoek",
+                      "version": "2.16.3",
+                      "newVersion": "4.2.1"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.82.0"
+                    },
+                    {
+                      "name": "hawk",
+                      "version": "3.1.3",
+                      "newVersion": "6.0.2"
+                    },
+                    {
+                      "name": "cryptiles",
+                      "version": "2.0.5",
+                      "newVersion": "3.0.0"
+                    },
+                    {
+                      "name": "boom",
+                      "version": "2.10.1",
+                      "newVersion": "3.1.3"
+                    },
+                    {
+                      "name": "hoek",
+                      "version": "2.16.3",
+                      "newVersion": "4.2.1"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "http-signature@0.11.0": {
+        "pkg": {
+          "name": "http-signature",
+          "version": "0.11.0"
+        },
+        "issues": {
+          "npm:http-signature:20150122": {
+            "issueId": "npm:http-signature:20150122",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "ms@0.7.1": {
+        "pkg": {
+          "name": "ms",
+          "version": "0.7.1"
+        },
+        "issues": {
+          "npm:ms:20170412": {
+            "issueId": "npm:ms:20170412",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-config",
+                      "version": "1.0.1",
+                      "newVersion": "1.0.1"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-module",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-try-require",
+                      "version": "1.1.1",
+                      "newVersion": "1.1.1"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-policy",
+                      "version": "1.5.2",
+                      "newVersion": "1.5.2"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-policy",
+                      "version": "1.5.2",
+                      "newVersion": "1.5.2"
+                    },
+                    {
+                      "name": "snyk-module",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "snyk-module",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-policy",
+                      "version": "1.5.2",
+                      "newVersion": "1.5.2"
+                    },
+                    {
+                      "name": "snyk-try-require",
+                      "version": "1.1.1",
+                      "newVersion": "1.1.1"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "snyk-try-require",
+                      "version": "1.1.1",
+                      "newVersion": "1.1.1"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "qs@0.6.6": {
+        "pkg": {
+          "name": "qs",
+          "version": "0.6.6"
+        },
+        "issues": {
+          "npm:qs:20140806": {
+            "issueId": "npm:qs:20140806",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "qs",
+                      "version": "0.6.6",
+                      "newVersion": "1.0.0"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "npm:qs:20140806-1": {
+            "issueId": "npm:qs:20140806-1",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "qs",
+                      "version": "0.6.6",
+                      "newVersion": "1.0.0"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "npm:qs:20170213": {
+            "issueId": "npm:qs:20170213",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "qs",
+                      "version": "0.6.6",
+                      "newVersion": "6.0.4"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "qs@3.1.0": {
+        "pkg": {
+          "name": "qs",
+          "version": "3.1.0"
+        },
+        "issues": {
+          "npm:qs:20170213": {
+            "issueId": "npm:qs:20170213",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "qs@6.2.1": {
+        "pkg": {
+          "name": "qs",
+          "version": "6.2.1"
+        },
+        "issues": {
+          "npm:qs:20170213": {
+            "issueId": "npm:qs:20170213",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.74.0"
+                    },
+                    {
+                      "name": "qs",
+                      "version": "6.2.1",
+                      "newVersion": "6.2.3"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "semver@2.3.2": {
+        "pkg": {
+          "name": "semver",
+          "version": "2.3.2"
+        },
+        "issues": {
+          "npm:semver:20150403": {
+            "issueId": "npm:semver:20150403",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "sshpk@1.9.1": {
+        "pkg": {
+          "name": "sshpk",
+          "version": "1.9.1"
+        },
+        "issues": {
+          "npm:sshpk:20180409": {
+            "issueId": "npm:sshpk:20180409",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.74.0"
+                    },
+                    {
+                      "name": "http-signature",
+                      "version": "1.1.1",
+                      "newVersion": "1.1.1"
+                    },
+                    {
+                      "name": "sshpk",
+                      "version": "1.9.1",
+                      "newVersion": "1.14.1"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "stringstream@0.0.5": {
+        "pkg": {
+          "name": "stringstream",
+          "version": "0.0.5"
+        },
+        "issues": {
+          "npm:stringstream:20180511": {
+            "issueId": "npm:stringstream:20180511",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.57.0",
+                      "newVersion": "2.57.0"
+                    },
+                    {
+                      "name": "stringstream",
+                      "version": "0.0.5",
+                      "newVersion": "0.0.6"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.74.0"
+                    },
+                    {
+                      "name": "stringstream",
+                      "version": "0.0.5",
+                      "newVersion": "0.0.6"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "tough-cookie@2.3.1": {
+        "pkg": {
+          "name": "tough-cookie",
+          "version": "2.3.1"
+        },
+        "issues": {
+          "npm:tough-cookie:20170905": {
+            "issueId": "npm:tough-cookie:20170905",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.57.0",
+                      "newVersion": "2.57.0"
+                    },
+                    {
+                      "name": "tough-cookie",
+                      "version": "2.3.1",
+                      "newVersion": "2.3.3"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.74.0"
+                    },
+                    {
+                      "name": "tough-cookie",
+                      "version": "2.3.1",
+                      "newVersion": "2.3.3"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "tunnel-agent@0.4.3": {
+        "pkg": {
+          "name": "tunnel-agent",
+          "version": "0.4.3"
+        },
+        "issues": {
+          "npm:tunnel-agent:20170305": {
+            "issueId": "npm:tunnel-agent:20170305",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.81.0"
+                    },
+                    {
+                      "name": "tunnel-agent",
+                      "version": "0.4.3",
+                      "newVersion": "0.6.0"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      }
+    },
+    "issuesData": {
+      "SNYK-JS-BL-608877": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:L/A:L/E:P",
+        "alternativeIds": [],
+        "creationTime": "2020-08-28T12:18:44.906258Z",
+        "credit": [
+          "chalker"
+        ],
+        "cvssScore": 7.7,
+        "description": "## Overview\n[bl](https://github.com/rvagg/bl) is a library that allows you to collect buffers and access with a standard readable buffer interface.\n\nAffected versions of this package are vulnerable to Remote Memory Exposure. If user input ends up in `consume()` argument and can become negative, BufferList state can be corrupted, tricking it into exposing uninitialized memory via regular `.slice()` calls.\r\n\r\n### PoC by chalker\r\n```\r\nconst { BufferList } = require('bl')\r\nconst secret = require('crypto').randomBytes(256)\r\nfor (let i = 0; i < 1e6; i++) {\r\n  const clone = Buffer.from(secret)\r\n  const bl = new BufferList()\r\n  bl.append(Buffer.from('a'))\r\n  bl.consume(-1024)\r\n  const buf = bl.slice(1)\r\n  if (buf.indexOf(clone) !== -1) {\r\n    console.error(`Match (at ${i})`, buf)\r\n  }\r\n}\r\n```\n## Remediation\nUpgrade `bl` to version 2.2.1, 3.0.1, 4.0.3, 1.2.3 or higher.\n## References\n- [Github Commit](https://github.com/rvagg/bl/commit/8a8c13c880e2bef519133ea43e0e9b78b5d0c91e)\n- [Github Commit](https://github.com/rvagg/bl/commit/d3e240e3b8ba4048d3c76ef5fb9dd1f8872d3190)\n- [Github Commit](https://github.com/rvagg/bl/commit/dacc4ac7d5fcd6201bcf26fbd886951be9537466)\n- [GitHub Commit](https://github.com/rvagg/bl/commit/0bd87ec97be399b129fc62feff2943ffa21bcc00)\n- [HackerOne Report](https://hackerone.com/reports/966347)\n",
+        "disclosureTime": "2020-08-27T15:16:42Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "2.2.1",
+          "3.0.1",
+          "4.0.3",
+          "1.2.3"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-BL-608877",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-8244"
+          ],
+          "CWE": [
+            "CWE-9"
+          ],
+          "GHSA": [
+            "GHSA-pp7h-53gx-mx7r"
+          ],
+          "NSP": [
+            "1555"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-09-04T12:31:03.817670Z",
+        "moduleName": "bl",
+        "packageManager": "npm",
+        "packageName": "bl",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-08-28T12:18:48Z",
+        "references": [
+          {
+            "title": "Github Commit",
+            "url": "https://github.com/rvagg/bl/commit/8a8c13c880e2bef519133ea43e0e9b78b5d0c91e"
+          },
+          {
+            "title": "Github Commit",
+            "url": "https://github.com/rvagg/bl/commit/d3e240e3b8ba4048d3c76ef5fb9dd1f8872d3190"
+          },
+          {
+            "title": "Github Commit",
+            "url": "https://github.com/rvagg/bl/commit/dacc4ac7d5fcd6201bcf26fbd886951be9537466"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/rvagg/bl/commit/0bd87ec97be399b129fc62feff2943ffa21bcc00"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/966347"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            ">=2.2.0 <2.2.1",
+            ">=3.0.0 <3.0.1",
+            ">=4.0.0 <4.0.3",
+            "<1.2.3"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Remote Memory Exposure"
+      },
+      "SNYK-JS-DOTPROP-543489": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-01-28T15:18:37.743372Z",
+        "credit": [
+          "aaron_costello"
+        ],
+        "cvssScore": 6.3,
+        "description": "## Overview\n[dot-prop](https://github.com/sindresorhus/dot-prop#readme) is a package to get, set, or delete a property from a nested object using a dot path.\n\nAffected versions of this package are vulnerable to Prototype Pollution. It is possible for a user to modify the prototype of a base object.\r\n\r\n## PoC by aaron_costello \r\n```\r\nvar dotProp = require(\"dot-prop\")\r\nconst object = {};\r\nconsole.log(\"Before \" + object.b); //Undefined\r\ndotProp.set(object, '__proto__.b', true);\r\nconsole.log(\"After \" + {}.b); //true\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `dot-prop` to version 4.2.1, 5.1.1 or higher.\n## References\n- [GitHub Commit](https://github.com/sindresorhus/dot-prop/commit/3039c8c07f6fdaa8b595ec869ae0895686a7a0f2)\n- [HackerOne Report](https://hackerone.com/reports/719856)\n",
+        "disclosureTime": "2020-01-28T10:17:51Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.2.1",
+          "5.1.1"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports.set"
+            },
+            "version": [
+              ">1.0.1 <5.1.1"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports.set"
+            },
+            "version": [
+              ">1.0.1 <5.1.1"
+            ]
+          }
+        ],
+        "id": "SNYK-JS-DOTPROP-543489",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-8116"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-ff7x-qrg7-qggm"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-27T08:47:24.715335Z",
+        "moduleName": "dot-prop",
+        "packageManager": "npm",
+        "packageName": "dot-prop",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-01-28T16:23:39Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/sindresorhus/dot-prop/commit/3039c8c07f6fdaa8b595ec869ae0895686a7a0f2"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/719856"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            ">1.0.1 <4.2.1",
+            ">=5.0.0 <5.1.1"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-HOSTEDGITINFO-1088355": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2021-03-23T16:13:42.109692Z",
+        "credit": [
+          "Yeting Li"
+        ],
+        "cvssScore": 5.3,
+        "description": "## Overview\n[hosted-git-info](https://www.npmjs.org/package/hosted-git-info) is a Provides metadata and conversions from repository urls for Github, Bitbucket and Gitlab\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) via regular expression `shortcutMatch ` in the `fromUrl` function in index.js. The affected regular expression exhibits polynomial worst-case time complexity.\r\n\r\n### PoC by Yeting Li\r\n```\r\nvar hostedGitInfo = require(\"hosted-git-info\")\r\nfunction build_attack(n) {\r\n    var ret = \"a:\"\r\n    for (var i = 0; i < n; i++) {\r\n        ret += \"a\"\r\n    }\r\n    return ret + \"!\";\r\n}\r\n\r\nfor(var i = 1; i <= 5000000; i++) {\r\n   if (i % 1000 == 0) {\r\n        var time = Date.now();\r\n        var attack_str = build_attack(i)\r\n       var parsedInfo = hostedGitInfo.fromUrl(attack_str)\r\n        var time_cost = Date.now() - time;\r\n        console.log(\"attack_str.length: \" + attack_str.length + \": \" + time_cost+\" ms\")\r\n}\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `hosted-git-info` to version 3.0.8, 2.8.9 or higher.\n## References\n- [GitHub Commit](https://github.com/npm/hosted-git-info/commit/bede0dc38e1785e732bf0a48ba6f81a4a908eba3)\n",
+        "disclosureTime": "2020-11-28T00:00:00Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "3.0.8",
+          "2.8.9"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-HOSTEDGITINFO-1088355",
+        "identifiers": {
+          "CVE": [
+            "CVE-2021-23362"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-43f8-2h32-f4cj"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2021-04-08T12:53:49.093606Z",
+        "moduleName": "hosted-git-info",
+        "packageManager": "npm",
+        "packageName": "hosted-git-info",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2021-03-23T17:13:24Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/npm/hosted-git-info/commit/bede0dc38e1785e732bf0a48ba6f81a4a908eba3"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            ">=3.0.0 <3.0.8",
+            "<2.8.9"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "SNYK-JS-INI-1048974": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P",
+        "alternativeIds": [],
+        "creationTime": "2020-12-08T15:34:07.743781Z",
+        "credit": [
+          "Eugene Lim",
+          "Government Technology Agency Cyber Security Group"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[ini](https://www.npmjs.org/package/ini) is an An ini encoder/decoder for node\n\nAffected versions of this package are vulnerable to Prototype Pollution. If an attacker submits a malicious INI file to an application that parses it with `ini.parse`, they will pollute the prototype on the application. This can be exploited further depending on the context.\r\n\r\n## PoC by Eugene Lim\r\n\r\npayload.ini\r\n```\r\n[__proto__]\r\npolluted = \"polluted\"\r\n```\r\n\r\npoc.js:\r\n```\r\nvar fs = require('fs')\r\nvar ini = require('ini')\r\n\r\nvar parsed = ini.parse(fs.readFileSync('./payload.ini', 'utf-8'))\r\nconsole.log(parsed)\r\nconsole.log(parsed.__proto__)\r\nconsole.log(polluted)\r\n```\r\n\r\n```\r\n> node poc.js\r\n{}\r\n{ polluted: 'polluted' }\r\n{ polluted: 'polluted' }\r\npolluted\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `ini` to version 1.3.6 or higher.\n## References\n- [Eugene Lim - Research Blog Post](https://medium.com/csg-govtech/supply-chain-pollution-discovering-a-16-million-download-week-node-js-2fa4d2c27cf7)\n- [GitHub Commit](https://github.com/npm/ini/commit/56d2805e07ccd94e2ba0984ac9240ff02d44b6f1)\n",
+        "disclosureTime": "2020-12-08T13:02:04Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "1.3.6"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-INI-1048974",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-7788"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-qqgx-2p2h-9c37"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-12-10T18:09:23.069283Z",
+        "moduleName": "ini",
+        "packageManager": "npm",
+        "packageName": "ini",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2020-12-10T18:08:38Z",
+        "references": [
+          {
+            "title": "Eugene Lim - Research Blog Post",
+            "url": "https://medium.com/csg-govtech/supply-chain-pollution-discovering-a-16-million-download-week-node-js-2fa4d2c27cf7"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/npm/ini/commit/56d2805e07ccd94e2ba0984ac9240ff02d44b6f1"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<1.3.6"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-ISMYJSONVALID-597165": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-08-02T12:09:52.577067Z",
+        "credit": [
+          "chalker"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n[is-my-json-valid](https://github.com/mafintosh/is-my-json-valid) is a JSONSchema / orderly validator that uses code generation to be extremely fast.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) via the `style` format. \r\n\r\n##PoC\r\n```\r\nconst imjv = require('is-my-json-valid')\r\nconst validate = imjv({ maxLength: 100, format: 'style' })\r\nconsole.log(validate(' '.repeat(1e4)))\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `is-my-json-valid` to version 2.20.2 or higher.\n## References\n- [GitHub Commit](https://github.com/mafintosh/is-my-json-valid/commit/c3fc04fc455d40e9b29537f8e2c73a28ce106edb)\n- [HackerOne Report](https://hackerone.com/reports/909757)\n",
+        "disclosureTime": "2020-07-31T17:13:38Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "2.20.2"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-ISMYJSONVALID-597165",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-02T15:04:47.420926Z",
+        "moduleName": "is-my-json-valid",
+        "packageManager": "npm",
+        "packageName": "is-my-json-valid",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-08-02T15:04:47.405171Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/mafintosh/is-my-json-valid/commit/c3fc04fc455d40e9b29537f8e2c73a28ce106edb"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/909757"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<2.20.2"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "SNYK-JS-ISMYJSONVALID-597167": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-08-02T12:14:47.006233Z",
+        "credit": [
+          "chalker"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[is-my-json-valid](https://github.com/mafintosh/is-my-json-valid) is a JSONSchema / orderly validator that uses code generation to be extremely fast.\n\nAffected versions of this package are vulnerable to Arbitrary Code Execution via the `formatName` function.\r\n\r\n##PoC\r\n```const validator = require('is-my-json-valid')\r\nconst schema = {\r\n  type: 'object',\r\n  properties: {\r\n    'x[console.log(process.mainModule.require(`child_process`).execSync(`cat /etc/passwd`).toString(`utf-8`))]': {\r\n      required: true,\r\n      type:'string'\r\n    }\r\n  },\r\n}\r\nvar validate = validator(schema);\r\nvalidate({})\r\n```\n## Remediation\nUpgrade `is-my-json-valid` to version 2.20.3 or higher.\n## References\n- [GitHub Commit](https://github.com/mafintosh/is-my-json-valid/commit/3419563687df463b4ca709a2b46be8e15d6a2b3d)\n- [HackerOne Report](https://hackerone.com/reports/894308)\n",
+        "disclosureTime": "2020-07-31T17:14:47Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "2.20.3"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-ISMYJSONVALID-597167",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-94"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-02T15:04:45.893491Z",
+        "moduleName": "is-my-json-valid",
+        "packageManager": "npm",
+        "packageName": "is-my-json-valid",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-08-02T15:04:45.880122Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/mafintosh/is-my-json-valid/commit/3419563687df463b4ca709a2b46be8e15d6a2b3d"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/894308"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<2.20.3"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Arbitrary Code Execution"
+      },
+      "SNYK-JS-JSONPOINTER-598804": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-08-17T15:07:51.732390Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 9.8,
+        "description": "## Overview\n[jsonpointer](https://www.npmjs.com/package/jsonpointer) is a Simple JSON Addressing.\n\nAffected versions of this package are vulnerable to Prototype Pollution via the `set` function.\r\n\r\n### POC by NerdJS\r\n```\r\nconst jsonpointer = require('jsonpointer');\r\njsonpointer.set({}, '/__proto__/polluted', true);\r\nconsole.log(polluted);\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `jsonpointer` to version 4.1.0 or higher.\n## References\n- [GitHub Commit](https://github.com/janl/node-jsonpointer/commit/234e3437019c6c07537ed2ad1e03b3e132b85e34)\n",
+        "disclosureTime": "2020-08-17T15:06:59Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.1.0"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-JSONPOINTER-598804",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-17T15:17:02.529823Z",
+        "moduleName": "jsonpointer",
+        "packageManager": "npm",
+        "packageName": "jsonpointer",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2020-08-17T15:17:02.764391Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/janl/node-jsonpointer/commit/234e3437019c6c07537ed2ad1e03b3e132b85e34"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.1.0"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "critical",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-JSYAML-173999": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/RL:O",
+        "alternativeIds": [],
+        "creationTime": "2019-03-24T09:59:28.172265Z",
+        "credit": [
+          "Shawn Rasheed",
+          "Jens DIetrich"
+        ],
+        "cvssScore": 5.9,
+        "description": "## Overview\n[js-yaml](https://www.npmjs.com/package/js-yaml) is a human-friendly data serialization language.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS). The parsing of a specially crafted YAML file may exhaust the system resources.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `js-yaml` to version 3.13.0 or higher.\n## References\n- [GitHub Commit](https://github.com/nodeca/js-yaml/commit/a567ef3c6e61eb319f0bfc2671d91061afb01235)\n- [GitHub Issue](https://github.com/nodeca/js-yaml/issues/475)\n",
+        "disclosureTime": "2019-03-18T21:29:08Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "3.13.0"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lib/js-yaml/loader.js",
+              "functionName": "storeMappingPair"
+            },
+            "version": [
+              ">=3.0.0 <3.13.0"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lib/js-yaml/loader.js",
+              "functionName": "storeMappingPair"
+            },
+            "version": [
+              ">=3.0.0 <3.13.0"
+            ]
+          }
+        ],
+        "id": "SNYK-JS-JSYAML-173999",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-2pr6-76vf-7546"
+          ],
+          "NSP": [
+            "788"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T14:36:55.564388Z",
+        "moduleName": "js-yaml",
+        "packageManager": "npm",
+        "packageName": "js-yaml",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2019-03-24T10:00:08Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/nodeca/js-yaml/commit/a567ef3c6e61eb319f0bfc2671d91061afb01235"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/nodeca/js-yaml/issues/475"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            ">=3.0.0 <3.13.0"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Denial of Service (DoS)"
+      },
+      "SNYK-JS-JSYAML-174129": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2019-04-07T11:15:19.826828Z",
+        "credit": [
+          "Alex Kocharin"
+        ],
+        "cvssScore": 8.1,
+        "description": "## Overview\n[js-yaml](https://www.npmjs.com/package/js-yaml) is a human-friendly data serialization language.\n\nAffected versions of this package are vulnerable to Arbitrary Code Execution. When an object with an executable `toString()` property used as a map key, it will execute that function. This happens only for `load()`, which should not be used with untrusted data anyway. `safeLoad()` is not affected because it can't parse functions.\n## Remediation\nUpgrade `js-yaml` to version 3.13.1 or higher.\n## References\n- [GitHub Commit](https://github.com/nodeca/js-yaml/pull/480/commits/e18afbf1edcafb7add2c4c7b22abc8d6ebc2fa61)\n- [GitHub PR](https://github.com/nodeca/js-yaml/pull/480)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/813)\n",
+        "disclosureTime": "2019-04-05T15:54:43Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "3.13.1"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lib/js-yaml/loader.js",
+              "functionName": "loadAll.storeMappingPair"
+            },
+            "version": [
+              ">1.0.3 <=2.1.3"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/js-yaml/loader.js",
+              "functionName": "storeMappingPair"
+            },
+            "version": [
+              ">2.1.3 <3.13.1"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lib/js-yaml/loader.js",
+              "functionName": "loadAll.storeMappingPair"
+            },
+            "version": [
+              ">1.0.3 <=2.1.3"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/js-yaml/loader.js",
+              "functionName": "storeMappingPair"
+            },
+            "version": [
+              ">2.1.3 <3.13.1"
+            ]
+          }
+        ],
+        "id": "SNYK-JS-JSYAML-174129",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-94"
+          ],
+          "GHSA": [
+            "GHSA-8j8c-7jfh-h6hx"
+          ],
+          "NSP": [
+            "813"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T14:37:01.431138Z",
+        "moduleName": "js-yaml",
+        "packageManager": "npm",
+        "packageName": "js-yaml",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2019-04-07T15:54:43Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/nodeca/js-yaml/pull/480/commits/e18afbf1edcafb7add2c4c7b22abc8d6ebc2fa61"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/nodeca/js-yaml/pull/480"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/813"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<3.13.1"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Arbitrary Code Execution"
+      },
+      "SNYK-JS-LODASH-1018905": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P",
+        "alternativeIds": [],
+        "creationTime": "2020-10-16T16:48:40.985673Z",
+        "credit": [
+          "Liyuan Chen"
+        ],
+        "cvssScore": 5.3,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) via the `toNumber`, `trim` and `trimEnd` functions.\r\n\r\n### POC\r\n```\r\nvar lo = require('lodash');\r\n\r\nfunction build_blank (n) {\r\nvar ret = \"1\"\r\nfor (var i = 0; i < n; i++) {\r\nret += \" \"\r\n}\r\n\r\nreturn ret + \"1\";\r\n}\r\n\r\nvar s = build_blank(50000)\r\nvar time0 = Date.now();\r\nlo.trim(s)\r\nvar time_cost0 = Date.now() - time0;\r\nconsole.log(\"time_cost0: \" + time_cost0)\r\n\r\nvar time1 = Date.now();\r\nlo.toNumber(s)\r\nvar time_cost1 = Date.now() - time1;\r\nconsole.log(\"time_cost1: \" + time_cost1)\r\n\r\nvar time2 = Date.now();\r\nlo.trimEnd(s)\r\nvar time_cost2 = Date.now() - time2;\r\nconsole.log(\"time_cost2: \" + time_cost2)\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `lodash` to version 4.17.21 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/c4847ebe7d14540bb28a8b932a9ce1b9ecbfee1a)\n- [GitHub Fix PR](https://github.com/lodash/lodash/pull/5065)\n",
+        "disclosureTime": "2020-10-16T16:47:34Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.17.21"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-LODASH-1018905",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-28500"
+          ],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2021-02-22T09:58:41.562106Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2021-02-15T11:50:49Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/lodash/lodash/commit/c4847ebe7d14540bb28a8b932a9ce1b9ecbfee1a"
+          },
+          {
+            "title": "GitHub Fix PR",
+            "url": "https://github.com/lodash/lodash/pull/5065"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.21"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "SNYK-JS-LODASH-1040724": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:P/RL:U/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-11-17T14:07:17.048472Z",
+        "credit": [
+          "Marc Hassan"
+        ],
+        "cvssScore": 7.2,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Command Injection via `template`.\r\n\r\n### PoC\r\n```\r\nvar _ = require('lodash');\r\n\r\n_.template('', { variable: '){console.log(process.env)}; with(obj' })()\r\n```\n## Remediation\nUpgrade `lodash` to version 4.17.21 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/3469357cff396a26c363f8c1b5a91dde28ba4b1c)\n- [Vulnerable Code](https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js#L14851)\n",
+        "disclosureTime": "2020-11-17T13:02:10Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.17.21"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-LODASH-1040724",
+        "identifiers": {
+          "CVE": [
+            "CVE-2021-23337"
+          ],
+          "CWE": [
+            "CWE-78"
+          ],
+          "GHSA": [
+            "GHSA-35jh-r3h4-6jhm"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2021-02-22T09:58:04.543992Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2021-02-15T11:50:50Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/lodash/lodash/commit/3469357cff396a26c363f8c1b5a91dde28ba4b1c"
+          },
+          {
+            "title": "Vulnerable Code",
+            "url": "https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js%23L14851"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.21"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Command Injection"
+      },
+      "SNYK-JS-LODASH-450202": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2019-06-19T12:04:21.040000Z",
+        "credit": [
+          "Snyk Security Team"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The function `defaultsDeep` could be tricked into adding or modifying properties of `Object.prototype` using a `constructor` payload.\r\n\r\n## PoC by Snyk\r\n```\r\nconst mergeFn = require('lodash').defaultsDeep;\r\nconst payload = '{\"constructor\": {\"prototype\": {\"a0\": true}}}'\r\n\r\nfunction check() {\r\n    mergeFn({}, JSON.parse(payload));\r\n    if (({})[`a0`] === true) {\r\n        console.log(`Vulnerable to Prototype Pollution via ${payload}`);\r\n    }\r\n  }\r\n\r\ncheck();\r\n```\r\n\r\nFor more information, check out our [blog post](https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/)\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.12 or higher.\n## References\n- [GitHub Issue](https://github.com/lodash/lodash/issues/4348)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4336)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4355)\n- [GitHub PR](https://github.com/sailshq/lodash/pull/1)\n- [Node Security Advisory](https://www.npmjs.com/advisories/1065)\n- [Snyk Blog](https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/)\n",
+        "disclosureTime": "2019-06-19T11:45:02Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.17.12"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.customDefaultsMerge"
+            },
+            "version": [
+              ">=4.17.3 <4.17.12"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.customDefaultsMerge"
+            },
+            "version": [
+              ">=4.17.3 <4.17.12"
+            ]
+          }
+        ],
+        "id": "SNYK-JS-LODASH-450202",
+        "identifiers": {
+          "CVE": [
+            "CVE-2019-10744"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-jf85-cpcp-j695"
+          ],
+          "NSP": [
+            "1065"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-24T08:59:58.227467Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:SNYK-JS-LODASH-450202:0",
+            "modificationTime": "2019-12-03T11:40:45.719849Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/lodash/20190702/lodash_20190702_0_0_1f8ea07746963a535385a5befc19fa687a627d2b.patch"
+            ],
+            "version": "=4.17.11"
+          }
+        ],
+        "proprietary": true,
+        "publicationTime": "2019-07-02T11:45:01Z",
+        "references": [
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/lodash/lodash/issues/4348"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4336"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4355"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/sailshq/lodash/pull/1"
+          },
+          {
+            "title": "Node Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1065"
+          },
+          {
+            "title": "Snyk Blog",
+            "url": "https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.12"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-LODASH-567746": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P/RL:U/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-04-28T14:32:13.683154Z",
+        "credit": [
+          "posix"
+        ],
+        "cvssScore": 6.3,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The function `zipObjectDeep` can be tricked into adding or modifying properties of the Object prototype. These properties will be present on all objects.\r\n\r\n## PoC\r\n```\r\nconst _ = require('lodash');\r\n_.zipObjectDeep(['__proto__.z'],[123])\r\nconsole.log(z) // 123\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.16 or higher.\n## References\n- [GitHub PR](https://github.com/lodash/lodash/pull/4759)\n- [HackerOne Report](https://hackerone.com/reports/712065)\n",
+        "disclosureTime": "2020-04-27T22:14:18Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.17.16"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-LODASH-567746",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-8203"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-p6mc-m468-83gw"
+          ],
+          "NSP": [
+            "1523"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-07-09T08:34:04.944267Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:SNYK-JS-LODASH-567746:0",
+            "modificationTime": "2020-04-30T14:28:46.729327Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/lodash/20200430/lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+            ],
+            "version": ">=4.14.2"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2020-04-28T14:59:14Z",
+        "references": [
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4759"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/712065"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.16"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-LODASH-590103": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2020-07-24T12:05:01.916784Z",
+        "credit": [
+          "reeser"
+        ],
+        "cvssScore": 9.8,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution in `zipObjectDeep` due to an incomplete fix for [CVE-2020-8203](https://snyk.io/vuln/SNYK-JS-LODASH-567746).\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.20 or higher.\n## References\n- [GitHub Issue](https://github.com/lodash/lodash/issues/4874)\n",
+        "disclosureTime": "2020-07-24T12:00:52Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "4.17.20"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-LODASH-590103",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-16T12:11:40.402299Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-08-16T13:09:06Z",
+        "references": [
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/lodash/lodash/issues/4874"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.20"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "critical",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-LODASH-608086": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-08-21T12:52:58.443440Z",
+        "credit": [
+          "awarau"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution via the `setWith` and `set` functions.\r\n\r\n### PoC by awarau\r\n* Create a JS file with this contents:\r\n```\r\nlod = require('lodash')\r\nlod.setWith({}, \"__proto__[test]\", \"123\")\r\nlod.set({}, \"__proto__[test2]\", \"456\")\r\nconsole.log(Object.prototype)\r\n```\r\n* Execute it with `node`\r\n* Observe that `test` and `test2` is now in the `Object.prototype`.\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.17 or higher.\n## References\n- [HackerOne Report](https://hackerone.com/reports/864701)\n",
+        "disclosureTime": "2020-08-21T10:34:29Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.17.17"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-LODASH-608086",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-27T16:44:20.914177Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-08-21T12:53:03Z",
+        "references": [
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/864701"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.17"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-LODASH-73638": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+        "alternativeIds": [],
+        "creationTime": "2019-02-03T09:06:37.726000Z",
+        "credit": [
+          "asgerf"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The functions `merge`, `mergeWith`, and `defaultsDeep` could be tricked into adding or modifying properties of `Object.prototype`. This is due to an incomplete fix to `CVE-2018-3721`.\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.11 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/380873)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1066)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1068)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1071)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/782)\n",
+        "disclosureTime": "2018-08-31T18:21:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "4.17.11"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "merge"
+            },
+            "version": [
+              ">=0.9.0 <1.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "dist/lodash.js",
+              "functionName": "merge"
+            },
+            "version": [
+              ">=1.0.0 <1.0.3"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "dist/lodash.js",
+              "functionName": "runInContext.merge"
+            },
+            "version": [
+              ">=1.1.0 <2.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.merge"
+            },
+            "version": [
+              ">=2.0.0 <3.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "runInContext.baseMerge"
+            },
+            "version": [
+              ">=3.0.0 <4.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "runInContext.baseMergeDeep"
+            },
+            "version": [
+              ">=3.0.0 <4.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.mergeDefaults"
+            },
+            "version": [
+              ">=4.0.0 <4.17.3"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.assignMergeValue"
+            },
+            "version": [
+              ">=4.0.0 <4.17.5"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.baseMerge"
+            },
+            "version": [
+              ">=4.0.0 <4.17.5"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.baseMergeDeep"
+            },
+            "version": [
+              ">=4.0.0 <4.17.5"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "safeGet"
+            },
+            "version": [
+              ">=4.17.5 <4.17.11"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "merge"
+            },
+            "version": [
+              ">=0.9.0 <1.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "dist/lodash.js",
+              "functionName": "merge"
+            },
+            "version": [
+              ">=1.0.0 <1.0.3"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "dist/lodash.js",
+              "functionName": "runInContext.merge"
+            },
+            "version": [
+              ">=1.1.0 <2.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.merge"
+            },
+            "version": [
+              ">=2.0.0 <3.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "runInContext.baseMerge"
+            },
+            "version": [
+              ">=3.0.0 <4.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "runInContext.baseMergeDeep"
+            },
+            "version": [
+              ">=3.0.0 <4.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.mergeDefaults"
+            },
+            "version": [
+              ">=4.0.0 <4.17.3"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.assignMergeValue"
+            },
+            "version": [
+              ">=4.0.0 <4.17.5"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.baseMerge"
+            },
+            "version": [
+              ">=4.0.0 <4.17.5"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.baseMergeDeep"
+            },
+            "version": [
+              ">=4.0.0 <4.17.5"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "safeGet"
+            },
+            "version": [
+              ">=4.17.5 <4.17.11"
+            ]
+          }
+        ],
+        "id": "SNYK-JS-LODASH-73638",
+        "identifiers": {
+          "CVE": [
+            "CVE-2018-16487"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-4xc9-xhrj-v574"
+          ],
+          "NSP": [
+            "1066",
+            "1068",
+            "1071",
+            "782"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-24T08:59:09.185738Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2019-02-01T18:21:00Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4337"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/380873"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1066"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1068"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1071"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/782"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.11"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-LODASH-73639": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:N/I:N/A:H",
+        "alternativeIds": [],
+        "creationTime": "2019-02-03T09:18:05.060741Z",
+        "credit": [
+          "cristianstaicu"
+        ],
+        "cvssScore": 4.4,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). It parses dates using regex strings, which may cause a slowdown of 2 seconds per 50k characters.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `lodash` to version 4.17.11 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/5c08f18d365b64063bfbfa686cbb97cdd6267347)\n- [GitHub Issue](https://github.com/lodash/lodash/issues/3359)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4450)\n",
+        "disclosureTime": "2017-09-05T09:14:29Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "4.17.11"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "hasUnicodeWord"
+            },
+            "version": [
+              ">=4.15.0 <4.17.11"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "hasUnicodeWord"
+            },
+            "version": [
+              ">=4.15.0 <4.17.11"
+            ]
+          }
+        ],
+        "id": "SNYK-JS-LODASH-73639",
+        "identifiers": {
+          "CVE": [
+            "CVE-2019-1010266"
+          ],
+          "CWE": [
+            "CWE-185"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T14:36:57.941198Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2019-04-05T09:14:22Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/lodash/lodash/commit/5c08f18d365b64063bfbfa686cbb97cdd6267347"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/lodash/lodash/issues/3359"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4450"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.11"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "SNYK-JS-LODASHDEFAULTSDEEP-450198": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P",
+        "alternativeIds": [],
+        "creationTime": "2019-06-19T11:41:45.817000Z",
+        "credit": [
+          "Olivier Arteau (HoLyVieR)"
+        ],
+        "cvssScore": 6.3,
+        "description": "## Overview\n[lodash.defaultsdeep](https://lodash.com/) is a Lodash method `_.defaultsDeep` exported as a Node.js module.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The utilities function allow modification of the `Object` prototype. If an attacker can control part of the structure passed to this function, they could add or modify an existing property.  \r\n\r\n## PoC by Olivier Arteau (HoLyVieR)\r\n```js\r\nvar _= require('lodash');\r\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\r\n\r\nvar a = {};\r\nconsole.log(\"Before : \" + a.oops);\r\n_.merge({}, JSON.parse(malicious_payload));\r\nconsole.log(\"After : \" + a.oops);\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash.defaultsdeep` to version 4.6.1 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/310443)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1067)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1069)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1070)\n",
+        "disclosureTime": "2018-01-30T22:28:27Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.6.1"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-LODASHDEFAULTSDEEP-450198",
+        "identifiers": {
+          "CVE": [
+            "CVE-2018-3721"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-2m96-9w4j-wgv7",
+            "GHSA-46fh-8fc5-xcwx",
+            "GHSA-5947-m4fg-xhqg",
+            "GHSA-fvqr-27wr-82fm"
+          ],
+          "NSP": [
+            "1067",
+            "1069",
+            "1070",
+            "577"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-25T09:41:03.215357Z",
+        "moduleName": "lodash.defaultsdeep",
+        "packageManager": "npm",
+        "packageName": "lodash.defaultsdeep",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2018-02-14T13:22:50Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4337"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/310443"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1067"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1069"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1070"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.6.1"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-LODASHDEFAULTSDEEP-450199": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+        "alternativeIds": [],
+        "creationTime": "2019-06-19T11:44:03.712000Z",
+        "credit": [
+          "asgerf"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[lodash.defaultsdeep](https://lodash.com/) is a Lodash method `_.defaultsDeep` exported as a Node.js module.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The functions `merge`, `mergeWith`, and `defaultsDeep` could be tricked into adding or modifying properties of `Object.prototype`. This is due to an incomplete fix to `CVE-2018-3721`.\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash.defaultsdeep` to version 4.6.1 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/380873)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1066)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1068)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1071)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/782)\n",
+        "disclosureTime": "2018-08-31T18:21:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "4.6.1"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-LODASHDEFAULTSDEEP-450199",
+        "identifiers": {
+          "CVE": [
+            "CVE-2018-16487"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-4xc9-xhrj-v574"
+          ],
+          "NSP": [
+            "1066",
+            "1068",
+            "1071",
+            "782"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-24T08:59:09.212950Z",
+        "moduleName": "lodash.defaultsdeep",
+        "packageManager": "npm",
+        "packageName": "lodash.defaultsdeep",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2019-02-01T18:21:00Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4337"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/380873"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1066"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1068"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1071"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/782"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.6.1"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-LODASHMERGEWITH-174136": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+        "alternativeIds": [],
+        "creationTime": "2019-04-08T14:32:04.805000Z",
+        "credit": [
+          "asgerf"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[lodash.mergewith](https://lodash.com/) is a Lodash method _.mergewith exported as a Node.js module.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The functions `merge`, `mergeWith`, and `defaultsDeep` could be tricked into adding or modifying properties of `Object.prototype`. This is due to an incomplete fix to `CVE-2018-3721`.\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash.mergewith` to version 4.6.2 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/380873)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1066)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1068)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1071)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/782)\n",
+        "disclosureTime": "2018-08-31T18:21:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "4.6.2"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "baseMerge"
+            },
+            "version": [
+              "*"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "baseMergeDeep"
+            },
+            "version": [
+              "*"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "baseMerge"
+            },
+            "version": [
+              "*"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "baseMergeDeep"
+            },
+            "version": [
+              "*"
+            ]
+          }
+        ],
+        "id": "SNYK-JS-LODASHMERGEWITH-174136",
+        "identifiers": {
+          "CVE": [
+            "CVE-2018-16487"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-4xc9-xhrj-v574"
+          ],
+          "NSP": [
+            "1066",
+            "1068",
+            "1071",
+            "782"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-24T08:59:09.204209Z",
+        "moduleName": "lodash.mergewith",
+        "packageManager": "npm",
+        "packageName": "lodash.mergewith",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2019-02-01T18:21:00Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4337"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/380873"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1066"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1068"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1071"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/782"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.6.2"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-LODASHMERGEWITH-174137": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P",
+        "alternativeIds": [],
+        "creationTime": "2019-04-08T14:35:02.142000Z",
+        "credit": [
+          "Olivier Arteau (HoLyVieR)"
+        ],
+        "cvssScore": 6.3,
+        "description": "## Overview\n[lodash.mergewith](https://lodash.com/) is a Lodash method _.mergewith exported as a Node.js module.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The utilities function allow modification of the `Object` prototype. If an attacker can control part of the structure passed to this function, they could add or modify an existing property.  \r\n\r\n## PoC by Olivier Arteau (HoLyVieR)\r\n```js\r\nvar _= require('lodash');\r\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\r\n\r\nvar a = {};\r\nconsole.log(\"Before : \" + a.oops);\r\n_.merge({}, JSON.parse(malicious_payload));\r\nconsole.log(\"After : \" + a.oops);\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash.mergewith` to version 4.6.1 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/310443)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1067)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1069)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1070)\n",
+        "disclosureTime": "2018-01-30T22:28:27Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.6.1"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "baseMerge"
+            },
+            "version": [
+              "<4.6.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "baseMergeDeep"
+            },
+            "version": [
+              "<4.6.1"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "baseMerge"
+            },
+            "version": [
+              "<4.6.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "baseMergeDeep"
+            },
+            "version": [
+              "<4.6.1"
+            ]
+          }
+        ],
+        "id": "SNYK-JS-LODASHMERGEWITH-174137",
+        "identifiers": {
+          "CVE": [
+            "CVE-2018-3721"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-2m96-9w4j-wgv7",
+            "GHSA-46fh-8fc5-xcwx",
+            "GHSA-5947-m4fg-xhqg",
+            "GHSA-fvqr-27wr-82fm"
+          ],
+          "NSP": [
+            "1067",
+            "1069",
+            "1070",
+            "577"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-25T09:41:03.208728Z",
+        "moduleName": "lodash.mergewith",
+        "packageManager": "npm",
+        "packageName": "lodash.mergewith",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2018-02-14T13:22:50Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4337"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/310443"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1067"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1069"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1070"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.6.1"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-MINIMIST-559764": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-03-11T08:25:47.093051Z",
+        "credit": [
+          "Snyk Security Team"
+        ],
+        "cvssScore": 5.6,
+        "description": "## Overview\n[minimist](https://www.npmjs.com/package/minimist) is a parse argument options module.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The library could be tricked into adding or modifying properties of `Object.prototype` using a `constructor` or `__proto__` payload.\r\n\r\n## PoC by Snyk\r\n```\r\nrequire('minimist')('--__proto__.injected0 value0'.split(' '));\r\nconsole.log(({}).injected0 === 'value0'); // true\r\n\r\nrequire('minimist')('--constructor.prototype.injected1 value1'.split(' '));\r\nconsole.log(({}).injected1 === 'value1'); // true\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `minimist` to version 0.2.1, 1.2.3 or higher.\n## References\n- [Command Injection PoC](https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a)\n- [GitHub Fix Commit #1](https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94)\n- [GitHub Fix Commit #2](https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab)\n- [Snyk Research Blog](https://snyk.io/blog/prototype-pollution-minimist/)\n",
+        "disclosureTime": "2020-03-10T08:22:24Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "0.2.1",
+          "1.2.3"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "setKey"
+            },
+            "version": [
+              "<0.2.1",
+              ">=1.0.0 <1.1.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports.setKey"
+            },
+            "version": [
+              "<0.2.1",
+              ">=1.1.1 <1.2.3"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "setKey"
+            },
+            "version": [
+              "<0.2.1",
+              ">=1.0.0 <1.1.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports.setKey"
+            },
+            "version": [
+              "<0.2.1",
+              ">=1.1.1 <1.2.3"
+            ]
+          }
+        ],
+        "id": "SNYK-JS-MINIMIST-559764",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-7598"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-vh95-rmgr-6w4m"
+          ],
+          "NSP": [
+            "1179"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-12-20T09:48:43.878574Z",
+        "moduleName": "minimist",
+        "packageManager": "npm",
+        "packageName": "minimist",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2020-03-11T08:22:19Z",
+        "references": [
+          {
+            "title": "Command Injection PoC",
+            "url": "https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a"
+          },
+          {
+            "title": "GitHub Fix Commit #1",
+            "url": "https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94"
+          },
+          {
+            "title": "GitHub Fix Commit #2",
+            "url": "https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab"
+          },
+          {
+            "title": "Snyk Research Blog",
+            "url": "https://snyk.io/blog/prototype-pollution-minimist/"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<0.2.1",
+            ">=1.0.0 <1.2.3"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-OPEN-174041": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/RL:O",
+        "alternativeIds": [],
+        "creationTime": "2019-03-31T10:27:47.709659Z",
+        "credit": [
+          "ChaLKer"
+        ],
+        "cvssScore": 9.8,
+        "description": "## Overview\n[open](https://www.npmjs.com/package/open) is a cross platform package that opens stuff like URLs, files, executables.\n\nAffected versions of this package are vulnerable to Arbitrary Code Injection when unsanitized user input is passed in.\r\n\r\nThe package does come with the following warning in the readme:\r\n\r\n```\r\nThe same care should be taken when calling open as if you were calling child_process.exec directly. If it is an executable it will run in a new shell.\r\n```\r\nThe package `open` is replacing the `opn` package, which is now deprecated. The older versions of `open` are vulnerable. \r\n\r\n**Note: Upgrading `open` to the last version will prevent this vulnerability but is also likely to have unwanted effects since it now has a very different API.**\n## Remediation\nUpgrade `open` to version 6.0.0 or higher.\n## References\n- [GitHub Issue](https://github.com/pwnall/node-open/issues/68)\n- [HackerOne Report](https://hackerone.com/reports/319473)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/663)\n",
+        "disclosureTime": "2018-05-16T19:36:39Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "6.0.0"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-OPEN-174041",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-94"
+          ],
+          "GHSA": [
+            "GHSA-28xh-wpgr-7fm8"
+          ],
+          "NSP": [
+            "663"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T14:36:55.653898Z",
+        "moduleName": "open",
+        "packageManager": "npm",
+        "packageName": "open",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2019-03-31T10:33:37Z",
+        "references": [
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/pwnall/node-open/issues/68"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/319473"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/663"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<6.0.0"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "critical",
+        "socialTrendAlert": false,
+        "title": "Arbitrary Code Injection"
+      },
+      "SNYK-JS-REQUEST-1314897": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N",
+        "alternativeIds": [],
+        "creationTime": "2021-06-29T09:27:06.371226Z",
+        "credit": [
+          "meandmax"
+        ],
+        "cvssScore": 3.7,
+        "description": "## Overview\n[request](https://www.npmjs.com/package/request) is a simplified http request client.\n\nAffected versions of this package are vulnerable to Insecure Encryption due to the usage of the insecure `sha1` cipher.\r\n\r\n**Note**: This library is deprecated.\n## Remediation\nA fix was pushed into the `master` branch but not yet published.\n## References\n- [GitHub Commit](https://github.com/request/request/pull/3385/commits/149e585d8f455b97c7c62df887c697f8045bb35d)\n- [GitHub PR](https://github.com/request/request/pull/3385)\n",
+        "disclosureTime": "2021-06-29T09:23:42Z",
+        "exploit": "Not Defined",
+        "fixedIn": [],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-REQUEST-1314897",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-326"
+          ]
+        },
+        "language": "js",
+        "modificationTime": "2021-06-29T15:26:06.017894Z",
+        "moduleName": "request",
+        "packageManager": "npm",
+        "packageName": "request",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2021-06-29T15:26:05.534835Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/request/request/pull/3385/commits/149e585d8f455b97c7c62df887c697f8045bb35d"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/request/request/pull/3385"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "*"
+          ]
+        },
+        "severity": "low",
+        "severityWithCritical": "low",
+        "title": "Insecure Encryption"
+      },
+      "SNYK-JS-UNDEFSAFE-548940": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-02-18T08:53:40.650407Z",
+        "credit": [
+          "JHU System Security Lab"
+        ],
+        "cvssScore": 6.3,
+        "description": "## Overview\n[undefsafe](https://www.npmjs.com/package/undefsafe) is a Simple function for retrieving deep object properties without getting \"Cannot read property 'X' of undefined\".\n\nAffected versions of this package are vulnerable to Prototype Pollution. The `a` function could be tricked into adding or modifying properties of `Object.prototype` using a `__proto__` payload.\r\n\r\n### PoC by JHU System Security Lab\r\n```js\r\nvar a = require(\"undefsafe\");\r\nvar payload = \"__proto__.toString\";\r\na({},payload,\"JHU\");\r\nconsole.log({}.toString);\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `undefsafe` to version 2.0.3 or higher.\n## References\n- [GitHub Commit](https://github.com/remy/undefsafe/commit/f272681b3a50e2c4cbb6a8533795e1453382c822)\n",
+        "disclosureTime": "2020-02-18T08:51:08Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "2.0.3"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-UNDEFSAFE-548940",
+        "identifiers": {
+          "CVE": [
+            "CVE-2019-10795"
+          ],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T14:36:59.362776Z",
+        "moduleName": "undefsafe",
+        "packageManager": "npm",
+        "packageName": "undefsafe",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2020-02-18T11:01:36Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/remy/undefsafe/commit/f272681b3a50e2c4cbb6a8533795e1453382c822"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<2.0.3"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-Y18N-1021887": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P",
+        "alternativeIds": [],
+        "creationTime": "2020-10-25T14:27:16.715665Z",
+        "credit": [
+          "po6ix"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[y18n](https://www.npmjs.com/package/y18n) is a the bare-bones internationalization library used by yargs\n\nAffected versions of this package are vulnerable to Prototype Pollution. PoC by po6ix:\r\n```\r\nconst y18n = require('y18n')();\r\n \r\ny18n.setLocale('__proto__');\r\ny18n.updateLocale({polluted: true});\r\n\r\nconsole.log(polluted); // true\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `y18n` to version 3.2.2, 4.0.1, 5.0.5 or higher.\n## References\n- [GitHub Issue](https://github.com/yargs/y18n/issues/96)\n- [GitHub PR](https://github.com/yargs/y18n/pull/108)\n",
+        "disclosureTime": "2020-10-25T14:24:22Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "3.2.2",
+          "4.0.1",
+          "5.0.5"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-Y18N-1021887",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-7774"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-c4w7-xm78-47vh"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2021-01-05T15:29:00.943111Z",
+        "moduleName": "y18n",
+        "packageManager": "npm",
+        "packageName": "y18n",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-11-10T15:27:28Z",
+        "references": [
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/yargs/y18n/issues/96"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/yargs/y18n/pull/108"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<3.2.2",
+            ">=4.0.0 <4.0.1",
+            ">=5.0.0 <5.0.5"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "npm:brace-expansion:20170302": {
+        "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "alternativeIds": [
+          "SNYK-JS-BRACEEXPANSION-10483"
+        ],
+        "creationTime": "2017-04-26T09:19:21.663000Z",
+        "credit": [
+          "kamael"
+        ],
+        "cvssScore": 6.2,
+        "description": "## Overview\r\n[`brace-expansion`](https://www.npmjs.com/package/brace-expansion) is a package that performs brace expansion as known from sh/bash.\r\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `brace-expansion` to version 1.1.7 or higher.\r\n\r\n## References\r\n- [GitHub PR](https://github.com/juliangruber/brace-expansion/pull/35)\r\n- [GitHub Issue](https://github.com/juliangruber/brace-expansion/issues/33)\r\n- [GitHub Commit](https://github.com/juliangruber/brace-expansion/pull/35/commits/b13381281cead487cbdbfd6a69fb097ea5e456c3)",
+        "disclosureTime": "2017-03-01T22:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "1.1.7"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "npm:brace-expansion:20170302",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-BRACEEXPANSION-10483"
+          ],
+          "CVE": [
+            "CVE-2017-18077"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-832h-xg76-4gv6"
+          ],
+          "NSP": [
+            "338"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2019-12-02T14:40:13.321868Z",
+        "moduleName": "brace-expansion",
+        "packageManager": "npm",
+        "packageName": "brace-expansion",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2017-04-26T09:19:21Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/juliangruber/brace-expansion/pull/35/commits/b13381281cead487cbdbfd6a69fb097ea5e456c3"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/juliangruber/brace-expansion/issues/33"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/juliangruber/brace-expansion/pull/35"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<1.1.7"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "npm:debug:20170905": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+        "alternativeIds": [
+          "SNYK-JS-DEBUG-10762"
+        ],
+        "creationTime": "2017-09-13T07:55:05.106000Z",
+        "credit": [
+          "Cristian-Alexandru Staicu"
+        ],
+        "cvssScore": 3.7,
+        "description": "## Overview\r\n[`debug`](https://www.npmjs.com/package/debug) is a JavaScript debugging utility modelled after Node.js core's debugging technique..\r\n\r\n`debug` uses [printf-style](https://wikipedia.org/wiki/Printf_format_string) formatting. Affected versions of this package are vulnerable to Regular expression Denial of Service (ReDoS) attacks via the the `%o` formatter (Pretty-print an Object all on a single line). It used a regular expression (`/\\s*\\n\\s*/g`) in order to strip whitespaces and replace newlines with spaces, in order to join the data into a single line. This can cause a very low impact of about 2 seconds matching time for data 50k characters long.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `debug` to version 2.6.9, 3.1.0 or higher.\r\n\r\n## References\r\n- [GitHub Issue](https://github.com/visionmedia/debug/issues/501)\r\n- [GitHub PR](https://github.com/visionmedia/debug/pull/504)",
+        "disclosureTime": "2017-09-05T21:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.6.9",
+          "3.1.0"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "src/node.js",
+              "functionName": "exports.formatters.o"
+            },
+            "version": [
+              ">= 2.5.0 <2.6.9",
+              ">=3.0.0 <3.1.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "node.js",
+              "functionName": "exports.formatters.o"
+            },
+            "version": [
+              ">=1.0.0 <2.5.0"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "src/node.js",
+              "functionName": "exports.formatters.o"
+            },
+            "version": [
+              ">= 2.5.0 <2.6.9",
+              ">=3.0.0 <3.1.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "node.js",
+              "functionName": "exports.formatters.o"
+            },
+            "version": [
+              ">=1.0.0 <2.5.0"
+            ]
+          }
+        ],
+        "id": "npm:debug:20170905",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-DEBUG-10762"
+          ],
+          "CVE": [
+            "CVE-2017-16137"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-gxpj-cx7g-858c"
+          ],
+          "NSP": [
+            "534"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2019-12-02T14:38:59.642834Z",
+        "moduleName": "debug",
+        "packageManager": "npm",
+        "packageName": "debug",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:debug:20170905:0",
+            "modificationTime": "2019-12-03T11:40:45.872397Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/debug/20170905/debug_20170905_0_0_c38a0166c266a679c8de012d4eaccec3f944e685.patch"
+            ],
+            "version": ">= 3.0.0 <=3.0.1"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:debug:20170905:1",
+            "modificationTime": "2019-12-03T11:40:45.873422Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/debug/20170905/debug_20170905_0_1_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+            ],
+            "version": ">=2.5.1 <2.6.9"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:debug:20170905:2",
+            "modificationTime": "2019-12-03T11:40:45.874399Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/debug/20170905/debug_20170905_0_2_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+            ],
+            "version": ">=2.4.0 <2.5.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:debug:20170905:3",
+            "modificationTime": "2019-12-03T11:40:45.875363Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/debug/20170905/debug_20170905_0_3_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+            ],
+            "version": ">=2.0.0 <2.4.0"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2017-09-26T03:55:05Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/visionmedia/debug/pull/504/commits/42a6ae0737f9243c80b6d3dbb08a69a7ae2a1061"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/visionmedia/debug/issues/501"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/visionmedia/debug/pull/504"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            ">=1.0.0 <2.6.9",
+            ">=3.0.0 <3.1.0"
+          ]
+        },
+        "severity": "low",
+        "severityWithCritical": "low",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "npm:deep-extend:20180409": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P",
+        "alternativeIds": [
+          "SNYK-JS-DEEPEXTEND-12120"
+        ],
+        "creationTime": "2018-04-15T20:11:17.552000Z",
+        "credit": [
+          "Olivier Arteau (HoLyVieR)"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[deep-extend](https://www.npmjs.com/package/deep-extend) is a library for Recursive object extending.\n\nAffected versions of this package are vulnerable to Prototype Pollution. Utilities function in all the listed modules can be tricked into modifying the prototype of \"Object\" when the attacker control part of the structure passed to these function. This can let an attacker add or modify existing property that will exist on all object.\r\n\r\n## PoC by HoLyVieR\r\n```js\r\nvar merge = require('deep-extend');\r\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\r\n\r\nvar a = {};\r\nconsole.log(\"Before : \" + a.oops);\r\nmerge({}, JSON.parse(malicious_payload));\r\nconsole.log(\"After : \" + a.oops);\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `deep-extend` to version 0.5.1 or higher.\n## References\n- [GitHub Commit](https://github.com/unclechu/node-deep-extend/commit/433ee51ed606f4e1867ece57b6ff5a47bebb492f)\n- [GitHub Issue](https://github.com/unclechu/node-deep-extend/issues/39)\n- [GitHub PR](https://github.com/unclechu/node-deep-extend/pull/40)\n- [HackerOne Report](https://hackerone.com/reports/311333)\n",
+        "disclosureTime": "2018-04-09T20:11:17Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "0.5.1"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports"
+            },
+            "version": [
+              "0.2.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "deepExtend"
+            },
+            "version": [
+              "<0.2.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports.deepExtend"
+            },
+            "version": [
+              ">=0.2.2 <0.2.5"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "deepExtend.module.exports"
+            },
+            "version": [
+              ">=0.2.5 <0.4.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/deep-extend.js",
+              "functionName": "cloneSpecificValue"
+            },
+            "version": [
+              ">=0.4.0 <0.5.1"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports"
+            },
+            "version": [
+              "0.2.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "deepExtend"
+            },
+            "version": [
+              "<0.2.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports.deepExtend"
+            },
+            "version": [
+              ">=0.2.2 <0.2.5"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "deepExtend.module.exports"
+            },
+            "version": [
+              ">=0.2.5 <0.4.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/deep-extend.js",
+              "functionName": "cloneSpecificValue"
+            },
+            "version": [
+              ">=0.4.0 <0.5.1"
+            ]
+          }
+        ],
+        "id": "npm:deep-extend:20180409",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-DEEPEXTEND-12120"
+          ],
+          "CVE": [
+            "CVE-2018-3750"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-hr2v-3952-633q"
+          ],
+          "NSP": [
+            "612"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T14:36:41.582307Z",
+        "moduleName": "deep-extend",
+        "packageManager": "npm",
+        "packageName": "deep-extend",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2018-04-25T07:45:48Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/unclechu/node-deep-extend/commit/433ee51ed606f4e1867ece57b6ff5a47bebb492f"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/unclechu/node-deep-extend/issues/39"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/unclechu/node-deep-extend/pull/40"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/311333"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<0.5.1"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "npm:extend:20180424": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+        "alternativeIds": [
+          "SNYK-JS-EXTEND-12179"
+        ],
+        "creationTime": "2018-07-23T17:51:10.908000Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[extend](https://www.npmjs.com/package/extend) is a port of the classic extend() method from jQuery.\n\nAffected versions of this package are vulnerable to Prototype Pollution. Utilities function can be tricked into modifying the prototype of \"Object\" when the attacker control part of the structure passed to these function. This can let an attacker add or modify existing property that will exist on all object.\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `extend` to version 2.0.2, 3.0.2 or higher.\n## References\n- [GitHub Commit](https://github.com/justmoon/node-extend/commit/0e68e71d93507fcc391e398bc84abd0666b28190)\n- [GitHub PR](https://github.com/justmoon/node-extend/pull/48#issuecomment-398261612)\n- [HackerOne Report](https://hackerone.com/reports/381185)\n",
+        "disclosureTime": "2018-04-24T17:51:10Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.0.2",
+          "3.0.2"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports"
+            },
+            "version": [
+              "<2.0.2",
+              ">=3.0.0 <3.0.2"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports"
+            },
+            "version": [
+              "<2.0.2",
+              ">=3.0.0 <3.0.2"
+            ]
+          }
+        ],
+        "id": "npm:extend:20180424",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-EXTEND-12179"
+          ],
+          "CVE": [
+            "CVE-2018-16492"
+          ],
+          "CWE": [
+            "CWE-1321"
+          ],
+          "GHSA": [
+            "GHSA-qrmc-fj45-qfc2"
+          ],
+          "NSP": [
+            "996"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2021-07-07T06:41:03.619163Z",
+        "moduleName": "extend",
+        "packageManager": "npm",
+        "packageName": "extend",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:extend:20180424:0",
+            "modificationTime": "2019-12-03T11:40:45.727650Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/extend/20180424/extend_20180424_0_0_0e68e71d93507fcc391e398bc84abd0666b28190.patch"
+            ],
+            "version": ">=3.0.0 <3.0.2"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2018-07-23T13:46:08Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/justmoon/node-extend/commit/0e68e71d93507fcc391e398bc84abd0666b28190"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/justmoon/node-extend/pull/48%23issuecomment-398261612"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/381185"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<2.0.2",
+            ">=3.0.0 <3.0.2"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "npm:hawk:20160119": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+        "alternativeIds": [
+          "SNYK-JS-HAWK-10080"
+        ],
+        "creationTime": "2016-01-19T23:24:51.834000Z",
+        "credit": [
+          "Adam Baldwin"
+        ],
+        "cvssScore": 3.7,
+        "description": "## Overview\r\n[`hawk`](https://www.npmjs.com/package/hawk) is an HTTP authentication scheme using a message authentication code (MAC) algorithm to provide partial HTTP request cryptographic verification.\r\n\r\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\nYou can read more about `Regular Expression Denial of Service (ReDoS)` on our [blog](https://snyk.io/blog/redos-and-catastrophic-backtracking/).\r\n\r\n## References\r\n- [GitHub Issue](https://github.com/hueniverse/hawk/issues/168)",
+        "disclosureTime": "2016-01-19T21:51:35Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "3.1.3",
+          "4.1.1"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lib/hawk.js",
+              "functionName": "exports.authenticate"
+            },
+            "version": [
+              "<=0.0.6"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/index.js",
+              "functionName": "exports.authenticate"
+            },
+            "version": [
+              ">=0.0.7 <0.10.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/server.js",
+              "functionName": "exports.authenticate"
+            },
+            "version": [
+              ">=0.10.0 <0.12.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/server.js",
+              "functionName": "exports.authenticateBewit"
+            },
+            "version": [
+              ">=0.12.1  <3.1.3",
+              ">=4.0.0 <4.1.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/utils.js",
+              "functionName": "exports.parseHost"
+            },
+            "version": [
+              ">=0.3.0 <3.1.3",
+              ">=4.0.0 <4.1.1"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lib/hawk.js",
+              "functionName": "exports.authenticate"
+            },
+            "version": [
+              "<=0.0.6"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/index.js",
+              "functionName": "exports.authenticate"
+            },
+            "version": [
+              ">=0.0.7 <0.10.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/server.js",
+              "functionName": "exports.authenticate"
+            },
+            "version": [
+              ">=0.10.0 <0.12.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/server.js",
+              "functionName": "exports.authenticateBewit"
+            },
+            "version": [
+              ">=0.12.1  <3.1.3",
+              ">=4.0.0 <4.1.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/utils.js",
+              "functionName": "exports.parseHost"
+            },
+            "version": [
+              ">=0.3.0 <3.1.3",
+              ">=4.0.0 <4.1.1"
+            ]
+          }
+        ],
+        "id": "npm:hawk:20160119",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-HAWK-10080"
+          ],
+          "CVE": [
+            "CVE-2016-2515"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-jcpv-g9rr-qxrc"
+          ],
+          "NSP": [
+            "77"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2019-04-29T17:06:31.778992Z",
+        "moduleName": "hawk",
+        "packageManager": "npm",
+        "packageName": "hawk",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:hawk:20160119:0",
+            "modificationTime": "2019-12-03T11:40:45.789189Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/hawk/20160119/hawk_20160119_0_0_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+            ],
+            "version": "<4.1.1 >=4.0.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:hawk:20160119:1",
+            "modificationTime": "2019-12-03T11:40:45.790286Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/hawk/20160119/hawk_20160119_0_1_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+            ],
+            "version": "<=3.1.2 >=3.0.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:hawk:20160119:2",
+            "modificationTime": "2019-12-03T11:40:45.791342Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/hawk/20160119/hawk_20160119_0_2_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+            ],
+            "version": "<= 2.3.1 >= 2.2.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:hawk:20160119:3",
+            "modificationTime": "2019-12-03T11:40:45.792397Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/hawk/20160119/hawk_20160119_0_3_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+            ],
+            "version": "<= 1.1.1 >= 1.0.0"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2016-01-19T23:24:51Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/hapijs/hawk/commit/0833f99ba64558525995a7e21d4093da1f3e15fa"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/hueniverse/hawk/issues/168"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<3.1.3",
+            ">=4.0.0 <4.1.1"
+          ]
+        },
+        "severity": "low",
+        "severityWithCritical": "low",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "npm:hoek:20180212": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P",
+        "alternativeIds": [
+          "SNYK-JS-HOEK-12061"
+        ],
+        "creationTime": "2018-02-12T22:28:27.612000Z",
+        "credit": [
+          "Olivier Arteau (HoLyVieR)"
+        ],
+        "cvssScore": 6.3,
+        "description": "## Overview\n[hoek](https://github.com/hapijs/hoek) is an Utility methods for the hapi ecosystem.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The utilities function allow modification of the `Object` prototype. If an attacker can control part of the structure passed to this function, they could add or modify an existing property.  \r\n\r\n## PoC by Olivier Arteau (HoLyVieR)\r\n```js\r\nvar Hoek = require('hoek');\r\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\r\n\r\nvar a = {};\r\nconsole.log(\"Before : \" + a.oops);\r\nHoek.merge({}, JSON.parse(malicious_payload));\r\nconsole.log(\"After : \" + a.oops);\r\n\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `hoek` to version 4.2.1, 5.0.3 or higher.\n## References\n- [GitHub Commit](https://github.com/hapijs/hoek/commit/32ed5c9413321fbc37da5ca81a7cbab693786dee)\n- [GitHub Commit](https://github.com/hapijs/hoek/commit/5aed1a8c4a3d55722d1c799f2368857bf418d6df)\n- [GitHub Issue](https://github.com/hapijs/hoek/issues/230)\n- [GitHub PR](https://github.com/hapijs/hoek/pull/227)\n- [HackerOne Report](https://hackerone.com/reports/310439)\n- [NPM Security Advisory](http://npmjs.com/advisories/566)\n",
+        "disclosureTime": "2018-02-12T22:28:27Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.2.1",
+          "5.0.3"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lib/hoek.js",
+              "functionName": "exports.merge"
+            },
+            "version": [
+              "<0.0.19"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/index.js",
+              "functionName": "exports.merge"
+            },
+            "version": [
+              ">0.0.18 <4.2.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/index.js",
+              "functionName": "exports.merge"
+            },
+            "version": [
+              ">=5.0.0 <5.0.3"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lib/hoek.js",
+              "functionName": "exports.merge"
+            },
+            "version": [
+              "<0.0.19"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/index.js",
+              "functionName": "exports.merge"
+            },
+            "version": [
+              ">0.0.18 <4.2.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/index.js",
+              "functionName": "exports.merge"
+            },
+            "version": [
+              ">=5.0.0 <5.0.3"
+            ]
+          }
+        ],
+        "id": "npm:hoek:20180212",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-HOEK-12061"
+          ],
+          "CVE": [
+            "CVE-2018-3728"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-jp4x-w63m-7wgm"
+          ],
+          "NSP": [
+            "566"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T14:36:45.981220Z",
+        "moduleName": "hoek",
+        "packageManager": "npm",
+        "packageName": "hoek",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:hoek:20180212:0",
+            "modificationTime": "2019-12-03T11:40:45.879582Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/hoek/20180212/20180212_0_0_hoek_5aed1a8c4a3d55722d1c799f2368857bf418d6df.patch"
+            ],
+            "version": "<4.2.1 >=4.1.0 || <3.0.4 >=3.0.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:hoek:20180212:1",
+            "modificationTime": "2019-12-03T11:40:45.880722Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/hoek/20180212/20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+            ],
+            "version": ">=2.0.0 <3.0.0"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2018-02-14T13:22:50Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/hapijs/hoek/commit/32ed5c9413321fbc37da5ca81a7cbab693786dee"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/hapijs/hoek/commit/5aed1a8c4a3d55722d1c799f2368857bf418d6df"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/hapijs/hoek/issues/230"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/hapijs/hoek/pull/227"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/310439"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "http://npmjs.com/advisories/566"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.2.1",
+            ">=5.0.0 <5.0.3"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "npm:http-signature:20150122": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+        "alternativeIds": [
+          "SNYK-JS-HTTPSIGNATURE-10664"
+        ],
+        "creationTime": "2017-06-28T13:07:29.691000Z",
+        "credit": [
+          "Alok Menghrajani"
+        ],
+        "cvssScore": 6.5,
+        "description": "## Overview\r\n[`http-signature`](https://www.npmjs.com/package/http-signature) is a reference implementation of Joyent's HTTP Signature scheme.\r\n\r\nAffected versions of the package are vulnerable to Timing Attacks due to time-variable comparison of signatures. \r\n\r\nThe library implemented a character to character comparison, similar to the built-in string comparison mechanism, `===`, and not a time constant string comparison. As a result, the comparison will fail faster when the first characters in the signature are incorrect.\r\nAn attacker can use this difference to perform a timing attack, essentially allowing them to guess the signature one character at a time.\r\n\r\nYou can read more about timing attacks in Node.js on the [Snyk blog](https://snyk.io/blog/node-js-timing-attack-ccc-ctf/).\r\n\r\n## Remediation\r\nUpgrade `http-signature` to version 1.0.0 or higher.\r\n\r\n## References\r\n- [Github PR](https://github.com/joyent/node-http-signature/pull/36)\r\n- [Github Commit](https://github.com/joyent/node-http-signature/commit/78ab1da232f31f695f5c362d863593a143aa8b56)",
+        "disclosureTime": "2015-01-21T22:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "1.0.0"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lib/verify.js",
+              "functionName": "module.exports.verifySignature"
+            },
+            "version": [
+              "<0.10.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/verify.js",
+              "functionName": "module.exports.verifyHMAC"
+            },
+            "version": [
+              ">=0.11.0 <1.0.0"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lib/verify.js",
+              "functionName": "module.exports.verifySignature"
+            },
+            "version": [
+              "<0.10.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/verify.js",
+              "functionName": "module.exports.verifyHMAC"
+            },
+            "version": [
+              ">=0.11.0 <1.0.0"
+            ]
+          }
+        ],
+        "id": "npm:http-signature:20150122",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-HTTPSIGNATURE-10664"
+          ],
+          "CVE": [],
+          "CWE": [
+            "CWE-310"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2019-04-29T15:44:53.819980Z",
+        "moduleName": "http-signature",
+        "packageManager": "npm",
+        "packageName": "http-signature",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:http-signature:20150122:0",
+            "modificationTime": "2019-12-03T11:40:45.867250Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/http-signature/20150122/20150122_0_0_http-signature_78ab1da232f31f695f5c362d863593a143aa8b56.patch"
+            ],
+            "version": "=0.10.1"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2017-06-28T13:07:29Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/joyent/node-http-signature/commit/78ab1da232f31f695f5c362d863593a143aa8b56"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/joyent/node-http-signature/pull/36"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<1.0.0"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Timing Attack"
+      },
+      "npm:is-my-json-valid:20180214": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L/E:F/RL:O/RC:C",
+        "alternativeIds": [
+          "SNYK-JS-ISMYJSONVALID-10887"
+        ],
+        "creationTime": "2018-02-15T14:36:50Z",
+        "credit": [
+          "Jamie Davis"
+        ],
+        "cvssScore": 3.7,
+        "description": "## Overview\r\n[`is-my-json-valid`](https://www.npmjs.com/package/is-my-json-valid) is a universal validation plugin.\r\n\r\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks. It used a regular expression (`/^\\S+@\\S+$/`) in order to validate emails. This can cause an impact of about 10 seconds matching time for data 90K characters long.\r\n\r\n## Disclosure Timeline\r\n* Feb 13th, 2018 - Initial Disclosure to package owner\r\n* Feb 14th, 2018 - Initial Response from package owner\r\n* Feb 14th, 2018 - Fix issued\r\n* Feb 15th, 2018 - Vulnerability published\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `is-my-json-valid` to version 2.17.2, 1.4.1 or higher.\r\n\r\n## References\r\n- [GitHub PR](https://github.com/mafintosh/is-my-json-valid/pull/159)\r\n- [GitHub Commit](https://github.com/mafintosh/is-my-json-valid/commit/b3051b277f7caa08cd2edc6f74f50aeda65d2976)",
+        "disclosureTime": "2018-02-13T20:39:06Z",
+        "exploit": "Functional",
+        "fixedIn": [
+          "1.4.1",
+          "2.17.2"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "npm:is-my-json-valid:20180214",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-ISMYJSONVALID-10887"
+          ],
+          "CVE": [
+            "CVE-2018-1107"
+          ],
+          "CWE": [
+            "CWE-185",
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-4x7c-cx64-49w8"
+          ],
+          "NSP": [
+            "572"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-09T09:57:45.620384Z",
+        "moduleName": "is-my-json-valid",
+        "packageManager": "npm",
+        "packageName": "is-my-json-valid",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2018-02-15T19:52:28Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/mafintosh/is-my-json-valid/commit/b3051b277f7caa08cd2edc6f74f50aeda65d2976"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/mafintosh/is-my-json-valid/pull/159"
+          },
+          {
+            "title": "Hackerone Report",
+            "url": "https://hackerone.com/reports/317548"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<1.4.1",
+            ">=2.0.0 <2.17.2"
+          ]
+        },
+        "severity": "low",
+        "severityWithCritical": "low",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "npm:lodash:20180130": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P",
+        "alternativeIds": [
+          "SNYK-JS-LODASH-174180"
+        ],
+        "creationTime": "2018-02-12T22:28:27.654000Z",
+        "credit": [
+          "Olivier Arteau (HoLyVieR)"
+        ],
+        "cvssScore": 6.3,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The utilities function allow modification of the `Object` prototype. If an attacker can control part of the structure passed to this function, they could add or modify an existing property.  \r\n\r\n## PoC by Olivier Arteau (HoLyVieR)\r\n```js\r\nvar _= require('lodash');\r\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\r\n\r\nvar a = {};\r\nconsole.log(\"Before : \" + a.oops);\r\n_.merge({}, JSON.parse(malicious_payload));\r\nconsole.log(\"After : \" + a.oops);\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.5 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/310443)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1067)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1069)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1070)\n",
+        "disclosureTime": "2018-01-30T22:28:27Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.17.5"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "dist/lodash.js",
+              "functionName": "merge"
+            },
+            "version": [
+              ">= 1.0.0 <1.0.3"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "merge"
+            },
+            "version": [
+              ">=0.9.0 <1.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "dist/lodash.js",
+              "functionName": "runInContext.merge"
+            },
+            "version": [
+              ">=1.1.0 <2.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.merge"
+            },
+            "version": [
+              ">=2.0.0 <3.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "runInContext.baseMergeDeep"
+            },
+            "version": [
+              ">=3.0.0 <4.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.baseMerge"
+            },
+            "version": [
+              ">=4.0.0 <4.17.5"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.baseMergeDeep"
+            },
+            "version": [
+              ">=4.0.0 <4.17.5"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "dist/lodash.js",
+              "functionName": "merge"
+            },
+            "version": [
+              ">= 1.0.0 <1.0.3"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "merge"
+            },
+            "version": [
+              ">=0.9.0 <1.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "dist/lodash.js",
+              "functionName": "runInContext.merge"
+            },
+            "version": [
+              ">=1.1.0 <2.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.merge"
+            },
+            "version": [
+              ">=2.0.0 <3.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "runInContext.baseMergeDeep"
+            },
+            "version": [
+              ">=3.0.0 <4.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.baseMerge"
+            },
+            "version": [
+              ">=4.0.0 <4.17.5"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.baseMergeDeep"
+            },
+            "version": [
+              ">=4.0.0 <4.17.5"
+            ]
+          }
+        ],
+        "id": "npm:lodash:20180130",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-LODASH-174180"
+          ],
+          "CVE": [
+            "CVE-2018-3721"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-2m96-9w4j-wgv7",
+            "GHSA-46fh-8fc5-xcwx",
+            "GHSA-5947-m4fg-xhqg",
+            "GHSA-fvqr-27wr-82fm"
+          ],
+          "NSP": [
+            "1067",
+            "1069",
+            "1070",
+            "577"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-25T09:41:03.189638Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:lodash:20180130:0",
+            "modificationTime": "2019-12-03T11:40:45.883000Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/lodash/20180130/20180130_0_0_lodash_d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a.patch"
+            ],
+            "version": "=3.10.1"
+          }
+        ],
+        "proprietary": true,
+        "publicationTime": "2018-02-14T13:22:50Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4337"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/310443"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1067"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1069"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1070"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.5"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "npm:ms:20170412": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+        "alternativeIds": [
+          "SNYK-JS-MS-10509"
+        ],
+        "creationTime": "2017-04-12T10:02:45.497000Z",
+        "credit": [
+          "Snyk Security Research Team"
+        ],
+        "cvssScore": 3.7,
+        "description": "## Overview\r\n[`ms`](https://www.npmjs.com/package/ms) is a tiny millisecond conversion utility.\r\n\r\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) due to an incomplete fix for previously reported vulnerability [npm:ms:20151024](https://snyk.io/vuln/npm:ms:20151024). The fix limited the length of accepted input string to 10,000 characters, and turned to be insufficient making it possible to block the event loop for 0.3 seconds (on a typical laptop) with a specially crafted string passed to `ms()` function.\r\n\r\n*Proof of concept*\r\n```js\r\nms = require('ms');\r\nms('1'.repeat(9998) + 'Q') // Takes about ~0.3s\r\n```\r\n\r\n**Note:** Snyk's patch for this vulnerability limits input length to 100 characters. This new limit was deemed to be a breaking change by the author.\r\nBased on user feedback, we believe the risk of breakage is _very_ low, while the value to your security is much greater, and therefore opted to still capture this change in a patch for earlier versions as well.  Whenever patching security issues, we always suggest to run tests on your code to validate that nothing has been broken.\r\n\r\nFor more information on `Regular Expression Denial of Service (ReDoS)` attacks, go to our [blog](https://snyk.io/blog/redos-and-catastrophic-backtracking/).\r\n\r\n## Disclosure Timeline\r\n- Feb 9th, 2017 - Reported the issue to package owner.\r\n- Feb 11th, 2017 - Issue acknowledged by package owner.\r\n- April 12th, 2017 - Fix PR opened by Snyk Security Team.\r\n- May 15th, 2017 - Vulnerability published.\r\n- May 16th, 2017 - Issue fixed and version `2.0.0` released.\r\n- May 21th, 2017 - Patches released for versions `>=0.7.1, <=1.0.0`.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `ms` to version 2.0.0 or higher.\r\n\r\n## References\r\n- [GitHub PR](https://github.com/zeit/ms/pull/89)\r\n- [GitHub Commit](https://github.com/zeit/ms/pull/89/commits/305f2ddcd4eff7cc7c518aca6bb2b2d2daad8fef)",
+        "disclosureTime": "2017-04-11T21:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.0.0"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "parse"
+            },
+            "version": [
+              ">=0.7.3 <2.0.0"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "parse"
+            },
+            "version": [
+              ">=0.7.3 <2.0.0"
+            ]
+          }
+        ],
+        "id": "npm:ms:20170412",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-MS-10509"
+          ],
+          "CVE": [],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-09T09:57:45.833759Z",
+        "moduleName": "ms",
+        "packageManager": "npm",
+        "packageName": "ms",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:ms:20170412:0",
+            "modificationTime": "2019-12-03T11:40:45.863964Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ms/20170412/ms_100.patch"
+            ],
+            "version": "=1.0.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:ms:20170412:1",
+            "modificationTime": "2019-12-03T11:40:45.865081Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ms/20170412/ms_072-073.patch"
+            ],
+            "version": "=0.7.2 || =0.7.3"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:ms:20170412:2",
+            "modificationTime": "2019-12-03T11:40:45.866206Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ms/20170412/ms_071.patch"
+            ],
+            "version": "=0.7.1"
+          }
+        ],
+        "proprietary": true,
+        "publicationTime": "2017-05-15T06:02:45Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/zeit/ms/pull/89/commits/305f2ddcd4eff7cc7c518aca6bb2b2d2daad8fef"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/zeit/ms/pull/89"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            ">=0.7.1 <2.0.0"
+          ]
+        },
+        "severity": "low",
+        "severityWithCritical": "low",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "npm:open:20180512": {
+        "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:O/RC:C",
+        "alternativeIds": [
+          "SNYK-JS-OPEN-12148"
+        ],
+        "creationTime": "2018-02-25T11:54:41.573000Z",
+        "credit": [
+          "ChALkeR"
+        ],
+        "cvssScore": 8.4,
+        "description": "## Overview\n[open](https://www.npmjs.com/package/open) is a cross platform package that opens stuff like URLs, files, executables.\n\nAffected versions of this package are vulnerable to Arbitrary Command Injection. Urls are not properly escaped before concatenating them into the command that is opened using `exec()`.\r\n\r\n**Note: Upgrading `open` to the last version will prevent this vulnerability but is also likely to have unwanted effects since it now has a very different API.**\n## Remediation\nUpgrade `open` to version 6.0.0 or higher.\n## References\n- [HackerOne Report](https://hackerone.com/reports/319473)\n",
+        "disclosureTime": "2018-05-12T11:54:41Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "6.0.0"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "npm:open:20180512",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-OPEN-12148"
+          ],
+          "CVE": [],
+          "CWE": [
+            "CWE-264"
+          ],
+          "NSP": [
+            "663"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T08:52:32.287783Z",
+        "moduleName": "open",
+        "packageManager": "npm",
+        "packageName": "open",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2018-05-13T14:26:27Z",
+        "references": [
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/319473"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<6.0.0"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Arbitrary Command Injection"
+      },
+      "npm:qs:20140806": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "alternativeIds": [
+          "SNYK-JS-QS-10019"
+        ],
+        "creationTime": "2014-08-06T06:10:22Z",
+        "credit": [
+          "Dustin Shiver"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n\n[qs](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.\n\n\nAffected versions of this package are vulnerable to Denial of Service (DoS).\nDuring parsing, the `qs` module may create a sparse area (an array where no elements are filled), and grow that array to the necessary size based on the indices used on it. An attacker can specify a high index value in a query string, thus making the server allocate a respectively big array. Truly large values can cause the server to run out of memory and cause it to crash - thus enabling a Denial-of-Service attack.\n\n## Remediation\n\nUpgrade `qs` to version 1.0.0 or higher.\n\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## References\n\n- [GitHub Commit](https://github.com/tj/node-querystring/pull/114/commits/43a604b7847e56bba49d0ce3e222fe89569354d8)\n\n- [GitHub Issue](https://github.com/visionmedia/node-querystring/issues/104)\n\n- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2014-7191)\n",
+        "disclosureTime": "2014-08-06T06:10:22Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "1.0.0"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "compact"
+            },
+            "version": [
+              "<1.0.0"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "compact"
+            },
+            "version": [
+              "<1.0.0"
+            ]
+          }
+        ],
+        "id": "npm:qs:20140806",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-QS-10019"
+          ],
+          "CVE": [
+            "CVE-2014-7191"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-jjv7-qpx3-h62q",
+            "GHSA-gqgv-6jq5-jjj9"
+          ],
+          "NSP": [
+            "29"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2019-02-18T08:28:59.375824Z",
+        "moduleName": "qs",
+        "packageManager": "npm",
+        "packageName": "qs",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20140806:1",
+            "modificationTime": "2019-12-03T11:40:45.728930Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20140806/qs_20140806_0_1_snyk_npm.patch"
+            ],
+            "version": "=0.5.6"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20140806:0",
+            "modificationTime": "2019-12-03T11:40:45.741062Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20140806/qs_20140806_0_0_43a604b7847e56bba49d0ce3e222fe89569354d8_snyk.patch"
+            ],
+            "version": "<1.0.0 >=0.6.5"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2014-08-06T06:10:22Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/tj/node-querystring/pull/114/commits/43a604b7847e56bba49d0ce3e222fe89569354d8"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/visionmedia/node-querystring/issues/104"
+          },
+          {
+            "title": "NVD",
+            "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-7191"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<1.0.0"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Denial of Service (DoS)"
+      },
+      "npm:qs:20140806-1": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+        "alternativeIds": [
+          "SNYK-JS-QS-10020"
+        ],
+        "creationTime": "2014-08-06T06:10:23Z",
+        "credit": [
+          "Tom Steele"
+        ],
+        "cvssScore": 6.5,
+        "description": "## Overview\n[qs](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS). When parsing a string representing a deeply nested object, qs will block the event loop for long periods of time. Such a delay may hold up the server's resources, keeping it from processing other requests in the meantime, thus enabling a Denial-of-Service attack.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `qs` to version 1.0.0 or higher.\n## References\n- [Node Security Advisory](https://nodesecurity.io/advisories/28)\n",
+        "disclosureTime": "2014-08-06T06:10:23Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "1.0.0"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "npm:qs:20140806-1",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-QS-10020"
+          ],
+          "CVE": [
+            "CVE-2014-10064"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-f9cm-p3w6-xvr3"
+          ],
+          "NSP": [
+            "28"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T14:36:44.334026Z",
+        "moduleName": "qs",
+        "packageManager": "npm",
+        "packageName": "qs",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20140806-1:0",
+            "modificationTime": "2019-12-03T11:40:45.742148Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20140806-1/qs_20140806-1_0_0_snyk.patch"
+            ],
+            "version": "<1.0.0 >=0.6.5"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20140806-1:1",
+            "modificationTime": "2019-12-03T11:40:45.744535Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20140806-1/qs_20140806-1_0_1_snyk.patch"
+            ],
+            "version": "=0.5.6"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2014-08-06T06:10:23Z",
+        "references": [
+          {
+            "title": "Node Security Advisory",
+            "url": "https://nodesecurity.io/advisories/28"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<1.0.0"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Denial of Service (DoS)"
+      },
+      "npm:qs:20170213": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "alternativeIds": [
+          "SNYK-JS-QS-10407"
+        ],
+        "creationTime": "2017-02-14T11:44:54.163000Z",
+        "credit": [
+          "Snyk Security Research Team"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n[qs](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.\n\nAffected versions of this package are vulnerable to Prototype Override Protection Bypass. By default `qs` protects against attacks that attempt to overwrite an object's existing prototype properties, such as `toString()`, `hasOwnProperty()`,etc.\r\n\r\nFrom [`qs` documentation](https://github.com/ljharb/qs):\r\n> By default parameters that would overwrite properties on the object prototype are ignored, if you wish to keep the data from those fields either use plainObjects as mentioned above, or set allowPrototypes to true which will allow user input to overwrite those properties. WARNING It is generally a bad idea to enable this option as it can cause problems when attempting to use the properties that have been overwritten. Always be careful with this option.\r\n\r\nOverwriting these properties can impact application logic, potentially allowing attackers to work around security controls, modify data, make the application unstable and more.\r\n\r\nIn versions of the package affected by this vulnerability, it is possible to circumvent this protection and overwrite prototype properties and functions by prefixing the name of the parameter with `[` or `]`. e.g. `qs.parse(\"]=toString\")` will return `{toString = true}`, as a result, calling `toString()` on the object will throw an exception.\r\n\r\n**Example:**\r\n```js\r\nqs.parse('toString=foo', { allowPrototypes: false })\r\n// {}\r\n\r\nqs.parse(\"]=toString\", { allowPrototypes: false })\r\n// {toString = true} <== prototype overwritten\r\n```\r\n\r\nFor more information, you can check out our [blog](https://snyk.io/blog/high-severity-vulnerability-qs/).\r\n\r\n## Disclosure Timeline\r\n- February 13th, 2017 - Reported the issue to package owner.\r\n- February 13th, 2017 - Issue acknowledged by package owner.\r\n- February 16th, 2017 - Partial fix released in versions `6.0.3`, `6.1.1`, `6.2.2`, `6.3.1`.\r\n- March 6th, 2017     - Final fix released in versions `6.4.0`,`6.3.2`, `6.2.3`, `6.1.2` and `6.0.4`\n## Remediation\nUpgrade `qs` to version 6.0.4, 6.1.2, 6.2.3, 6.3.2 or higher.\n## References\n- [GitHub Commit](https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d)\n- [GitHub Issue](https://github.com/ljharb/qs/issues/200)\n",
+        "disclosureTime": "2017-02-13T00:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "6.0.4",
+          "6.1.2",
+          "6.2.3",
+          "6.3.2"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lib/parse.js",
+              "functionName": "internals.parseObject"
+            },
+            "version": [
+              "<6.0.4"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/parse.js",
+              "functionName": "parseObject"
+            },
+            "version": [
+              ">=6.2.0 <6.2.3",
+              "6.3.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/parse.js",
+              "functionName": "parseObjectRecursive"
+            },
+            "version": [
+              ">=6.3.1 <6.3.2"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lib/parse.js",
+              "functionName": "internals.parseObject"
+            },
+            "version": [
+              "<6.0.4"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/parse.js",
+              "functionName": "parseObject"
+            },
+            "version": [
+              ">=6.2.0 <6.2.3",
+              "6.3.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/parse.js",
+              "functionName": "parseObjectRecursive"
+            },
+            "version": [
+              ">=6.3.1 <6.3.2"
+            ]
+          }
+        ],
+        "id": "npm:qs:20170213",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-QS-10407"
+          ],
+          "CVE": [
+            "CVE-2017-1000048"
+          ],
+          "CWE": [
+            "CWE-20"
+          ],
+          "GHSA": [
+            "GHSA-gqgv-6jq5-jjj9"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T14:36:53.880024Z",
+        "moduleName": "qs",
+        "packageManager": "npm",
+        "packageName": "qs",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:0",
+            "modificationTime": "2019-12-03T11:40:45.855245Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/630_632.patch"
+            ],
+            "version": "=6.3.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:1",
+            "modificationTime": "2019-12-03T11:40:45.856271Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/631_632.patch"
+            ],
+            "version": "=6.3.1"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:2",
+            "modificationTime": "2019-12-03T11:40:45.857318Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/621_623.patch"
+            ],
+            "version": "=6.2.1"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:3",
+            "modificationTime": "2019-12-03T11:40:45.858334Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/622_623.patch"
+            ],
+            "version": "=6.2.2"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:4",
+            "modificationTime": "2019-12-03T11:40:45.859411Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/610_612.patch"
+            ],
+            "version": "=6.1.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:5",
+            "modificationTime": "2019-12-03T11:40:45.860523Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/611_612.patch"
+            ],
+            "version": "=6.1.1"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:6",
+            "modificationTime": "2019-12-03T11:40:45.861504Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/602_604.patch"
+            ],
+            "version": "=6.0.2"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:7",
+            "modificationTime": "2019-12-03T11:40:45.862615Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/603_604.patch"
+            ],
+            "version": "=6.0.3"
+          }
+        ],
+        "proprietary": true,
+        "publicationTime": "2017-03-01T10:00:54Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/ljharb/qs/issues/200"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<6.0.4",
+            ">=6.1.0 <6.1.2",
+            ">=6.2.0 <6.2.3",
+            ">=6.3.0 <6.3.2"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Override Protection Bypass"
+      },
+      "npm:request:20160119": {
+        "CVSSv3": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
+        "alternativeIds": [
+          "SNYK-JS-REQUEST-10088"
+        ],
+        "creationTime": "2016-03-22T12:00:05.158000Z",
+        "credit": [
+          "Feross Aboukhadijeh"
+        ],
+        "cvssScore": 5.1,
+        "description": "## Overview\n\n[request](https://www.npmjs.com/package/request) is a simplified http request client.\n\n\nAffected versions of this package are vulnerable to Remote Memory Exposure.\nA potential remote memory exposure vulnerability exists in `request`. If a `request` uses a multipart attachment and the _body type_ option is `number` with value X, then X bytes of uninitialized memory will be sent in the body of the request.\r\n\r\nNote that while the impact of this vulnerability is high (memory exposure), exploiting it is likely difficult, as the attacker needs to somehow control the body type of the request. One potential exploit scenario is when a request is composed based on JSON input, including the body type, allowing a malicious JSON to trigger the memory leak.\r\n\r\n## Details\r\nConstructing a `Buffer` class with integer `N` creates a `Buffer`\r\nof length `N` with non zero-ed out memory.\r\n**Example:**\r\n```js\r\nvar x = new Buffer(100); // uninitialized Buffer of length 100\r\n// vs\r\nvar x = new Buffer('100'); // initialized Buffer with value of '100'\r\n```\r\n\r\nInitializing a multipart body in such manner will cause uninitialized memory to be sent in the body of the request.\r\n\r\n#### Proof of concept\r\n```js\r\nvar http = require('http')\r\nvar request = require('request')\r\n\r\nhttp.createServer(function (req, res) {\r\n  var data = ''\r\n  req.setEncoding('utf8')\r\n  req.on('data', function (chunk) {\r\n    console.log('data')\r\n    data += chunk\r\n  })\r\n  req.on('end', function () {\r\n    // this will print uninitialized memory from the client\r\n    console.log('Client sent:\\n', data)\r\n  })\r\n  res.end()\r\n}).listen(8000)\r\n\r\nrequest({\r\n  method: 'POST',\r\n  uri: 'http://localhost:8000',\r\n  multipart: [{ body: 1000 }]\r\n},\r\nfunction (err, res, body) {\r\n  if (err) return console.error('upload failed:', err)\r\n  console.log('sent')\r\n})\r\n```\n\n## Remediation\n\nUpgrade `request` to version 2.68.0 or higher.\n\n\n## References\n\n- [Blog: Information about Buffer](https://github.com/ChALkeR/notes/blob/master/Buffer-knows-everything.md)\n\n- [Blog: Node Buffer API fix](https://github.com/ChALkeR/notes/blob/master/Lets-fix-Buffer-API.md#previous-materials)\n\n- [GitHub Commit](https://github.com/request/request/pull/2018/commits/3d31d4526fa4d4e4f59b89cabe194fb671063cdb)\n\n- [GitHub PR](https://github.com/request/request/pull/2018)\n",
+        "disclosureTime": "2016-01-19T04:57:05Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.68.0"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "Request.prototype.multipart"
+            },
+            "version": [
+              ">=2.16.0 <2.27.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "main.js",
+              "functionName": "Request.prototype.request"
+            },
+            "version": [
+              ">=2.2.6 <2.9.150"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "request.js",
+              "functionName": "Request.prototype.multipart"
+            },
+            "version": [
+              ">=2.27.0 <2.54.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/multipart.js",
+              "functionName": "Multipart.prototype.build.add"
+            },
+            "version": [
+              ">=2.54.0 <2.68.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "main.js",
+              "functionName": "Request.prototype.multipart"
+            },
+            "version": [
+              ">=2.9.150 <2.16.0"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "Request.prototype.multipart"
+            },
+            "version": [
+              ">=2.16.0 <2.27.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "main.js",
+              "functionName": "Request.prototype.request"
+            },
+            "version": [
+              ">=2.2.6 <2.9.150"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "request.js",
+              "functionName": "Request.prototype.multipart"
+            },
+            "version": [
+              ">=2.27.0 <2.54.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/multipart.js",
+              "functionName": "Multipart.prototype.build.add"
+            },
+            "version": [
+              ">=2.54.0 <2.68.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "main.js",
+              "functionName": "Request.prototype.multipart"
+            },
+            "version": [
+              ">=2.9.150 <2.16.0"
+            ]
+          }
+        ],
+        "id": "npm:request:20160119",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-REQUEST-10088"
+          ],
+          "CVE": [
+            "CVE-2017-16026"
+          ],
+          "CWE": [
+            "CWE-201"
+          ],
+          "GHSA": [
+            "GHSA-7xfp-9c55-5vqj"
+          ],
+          "NSP": [
+            "309"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2019-12-02T14:39:20.112971Z",
+        "moduleName": "request",
+        "packageManager": "npm",
+        "packageName": "request",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:request:20160119:0",
+            "modificationTime": "2019-12-03T11:40:45.805489Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/request/20160119/request_20160119_0_0_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+            ],
+            "version": "<2.68.0 >=2.54.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:request:20160119:1",
+            "modificationTime": "2019-12-03T11:40:45.806558Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/request/20160119/request_20160119_0_1_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+            ],
+            "version": "<2.54.0 >2.51.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:request:20160119:2",
+            "modificationTime": "2019-12-03T11:40:45.807612Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/request/20160119/request_20160119_0_2_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+            ],
+            "version": "<=2.51.0 >2.47.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:request:20160119:3",
+            "modificationTime": "2019-12-03T11:40:45.808645Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/request/20160119/request_20160119_0_3_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+            ],
+            "version": "=2.47.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:request:20160119:4",
+            "modificationTime": "2019-12-03T11:40:45.809647Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/request/20160119/request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+            ],
+            "version": "<2.47.0 >=2.27.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:request:20160119:5",
+            "modificationTime": "2019-12-03T11:40:45.810808Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/request/20160119/request_20160119_0_5_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+            ],
+            "version": "<2.27.0 >=2.16.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:request:20160119:6",
+            "modificationTime": "2019-12-03T11:40:45.811942Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/request/20160119/request_20160119_0_6_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+            ],
+            "version": "<2.16.0 >=2.9.150"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:request:20160119:7",
+            "modificationTime": "2019-12-03T11:40:45.813062Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/request/20160119/request_20160119_0_7_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+            ],
+            "version": "<2.9.150 >=2.9.3"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:request:20160119:8",
+            "modificationTime": "2019-12-03T11:40:45.814179Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/request/20160119/request_20160119_0_8_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+            ],
+            "version": "<2.9.3 >=2.2.6"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2016-03-22T12:00:05Z",
+        "references": [
+          {
+            "title": "Blog: Information about Buffer",
+            "url": "https://github.com/ChALkeR/notes/blob/master/Buffer-knows-everything.md"
+          },
+          {
+            "title": "Blog: Node Buffer API fix",
+            "url": "https://github.com/ChALkeR/notes/blob/master/Lets-fix-Buffer-API.md%23previous-materials"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/request/request/pull/2018/commits/3d31d4526fa4d4e4f59b89cabe194fb671063cdb"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/request/request/pull/2018"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            ">2.2.5 <2.68.0"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Remote Memory Exposure"
+      },
+      "npm:semver:20150403": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+        "alternativeIds": [
+          "SNYK-JS-SEMVER-10038"
+        ],
+        "creationTime": "2015-04-03T16:00:00Z",
+        "credit": [
+          "Adam Baldwin"
+        ],
+        "cvssScore": 5.3,
+        "description": "## Overview\n[semver](https://github.com/npm/node-semver) is a semantic version parser used by npm.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS).\n\n## Overview\r\n[npm](https://github.com/npm/npm) is a package manager for javascript.\r\n\r\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS).\r\nThe semver module uses regular expressions when parsing a version string. For a carefully crafted input, the time it takes to process these regular expressions is not linear to the length of the input. Since the semver module did not enforce a limit on the version string length, an attacker could provide a long string that would take up a large amount of resources, potentially taking a server down. This issue therefore enables a potential Denial of Service attack. This is a slightly differnt variant of a typical Regular Expression Denial of Service ([ReDoS](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS)) vulnerability.\r\n\r\n## Details\r\n<<ReDoS>>\r\n\r\n\r\n## Remediation\r\nUpdate to a version 4.3.2 or greater. From the issue description [2]: \"Package version can no longer be more than 256 characters long. This prevents a situation in which parsing the version number can use exponentially more time and memory to parse, leading to a potential denial of service.\"\r\n\r\n## References\r\n- [GitHub Release](https://github.com/npm/npm/releases/tag/v2.7.5)\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `semver` to version 4.3.2 or higher.\n## References\n- [GitHub Release](https://github.com/npm/npm/releases/tag/v2.7.5)\n",
+        "disclosureTime": "2015-04-03T16:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "4.3.2"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "npm:semver:20150403",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-SEMVER-10038"
+          ],
+          "CVE": [
+            "CVE-2015-8855"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-x6fg-f45m-jf5q"
+          ],
+          "NSP": [
+            "31"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T14:36:43.088858Z",
+        "moduleName": "semver",
+        "packageManager": "npm",
+        "packageName": "semver",
+        "patches": [
+          {
+            "comments": [
+              "https://github.com/npm/node-semver/commit/c80180d8341a8ada0236815c29a2be59864afd70.patch"
+            ],
+            "id": "patch:npm:semver:20150403:0",
+            "modificationTime": "2019-12-03T11:40:45.754335Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/semver/20150403/semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+            ],
+            "version": "<4.3.2 >= 2.0.2"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2015-04-03T16:00:00Z",
+        "references": [
+          {
+            "title": "GitHub Release",
+            "url": "https://github.com/npm/npm/releases/tag/v2.7.5"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.3.2"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "npm:sshpk:20180409": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P/RL:O/RC:C",
+        "alternativeIds": [
+          "SNYK-JS-SSHPK-12114"
+        ],
+        "creationTime": "2018-02-25T08:09:56.427000Z",
+        "credit": [
+          "ChALkeR"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\r\n[sshpk](https://www.npmjs.com/package/sshpk) is Parse, convert, fingerprint and use SSH keys in pure node.js.\r\n\r\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks when parsing crafted invalid public keys.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `sshpk` to version 1.13.2 or higher.\r\n\r\n## References\r\n- [HackerOne Report](https://hackerone.com/reports/319593)",
+        "disclosureTime": "2018-04-09T08:09:56Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "1.14.1"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lib/key.js",
+              "functionName": "Key.parse"
+            },
+            "version": [
+              "<1.14.1"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lib/key.js",
+              "functionName": "Key.parse"
+            },
+            "version": [
+              "<1.14.1"
+            ]
+          }
+        ],
+        "id": "npm:sshpk:20180409",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-SSHPK-12114"
+          ],
+          "CVE": [
+            "CVE-2018-3737"
+          ],
+          "CWE": [
+            "CWE-185"
+          ],
+          "GHSA": [
+            "GHSA-2m39-62fm-q8r3"
+          ],
+          "NSP": [
+            "606"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2019-12-31T10:17:09.068690Z",
+        "moduleName": "sshpk",
+        "packageManager": "npm",
+        "packageName": "sshpk",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2018-04-09T15:17:27Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/joyent/node-sshpk/commit/46065d38a5e6d1bccf86d3efb2fb83c14e3f9957"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/319593"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<1.14.1"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "npm:stringstream:20180511": {
+        "CVSSv3": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:H/E:F/RL:O/RC:C",
+        "alternativeIds": [
+          "SNYK-JS-STRINGSTREAM-12147"
+        ],
+        "creationTime": "2018-03-03T11:54:41.571000Z",
+        "credit": [
+          "ChALkeR"
+        ],
+        "cvssScore": 5.2,
+        "description": "## Overview\r\n[stringstream](https://www.npmjs.com/package/stringstream) Encode and decode streams into string streams in node.js.\r\n\r\nAffected versions of this package are vulnerable to Uninitialized Memory Exposure. An attacker could extract sensitive data from uninitialized memory or to cause a DoS by passing in a large number, in setups where typed user input can be passed to the stream (e.g. from JSON).\r\n\r\n## Details\r\nThe Buffer class on Node.js is a mutable array of binary data, and can be initialized with a string, array or number.\r\n```js\r\nconst buf1 = new Buffer([1,2,3]);\r\n// creates a buffer containing [01, 02, 03]\r\nconst buf2 = new Buffer('test');\r\n// creates a buffer containing ASCII bytes [74, 65, 73, 74]\r\nconst buf3 = new Buffer(10);\r\n// creates a buffer of length 10\r\n```\r\n\r\nThe first two variants simply create a binary representation of the value it received. The last one, however, pre-allocates a buffer of the specified size, making it a useful buffer, especially when reading data from a stream.\r\nWhen using the number constructor of Buffer, it will allocate the memory, but will not fill it with zeros. Instead, the allocated buffer will hold whatever was in memory at the time. If the buffer is not `zeroed` by using `buf.fill(0)`, it may leak sensitive information like keys, source code, and system info.\r\n\r\n\r\n**Note** This is vulnerable only for Node <=4\r\n\r\n## Remediation\r\nUpgrade `stringstream` to version 0.0.6 or higher.\n\n## References\n- [GitHub Commit](https://github.com/mhart/StringStream/commit/afbc7442220358419e330618e47f3a65fc265b1b)\n- [GitHub Issue](https://github.com/mhart/StringStream/issues/7)\n- [HAckerOne Report](https://hackerone.com/reports/321670)\n",
+        "disclosureTime": "2018-05-11T11:54:41Z",
+        "exploit": "Functional",
+        "fixedIn": [
+          "0.0.6"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "stringstream.js",
+              "functionName": "StringStream.prototype.write"
+            },
+            "version": [
+              ">0.0.0 <0.0.6"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "stringstream.js",
+              "functionName": "StringStream.prototype.write"
+            },
+            "version": [
+              ">0.0.0 <0.0.6"
+            ]
+          }
+        ],
+        "id": "npm:stringstream:20180511",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-STRINGSTREAM-12147"
+          ],
+          "CVE": [
+            "CVE-2018-21270"
+          ],
+          "CWE": [
+            "CWE-201",
+            "CWE-215"
+          ],
+          "GHSA": [
+            "GHSA-mf6x-7mm4-x2g7"
+          ],
+          "NSP": [
+            "664"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2019-03-05T12:06:41.274818Z",
+        "moduleName": "stringstream",
+        "packageManager": "npm",
+        "packageName": "stringstream",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:stringstream:20180511:0",
+            "modificationTime": "2019-12-03T11:40:45.881859Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/stringstream/20180511/20180511_0_0_stringstream_afbc7442220358419e330618e47f3a65fc265b1b.patch"
+            ],
+            "version": "<0.0.6 >=0.0.4"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2018-05-13T14:26:27Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/mhart/StringStream/commit/afbc7442220358419e330618e47f3a65fc265b1b"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/mhart/StringStream/issues/7"
+          },
+          {
+            "title": "HAckerOne Report",
+            "url": "https://hackerone.com/reports/321670"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<0.0.6"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Uninitialized Memory Exposure"
+      },
+      "npm:tough-cookie:20170905": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "alternativeIds": [
+          "SNYK-JS-TOUGHCOOKIE-10760"
+        ],
+        "creationTime": "2017-09-21T08:07:51.834000Z",
+        "credit": [
+          "Cristian-Alexandru Staicu"
+        ],
+        "cvssScore": 5.9,
+        "description": "## Overview\r\n[`tough-cookie`](https://www.npmjs.com/package/tough-cookie) is RFC6265 Cookies and Cookie Jar for node.js.\r\n\r\nAffected versions of this package are vulnerable to Regular expression Denial of Service (ReDoS) attacks. An attacker may pass a specially crafted cookie, causing the server to hang.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade to version `2.3.3` or newer.\r\n\r\n## References\r\n- [Github Issue](https://github.com/salesforce/tough-cookie/issues/92)",
+        "disclosureTime": "2017-09-07T21:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.3.3"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lib/cookie.js",
+              "functionName": "parse"
+            },
+            "version": [
+              "<2.3.3"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lib/cookie.js",
+              "functionName": "parse"
+            },
+            "version": [
+              "<2.3.3"
+            ]
+          }
+        ],
+        "id": "npm:tough-cookie:20170905",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-TOUGHCOOKIE-10760"
+          ],
+          "CVE": [
+            "CVE-2017-15010"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-g7q5-pjjr-gqvp"
+          ],
+          "NSP": [
+            "525"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2019-12-02T14:40:19.359490Z",
+        "moduleName": "tough-cookie",
+        "packageManager": "npm",
+        "packageName": "tough-cookie",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:tough-cookie:20170905:0",
+            "modificationTime": "2019-12-03T11:40:45.869349Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/tough-cookie/20170905/220_221.patch"
+            ],
+            "version": "=2.2.0 || =2.2.1"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:tough-cookie:20170905:1",
+            "modificationTime": "2019-12-03T11:40:45.870315Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/tough-cookie/20170905/222.patch"
+            ],
+            "version": "=2.2.2"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:tough-cookie:20170905:2",
+            "modificationTime": "2019-12-03T11:40:45.871421Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/tough-cookie/20170905/230_232.patch"
+            ],
+            "version": "=2.3.0 || =2.3.1 || =2.3.2"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2017-09-21T08:07:51Z",
+        "references": [
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/salesforce/tough-cookie/issues/92"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<2.3.3"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "npm:tunnel-agent:20170305": {
+        "CVSSv3": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N/E:P/RL:O/RC:C",
+        "alternativeIds": [
+          "SNYK-JS-TUNNELAGENT-10672"
+        ],
+        "creationTime": "2017-07-05T07:23:57.738000Z",
+        "credit": [
+          "ChALkeR"
+        ],
+        "cvssScore": 5.1,
+        "description": "## Overview\r\n[`tunnel-agent`](https://www.npmjs.com/package/tunnel-agent) is HTTP proxy tunneling agent. Affected versions of the package are vulnerable to Uninitialized Memory Exposure. \r\n\r\nA possible memory disclosure vulnerability exists when a value of type `number` is used to set the _proxy.auth_ option of a request `request` and results in a possible uninitialized memory exposures in the request body.\r\n\r\nThis is a result of unobstructed use of the `Buffer` constructor, whose [insecure default constructor increases the odds of memory leakage](https://snyk.io/blog/exploiting-buffer/).\r\n\r\n## Details\r\nConstructing a `Buffer` class with integer `N` creates a `Buffer` of length `N` with raw (not \"zero-ed\") memory.\r\n\r\nIn the following example, the first call would allocate 100 bytes of memory, while the second example will allocate the memory needed for the string \"100\":\r\n```js\r\n// uninitialized Buffer of length 100\r\nx = new Buffer(100);\r\n// initialized Buffer with value of '100'\r\nx = new Buffer('100');\r\n```\r\n\r\n`tunnel-agent`'s `request` construction uses the default `Buffer` constructor as-is, making it easy to append uninitialized memory to an existing list. If the value of the buffer list is exposed to users, it may expose raw server side memory, potentially holding secrets, private data and code. This is a similar vulnerability to the infamous [`Heartbleed`](http://heartbleed.com/) flaw in OpenSSL.\r\n\r\n#### Proof of concept by ChALkeR\r\n```js\r\nrequire('request')({\r\n  method: 'GET',\r\n  uri: 'http://www.example.com',\r\n  tunnel: true,\r\n  proxy:{\r\n      protocol: 'http:',\r\n      host:\"127.0.0.1\",\r\n      port:8080,\r\n      auth:80\r\n  }\r\n});\r\n```\r\n\r\nYou can read more about the insecure `Buffer` behavior [on our blog](https://snyk.io/blog/exploiting-buffer/).\r\n\r\nSimilar vulnerabilities were discovered in [request](https://snyk.io/vuln/npm:request:20160119), [mongoose](https://snyk.io/vuln/npm:mongoose:20160116), [ws](https://snyk.io/vuln/npm:ws:20160104) and [sequelize](https://snyk.io/vuln/npm:sequelize:20160115).\r\n\r\n## Remediation\r\nUpgrade `tunnel-agent` to version 0.6.0 or higher.\r\n**Note** This is vulnerable only for Node <=4\n\n## References\n- [GitHub Commit](https://github.com/request/tunnel-agent/commit/9ca95ec7219daface8a6fc2674000653de0922c0)\n- [PoC by ChALkeR](https://gist.github.com/ChALkeR/fd6b2c445834244e7d440a043f9d2ff4)\n",
+        "disclosureTime": "2017-03-04T22:00:00Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "0.6.0"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "TunnelingAgent.prototype.createSocket"
+            },
+            "version": [
+              "<0.6.0"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "TunnelingAgent.prototype.createSocket"
+            },
+            "version": [
+              "<0.6.0"
+            ]
+          }
+        ],
+        "id": "npm:tunnel-agent:20170305",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-TUNNELAGENT-10672"
+          ],
+          "CVE": [],
+          "CWE": [
+            "CWE-201"
+          ],
+          "GHSA": [
+            "GHSA-xc7v-wxcw-j472"
+          ],
+          "NSP": [
+            "598"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2019-12-02T14:38:58.879097Z",
+        "moduleName": "tunnel-agent",
+        "packageManager": "npm",
+        "packageName": "tunnel-agent",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:tunnel-agent:20170305:0",
+            "modificationTime": "2019-12-03T11:40:45.868281Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/tunnel-agent/20170305/tunnel-agent_20170305_0_0_9ca95ec7219daface8a6fc2674000653de0922c0.patch"
+            ],
+            "version": "=0.4.3 || =0.5.0"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2017-07-05T14:05:50Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/request/tunnel-agent/commit/9ca95ec7219daface8a6fc2674000653de0922c0"
+          },
+          {
+            "title": "PoC by ChALkeR",
+            "url": "https://gist.github.com/ChALkeR/fd6b2c445834244e7d440a043f9d2ff4"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<0.6.0"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Uninitialized Memory Exposure"
+      }
+    },
+    "remediation": {
+      "unresolved": [
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:L/A:L/E:P",
+          "alternativeIds": [],
+          "creationTime": "2020-08-28T12:18:44.906258Z",
+          "credit": [
+            "chalker"
+          ],
+          "cvssScore": 7.7,
+          "description": "## Overview\n[bl](https://github.com/rvagg/bl) is a library that allows you to collect buffers and access with a standard readable buffer interface.\n\nAffected versions of this package are vulnerable to Remote Memory Exposure. If user input ends up in `consume()` argument and can become negative, BufferList state can be corrupted, tricking it into exposing uninitialized memory via regular `.slice()` calls.\r\n\r\n### PoC by chalker\r\n```\r\nconst { BufferList } = require('bl')\r\nconst secret = require('crypto').randomBytes(256)\r\nfor (let i = 0; i < 1e6; i++) {\r\n  const clone = Buffer.from(secret)\r\n  const bl = new BufferList()\r\n  bl.append(Buffer.from('a'))\r\n  bl.consume(-1024)\r\n  const buf = bl.slice(1)\r\n  if (buf.indexOf(clone) !== -1) {\r\n    console.error(`Match (at ${i})`, buf)\r\n  }\r\n}\r\n```\n## Remediation\nUpgrade `bl` to version 2.2.1, 3.0.1, 4.0.3, 1.2.3 or higher.\n## References\n- [Github Commit](https://github.com/rvagg/bl/commit/8a8c13c880e2bef519133ea43e0e9b78b5d0c91e)\n- [Github Commit](https://github.com/rvagg/bl/commit/d3e240e3b8ba4048d3c76ef5fb9dd1f8872d3190)\n- [Github Commit](https://github.com/rvagg/bl/commit/dacc4ac7d5fcd6201bcf26fbd886951be9537466)\n- [GitHub Commit](https://github.com/rvagg/bl/commit/0bd87ec97be399b129fc62feff2943ffa21bcc00)\n- [HackerOne Report](https://hackerone.com/reports/966347)\n",
+          "disclosureTime": "2020-08-27T15:16:42Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "2.2.1",
+            "3.0.1",
+            "4.0.3",
+            "1.2.3"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-BL-608877",
+          "identifiers": {
+            "CVE": [
+              "CVE-2020-8244"
+            ],
+            "CWE": [
+              "CWE-9"
+            ],
+            "GHSA": [
+              "GHSA-pp7h-53gx-mx7r"
+            ],
+            "NSP": [
+              "1555"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-09-04T12:31:03.817670Z",
+          "moduleName": "bl",
+          "packageManager": "npm",
+          "packageName": "bl",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2020-08-28T12:18:48Z",
+          "references": [
+            {
+              "title": "Github Commit",
+              "url": "https://github.com/rvagg/bl/commit/8a8c13c880e2bef519133ea43e0e9b78b5d0c91e"
+            },
+            {
+              "title": "Github Commit",
+              "url": "https://github.com/rvagg/bl/commit/d3e240e3b8ba4048d3c76ef5fb9dd1f8872d3190"
+            },
+            {
+              "title": "Github Commit",
+              "url": "https://github.com/rvagg/bl/commit/dacc4ac7d5fcd6201bcf26fbd886951be9537466"
+            },
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/rvagg/bl/commit/0bd87ec97be399b129fc62feff2943ffa21bcc00"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/966347"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              ">=2.2.0 <2.2.1",
+              ">=3.0.0 <3.0.1",
+              ">=4.0.0 <4.0.3",
+              "<1.2.3"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Remote Memory Exposure",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "bl@1.1.2"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.76.0"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "bl",
+          "version": "1.1.2"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2020-01-28T15:18:37.743372Z",
+          "credit": [
+            "aaron_costello"
+          ],
+          "cvssScore": 6.3,
+          "description": "## Overview\n[dot-prop](https://github.com/sindresorhus/dot-prop#readme) is a package to get, set, or delete a property from a nested object using a dot path.\n\nAffected versions of this package are vulnerable to Prototype Pollution. It is possible for a user to modify the prototype of a base object.\r\n\r\n## PoC by aaron_costello \r\n```\r\nvar dotProp = require(\"dot-prop\")\r\nconst object = {};\r\nconsole.log(\"Before \" + object.b); //Undefined\r\ndotProp.set(object, '__proto__.b', true);\r\nconsole.log(\"After \" + {}.b); //true\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `dot-prop` to version 4.2.1, 5.1.1 or higher.\n## References\n- [GitHub Commit](https://github.com/sindresorhus/dot-prop/commit/3039c8c07f6fdaa8b595ec869ae0895686a7a0f2)\n- [HackerOne Report](https://hackerone.com/reports/719856)\n",
+          "disclosureTime": "2020-01-28T10:17:51Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "4.2.1",
+            "5.1.1"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "module.exports.set"
+              },
+              "version": [
+                ">1.0.1 <5.1.1"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "module.exports.set"
+              },
+              "version": [
+                ">1.0.1 <5.1.1"
+              ]
+            }
+          ],
+          "id": "SNYK-JS-DOTPROP-543489",
+          "identifiers": {
+            "CVE": [
+              "CVE-2020-8116"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-ff7x-qrg7-qggm"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-27T08:47:24.715335Z",
+          "moduleName": "dot-prop",
+          "packageManager": "npm",
+          "packageName": "dot-prop",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2020-01-28T16:23:39Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/sindresorhus/dot-prop/commit/3039c8c07f6fdaa8b595ec869ae0895686a7a0f2"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/719856"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              ">1.0.1 <4.2.1",
+              ">=5.0.0 <5.1.1"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "update-notifier@0.6.3",
+            "configstore@2.0.0",
+            "dot-prop@2.4.0"
+          ],
+          "upgradePath": [],
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "dot-prop",
+          "version": "2.4.0"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P/RL:O/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2021-03-23T16:13:42.109692Z",
+          "credit": [
+            "Yeting Li"
+          ],
+          "cvssScore": 5.3,
+          "description": "## Overview\n[hosted-git-info](https://www.npmjs.org/package/hosted-git-info) is a Provides metadata and conversions from repository urls for Github, Bitbucket and Gitlab\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) via regular expression `shortcutMatch ` in the `fromUrl` function in index.js. The affected regular expression exhibits polynomial worst-case time complexity.\r\n\r\n### PoC by Yeting Li\r\n```\r\nvar hostedGitInfo = require(\"hosted-git-info\")\r\nfunction build_attack(n) {\r\n    var ret = \"a:\"\r\n    for (var i = 0; i < n; i++) {\r\n        ret += \"a\"\r\n    }\r\n    return ret + \"!\";\r\n}\r\n\r\nfor(var i = 1; i <= 5000000; i++) {\r\n   if (i % 1000 == 0) {\r\n        var time = Date.now();\r\n        var attack_str = build_attack(i)\r\n       var parsedInfo = hostedGitInfo.fromUrl(attack_str)\r\n        var time_cost = Date.now() - time;\r\n        console.log(\"attack_str.length: \" + attack_str.length + \": \" + time_cost+\" ms\")\r\n}\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `hosted-git-info` to version 3.0.8, 2.8.9 or higher.\n## References\n- [GitHub Commit](https://github.com/npm/hosted-git-info/commit/bede0dc38e1785e732bf0a48ba6f81a4a908eba3)\n",
+          "disclosureTime": "2020-11-28T00:00:00Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "3.0.8",
+            "2.8.9"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-HOSTEDGITINFO-1088355",
+          "identifiers": {
+            "CVE": [
+              "CVE-2021-23362"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-43f8-2h32-f4cj"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2021-04-08T12:53:49.093606Z",
+          "moduleName": "hosted-git-info",
+          "packageManager": "npm",
+          "packageName": "hosted-git-info",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2021-03-23T17:13:24Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/npm/hosted-git-info/commit/bede0dc38e1785e732bf0a48ba6f81a4a908eba3"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              ">=3.0.0 <3.0.8",
+              "<2.8.9"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Regular Expression Denial of Service (ReDoS)",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "yargs@4.8.1",
+            "read-pkg-up@1.0.1",
+            "read-pkg@1.1.0",
+            "normalize-package-data@2.3.5",
+            "hosted-git-info@2.1.5"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "yargs@4.8.1",
+            "read-pkg-up@1.0.1",
+            "read-pkg@1.1.0",
+            "normalize-package-data@2.3.5",
+            "hosted-git-info@2.8.9"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "hosted-git-info",
+          "version": "2.1.5"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P",
+          "alternativeIds": [],
+          "creationTime": "2020-12-08T15:34:07.743781Z",
+          "credit": [
+            "Eugene Lim",
+            "Government Technology Agency Cyber Security Group"
+          ],
+          "cvssScore": 7.3,
+          "description": "## Overview\n[ini](https://www.npmjs.org/package/ini) is an An ini encoder/decoder for node\n\nAffected versions of this package are vulnerable to Prototype Pollution. If an attacker submits a malicious INI file to an application that parses it with `ini.parse`, they will pollute the prototype on the application. This can be exploited further depending on the context.\r\n\r\n## PoC by Eugene Lim\r\n\r\npayload.ini\r\n```\r\n[__proto__]\r\npolluted = \"polluted\"\r\n```\r\n\r\npoc.js:\r\n```\r\nvar fs = require('fs')\r\nvar ini = require('ini')\r\n\r\nvar parsed = ini.parse(fs.readFileSync('./payload.ini', 'utf-8'))\r\nconsole.log(parsed)\r\nconsole.log(parsed.__proto__)\r\nconsole.log(polluted)\r\n```\r\n\r\n```\r\n> node poc.js\r\n{}\r\n{ polluted: 'polluted' }\r\n{ polluted: 'polluted' }\r\npolluted\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `ini` to version 1.3.6 or higher.\n## References\n- [Eugene Lim - Research Blog Post](https://medium.com/csg-govtech/supply-chain-pollution-discovering-a-16-million-download-week-node-js-2fa4d2c27cf7)\n- [GitHub Commit](https://github.com/npm/ini/commit/56d2805e07ccd94e2ba0984ac9240ff02d44b6f1)\n",
+          "disclosureTime": "2020-12-08T13:02:04Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "1.3.6"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-INI-1048974",
+          "identifiers": {
+            "CVE": [
+              "CVE-2020-7788"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-qqgx-2p2h-9c37"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-12-10T18:09:23.069283Z",
+          "moduleName": "ini",
+          "packageManager": "npm",
+          "packageName": "ini",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2020-12-10T18:08:38Z",
+          "references": [
+            {
+              "title": "Eugene Lim - Research Blog Post",
+              "url": "https://medium.com/csg-govtech/supply-chain-pollution-discovering-a-16-million-download-week-node-js-2fa4d2c27cf7"
+            },
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/npm/ini/commit/56d2805e07ccd94e2ba0984ac9240ff02d44b6f1"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<1.3.6"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "update-notifier@0.6.3",
+            "latest-version@2.0.0",
+            "package-json@2.3.3",
+            "registry-url@3.1.0",
+            "rc@1.1.6",
+            "ini@1.3.4"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "update-notifier@0.6.3",
+            "latest-version@2.0.0",
+            "package-json@2.3.3",
+            "registry-url@3.1.0",
+            "rc@1.1.6",
+            "ini@1.3.6"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "ini",
+          "version": "1.3.4"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P/RL:O/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2020-08-02T12:09:52.577067Z",
+          "credit": [
+            "chalker"
+          ],
+          "cvssScore": 7.5,
+          "description": "## Overview\n[is-my-json-valid](https://github.com/mafintosh/is-my-json-valid) is a JSONSchema / orderly validator that uses code generation to be extremely fast.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) via the `style` format. \r\n\r\n##PoC\r\n```\r\nconst imjv = require('is-my-json-valid')\r\nconst validate = imjv({ maxLength: 100, format: 'style' })\r\nconsole.log(validate(' '.repeat(1e4)))\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `is-my-json-valid` to version 2.20.2 or higher.\n## References\n- [GitHub Commit](https://github.com/mafintosh/is-my-json-valid/commit/c3fc04fc455d40e9b29537f8e2c73a28ce106edb)\n- [HackerOne Report](https://hackerone.com/reports/909757)\n",
+          "disclosureTime": "2020-07-31T17:13:38Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "2.20.2"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-ISMYJSONVALID-597165",
+          "identifiers": {
+            "CVE": [],
+            "CWE": [
+              "CWE-400"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-02T15:04:47.420926Z",
+          "moduleName": "is-my-json-valid",
+          "packageManager": "npm",
+          "packageName": "is-my-json-valid",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2020-08-02T15:04:47.405171Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/mafintosh/is-my-json-valid/commit/c3fc04fc455d40e9b29537f8e2c73a28ce106edb"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/909757"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<2.20.2"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Regular Expression Denial of Service (ReDoS)",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "har-validator@2.0.6",
+            "is-my-json-valid@2.13.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "har-validator@2.0.6",
+            "is-my-json-valid@2.20.2"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "is-my-json-valid",
+          "version": "2.13.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2020-08-02T12:14:47.006233Z",
+          "credit": [
+            "chalker"
+          ],
+          "cvssScore": 7.3,
+          "description": "## Overview\n[is-my-json-valid](https://github.com/mafintosh/is-my-json-valid) is a JSONSchema / orderly validator that uses code generation to be extremely fast.\n\nAffected versions of this package are vulnerable to Arbitrary Code Execution via the `formatName` function.\r\n\r\n##PoC\r\n```const validator = require('is-my-json-valid')\r\nconst schema = {\r\n  type: 'object',\r\n  properties: {\r\n    'x[console.log(process.mainModule.require(`child_process`).execSync(`cat /etc/passwd`).toString(`utf-8`))]': {\r\n      required: true,\r\n      type:'string'\r\n    }\r\n  },\r\n}\r\nvar validate = validator(schema);\r\nvalidate({})\r\n```\n## Remediation\nUpgrade `is-my-json-valid` to version 2.20.3 or higher.\n## References\n- [GitHub Commit](https://github.com/mafintosh/is-my-json-valid/commit/3419563687df463b4ca709a2b46be8e15d6a2b3d)\n- [HackerOne Report](https://hackerone.com/reports/894308)\n",
+          "disclosureTime": "2020-07-31T17:14:47Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "2.20.3"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-ISMYJSONVALID-597167",
+          "identifiers": {
+            "CVE": [],
+            "CWE": [
+              "CWE-94"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-02T15:04:45.893491Z",
+          "moduleName": "is-my-json-valid",
+          "packageManager": "npm",
+          "packageName": "is-my-json-valid",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2020-08-02T15:04:45.880122Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/mafintosh/is-my-json-valid/commit/3419563687df463b4ca709a2b46be8e15d6a2b3d"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/894308"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<2.20.3"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Arbitrary Code Execution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "har-validator@2.0.6",
+            "is-my-json-valid@2.13.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "har-validator@2.0.6",
+            "is-my-json-valid@2.20.3"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "is-my-json-valid",
+          "version": "2.13.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L/E:F/RL:O/RC:C",
+          "alternativeIds": [
+            "SNYK-JS-ISMYJSONVALID-10887"
+          ],
+          "creationTime": "2018-02-15T14:36:50Z",
+          "credit": [
+            "Jamie Davis"
+          ],
+          "cvssScore": 3.7,
+          "description": "## Overview\r\n[`is-my-json-valid`](https://www.npmjs.com/package/is-my-json-valid) is a universal validation plugin.\r\n\r\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks. It used a regular expression (`/^\\S+@\\S+$/`) in order to validate emails. This can cause an impact of about 10 seconds matching time for data 90K characters long.\r\n\r\n## Disclosure Timeline\r\n* Feb 13th, 2018 - Initial Disclosure to package owner\r\n* Feb 14th, 2018 - Initial Response from package owner\r\n* Feb 14th, 2018 - Fix issued\r\n* Feb 15th, 2018 - Vulnerability published\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `is-my-json-valid` to version 2.17.2, 1.4.1 or higher.\r\n\r\n## References\r\n- [GitHub PR](https://github.com/mafintosh/is-my-json-valid/pull/159)\r\n- [GitHub Commit](https://github.com/mafintosh/is-my-json-valid/commit/b3051b277f7caa08cd2edc6f74f50aeda65d2976)",
+          "disclosureTime": "2018-02-13T20:39:06Z",
+          "exploit": "Functional",
+          "fixedIn": [
+            "1.4.1",
+            "2.17.2"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "npm:is-my-json-valid:20180214",
+          "identifiers": {
+            "ALTERNATIVE": [
+              "SNYK-JS-ISMYJSONVALID-10887"
+            ],
+            "CVE": [
+              "CVE-2018-1107"
+            ],
+            "CWE": [
+              "CWE-185",
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-4x7c-cx64-49w8"
+            ],
+            "NSP": [
+              "572"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-06-09T09:57:45.620384Z",
+          "moduleName": "is-my-json-valid",
+          "packageManager": "npm",
+          "packageName": "is-my-json-valid",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2018-02-15T19:52:28Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/mafintosh/is-my-json-valid/commit/b3051b277f7caa08cd2edc6f74f50aeda65d2976"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/mafintosh/is-my-json-valid/pull/159"
+            },
+            {
+              "title": "Hackerone Report",
+              "url": "https://hackerone.com/reports/317548"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<1.4.1",
+              ">=2.0.0 <2.17.2"
+            ]
+          },
+          "severity": "low",
+          "severityWithCritical": "low",
+          "socialTrendAlert": false,
+          "title": "Regular Expression Denial of Service (ReDoS)",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "har-validator@2.0.6",
+            "is-my-json-valid@2.13.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "har-validator@2.0.6",
+            "is-my-json-valid@2.17.2"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "is-my-json-valid",
+          "version": "2.13.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:O/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2020-08-17T15:07:51.732390Z",
+          "credit": [
+            "Unknown"
+          ],
+          "cvssScore": 9.8,
+          "description": "## Overview\n[jsonpointer](https://www.npmjs.com/package/jsonpointer) is a Simple JSON Addressing.\n\nAffected versions of this package are vulnerable to Prototype Pollution via the `set` function.\r\n\r\n### POC by NerdJS\r\n```\r\nconst jsonpointer = require('jsonpointer');\r\njsonpointer.set({}, '/__proto__/polluted', true);\r\nconsole.log(polluted);\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `jsonpointer` to version 4.1.0 or higher.\n## References\n- [GitHub Commit](https://github.com/janl/node-jsonpointer/commit/234e3437019c6c07537ed2ad1e03b3e132b85e34)\n",
+          "disclosureTime": "2020-08-17T15:06:59Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "4.1.0"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-JSONPOINTER-598804",
+          "identifiers": {
+            "CVE": [],
+            "CWE": [
+              "CWE-400"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-17T15:17:02.529823Z",
+          "moduleName": "jsonpointer",
+          "packageManager": "npm",
+          "packageName": "jsonpointer",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2020-08-17T15:17:02.764391Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/janl/node-jsonpointer/commit/234e3437019c6c07537ed2ad1e03b3e132b85e34"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.1.0"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "critical",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "har-validator@2.0.6",
+            "is-my-json-valid@2.13.1",
+            "jsonpointer@2.0.0"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "har-validator@2.0.6",
+            "is-my-json-valid@2.15.0",
+            "jsonpointer@4.1.0"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "jsonpointer",
+          "version": "2.0.0"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/RL:O",
+          "alternativeIds": [],
+          "creationTime": "2019-03-24T09:59:28.172265Z",
+          "credit": [
+            "Shawn Rasheed",
+            "Jens DIetrich"
+          ],
+          "cvssScore": 5.9,
+          "description": "## Overview\n[js-yaml](https://www.npmjs.com/package/js-yaml) is a human-friendly data serialization language.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS). The parsing of a specially crafted YAML file may exhaust the system resources.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `js-yaml` to version 3.13.0 or higher.\n## References\n- [GitHub Commit](https://github.com/nodeca/js-yaml/commit/a567ef3c6e61eb319f0bfc2671d91061afb01235)\n- [GitHub Issue](https://github.com/nodeca/js-yaml/issues/475)\n",
+          "disclosureTime": "2019-03-18T21:29:08Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "3.13.0"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "lib/js-yaml/loader.js",
+                "functionName": "storeMappingPair"
+              },
+              "version": [
+                ">=3.0.0 <3.13.0"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "lib/js-yaml/loader.js",
+                "functionName": "storeMappingPair"
+              },
+              "version": [
+                ">=3.0.0 <3.13.0"
+              ]
+            }
+          ],
+          "id": "SNYK-JS-JSYAML-173999",
+          "identifiers": {
+            "CVE": [],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-2pr6-76vf-7546"
+            ],
+            "NSP": [
+              "788"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-06-12T14:36:55.564388Z",
+          "moduleName": "js-yaml",
+          "packageManager": "npm",
+          "packageName": "js-yaml",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2019-03-24T10:00:08Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/nodeca/js-yaml/commit/a567ef3c6e61eb319f0bfc2671d91061afb01235"
+            },
+            {
+              "title": "GitHub Issue",
+              "url": "https://github.com/nodeca/js-yaml/issues/475"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              ">=3.0.0 <3.13.0"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Denial of Service (DoS)",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-policy@1.5.2",
+            "js-yaml@3.6.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-policy@1.5.2",
+            "js-yaml@3.13.0"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "js-yaml",
+          "version": "3.6.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "alternativeIds": [],
+          "creationTime": "2019-04-07T11:15:19.826828Z",
+          "credit": [
+            "Alex Kocharin"
+          ],
+          "cvssScore": 8.1,
+          "description": "## Overview\n[js-yaml](https://www.npmjs.com/package/js-yaml) is a human-friendly data serialization language.\n\nAffected versions of this package are vulnerable to Arbitrary Code Execution. When an object with an executable `toString()` property used as a map key, it will execute that function. This happens only for `load()`, which should not be used with untrusted data anyway. `safeLoad()` is not affected because it can't parse functions.\n## Remediation\nUpgrade `js-yaml` to version 3.13.1 or higher.\n## References\n- [GitHub Commit](https://github.com/nodeca/js-yaml/pull/480/commits/e18afbf1edcafb7add2c4c7b22abc8d6ebc2fa61)\n- [GitHub PR](https://github.com/nodeca/js-yaml/pull/480)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/813)\n",
+          "disclosureTime": "2019-04-05T15:54:43Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "3.13.1"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "lib/js-yaml/loader.js",
+                "functionName": "loadAll.storeMappingPair"
+              },
+              "version": [
+                ">1.0.3 <=2.1.3"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lib/js-yaml/loader.js",
+                "functionName": "storeMappingPair"
+              },
+              "version": [
+                ">2.1.3 <3.13.1"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "lib/js-yaml/loader.js",
+                "functionName": "loadAll.storeMappingPair"
+              },
+              "version": [
+                ">1.0.3 <=2.1.3"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lib/js-yaml/loader.js",
+                "functionName": "storeMappingPair"
+              },
+              "version": [
+                ">2.1.3 <3.13.1"
+              ]
+            }
+          ],
+          "id": "SNYK-JS-JSYAML-174129",
+          "identifiers": {
+            "CVE": [],
+            "CWE": [
+              "CWE-94"
+            ],
+            "GHSA": [
+              "GHSA-8j8c-7jfh-h6hx"
+            ],
+            "NSP": [
+              "813"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-06-12T14:37:01.431138Z",
+          "moduleName": "js-yaml",
+          "packageManager": "npm",
+          "packageName": "js-yaml",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2019-04-07T15:54:43Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/nodeca/js-yaml/pull/480/commits/e18afbf1edcafb7add2c4c7b22abc8d6ebc2fa61"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/nodeca/js-yaml/pull/480"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/813"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<3.13.1"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Arbitrary Code Execution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-policy@1.5.2",
+            "js-yaml@3.6.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-policy@1.5.2",
+            "js-yaml@3.13.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "js-yaml",
+          "version": "3.6.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P",
+          "alternativeIds": [],
+          "creationTime": "2020-10-16T16:48:40.985673Z",
+          "credit": [
+            "Liyuan Chen"
+          ],
+          "cvssScore": 5.3,
+          "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) via the `toNumber`, `trim` and `trimEnd` functions.\r\n\r\n### POC\r\n```\r\nvar lo = require('lodash');\r\n\r\nfunction build_blank (n) {\r\nvar ret = \"1\"\r\nfor (var i = 0; i < n; i++) {\r\nret += \" \"\r\n}\r\n\r\nreturn ret + \"1\";\r\n}\r\n\r\nvar s = build_blank(50000)\r\nvar time0 = Date.now();\r\nlo.trim(s)\r\nvar time_cost0 = Date.now() - time0;\r\nconsole.log(\"time_cost0: \" + time_cost0)\r\n\r\nvar time1 = Date.now();\r\nlo.toNumber(s)\r\nvar time_cost1 = Date.now() - time1;\r\nconsole.log(\"time_cost1: \" + time_cost1)\r\n\r\nvar time2 = Date.now();\r\nlo.trimEnd(s)\r\nvar time_cost2 = Date.now() - time2;\r\nconsole.log(\"time_cost2: \" + time_cost2)\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `lodash` to version 4.17.21 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/c4847ebe7d14540bb28a8b932a9ce1b9ecbfee1a)\n- [GitHub Fix PR](https://github.com/lodash/lodash/pull/5065)\n",
+          "disclosureTime": "2020-10-16T16:47:34Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "4.17.21"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-LODASH-1018905",
+          "identifiers": {
+            "CVE": [
+              "CVE-2020-28500"
+            ],
+            "CWE": [
+              "CWE-400"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2021-02-22T09:58:41.562106Z",
+          "moduleName": "lodash",
+          "packageManager": "npm",
+          "packageName": "lodash",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2021-02-15T11:50:49Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/lodash/lodash/commit/c4847ebe7d14540bb28a8b932a9ce1b9ecbfee1a"
+            },
+            {
+              "title": "GitHub Fix PR",
+              "url": "https://github.com/lodash/lodash/pull/5065"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.17.21"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Regular Expression Denial of Service (ReDoS)",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "lodash@3.10.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.19.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash",
+          "version": "3.10.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:P/RL:U/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2020-11-17T14:07:17.048472Z",
+          "credit": [
+            "Marc Hassan"
+          ],
+          "cvssScore": 7.2,
+          "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Command Injection via `template`.\r\n\r\n### PoC\r\n```\r\nvar _ = require('lodash');\r\n\r\n_.template('', { variable: '){console.log(process.env)}; with(obj' })()\r\n```\n## Remediation\nUpgrade `lodash` to version 4.17.21 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/3469357cff396a26c363f8c1b5a91dde28ba4b1c)\n- [Vulnerable Code](https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js#L14851)\n",
+          "disclosureTime": "2020-11-17T13:02:10Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "4.17.21"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-LODASH-1040724",
+          "identifiers": {
+            "CVE": [
+              "CVE-2021-23337"
+            ],
+            "CWE": [
+              "CWE-78"
+            ],
+            "GHSA": [
+              "GHSA-35jh-r3h4-6jhm"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2021-02-22T09:58:04.543992Z",
+          "moduleName": "lodash",
+          "packageManager": "npm",
+          "packageName": "lodash",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2021-02-15T11:50:50Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/lodash/lodash/commit/3469357cff396a26c363f8c1b5a91dde28ba4b1c"
+            },
+            {
+              "title": "Vulnerable Code",
+              "url": "https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js%23L14851"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.17.21"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Command Injection",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "lodash@3.10.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.19.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash",
+          "version": "3.10.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2019-06-19T12:04:21.040000Z",
+          "credit": [
+            "Snyk Security Team"
+          ],
+          "cvssScore": 7.3,
+          "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The function `defaultsDeep` could be tricked into adding or modifying properties of `Object.prototype` using a `constructor` payload.\r\n\r\n## PoC by Snyk\r\n```\r\nconst mergeFn = require('lodash').defaultsDeep;\r\nconst payload = '{\"constructor\": {\"prototype\": {\"a0\": true}}}'\r\n\r\nfunction check() {\r\n    mergeFn({}, JSON.parse(payload));\r\n    if (({})[`a0`] === true) {\r\n        console.log(`Vulnerable to Prototype Pollution via ${payload}`);\r\n    }\r\n  }\r\n\r\ncheck();\r\n```\r\n\r\nFor more information, check out our [blog post](https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/)\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.12 or higher.\n## References\n- [GitHub Issue](https://github.com/lodash/lodash/issues/4348)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4336)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4355)\n- [GitHub PR](https://github.com/sailshq/lodash/pull/1)\n- [Node Security Advisory](https://www.npmjs.com/advisories/1065)\n- [Snyk Blog](https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/)\n",
+          "disclosureTime": "2019-06-19T11:45:02Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "4.17.12"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.customDefaultsMerge"
+              },
+              "version": [
+                ">=4.17.3 <4.17.12"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.customDefaultsMerge"
+              },
+              "version": [
+                ">=4.17.3 <4.17.12"
+              ]
+            }
+          ],
+          "id": "SNYK-JS-LODASH-450202",
+          "identifiers": {
+            "CVE": [
+              "CVE-2019-10744"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-jf85-cpcp-j695"
+            ],
+            "NSP": [
+              "1065"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-24T08:59:58.227467Z",
+          "moduleName": "lodash",
+          "packageManager": "npm",
+          "packageName": "lodash",
+          "patches": [
+            {
+              "comments": [],
+              "id": "patch:SNYK-JS-LODASH-450202:0",
+              "modificationTime": "2019-12-03T11:40:45.719849Z",
+              "urls": [
+                "https://snyk-patches.s3.amazonaws.com/npm/lodash/20190702/lodash_20190702_0_0_1f8ea07746963a535385a5befc19fa687a627d2b.patch"
+              ],
+              "version": "=4.17.11"
+            }
+          ],
+          "proprietary": true,
+          "publicationTime": "2019-07-02T11:45:01Z",
+          "references": [
+            {
+              "title": "GitHub Issue",
+              "url": "https://github.com/lodash/lodash/issues/4348"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/lodash/lodash/pull/4336"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/lodash/lodash/pull/4355"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/sailshq/lodash/pull/1"
+            },
+            {
+              "title": "Node Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1065"
+            },
+            {
+              "title": "Snyk Blog",
+              "url": "https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.17.12"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "lodash@3.10.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.19.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash",
+          "version": "3.10.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P/RL:U/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2020-04-28T14:32:13.683154Z",
+          "credit": [
+            "posix"
+          ],
+          "cvssScore": 6.3,
+          "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The function `zipObjectDeep` can be tricked into adding or modifying properties of the Object prototype. These properties will be present on all objects.\r\n\r\n## PoC\r\n```\r\nconst _ = require('lodash');\r\n_.zipObjectDeep(['__proto__.z'],[123])\r\nconsole.log(z) // 123\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.16 or higher.\n## References\n- [GitHub PR](https://github.com/lodash/lodash/pull/4759)\n- [HackerOne Report](https://hackerone.com/reports/712065)\n",
+          "disclosureTime": "2020-04-27T22:14:18Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "4.17.16"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-LODASH-567746",
+          "identifiers": {
+            "CVE": [
+              "CVE-2020-8203"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-p6mc-m468-83gw"
+            ],
+            "NSP": [
+              "1523"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-07-09T08:34:04.944267Z",
+          "moduleName": "lodash",
+          "packageManager": "npm",
+          "packageName": "lodash",
+          "patches": [
+            {
+              "comments": [],
+              "id": "patch:SNYK-JS-LODASH-567746:0",
+              "modificationTime": "2020-04-30T14:28:46.729327Z",
+              "urls": [
+                "https://snyk-patches.s3.amazonaws.com/npm/lodash/20200430/lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+              ],
+              "version": ">=4.14.2"
+            }
+          ],
+          "proprietary": false,
+          "publicationTime": "2020-04-28T14:59:14Z",
+          "references": [
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/lodash/lodash/pull/4759"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/712065"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.17.16"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "lodash@3.10.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.19.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash",
+          "version": "3.10.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "alternativeIds": [],
+          "creationTime": "2020-07-24T12:05:01.916784Z",
+          "credit": [
+            "reeser"
+          ],
+          "cvssScore": 9.8,
+          "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution in `zipObjectDeep` due to an incomplete fix for [CVE-2020-8203](https://snyk.io/vuln/SNYK-JS-LODASH-567746).\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.20 or higher.\n## References\n- [GitHub Issue](https://github.com/lodash/lodash/issues/4874)\n",
+          "disclosureTime": "2020-07-24T12:00:52Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "4.17.20"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-LODASH-590103",
+          "identifiers": {
+            "CVE": [],
+            "CWE": [
+              "CWE-400"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-16T12:11:40.402299Z",
+          "moduleName": "lodash",
+          "packageManager": "npm",
+          "packageName": "lodash",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2020-08-16T13:09:06Z",
+          "references": [
+            {
+              "title": "GitHub Issue",
+              "url": "https://github.com/lodash/lodash/issues/4874"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.17.20"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "critical",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "lodash@3.10.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.19.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash",
+          "version": "3.10.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2020-08-21T12:52:58.443440Z",
+          "credit": [
+            "awarau"
+          ],
+          "cvssScore": 7.3,
+          "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution via the `setWith` and `set` functions.\r\n\r\n### PoC by awarau\r\n* Create a JS file with this contents:\r\n```\r\nlod = require('lodash')\r\nlod.setWith({}, \"__proto__[test]\", \"123\")\r\nlod.set({}, \"__proto__[test2]\", \"456\")\r\nconsole.log(Object.prototype)\r\n```\r\n* Execute it with `node`\r\n* Observe that `test` and `test2` is now in the `Object.prototype`.\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.17 or higher.\n## References\n- [HackerOne Report](https://hackerone.com/reports/864701)\n",
+          "disclosureTime": "2020-08-21T10:34:29Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "4.17.17"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-LODASH-608086",
+          "identifiers": {
+            "CVE": [],
+            "CWE": [
+              "CWE-400"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-27T16:44:20.914177Z",
+          "moduleName": "lodash",
+          "packageManager": "npm",
+          "packageName": "lodash",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2020-08-21T12:53:03Z",
+          "references": [
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/864701"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.17.17"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "lodash@3.10.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.19.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash",
+          "version": "3.10.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+          "alternativeIds": [],
+          "creationTime": "2019-02-03T09:06:37.726000Z",
+          "credit": [
+            "asgerf"
+          ],
+          "cvssScore": 7.3,
+          "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The functions `merge`, `mergeWith`, and `defaultsDeep` could be tricked into adding or modifying properties of `Object.prototype`. This is due to an incomplete fix to `CVE-2018-3721`.\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.11 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/380873)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1066)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1068)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1071)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/782)\n",
+          "disclosureTime": "2018-08-31T18:21:00Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "4.17.11"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "merge"
+              },
+              "version": [
+                ">=0.9.0 <1.0.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "dist/lodash.js",
+                "functionName": "merge"
+              },
+              "version": [
+                ">=1.0.0 <1.0.3"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "dist/lodash.js",
+                "functionName": "runInContext.merge"
+              },
+              "version": [
+                ">=1.1.0 <2.0.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.merge"
+              },
+              "version": [
+                ">=2.0.0 <3.0.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "runInContext.baseMerge"
+              },
+              "version": [
+                ">=3.0.0 <4.0.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "runInContext.baseMergeDeep"
+              },
+              "version": [
+                ">=3.0.0 <4.0.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.mergeDefaults"
+              },
+              "version": [
+                ">=4.0.0 <4.17.3"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.assignMergeValue"
+              },
+              "version": [
+                ">=4.0.0 <4.17.5"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.baseMerge"
+              },
+              "version": [
+                ">=4.0.0 <4.17.5"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.baseMergeDeep"
+              },
+              "version": [
+                ">=4.0.0 <4.17.5"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "safeGet"
+              },
+              "version": [
+                ">=4.17.5 <4.17.11"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "merge"
+              },
+              "version": [
+                ">=0.9.0 <1.0.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "dist/lodash.js",
+                "functionName": "merge"
+              },
+              "version": [
+                ">=1.0.0 <1.0.3"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "dist/lodash.js",
+                "functionName": "runInContext.merge"
+              },
+              "version": [
+                ">=1.1.0 <2.0.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.merge"
+              },
+              "version": [
+                ">=2.0.0 <3.0.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "runInContext.baseMerge"
+              },
+              "version": [
+                ">=3.0.0 <4.0.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "runInContext.baseMergeDeep"
+              },
+              "version": [
+                ">=3.0.0 <4.0.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.mergeDefaults"
+              },
+              "version": [
+                ">=4.0.0 <4.17.3"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.assignMergeValue"
+              },
+              "version": [
+                ">=4.0.0 <4.17.5"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.baseMerge"
+              },
+              "version": [
+                ">=4.0.0 <4.17.5"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.baseMergeDeep"
+              },
+              "version": [
+                ">=4.0.0 <4.17.5"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "safeGet"
+              },
+              "version": [
+                ">=4.17.5 <4.17.11"
+              ]
+            }
+          ],
+          "id": "SNYK-JS-LODASH-73638",
+          "identifiers": {
+            "CVE": [
+              "CVE-2018-16487"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-4xc9-xhrj-v574"
+            ],
+            "NSP": [
+              "1066",
+              "1068",
+              "1071",
+              "782"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-24T08:59:09.185738Z",
+          "moduleName": "lodash",
+          "packageManager": "npm",
+          "packageName": "lodash",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2019-02-01T18:21:00Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/lodash/lodash/pull/4337"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/380873"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1066"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1068"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1071"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/782"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.17.11"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "lodash@3.10.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.19.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash",
+          "version": "3.10.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:N/I:N/A:H",
+          "alternativeIds": [],
+          "creationTime": "2019-02-03T09:18:05.060741Z",
+          "credit": [
+            "cristianstaicu"
+          ],
+          "cvssScore": 4.4,
+          "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). It parses dates using regex strings, which may cause a slowdown of 2 seconds per 50k characters.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `lodash` to version 4.17.11 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/5c08f18d365b64063bfbfa686cbb97cdd6267347)\n- [GitHub Issue](https://github.com/lodash/lodash/issues/3359)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4450)\n",
+          "disclosureTime": "2017-09-05T09:14:29Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "4.17.11"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "hasUnicodeWord"
+              },
+              "version": [
+                ">=4.15.0 <4.17.11"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "hasUnicodeWord"
+              },
+              "version": [
+                ">=4.15.0 <4.17.11"
+              ]
+            }
+          ],
+          "id": "SNYK-JS-LODASH-73639",
+          "identifiers": {
+            "CVE": [
+              "CVE-2019-1010266"
+            ],
+            "CWE": [
+              "CWE-185"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-06-12T14:36:57.941198Z",
+          "moduleName": "lodash",
+          "packageManager": "npm",
+          "packageName": "lodash",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2019-04-05T09:14:22Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/lodash/lodash/commit/5c08f18d365b64063bfbfa686cbb97cdd6267347"
+            },
+            {
+              "title": "GitHub Issue",
+              "url": "https://github.com/lodash/lodash/issues/3359"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/lodash/lodash/pull/4450"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.17.11"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Regular Expression Denial of Service (ReDoS)",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "lodash@3.10.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.19.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash",
+          "version": "3.10.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P",
+          "alternativeIds": [],
+          "creationTime": "2019-06-19T11:41:45.817000Z",
+          "credit": [
+            "Olivier Arteau (HoLyVieR)"
+          ],
+          "cvssScore": 6.3,
+          "description": "## Overview\n[lodash.defaultsdeep](https://lodash.com/) is a Lodash method `_.defaultsDeep` exported as a Node.js module.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The utilities function allow modification of the `Object` prototype. If an attacker can control part of the structure passed to this function, they could add or modify an existing property.  \r\n\r\n## PoC by Olivier Arteau (HoLyVieR)\r\n```js\r\nvar _= require('lodash');\r\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\r\n\r\nvar a = {};\r\nconsole.log(\"Before : \" + a.oops);\r\n_.merge({}, JSON.parse(malicious_payload));\r\nconsole.log(\"After : \" + a.oops);\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash.defaultsdeep` to version 4.6.1 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/310443)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1067)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1069)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1070)\n",
+          "disclosureTime": "2018-01-30T22:28:27Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "4.6.1"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-LODASHDEFAULTSDEEP-450198",
+          "identifiers": {
+            "CVE": [
+              "CVE-2018-3721"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-2m96-9w4j-wgv7",
+              "GHSA-46fh-8fc5-xcwx",
+              "GHSA-5947-m4fg-xhqg",
+              "GHSA-fvqr-27wr-82fm"
+            ],
+            "NSP": [
+              "1067",
+              "1069",
+              "1070",
+              "577"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-25T09:41:03.215357Z",
+          "moduleName": "lodash.defaultsdeep",
+          "packageManager": "npm",
+          "packageName": "lodash.defaultsdeep",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2018-02-14T13:22:50Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/lodash/lodash/pull/4337"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/310443"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1067"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1069"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1070"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.6.1"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "lodash.defaultsdeep@4.5.0"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "lodash.defaultsdeep@4.6.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash.defaultsdeep",
+          "version": "4.5.0"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+          "alternativeIds": [],
+          "creationTime": "2019-06-19T11:44:03.712000Z",
+          "credit": [
+            "asgerf"
+          ],
+          "cvssScore": 7.3,
+          "description": "## Overview\n[lodash.defaultsdeep](https://lodash.com/) is a Lodash method `_.defaultsDeep` exported as a Node.js module.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The functions `merge`, `mergeWith`, and `defaultsDeep` could be tricked into adding or modifying properties of `Object.prototype`. This is due to an incomplete fix to `CVE-2018-3721`.\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash.defaultsdeep` to version 4.6.1 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/380873)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1066)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1068)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1071)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/782)\n",
+          "disclosureTime": "2018-08-31T18:21:00Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "4.6.1"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-LODASHDEFAULTSDEEP-450199",
+          "identifiers": {
+            "CVE": [
+              "CVE-2018-16487"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-4xc9-xhrj-v574"
+            ],
+            "NSP": [
+              "1066",
+              "1068",
+              "1071",
+              "782"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-24T08:59:09.212950Z",
+          "moduleName": "lodash.defaultsdeep",
+          "packageManager": "npm",
+          "packageName": "lodash.defaultsdeep",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2019-02-01T18:21:00Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/lodash/lodash/pull/4337"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/380873"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1066"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1068"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1071"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/782"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.6.1"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "lodash.defaultsdeep@4.5.0"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "lodash.defaultsdeep@4.6.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash.defaultsdeep",
+          "version": "4.5.0"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+          "alternativeIds": [],
+          "creationTime": "2019-04-08T14:32:04.805000Z",
+          "credit": [
+            "asgerf"
+          ],
+          "cvssScore": 7.3,
+          "description": "## Overview\n[lodash.mergewith](https://lodash.com/) is a Lodash method _.mergewith exported as a Node.js module.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The functions `merge`, `mergeWith`, and `defaultsDeep` could be tricked into adding or modifying properties of `Object.prototype`. This is due to an incomplete fix to `CVE-2018-3721`.\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash.mergewith` to version 4.6.2 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/380873)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1066)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1068)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1071)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/782)\n",
+          "disclosureTime": "2018-08-31T18:21:00Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "4.6.2"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "baseMerge"
+              },
+              "version": [
+                "*"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "baseMergeDeep"
+              },
+              "version": [
+                "*"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "baseMerge"
+              },
+              "version": [
+                "*"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "baseMergeDeep"
+              },
+              "version": [
+                "*"
+              ]
+            }
+          ],
+          "id": "SNYK-JS-LODASHMERGEWITH-174136",
+          "identifiers": {
+            "CVE": [
+              "CVE-2018-16487"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-4xc9-xhrj-v574"
+            ],
+            "NSP": [
+              "1066",
+              "1068",
+              "1071",
+              "782"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-24T08:59:09.204209Z",
+          "moduleName": "lodash.mergewith",
+          "packageManager": "npm",
+          "packageName": "lodash.mergewith",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2019-02-01T18:21:00Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/lodash/lodash/pull/4337"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/380873"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1066"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1068"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1071"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/782"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.6.2"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "lodash.mergewith@4.5.0"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "lodash.mergewith@4.6.2"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash.mergewith",
+          "version": "4.5.0"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P",
+          "alternativeIds": [],
+          "creationTime": "2019-04-08T14:35:02.142000Z",
+          "credit": [
+            "Olivier Arteau (HoLyVieR)"
+          ],
+          "cvssScore": 6.3,
+          "description": "## Overview\n[lodash.mergewith](https://lodash.com/) is a Lodash method _.mergewith exported as a Node.js module.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The utilities function allow modification of the `Object` prototype. If an attacker can control part of the structure passed to this function, they could add or modify an existing property.  \r\n\r\n## PoC by Olivier Arteau (HoLyVieR)\r\n```js\r\nvar _= require('lodash');\r\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\r\n\r\nvar a = {};\r\nconsole.log(\"Before : \" + a.oops);\r\n_.merge({}, JSON.parse(malicious_payload));\r\nconsole.log(\"After : \" + a.oops);\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash.mergewith` to version 4.6.1 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/310443)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1067)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1069)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1070)\n",
+          "disclosureTime": "2018-01-30T22:28:27Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "4.6.1"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "baseMerge"
+              },
+              "version": [
+                "<4.6.1"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "baseMergeDeep"
+              },
+              "version": [
+                "<4.6.1"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "baseMerge"
+              },
+              "version": [
+                "<4.6.1"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "baseMergeDeep"
+              },
+              "version": [
+                "<4.6.1"
+              ]
+            }
+          ],
+          "id": "SNYK-JS-LODASHMERGEWITH-174137",
+          "identifiers": {
+            "CVE": [
+              "CVE-2018-3721"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-2m96-9w4j-wgv7",
+              "GHSA-46fh-8fc5-xcwx",
+              "GHSA-5947-m4fg-xhqg",
+              "GHSA-fvqr-27wr-82fm"
+            ],
+            "NSP": [
+              "1067",
+              "1069",
+              "1070",
+              "577"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-25T09:41:03.208728Z",
+          "moduleName": "lodash.mergewith",
+          "packageManager": "npm",
+          "packageName": "lodash.mergewith",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2018-02-14T13:22:50Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/lodash/lodash/pull/4337"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/310443"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1067"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1069"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1070"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.6.1"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "lodash.mergewith@4.5.0"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "lodash.mergewith@4.6.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash.mergewith",
+          "version": "4.5.0"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2020-03-11T08:25:47.093051Z",
+          "credit": [
+            "Snyk Security Team"
+          ],
+          "cvssScore": 5.6,
+          "description": "## Overview\n[minimist](https://www.npmjs.com/package/minimist) is a parse argument options module.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The library could be tricked into adding or modifying properties of `Object.prototype` using a `constructor` or `__proto__` payload.\r\n\r\n## PoC by Snyk\r\n```\r\nrequire('minimist')('--__proto__.injected0 value0'.split(' '));\r\nconsole.log(({}).injected0 === 'value0'); // true\r\n\r\nrequire('minimist')('--constructor.prototype.injected1 value1'.split(' '));\r\nconsole.log(({}).injected1 === 'value1'); // true\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `minimist` to version 0.2.1, 1.2.3 or higher.\n## References\n- [Command Injection PoC](https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a)\n- [GitHub Fix Commit #1](https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94)\n- [GitHub Fix Commit #2](https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab)\n- [Snyk Research Blog](https://snyk.io/blog/prototype-pollution-minimist/)\n",
+          "disclosureTime": "2020-03-10T08:22:24Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "0.2.1",
+            "1.2.3"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "setKey"
+              },
+              "version": [
+                "<0.2.1",
+                ">=1.0.0 <1.1.1"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "module.exports.setKey"
+              },
+              "version": [
+                "<0.2.1",
+                ">=1.1.1 <1.2.3"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "setKey"
+              },
+              "version": [
+                "<0.2.1",
+                ">=1.0.0 <1.1.1"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "module.exports.setKey"
+              },
+              "version": [
+                "<0.2.1",
+                ">=1.1.1 <1.2.3"
+              ]
+            }
+          ],
+          "id": "SNYK-JS-MINIMIST-559764",
+          "identifiers": {
+            "CVE": [
+              "CVE-2020-7598"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-vh95-rmgr-6w4m"
+            ],
+            "NSP": [
+              "1179"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-12-20T09:48:43.878574Z",
+          "moduleName": "minimist",
+          "packageManager": "npm",
+          "packageName": "minimist",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2020-03-11T08:22:19Z",
+          "references": [
+            {
+              "title": "Command Injection PoC",
+              "url": "https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a"
+            },
+            {
+              "title": "GitHub Fix Commit #1",
+              "url": "https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94"
+            },
+            {
+              "title": "GitHub Fix Commit #2",
+              "url": "https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab"
+            },
+            {
+              "title": "Snyk Research Blog",
+              "url": "https://snyk.io/blog/prototype-pollution-minimist/"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<0.2.1",
+              ">=1.0.0 <1.2.3"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "update-notifier@0.6.3",
+            "latest-version@2.0.0",
+            "package-json@2.3.3",
+            "registry-url@3.1.0",
+            "rc@1.1.6",
+            "minimist@1.2.0"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "update-notifier@0.6.3",
+            "latest-version@2.0.0",
+            "package-json@2.3.3",
+            "registry-url@3.1.0",
+            "rc@1.1.6",
+            "minimist@1.2.3"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "minimist",
+          "version": "1.2.0"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/RL:O",
+          "alternativeIds": [],
+          "creationTime": "2019-03-31T10:27:47.709659Z",
+          "credit": [
+            "ChaLKer"
+          ],
+          "cvssScore": 9.8,
+          "description": "## Overview\n[open](https://www.npmjs.com/package/open) is a cross platform package that opens stuff like URLs, files, executables.\n\nAffected versions of this package are vulnerable to Arbitrary Code Injection when unsanitized user input is passed in.\r\n\r\nThe package does come with the following warning in the readme:\r\n\r\n```\r\nThe same care should be taken when calling open as if you were calling child_process.exec directly. If it is an executable it will run in a new shell.\r\n```\r\nThe package `open` is replacing the `opn` package, which is now deprecated. The older versions of `open` are vulnerable. \r\n\r\n**Note: Upgrading `open` to the last version will prevent this vulnerability but is also likely to have unwanted effects since it now has a very different API.**\n## Remediation\nUpgrade `open` to version 6.0.0 or higher.\n## References\n- [GitHub Issue](https://github.com/pwnall/node-open/issues/68)\n- [HackerOne Report](https://hackerone.com/reports/319473)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/663)\n",
+          "disclosureTime": "2018-05-16T19:36:39Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "6.0.0"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-OPEN-174041",
+          "identifiers": {
+            "CVE": [],
+            "CWE": [
+              "CWE-94"
+            ],
+            "GHSA": [
+              "GHSA-28xh-wpgr-7fm8"
+            ],
+            "NSP": [
+              "663"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-06-12T14:36:55.653898Z",
+          "moduleName": "open",
+          "packageManager": "npm",
+          "packageName": "open",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2019-03-31T10:33:37Z",
+          "references": [
+            {
+              "title": "GitHub Issue",
+              "url": "https://github.com/pwnall/node-open/issues/68"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/319473"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/663"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<6.0.0"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "critical",
+          "socialTrendAlert": false,
+          "title": "Arbitrary Code Injection",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "open@0.0.5"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.76.0"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "open",
+          "version": "0.0.5"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:O/RC:C",
+          "alternativeIds": [
+            "SNYK-JS-OPEN-12148"
+          ],
+          "creationTime": "2018-02-25T11:54:41.573000Z",
+          "credit": [
+            "ChALkeR"
+          ],
+          "cvssScore": 8.4,
+          "description": "## Overview\n[open](https://www.npmjs.com/package/open) is a cross platform package that opens stuff like URLs, files, executables.\n\nAffected versions of this package are vulnerable to Arbitrary Command Injection. Urls are not properly escaped before concatenating them into the command that is opened using `exec()`.\r\n\r\n**Note: Upgrading `open` to the last version will prevent this vulnerability but is also likely to have unwanted effects since it now has a very different API.**\n## Remediation\nUpgrade `open` to version 6.0.0 or higher.\n## References\n- [HackerOne Report](https://hackerone.com/reports/319473)\n",
+          "disclosureTime": "2018-05-12T11:54:41Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "6.0.0"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "npm:open:20180512",
+          "identifiers": {
+            "ALTERNATIVE": [
+              "SNYK-JS-OPEN-12148"
+            ],
+            "CVE": [],
+            "CWE": [
+              "CWE-264"
+            ],
+            "NSP": [
+              "663"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-06-12T08:52:32.287783Z",
+          "moduleName": "open",
+          "packageManager": "npm",
+          "packageName": "open",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2018-05-13T14:26:27Z",
+          "references": [
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/319473"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<6.0.0"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Arbitrary Command Injection",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "open@0.0.5"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.76.0"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "open",
+          "version": "0.0.5"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N",
+          "alternativeIds": [],
+          "creationTime": "2021-06-29T09:27:06.371226Z",
+          "credit": [
+            "meandmax"
+          ],
+          "cvssScore": 3.7,
+          "description": "## Overview\n[request](https://www.npmjs.com/package/request) is a simplified http request client.\n\nAffected versions of this package are vulnerable to Insecure Encryption due to the usage of the insecure `sha1` cipher.\r\n\r\n**Note**: This library is deprecated.\n## Remediation\nA fix was pushed into the `master` branch but not yet published.\n## References\n- [GitHub Commit](https://github.com/request/request/pull/3385/commits/149e585d8f455b97c7c62df887c697f8045bb35d)\n- [GitHub PR](https://github.com/request/request/pull/3385)\n",
+          "disclosureTime": "2021-06-29T09:23:42Z",
+          "exploit": "Not Defined",
+          "fixedIn": [],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-REQUEST-1314897",
+          "identifiers": {
+            "CVE": [],
+            "CWE": [
+              "CWE-326"
+            ]
+          },
+          "language": "js",
+          "modificationTime": "2021-06-29T15:26:06.017894Z",
+          "moduleName": "request",
+          "packageManager": "npm",
+          "packageName": "request",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2021-06-29T15:26:05.534835Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/request/request/pull/3385/commits/149e585d8f455b97c7c62df887c697f8045bb35d"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/request/request/pull/3385"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "*"
+            ]
+          },
+          "severity": "low",
+          "severityWithCritical": "low",
+          "title": "Insecure Encryption",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0"
+          ],
+          "upgradePath": [],
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "request",
+          "version": "2.74.0"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2020-02-18T08:53:40.650407Z",
+          "credit": [
+            "JHU System Security Lab"
+          ],
+          "cvssScore": 6.3,
+          "description": "## Overview\n[undefsafe](https://www.npmjs.com/package/undefsafe) is a Simple function for retrieving deep object properties without getting \"Cannot read property 'X' of undefined\".\n\nAffected versions of this package are vulnerable to Prototype Pollution. The `a` function could be tricked into adding or modifying properties of `Object.prototype` using a `__proto__` payload.\r\n\r\n### PoC by JHU System Security Lab\r\n```js\r\nvar a = require(\"undefsafe\");\r\nvar payload = \"__proto__.toString\";\r\na({},payload,\"JHU\");\r\nconsole.log({}.toString);\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `undefsafe` to version 2.0.3 or higher.\n## References\n- [GitHub Commit](https://github.com/remy/undefsafe/commit/f272681b3a50e2c4cbb6a8533795e1453382c822)\n",
+          "disclosureTime": "2020-02-18T08:51:08Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "2.0.3"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-UNDEFSAFE-548940",
+          "identifiers": {
+            "CVE": [
+              "CVE-2019-10795"
+            ],
+            "CWE": [
+              "CWE-400"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-06-12T14:36:59.362776Z",
+          "moduleName": "undefsafe",
+          "packageManager": "npm",
+          "packageName": "undefsafe",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2020-02-18T11:01:36Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/remy/undefsafe/commit/f272681b3a50e2c4cbb6a8533795e1453382c822"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<2.0.3"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "undefsafe@0.0.3"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.78.0",
+            "undefsafe@2.0.3"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "undefsafe",
+          "version": "0.0.3"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P",
+          "alternativeIds": [],
+          "creationTime": "2020-10-25T14:27:16.715665Z",
+          "credit": [
+            "po6ix"
+          ],
+          "cvssScore": 7.3,
+          "description": "## Overview\n[y18n](https://www.npmjs.com/package/y18n) is a the bare-bones internationalization library used by yargs\n\nAffected versions of this package are vulnerable to Prototype Pollution. PoC by po6ix:\r\n```\r\nconst y18n = require('y18n')();\r\n \r\ny18n.setLocale('__proto__');\r\ny18n.updateLocale({polluted: true});\r\n\r\nconsole.log(polluted); // true\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `y18n` to version 3.2.2, 4.0.1, 5.0.5 or higher.\n## References\n- [GitHub Issue](https://github.com/yargs/y18n/issues/96)\n- [GitHub PR](https://github.com/yargs/y18n/pull/108)\n",
+          "disclosureTime": "2020-10-25T14:24:22Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "3.2.2",
+            "4.0.1",
+            "5.0.5"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-Y18N-1021887",
+          "identifiers": {
+            "CVE": [
+              "CVE-2020-7774"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-c4w7-xm78-47vh"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2021-01-05T15:29:00.943111Z",
+          "moduleName": "y18n",
+          "packageManager": "npm",
+          "packageName": "y18n",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2020-11-10T15:27:28Z",
+          "references": [
+            {
+              "title": "GitHub Issue",
+              "url": "https://github.com/yargs/y18n/issues/96"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/yargs/y18n/pull/108"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<3.2.2",
+              ">=4.0.0 <4.0.1",
+              ">=5.0.0 <5.0.5"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "yargs@4.8.1",
+            "y18n@3.2.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "yargs@4.8.1",
+            "y18n@3.2.2"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "y18n",
+          "version": "3.2.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "alternativeIds": [
+            "SNYK-JS-BRACEEXPANSION-10483"
+          ],
+          "creationTime": "2017-04-26T09:19:21.663000Z",
+          "credit": [
+            "kamael"
+          ],
+          "cvssScore": 6.2,
+          "description": "## Overview\r\n[`brace-expansion`](https://www.npmjs.com/package/brace-expansion) is a package that performs brace expansion as known from sh/bash.\r\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `brace-expansion` to version 1.1.7 or higher.\r\n\r\n## References\r\n- [GitHub PR](https://github.com/juliangruber/brace-expansion/pull/35)\r\n- [GitHub Issue](https://github.com/juliangruber/brace-expansion/issues/33)\r\n- [GitHub Commit](https://github.com/juliangruber/brace-expansion/pull/35/commits/b13381281cead487cbdbfd6a69fb097ea5e456c3)",
+          "disclosureTime": "2017-03-01T22:00:00Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "1.1.7"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "npm:brace-expansion:20170302",
+          "identifiers": {
+            "ALTERNATIVE": [
+              "SNYK-JS-BRACEEXPANSION-10483"
+            ],
+            "CVE": [
+              "CVE-2017-18077"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-832h-xg76-4gv6"
+            ],
+            "NSP": [
+              "338"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2019-12-02T14:40:13.321868Z",
+          "moduleName": "brace-expansion",
+          "packageManager": "npm",
+          "packageName": "brace-expansion",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2017-04-26T09:19:21Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/juliangruber/brace-expansion/pull/35/commits/b13381281cead487cbdbfd6a69fb097ea5e456c3"
+            },
+            {
+              "title": "GitHub Issue",
+              "url": "https://github.com/juliangruber/brace-expansion/issues/33"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/juliangruber/brace-expansion/pull/35"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<1.1.7"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Regular Expression Denial of Service (ReDoS)",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-recursive-readdir@2.0.0",
+            "minimatch@3.0.2",
+            "brace-expansion@1.1.6"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-recursive-readdir@2.0.0",
+            "minimatch@3.0.2",
+            "brace-expansion@1.1.7"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "brace-expansion",
+          "version": "1.1.6"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P",
+          "alternativeIds": [
+            "SNYK-JS-DEEPEXTEND-12120"
+          ],
+          "creationTime": "2018-04-15T20:11:17.552000Z",
+          "credit": [
+            "Olivier Arteau (HoLyVieR)"
+          ],
+          "cvssScore": 7.3,
+          "description": "## Overview\n[deep-extend](https://www.npmjs.com/package/deep-extend) is a library for Recursive object extending.\n\nAffected versions of this package are vulnerable to Prototype Pollution. Utilities function in all the listed modules can be tricked into modifying the prototype of \"Object\" when the attacker control part of the structure passed to these function. This can let an attacker add or modify existing property that will exist on all object.\r\n\r\n## PoC by HoLyVieR\r\n```js\r\nvar merge = require('deep-extend');\r\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\r\n\r\nvar a = {};\r\nconsole.log(\"Before : \" + a.oops);\r\nmerge({}, JSON.parse(malicious_payload));\r\nconsole.log(\"After : \" + a.oops);\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `deep-extend` to version 0.5.1 or higher.\n## References\n- [GitHub Commit](https://github.com/unclechu/node-deep-extend/commit/433ee51ed606f4e1867ece57b6ff5a47bebb492f)\n- [GitHub Issue](https://github.com/unclechu/node-deep-extend/issues/39)\n- [GitHub PR](https://github.com/unclechu/node-deep-extend/pull/40)\n- [HackerOne Report](https://hackerone.com/reports/311333)\n",
+          "disclosureTime": "2018-04-09T20:11:17Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "0.5.1"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "module.exports"
+              },
+              "version": [
+                "0.2.1"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "deepExtend"
+              },
+              "version": [
+                "<0.2.1"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "module.exports.deepExtend"
+              },
+              "version": [
+                ">=0.2.2 <0.2.5"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "deepExtend.module.exports"
+              },
+              "version": [
+                ">=0.2.5 <0.4.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lib/deep-extend.js",
+                "functionName": "cloneSpecificValue"
+              },
+              "version": [
+                ">=0.4.0 <0.5.1"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "module.exports"
+              },
+              "version": [
+                "0.2.1"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "deepExtend"
+              },
+              "version": [
+                "<0.2.1"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "module.exports.deepExtend"
+              },
+              "version": [
+                ">=0.2.2 <0.2.5"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "deepExtend.module.exports"
+              },
+              "version": [
+                ">=0.2.5 <0.4.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lib/deep-extend.js",
+                "functionName": "cloneSpecificValue"
+              },
+              "version": [
+                ">=0.4.0 <0.5.1"
+              ]
+            }
+          ],
+          "id": "npm:deep-extend:20180409",
+          "identifiers": {
+            "ALTERNATIVE": [
+              "SNYK-JS-DEEPEXTEND-12120"
+            ],
+            "CVE": [
+              "CVE-2018-3750"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-hr2v-3952-633q"
+            ],
+            "NSP": [
+              "612"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-06-12T14:36:41.582307Z",
+          "moduleName": "deep-extend",
+          "packageManager": "npm",
+          "packageName": "deep-extend",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2018-04-25T07:45:48Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/unclechu/node-deep-extend/commit/433ee51ed606f4e1867ece57b6ff5a47bebb492f"
+            },
+            {
+              "title": "GitHub Issue",
+              "url": "https://github.com/unclechu/node-deep-extend/issues/39"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/unclechu/node-deep-extend/pull/40"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/311333"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<0.5.1"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "update-notifier@0.6.3",
+            "latest-version@2.0.0",
+            "package-json@2.3.3",
+            "registry-url@3.1.0",
+            "rc@1.1.6",
+            "deep-extend@0.4.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "update-notifier@0.6.3",
+            "latest-version@2.0.0",
+            "package-json@2.3.3",
+            "registry-url@3.1.0",
+            "rc@1.2.7",
+            "deep-extend@0.5.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "deep-extend",
+          "version": "0.4.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+          "alternativeIds": [
+            "SNYK-JS-HTTPSIGNATURE-10664"
+          ],
+          "creationTime": "2017-06-28T13:07:29.691000Z",
+          "credit": [
+            "Alok Menghrajani"
+          ],
+          "cvssScore": 6.5,
+          "description": "## Overview\r\n[`http-signature`](https://www.npmjs.com/package/http-signature) is a reference implementation of Joyent's HTTP Signature scheme.\r\n\r\nAffected versions of the package are vulnerable to Timing Attacks due to time-variable comparison of signatures. \r\n\r\nThe library implemented a character to character comparison, similar to the built-in string comparison mechanism, `===`, and not a time constant string comparison. As a result, the comparison will fail faster when the first characters in the signature are incorrect.\r\nAn attacker can use this difference to perform a timing attack, essentially allowing them to guess the signature one character at a time.\r\n\r\nYou can read more about timing attacks in Node.js on the [Snyk blog](https://snyk.io/blog/node-js-timing-attack-ccc-ctf/).\r\n\r\n## Remediation\r\nUpgrade `http-signature` to version 1.0.0 or higher.\r\n\r\n## References\r\n- [Github PR](https://github.com/joyent/node-http-signature/pull/36)\r\n- [Github Commit](https://github.com/joyent/node-http-signature/commit/78ab1da232f31f695f5c362d863593a143aa8b56)",
+          "disclosureTime": "2015-01-21T22:00:00Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "1.0.0"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "lib/verify.js",
+                "functionName": "module.exports.verifySignature"
+              },
+              "version": [
+                "<0.10.1"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lib/verify.js",
+                "functionName": "module.exports.verifyHMAC"
+              },
+              "version": [
+                ">=0.11.0 <1.0.0"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "lib/verify.js",
+                "functionName": "module.exports.verifySignature"
+              },
+              "version": [
+                "<0.10.1"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lib/verify.js",
+                "functionName": "module.exports.verifyHMAC"
+              },
+              "version": [
+                ">=0.11.0 <1.0.0"
+              ]
+            }
+          ],
+          "id": "npm:http-signature:20150122",
+          "identifiers": {
+            "ALTERNATIVE": [
+              "SNYK-JS-HTTPSIGNATURE-10664"
+            ],
+            "CVE": [],
+            "CWE": [
+              "CWE-310"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2019-04-29T15:44:53.819980Z",
+          "moduleName": "http-signature",
+          "packageManager": "npm",
+          "packageName": "http-signature",
+          "patches": [
+            {
+              "comments": [],
+              "id": "patch:npm:http-signature:20150122:0",
+              "modificationTime": "2019-12-03T11:40:45.867250Z",
+              "urls": [
+                "https://snyk-patches.s3.amazonaws.com/npm/http-signature/20150122/20150122_0_0_http-signature_78ab1da232f31f695f5c362d863593a143aa8b56.patch"
+              ],
+              "version": "=0.10.1"
+            }
+          ],
+          "proprietary": false,
+          "publicationTime": "2017-06-28T13:07:29Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/joyent/node-http-signature/commit/78ab1da232f31f695f5c362d863593a143aa8b56"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/joyent/node-http-signature/pull/36"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<1.0.0"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Timing Attack",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "request@2.57.0",
+            "http-signature@0.11.0"
+          ],
+          "upgradePath": [],
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "http-signature",
+          "version": "0.11.0"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P/RL:O/RC:C",
+          "alternativeIds": [
+            "SNYK-JS-SSHPK-12114"
+          ],
+          "creationTime": "2018-02-25T08:09:56.427000Z",
+          "credit": [
+            "ChALkeR"
+          ],
+          "cvssScore": 7.5,
+          "description": "## Overview\r\n[sshpk](https://www.npmjs.com/package/sshpk) is Parse, convert, fingerprint and use SSH keys in pure node.js.\r\n\r\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks when parsing crafted invalid public keys.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `sshpk` to version 1.13.2 or higher.\r\n\r\n## References\r\n- [HackerOne Report](https://hackerone.com/reports/319593)",
+          "disclosureTime": "2018-04-09T08:09:56Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "1.14.1"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "lib/key.js",
+                "functionName": "Key.parse"
+              },
+              "version": [
+                "<1.14.1"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "lib/key.js",
+                "functionName": "Key.parse"
+              },
+              "version": [
+                "<1.14.1"
+              ]
+            }
+          ],
+          "id": "npm:sshpk:20180409",
+          "identifiers": {
+            "ALTERNATIVE": [
+              "SNYK-JS-SSHPK-12114"
+            ],
+            "CVE": [
+              "CVE-2018-3737"
+            ],
+            "CWE": [
+              "CWE-185"
+            ],
+            "GHSA": [
+              "GHSA-2m39-62fm-q8r3"
+            ],
+            "NSP": [
+              "606"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2019-12-31T10:17:09.068690Z",
+          "moduleName": "sshpk",
+          "packageManager": "npm",
+          "packageName": "sshpk",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2018-04-09T15:17:27Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/joyent/node-sshpk/commit/46065d38a5e6d1bccf86d3efb2fb83c14e3f9957"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/319593"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<1.14.1"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Regular Expression Denial of Service (ReDoS)",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "http-signature@1.1.1",
+            "sshpk@1.9.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "http-signature@1.1.1",
+            "sshpk@1.14.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "sshpk",
+          "version": "1.9.1"
+        }
+      ],
+      "upgrade": {
+        "qs@0.6.6": {
+          "upgradeTo": "qs@6.0.4",
+          "upgrades": [
+            "qs@0.6.6",
+            "qs@0.6.6",
+            "qs@0.6.6"
+          ],
+          "vulns": [
+            "npm:qs:20170213",
+            "npm:qs:20140806",
+            "npm:qs:20140806-1"
+          ]
+        }
+      },
+      "patch": {
+        "npm:debug:20170905": {
+          "paths": [
+            {
+              "@remy/protect-test > snyk > debug": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-config > debug": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-module > debug": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve > debug": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-try-require > debug": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-policy > debug": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve-deps > debug": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-policy > snyk-module > debug": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve-deps > snyk-module > debug": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-policy > snyk-resolve > debug": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve-deps > snyk-resolve > debug": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-policy > snyk-try-require > debug": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve-deps > snyk-try-require > debug": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve-deps > clite > debug": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            }
+          ]
+        },
+        "npm:extend:20180424": {
+          "paths": [
+            {
+              "@remy/protect-test > snyk > request > extend": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            }
+          ]
+        },
+        "npm:hoek:20180212": {
+          "paths": [
+            {
+              "@remy/protect-test > request > hawk > hoek": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > request > hawk > boom > hoek": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > request > hawk > sntp > hoek": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > request > hawk > hoek": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > request > hawk > cryptiles > boom > hoek": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > request > hawk > boom > hoek": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > request > hawk > sntp > hoek": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > request > hawk > cryptiles > boom > hoek": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            }
+          ]
+        },
+        "npm:lodash:20180130": {
+          "paths": [
+            {
+              "@remy/protect-test > snyk > lodash": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            }
+          ]
+        },
+        "npm:ms:20170412": {
+          "paths": [
+            {
+              "@remy/protect-test > snyk > debug > ms": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-config > debug > ms": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-module > debug > ms": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve > debug > ms": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-try-require > debug > ms": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-policy > debug > ms": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve-deps > debug > ms": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-policy > snyk-module > debug > ms": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve-deps > snyk-module > debug > ms": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-policy > snyk-resolve > debug > ms": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve-deps > snyk-resolve > debug > ms": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-policy > snyk-try-require > debug > ms": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve-deps > snyk-try-require > debug > ms": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve-deps > clite > debug > ms": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            }
+          ]
+        },
+        "npm:qs:20170213": {
+          "paths": [
+            {
+              "@remy/protect-test > snyk > request > qs": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            }
+          ]
+        },
+        "npm:stringstream:20180511": {
+          "paths": [
+            {
+              "@remy/protect-test > request > stringstream": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > request > stringstream": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            }
+          ]
+        },
+        "npm:tough-cookie:20170905": {
+          "paths": [
+            {
+              "@remy/protect-test > request > tough-cookie": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > request > tough-cookie": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            }
+          ]
+        },
+        "npm:tunnel-agent:20170305": {
+          "paths": [
+            {
+              "@remy/protect-test > request > tunnel-agent": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > request > tunnel-agent": {
+                "patched": "2021-09-03T20:01:52.645Z"
+              }
+            }
+          ]
+        }
+      },
+      "ignore": {},
+      "pin": {}
+    }
+  },
+  "meta": {
+    "isPrivate": true,
+    "isLicensesEnabled": true,
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.21.5\n# ignores vulnerabilities until expiry date; change duration by modifying expiry date\nignore:\n  'npm:hawk:20160119':\n    - '@remy/protect-test@1.0.13 > request > hawk':\n        reason: test trust policies\n        expires: '2116-03-19T17:42:05.690Z'\n        from: '@remy/protect-test@1.0.13'\n        source: cli\n  'npm:request:20160119':\n    - '@remy/protect-test@1.0.13 > request':\n        reason: test trust policies\n        expires: '2116-03-19T17:42:05.690Z'\n        from: '@remy/protect-test@1.0.13'\n        source: cli\n# patches apply the minimum changes required to fix a vulnerability\npatch:\n  'npm:semver:20150403':\n    - '@remy/protect-test@1.0.13 > semver@2.3.2':\n        patched: '2015-10-28T21:22:32.573Z'\n        from: '@remy/protect-test@1.0.13'\n",
+    "ignoreSettings": null,
+    "org": "demo-applications",
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {
+        "AGPL-1.0": {
+          "licenseType": "AGPL-1.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "AGPL-3.0": {
+          "licenseType": "AGPL-3.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "Artistic-1.0": {
+          "licenseType": "Artistic-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "Artistic-2.0": {
+          "licenseType": "Artistic-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "CDDL-1.0": {
+          "licenseType": "CDDL-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "CPOL-1.02": {
+          "licenseType": "CPOL-1.02",
+          "severity": "high",
+          "instructions": ""
+        },
+        "EPL-1.0": {
+          "licenseType": "EPL-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "GPL-2.0": {
+          "licenseType": "GPL-2.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "GPL-3.0": {
+          "licenseType": "GPL-3.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "LGPL-2.0": {
+          "licenseType": "LGPL-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "LGPL-2.1": {
+          "licenseType": "LGPL-2.1",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "LGPL-3.0": {
+          "licenseType": "LGPL-3.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MPL-1.1": {
+          "licenseType": "MPL-1.1",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MPL-2.0": {
+          "licenseType": "MPL-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MS-RL": {
+          "licenseType": "MS-RL",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "SimPL-2.0": {
+          "licenseType": "SimPL-2.0",
+          "severity": "high",
+          "instructions": ""
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/qs-package/test-dep-graph-result.json
+++ b/test/fixtures/qs-package/test-dep-graph-result.json
@@ -1,0 +1,12343 @@
+{
+  "result": {
+    "affectedPkgs": {
+      "bl@0.9.5": {
+        "pkg": {
+          "name": "bl",
+          "version": "0.9.5"
+        },
+        "issues": {
+          "SNYK-JS-BL-608877": {
+            "issueId": "SNYK-JS-BL-608877",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "bl@1.1.2": {
+        "pkg": {
+          "name": "bl",
+          "version": "1.1.2"
+        },
+        "issues": {
+          "SNYK-JS-BL-608877": {
+            "issueId": "SNYK-JS-BL-608877",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.76.0"
+                    },
+                    {
+                      "name": "bl",
+                      "version": "1.1.2",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "dot-prop@2.4.0": {
+        "pkg": {
+          "name": "dot-prop",
+          "version": "2.4.0"
+        },
+        "issues": {
+          "SNYK-JS-DOTPROP-543489": {
+            "issueId": "SNYK-JS-DOTPROP-543489",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "hosted-git-info@2.1.5": {
+        "pkg": {
+          "name": "hosted-git-info",
+          "version": "2.1.5"
+        },
+        "issues": {
+          "SNYK-JS-HOSTEDGITINFO-1088355": {
+            "issueId": "SNYK-JS-HOSTEDGITINFO-1088355",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-module",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "hosted-git-info",
+                      "version": "2.1.5",
+                      "newVersion": "2.8.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-policy",
+                      "version": "1.5.2",
+                      "newVersion": "1.5.2"
+                    },
+                    {
+                      "name": "snyk-module",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "hosted-git-info",
+                      "version": "2.1.5",
+                      "newVersion": "2.8.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "snyk-module",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "hosted-git-info",
+                      "version": "2.1.5",
+                      "newVersion": "2.8.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "yargs",
+                      "version": "4.8.1",
+                      "newVersion": "4.8.1"
+                    },
+                    {
+                      "name": "read-pkg-up",
+                      "version": "1.0.1",
+                      "newVersion": "1.0.1"
+                    },
+                    {
+                      "name": "read-pkg",
+                      "version": "1.1.0",
+                      "newVersion": "1.1.0"
+                    },
+                    {
+                      "name": "normalize-package-data",
+                      "version": "2.3.5",
+                      "newVersion": "2.3.5"
+                    },
+                    {
+                      "name": "hosted-git-info",
+                      "version": "2.1.5",
+                      "newVersion": "2.8.9"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "ini@1.3.4": {
+        "pkg": {
+          "name": "ini",
+          "version": "1.3.4"
+        },
+        "issues": {
+          "SNYK-JS-INI-1048974": {
+            "issueId": "SNYK-JS-INI-1048974",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-config",
+                      "version": "1.0.1",
+                      "newVersion": "1.0.1"
+                    },
+                    {
+                      "name": "nconf",
+                      "version": "0.7.2",
+                      "newVersion": "0.7.2"
+                    },
+                    {
+                      "name": "ini",
+                      "version": "1.3.4",
+                      "newVersion": "1.3.6"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.5.0",
+                      "newVersion": "0.5.0"
+                    },
+                    {
+                      "name": "latest-version",
+                      "version": "1.0.1",
+                      "newVersion": "1.0.1"
+                    },
+                    {
+                      "name": "package-json",
+                      "version": "1.2.0",
+                      "newVersion": "1.2.0"
+                    },
+                    {
+                      "name": "registry-url",
+                      "version": "3.1.0",
+                      "newVersion": "3.1.0"
+                    },
+                    {
+                      "name": "rc",
+                      "version": "1.1.6",
+                      "newVersion": "1.1.6"
+                    },
+                    {
+                      "name": "ini",
+                      "version": "1.3.4",
+                      "newVersion": "1.3.6"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.6.3",
+                      "newVersion": "0.6.3"
+                    },
+                    {
+                      "name": "latest-version",
+                      "version": "2.0.0",
+                      "newVersion": "2.0.0"
+                    },
+                    {
+                      "name": "package-json",
+                      "version": "2.3.3",
+                      "newVersion": "2.3.3"
+                    },
+                    {
+                      "name": "rc",
+                      "version": "1.1.6",
+                      "newVersion": "1.1.6"
+                    },
+                    {
+                      "name": "ini",
+                      "version": "1.3.4",
+                      "newVersion": "1.3.6"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.6.3",
+                      "newVersion": "0.6.3"
+                    },
+                    {
+                      "name": "latest-version",
+                      "version": "2.0.0",
+                      "newVersion": "2.0.0"
+                    },
+                    {
+                      "name": "package-json",
+                      "version": "2.3.3",
+                      "newVersion": "2.3.3"
+                    },
+                    {
+                      "name": "registry-url",
+                      "version": "3.1.0",
+                      "newVersion": "3.1.0"
+                    },
+                    {
+                      "name": "rc",
+                      "version": "1.1.6",
+                      "newVersion": "1.1.6"
+                    },
+                    {
+                      "name": "ini",
+                      "version": "1.3.4",
+                      "newVersion": "1.3.6"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "is-my-json-valid@2.13.1": {
+        "pkg": {
+          "name": "is-my-json-valid",
+          "version": "2.13.1"
+        },
+        "issues": {
+          "SNYK-JS-ISMYJSONVALID-597165": {
+            "issueId": "SNYK-JS-ISMYJSONVALID-597165",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.57.0",
+                      "newVersion": "2.57.0"
+                    },
+                    {
+                      "name": "har-validator",
+                      "version": "1.8.0",
+                      "newVersion": "1.8.0"
+                    },
+                    {
+                      "name": "is-my-json-valid",
+                      "version": "2.13.1",
+                      "newVersion": "2.20.2"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.74.0"
+                    },
+                    {
+                      "name": "har-validator",
+                      "version": "2.0.6",
+                      "newVersion": "2.0.6"
+                    },
+                    {
+                      "name": "is-my-json-valid",
+                      "version": "2.13.1",
+                      "newVersion": "2.20.2"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-ISMYJSONVALID-597167": {
+            "issueId": "SNYK-JS-ISMYJSONVALID-597167",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.57.0",
+                      "newVersion": "2.57.0"
+                    },
+                    {
+                      "name": "har-validator",
+                      "version": "1.8.0",
+                      "newVersion": "1.8.0"
+                    },
+                    {
+                      "name": "is-my-json-valid",
+                      "version": "2.13.1",
+                      "newVersion": "2.20.3"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.74.0"
+                    },
+                    {
+                      "name": "har-validator",
+                      "version": "2.0.6",
+                      "newVersion": "2.0.6"
+                    },
+                    {
+                      "name": "is-my-json-valid",
+                      "version": "2.13.1",
+                      "newVersion": "2.20.3"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "npm:is-my-json-valid:20180214": {
+            "issueId": "npm:is-my-json-valid:20180214",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.57.0",
+                      "newVersion": "2.57.0"
+                    },
+                    {
+                      "name": "har-validator",
+                      "version": "1.8.0",
+                      "newVersion": "1.8.0"
+                    },
+                    {
+                      "name": "is-my-json-valid",
+                      "version": "2.13.1",
+                      "newVersion": "2.17.2"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.74.0"
+                    },
+                    {
+                      "name": "har-validator",
+                      "version": "2.0.6",
+                      "newVersion": "2.0.6"
+                    },
+                    {
+                      "name": "is-my-json-valid",
+                      "version": "2.13.1",
+                      "newVersion": "2.17.2"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "jsonpointer@2.0.0": {
+        "pkg": {
+          "name": "jsonpointer",
+          "version": "2.0.0"
+        },
+        "issues": {
+          "SNYK-JS-JSONPOINTER-598804": {
+            "issueId": "SNYK-JS-JSONPOINTER-598804",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.57.0",
+                      "newVersion": "2.57.0"
+                    },
+                    {
+                      "name": "har-validator",
+                      "version": "1.8.0",
+                      "newVersion": "1.8.0"
+                    },
+                    {
+                      "name": "is-my-json-valid",
+                      "version": "2.13.1",
+                      "newVersion": "2.15.0"
+                    },
+                    {
+                      "name": "jsonpointer",
+                      "version": "2.0.0",
+                      "newVersion": "4.1.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.74.0"
+                    },
+                    {
+                      "name": "har-validator",
+                      "version": "2.0.6",
+                      "newVersion": "2.0.6"
+                    },
+                    {
+                      "name": "is-my-json-valid",
+                      "version": "2.13.1",
+                      "newVersion": "2.15.0"
+                    },
+                    {
+                      "name": "jsonpointer",
+                      "version": "2.0.0",
+                      "newVersion": "4.1.0"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "js-yaml@3.6.1": {
+        "pkg": {
+          "name": "js-yaml",
+          "version": "3.6.1"
+        },
+        "issues": {
+          "SNYK-JS-JSYAML-173999": {
+            "issueId": "SNYK-JS-JSYAML-173999",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-policy",
+                      "version": "1.5.2",
+                      "newVersion": "1.5.2"
+                    },
+                    {
+                      "name": "js-yaml",
+                      "version": "3.6.1",
+                      "newVersion": "3.13.0"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-JSYAML-174129": {
+            "issueId": "SNYK-JS-JSYAML-174129",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-policy",
+                      "version": "1.5.2",
+                      "newVersion": "1.5.2"
+                    },
+                    {
+                      "name": "js-yaml",
+                      "version": "3.6.1",
+                      "newVersion": "3.13.1"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "lodash@4.14.0": {
+        "pkg": {
+          "name": "lodash",
+          "version": "4.14.0"
+        },
+        "issues": {
+          "SNYK-JS-LODASH-1018905": {
+            "issueId": "SNYK-JS-LODASH-1018905",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "inquirer",
+                      "version": "1.0.3",
+                      "newVersion": "1.0.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.21"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.21"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-1040724": {
+            "issueId": "SNYK-JS-LODASH-1040724",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "inquirer",
+                      "version": "1.0.3",
+                      "newVersion": "1.0.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.21"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.21"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-450202": {
+            "issueId": "SNYK-JS-LODASH-450202",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "inquirer",
+                      "version": "1.0.3",
+                      "newVersion": "1.0.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.12"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.12"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-567746": {
+            "issueId": "SNYK-JS-LODASH-567746",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "inquirer",
+                      "version": "1.0.3",
+                      "newVersion": "1.0.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.16"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.16"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-590103": {
+            "issueId": "SNYK-JS-LODASH-590103",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "inquirer",
+                      "version": "1.0.3",
+                      "newVersion": "1.0.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.20"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.20"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-608086": {
+            "issueId": "SNYK-JS-LODASH-608086",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "inquirer",
+                      "version": "1.0.3",
+                      "newVersion": "1.0.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.17"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.17"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-73638": {
+            "issueId": "SNYK-JS-LODASH-73638",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "inquirer",
+                      "version": "1.0.3",
+                      "newVersion": "1.0.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.11"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.11"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-73639": {
+            "issueId": "SNYK-JS-LODASH-73639",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "inquirer",
+                      "version": "1.0.3",
+                      "newVersion": "1.0.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.11"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.11"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "npm:lodash:20180130": {
+            "issueId": "npm:lodash:20180130",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "inquirer",
+                      "version": "1.0.3",
+                      "newVersion": "1.0.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.5"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.14.0",
+                      "newVersion": "4.17.5"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "lodash@3.10.1": {
+        "pkg": {
+          "name": "lodash",
+          "version": "3.10.1"
+        },
+        "issues": {
+          "SNYK-JS-LODASH-1018905": {
+            "issueId": "SNYK-JS-LODASH-1018905",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.19.1"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "3.10.1",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-1040724": {
+            "issueId": "SNYK-JS-LODASH-1040724",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.19.1"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "3.10.1",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-450202": {
+            "issueId": "SNYK-JS-LODASH-450202",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.19.1"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "3.10.1",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-567746": {
+            "issueId": "SNYK-JS-LODASH-567746",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.19.1"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "3.10.1",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-590103": {
+            "issueId": "SNYK-JS-LODASH-590103",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.19.1"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "3.10.1",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-608086": {
+            "issueId": "SNYK-JS-LODASH-608086",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.19.1"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "3.10.1",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-73638": {
+            "issueId": "SNYK-JS-LODASH-73638",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.19.1"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "3.10.1",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-73639": {
+            "issueId": "SNYK-JS-LODASH-73639",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.19.1"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "3.10.1",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "npm:lodash:20180130": {
+            "issueId": "npm:lodash:20180130",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.19.1"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "3.10.1",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "lodash.defaultsdeep@4.5.0": {
+        "pkg": {
+          "name": "lodash.defaultsdeep",
+          "version": "4.5.0"
+        },
+        "issues": {
+          "SNYK-JS-LODASHDEFAULTSDEEP-450198": {
+            "issueId": "SNYK-JS-LODASHDEFAULTSDEEP-450198",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "lodash.defaultsdeep",
+                      "version": "4.5.0",
+                      "newVersion": "4.6.1"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASHDEFAULTSDEEP-450199": {
+            "issueId": "SNYK-JS-LODASHDEFAULTSDEEP-450199",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "lodash.defaultsdeep",
+                      "version": "4.5.0",
+                      "newVersion": "4.6.1"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "lodash.mergewith@4.5.0": {
+        "pkg": {
+          "name": "lodash.mergewith",
+          "version": "4.5.0"
+        },
+        "issues": {
+          "SNYK-JS-LODASHMERGEWITH-174136": {
+            "issueId": "SNYK-JS-LODASHMERGEWITH-174136",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "lodash.mergewith",
+                      "version": "4.5.0",
+                      "newVersion": "4.6.2"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASHMERGEWITH-174137": {
+            "issueId": "SNYK-JS-LODASHMERGEWITH-174137",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "lodash.mergewith",
+                      "version": "4.5.0",
+                      "newVersion": "4.6.1"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "minimist@0.0.8": {
+        "pkg": {
+          "name": "minimist",
+          "version": "0.0.8"
+        },
+        "issues": {
+          "SNYK-JS-MINIMIST-559764": {
+            "issueId": "SNYK-JS-MINIMIST-559764",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "configstore",
+                      "version": "1.4.0",
+                      "newVersion": "1.4.0"
+                    },
+                    {
+                      "name": "mkdirp",
+                      "version": "0.5.1",
+                      "newVersion": "0.5.2"
+                    },
+                    {
+                      "name": "minimist",
+                      "version": "0.0.8",
+                      "newVersion": "1.2.5"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.5.0",
+                      "newVersion": "0.5.0"
+                    },
+                    {
+                      "name": "configstore",
+                      "version": "1.4.0",
+                      "newVersion": "1.4.0"
+                    },
+                    {
+                      "name": "mkdirp",
+                      "version": "0.5.1",
+                      "newVersion": "0.5.2"
+                    },
+                    {
+                      "name": "minimist",
+                      "version": "0.0.8",
+                      "newVersion": "1.2.5"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.6.3",
+                      "newVersion": "0.6.3"
+                    },
+                    {
+                      "name": "configstore",
+                      "version": "2.0.0",
+                      "newVersion": "2.0.0"
+                    },
+                    {
+                      "name": "mkdirp",
+                      "version": "0.5.1",
+                      "newVersion": "0.5.2"
+                    },
+                    {
+                      "name": "minimist",
+                      "version": "0.0.8",
+                      "newVersion": "1.2.5"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "minimist@1.2.0": {
+        "pkg": {
+          "name": "minimist",
+          "version": "1.2.0"
+        },
+        "issues": {
+          "SNYK-JS-MINIMIST-559764": {
+            "issueId": "SNYK-JS-MINIMIST-559764",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "minimist",
+                      "version": "1.2.0",
+                      "newVersion": "1.2.3"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "os-name",
+                      "version": "1.0.3",
+                      "newVersion": "1.0.3"
+                    },
+                    {
+                      "name": "osx-release",
+                      "version": "1.1.0",
+                      "newVersion": "1.1.0"
+                    },
+                    {
+                      "name": "minimist",
+                      "version": "1.2.0",
+                      "newVersion": "1.2.3"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.5.0",
+                      "newVersion": "0.5.0"
+                    },
+                    {
+                      "name": "latest-version",
+                      "version": "1.0.1",
+                      "newVersion": "1.0.1"
+                    },
+                    {
+                      "name": "package-json",
+                      "version": "1.2.0",
+                      "newVersion": "1.2.0"
+                    },
+                    {
+                      "name": "registry-url",
+                      "version": "3.1.0",
+                      "newVersion": "3.1.0"
+                    },
+                    {
+                      "name": "rc",
+                      "version": "1.1.6",
+                      "newVersion": "1.1.6"
+                    },
+                    {
+                      "name": "minimist",
+                      "version": "1.2.0",
+                      "newVersion": "1.2.3"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.6.3",
+                      "newVersion": "0.6.3"
+                    },
+                    {
+                      "name": "latest-version",
+                      "version": "2.0.0",
+                      "newVersion": "2.0.0"
+                    },
+                    {
+                      "name": "package-json",
+                      "version": "2.3.3",
+                      "newVersion": "2.3.3"
+                    },
+                    {
+                      "name": "rc",
+                      "version": "1.1.6",
+                      "newVersion": "1.1.6"
+                    },
+                    {
+                      "name": "minimist",
+                      "version": "1.2.0",
+                      "newVersion": "1.2.3"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.6.3",
+                      "newVersion": "0.6.3"
+                    },
+                    {
+                      "name": "latest-version",
+                      "version": "2.0.0",
+                      "newVersion": "2.0.0"
+                    },
+                    {
+                      "name": "package-json",
+                      "version": "2.3.3",
+                      "newVersion": "2.3.3"
+                    },
+                    {
+                      "name": "registry-url",
+                      "version": "3.1.0",
+                      "newVersion": "3.1.0"
+                    },
+                    {
+                      "name": "rc",
+                      "version": "1.1.6",
+                      "newVersion": "1.1.6"
+                    },
+                    {
+                      "name": "minimist",
+                      "version": "1.2.0",
+                      "newVersion": "1.2.3"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "open@0.0.5": {
+        "pkg": {
+          "name": "open",
+          "version": "0.0.5"
+        },
+        "issues": {
+          "SNYK-JS-OPEN-174041": {
+            "issueId": "SNYK-JS-OPEN-174041",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.76.0"
+                    },
+                    {
+                      "name": "open",
+                      "version": "0.0.5",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "npm:open:20180512": {
+            "issueId": "npm:open:20180512",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.76.0"
+                    },
+                    {
+                      "name": "open",
+                      "version": "0.0.5",
+                      "isDropped": true
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "request@2.57.0": {
+        "pkg": {
+          "name": "request",
+          "version": "2.57.0"
+        },
+        "issues": {
+          "SNYK-JS-REQUEST-1314897": {
+            "issueId": "SNYK-JS-REQUEST-1314897",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [],
+              "isPinnable": false
+            }
+          },
+          "npm:request:20160119": {
+            "issueId": "npm:request:20160119",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "request@2.74.0": {
+        "pkg": {
+          "name": "request",
+          "version": "2.74.0"
+        },
+        "issues": {
+          "SNYK-JS-REQUEST-1314897": {
+            "issueId": "SNYK-JS-REQUEST-1314897",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "undefsafe@0.0.3": {
+        "pkg": {
+          "name": "undefsafe",
+          "version": "0.0.3"
+        },
+        "issues": {
+          "SNYK-JS-UNDEFSAFE-548940": {
+            "issueId": "SNYK-JS-UNDEFSAFE-548940",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.78.0"
+                    },
+                    {
+                      "name": "undefsafe",
+                      "version": "0.0.3",
+                      "newVersion": "2.0.3"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "y18n@3.2.1": {
+        "pkg": {
+          "name": "y18n",
+          "version": "3.2.1"
+        },
+        "issues": {
+          "SNYK-JS-Y18N-1021887": {
+            "issueId": "SNYK-JS-Y18N-1021887",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "yargs",
+                      "version": "4.8.1",
+                      "newVersion": "4.8.1"
+                    },
+                    {
+                      "name": "y18n",
+                      "version": "3.2.1",
+                      "newVersion": "3.2.2"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "brace-expansion@1.1.6": {
+        "pkg": {
+          "name": "brace-expansion",
+          "version": "1.1.6"
+        },
+        "issues": {
+          "npm:brace-expansion:20170302": {
+            "issueId": "npm:brace-expansion:20170302",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-recursive-readdir",
+                      "version": "2.0.0",
+                      "newVersion": "2.0.0"
+                    },
+                    {
+                      "name": "minimatch",
+                      "version": "3.0.2",
+                      "newVersion": "3.0.2"
+                    },
+                    {
+                      "name": "brace-expansion",
+                      "version": "1.1.6",
+                      "newVersion": "1.1.7"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "debug@2.2.0": {
+        "pkg": {
+          "name": "debug",
+          "version": "2.2.0"
+        },
+        "issues": {
+          "npm:debug:20170905": {
+            "issueId": "npm:debug:20170905",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-config",
+                      "version": "1.0.1",
+                      "newVersion": "1.0.1"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-module",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-try-require",
+                      "version": "1.1.1",
+                      "newVersion": "1.1.1"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-policy",
+                      "version": "1.5.2",
+                      "newVersion": "1.5.2"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-policy",
+                      "version": "1.5.2",
+                      "newVersion": "1.5.2"
+                    },
+                    {
+                      "name": "snyk-module",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "snyk-module",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-policy",
+                      "version": "1.5.2",
+                      "newVersion": "1.5.2"
+                    },
+                    {
+                      "name": "snyk-try-require",
+                      "version": "1.1.1",
+                      "newVersion": "1.1.1"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "snyk-try-require",
+                      "version": "1.1.1",
+                      "newVersion": "1.1.1"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.9"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "deep-extend@0.4.1": {
+        "pkg": {
+          "name": "deep-extend",
+          "version": "0.4.1"
+        },
+        "issues": {
+          "npm:deep-extend:20180409": {
+            "issueId": "npm:deep-extend:20180409",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.5.0",
+                      "newVersion": "0.5.0"
+                    },
+                    {
+                      "name": "latest-version",
+                      "version": "1.0.1",
+                      "newVersion": "1.0.1"
+                    },
+                    {
+                      "name": "package-json",
+                      "version": "1.2.0",
+                      "newVersion": "1.2.0"
+                    },
+                    {
+                      "name": "registry-url",
+                      "version": "3.1.0",
+                      "newVersion": "3.1.0"
+                    },
+                    {
+                      "name": "rc",
+                      "version": "1.1.6",
+                      "newVersion": "1.2.7"
+                    },
+                    {
+                      "name": "deep-extend",
+                      "version": "0.4.1",
+                      "newVersion": "0.5.1"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.6.3",
+                      "newVersion": "0.6.3"
+                    },
+                    {
+                      "name": "latest-version",
+                      "version": "2.0.0",
+                      "newVersion": "2.0.0"
+                    },
+                    {
+                      "name": "package-json",
+                      "version": "2.3.3",
+                      "newVersion": "2.3.3"
+                    },
+                    {
+                      "name": "rc",
+                      "version": "1.1.6",
+                      "newVersion": "1.2.7"
+                    },
+                    {
+                      "name": "deep-extend",
+                      "version": "0.4.1",
+                      "newVersion": "0.5.1"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "update-notifier",
+                      "version": "0.6.3",
+                      "newVersion": "0.6.3"
+                    },
+                    {
+                      "name": "latest-version",
+                      "version": "2.0.0",
+                      "newVersion": "2.0.0"
+                    },
+                    {
+                      "name": "package-json",
+                      "version": "2.3.3",
+                      "newVersion": "2.3.3"
+                    },
+                    {
+                      "name": "registry-url",
+                      "version": "3.1.0",
+                      "newVersion": "3.1.0"
+                    },
+                    {
+                      "name": "rc",
+                      "version": "1.1.6",
+                      "newVersion": "1.2.7"
+                    },
+                    {
+                      "name": "deep-extend",
+                      "version": "0.4.1",
+                      "newVersion": "0.5.1"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "extend@3.0.0": {
+        "pkg": {
+          "name": "extend",
+          "version": "3.0.0"
+        },
+        "issues": {
+          "npm:extend:20180424": {
+            "issueId": "npm:extend:20180424",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.74.0"
+                    },
+                    {
+                      "name": "extend",
+                      "version": "3.0.0",
+                      "newVersion": "3.0.2"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "hawk@2.3.1": {
+        "pkg": {
+          "name": "hawk",
+          "version": "2.3.1"
+        },
+        "issues": {
+          "npm:hawk:20160119": {
+            "issueId": "npm:hawk:20160119",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "hoek@2.16.3": {
+        "pkg": {
+          "name": "hoek",
+          "version": "2.16.3"
+        },
+        "issues": {
+          "npm:hoek:20180212": {
+            "issueId": "npm:hoek:20180212",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.82.0"
+                    },
+                    {
+                      "name": "hawk",
+                      "version": "3.1.3",
+                      "newVersion": "6.0.2"
+                    },
+                    {
+                      "name": "hoek",
+                      "version": "2.16.3",
+                      "newVersion": "4.2.1"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.82.0"
+                    },
+                    {
+                      "name": "hawk",
+                      "version": "3.1.3",
+                      "newVersion": "6.0.2"
+                    },
+                    {
+                      "name": "boom",
+                      "version": "2.10.1",
+                      "newVersion": "4.0.0"
+                    },
+                    {
+                      "name": "hoek",
+                      "version": "2.16.3",
+                      "newVersion": "4.2.1"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.82.0"
+                    },
+                    {
+                      "name": "hawk",
+                      "version": "3.1.3",
+                      "newVersion": "6.0.2"
+                    },
+                    {
+                      "name": "sntp",
+                      "version": "1.0.9",
+                      "newVersion": "2.0.1"
+                    },
+                    {
+                      "name": "hoek",
+                      "version": "2.16.3",
+                      "newVersion": "4.2.1"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.82.0"
+                    },
+                    {
+                      "name": "hawk",
+                      "version": "3.1.3",
+                      "newVersion": "6.0.2"
+                    },
+                    {
+                      "name": "cryptiles",
+                      "version": "2.0.5",
+                      "newVersion": "3.0.0"
+                    },
+                    {
+                      "name": "boom",
+                      "version": "2.10.1",
+                      "newVersion": "3.1.3"
+                    },
+                    {
+                      "name": "hoek",
+                      "version": "2.16.3",
+                      "newVersion": "4.2.1"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "http-signature@0.11.0": {
+        "pkg": {
+          "name": "http-signature",
+          "version": "0.11.0"
+        },
+        "issues": {
+          "npm:http-signature:20150122": {
+            "issueId": "npm:http-signature:20150122",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "ms@0.7.1": {
+        "pkg": {
+          "name": "ms",
+          "version": "0.7.1"
+        },
+        "issues": {
+          "npm:ms:20170412": {
+            "issueId": "npm:ms:20170412",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-config",
+                      "version": "1.0.1",
+                      "newVersion": "1.0.1"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-module",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-try-require",
+                      "version": "1.1.1",
+                      "newVersion": "1.1.1"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-policy",
+                      "version": "1.5.2",
+                      "newVersion": "1.5.2"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-policy",
+                      "version": "1.5.2",
+                      "newVersion": "1.5.2"
+                    },
+                    {
+                      "name": "snyk-module",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "snyk-module",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-policy",
+                      "version": "1.5.2",
+                      "newVersion": "1.5.2"
+                    },
+                    {
+                      "name": "snyk-try-require",
+                      "version": "1.1.1",
+                      "newVersion": "1.1.1"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "snyk-try-require",
+                      "version": "1.1.1",
+                      "newVersion": "1.1.1"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "snyk-resolve-deps",
+                      "version": "1.7.0",
+                      "newVersion": "1.7.0"
+                    },
+                    {
+                      "name": "clite",
+                      "version": "0.3.0",
+                      "newVersion": "0.3.0"
+                    },
+                    {
+                      "name": "debug",
+                      "version": "2.2.0",
+                      "newVersion": "2.6.7"
+                    },
+                    {
+                      "name": "ms",
+                      "version": "0.7.1",
+                      "newVersion": "2.0.0"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "qs@0.6.6": {
+        "pkg": {
+          "name": "qs",
+          "version": "0.6.6"
+        },
+        "issues": {
+          "npm:qs:20140806": {
+            "issueId": "npm:qs:20140806",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "qs",
+                      "version": "0.6.6",
+                      "newVersion": "1.0.0"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "npm:qs:20140806-1": {
+            "issueId": "npm:qs:20140806-1",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "qs",
+                      "version": "0.6.6",
+                      "newVersion": "1.0.0"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "npm:qs:20170213": {
+            "issueId": "npm:qs:20170213",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "qs",
+                      "version": "0.6.6",
+                      "newVersion": "6.0.4"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "qs@3.1.0": {
+        "pkg": {
+          "name": "qs",
+          "version": "3.1.0"
+        },
+        "issues": {
+          "npm:qs:20170213": {
+            "issueId": "npm:qs:20170213",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "qs@6.2.1": {
+        "pkg": {
+          "name": "qs",
+          "version": "6.2.1"
+        },
+        "issues": {
+          "npm:qs:20170213": {
+            "issueId": "npm:qs:20170213",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.74.0"
+                    },
+                    {
+                      "name": "qs",
+                      "version": "6.2.1",
+                      "newVersion": "6.2.3"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "semver@2.3.2": {
+        "pkg": {
+          "name": "semver",
+          "version": "2.3.2"
+        },
+        "issues": {
+          "npm:semver:20150403": {
+            "issueId": "npm:semver:20150403",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "sshpk@1.9.1": {
+        "pkg": {
+          "name": "sshpk",
+          "version": "1.9.1"
+        },
+        "issues": {
+          "npm:sshpk:20180409": {
+            "issueId": "npm:sshpk:20180409",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.74.0"
+                    },
+                    {
+                      "name": "http-signature",
+                      "version": "1.1.1",
+                      "newVersion": "1.1.1"
+                    },
+                    {
+                      "name": "sshpk",
+                      "version": "1.9.1",
+                      "newVersion": "1.14.1"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "stringstream@0.0.5": {
+        "pkg": {
+          "name": "stringstream",
+          "version": "0.0.5"
+        },
+        "issues": {
+          "npm:stringstream:20180511": {
+            "issueId": "npm:stringstream:20180511",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.57.0",
+                      "newVersion": "2.57.0"
+                    },
+                    {
+                      "name": "stringstream",
+                      "version": "0.0.5",
+                      "newVersion": "0.0.6"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.74.0"
+                    },
+                    {
+                      "name": "stringstream",
+                      "version": "0.0.5",
+                      "newVersion": "0.0.6"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "tough-cookie@2.3.1": {
+        "pkg": {
+          "name": "tough-cookie",
+          "version": "2.3.1"
+        },
+        "issues": {
+          "npm:tough-cookie:20170905": {
+            "issueId": "npm:tough-cookie:20170905",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.57.0",
+                      "newVersion": "2.57.0"
+                    },
+                    {
+                      "name": "tough-cookie",
+                      "version": "2.3.1",
+                      "newVersion": "2.3.3"
+                    }
+                  ]
+                },
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.74.0"
+                    },
+                    {
+                      "name": "tough-cookie",
+                      "version": "2.3.1",
+                      "newVersion": "2.3.3"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "tunnel-agent@0.4.3": {
+        "pkg": {
+          "name": "tunnel-agent",
+          "version": "0.4.3"
+        },
+        "issues": {
+          "npm:tunnel-agent:20170305": {
+            "issueId": "npm:tunnel-agent:20170305",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "qs-package",
+                      "version": "1.0.0"
+                    },
+                    {
+                      "name": "@remy/protect-test",
+                      "version": "1.0.13",
+                      "newVersion": "1.0.13"
+                    },
+                    {
+                      "name": "snyk",
+                      "version": "1.17.4",
+                      "newVersion": "1.17.4"
+                    },
+                    {
+                      "name": "request",
+                      "version": "2.74.0",
+                      "newVersion": "2.81.0"
+                    },
+                    {
+                      "name": "tunnel-agent",
+                      "version": "0.4.3",
+                      "newVersion": "0.6.0"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      }
+    },
+    "issuesData": {
+      "SNYK-JS-BL-608877": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:L/A:L/E:P",
+        "alternativeIds": [],
+        "creationTime": "2020-08-28T12:18:44.906258Z",
+        "credit": [
+          "chalker"
+        ],
+        "cvssScore": 7.7,
+        "description": "## Overview\n[bl](https://github.com/rvagg/bl) is a library that allows you to collect buffers and access with a standard readable buffer interface.\n\nAffected versions of this package are vulnerable to Remote Memory Exposure. If user input ends up in `consume()` argument and can become negative, BufferList state can be corrupted, tricking it into exposing uninitialized memory via regular `.slice()` calls.\r\n\r\n### PoC by chalker\r\n```\r\nconst { BufferList } = require('bl')\r\nconst secret = require('crypto').randomBytes(256)\r\nfor (let i = 0; i < 1e6; i++) {\r\n  const clone = Buffer.from(secret)\r\n  const bl = new BufferList()\r\n  bl.append(Buffer.from('a'))\r\n  bl.consume(-1024)\r\n  const buf = bl.slice(1)\r\n  if (buf.indexOf(clone) !== -1) {\r\n    console.error(`Match (at ${i})`, buf)\r\n  }\r\n}\r\n```\n## Remediation\nUpgrade `bl` to version 2.2.1, 3.0.1, 4.0.3, 1.2.3 or higher.\n## References\n- [Github Commit](https://github.com/rvagg/bl/commit/8a8c13c880e2bef519133ea43e0e9b78b5d0c91e)\n- [Github Commit](https://github.com/rvagg/bl/commit/d3e240e3b8ba4048d3c76ef5fb9dd1f8872d3190)\n- [Github Commit](https://github.com/rvagg/bl/commit/dacc4ac7d5fcd6201bcf26fbd886951be9537466)\n- [GitHub Commit](https://github.com/rvagg/bl/commit/0bd87ec97be399b129fc62feff2943ffa21bcc00)\n- [HackerOne Report](https://hackerone.com/reports/966347)\n",
+        "disclosureTime": "2020-08-27T15:16:42Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "2.2.1",
+          "3.0.1",
+          "4.0.3",
+          "1.2.3"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-BL-608877",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-8244"
+          ],
+          "CWE": [
+            "CWE-9"
+          ],
+          "GHSA": [
+            "GHSA-pp7h-53gx-mx7r"
+          ],
+          "NSP": [
+            "1555"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-09-04T12:31:03.817670Z",
+        "moduleName": "bl",
+        "packageManager": "npm",
+        "packageName": "bl",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-08-28T12:18:48Z",
+        "references": [
+          {
+            "title": "Github Commit",
+            "url": "https://github.com/rvagg/bl/commit/8a8c13c880e2bef519133ea43e0e9b78b5d0c91e"
+          },
+          {
+            "title": "Github Commit",
+            "url": "https://github.com/rvagg/bl/commit/d3e240e3b8ba4048d3c76ef5fb9dd1f8872d3190"
+          },
+          {
+            "title": "Github Commit",
+            "url": "https://github.com/rvagg/bl/commit/dacc4ac7d5fcd6201bcf26fbd886951be9537466"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/rvagg/bl/commit/0bd87ec97be399b129fc62feff2943ffa21bcc00"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/966347"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            ">=2.2.0 <2.2.1",
+            ">=3.0.0 <3.0.1",
+            ">=4.0.0 <4.0.3",
+            "<1.2.3"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Remote Memory Exposure"
+      },
+      "SNYK-JS-DOTPROP-543489": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-01-28T15:18:37.743372Z",
+        "credit": [
+          "aaron_costello"
+        ],
+        "cvssScore": 6.3,
+        "description": "## Overview\n[dot-prop](https://github.com/sindresorhus/dot-prop#readme) is a package to get, set, or delete a property from a nested object using a dot path.\n\nAffected versions of this package are vulnerable to Prototype Pollution. It is possible for a user to modify the prototype of a base object.\r\n\r\n## PoC by aaron_costello \r\n```\r\nvar dotProp = require(\"dot-prop\")\r\nconst object = {};\r\nconsole.log(\"Before \" + object.b); //Undefined\r\ndotProp.set(object, '__proto__.b', true);\r\nconsole.log(\"After \" + {}.b); //true\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `dot-prop` to version 4.2.1, 5.1.1 or higher.\n## References\n- [GitHub Commit](https://github.com/sindresorhus/dot-prop/commit/3039c8c07f6fdaa8b595ec869ae0895686a7a0f2)\n- [HackerOne Report](https://hackerone.com/reports/719856)\n",
+        "disclosureTime": "2020-01-28T10:17:51Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.2.1",
+          "5.1.1"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports.set"
+            },
+            "version": [
+              ">1.0.1 <5.1.1"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports.set"
+            },
+            "version": [
+              ">1.0.1 <5.1.1"
+            ]
+          }
+        ],
+        "id": "SNYK-JS-DOTPROP-543489",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-8116"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-ff7x-qrg7-qggm"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-27T08:47:24.715335Z",
+        "moduleName": "dot-prop",
+        "packageManager": "npm",
+        "packageName": "dot-prop",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-01-28T16:23:39Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/sindresorhus/dot-prop/commit/3039c8c07f6fdaa8b595ec869ae0895686a7a0f2"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/719856"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            ">1.0.1 <4.2.1",
+            ">=5.0.0 <5.1.1"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-HOSTEDGITINFO-1088355": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2021-03-23T16:13:42.109692Z",
+        "credit": [
+          "Yeting Li"
+        ],
+        "cvssScore": 5.3,
+        "description": "## Overview\n[hosted-git-info](https://www.npmjs.org/package/hosted-git-info) is a Provides metadata and conversions from repository urls for Github, Bitbucket and Gitlab\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) via regular expression `shortcutMatch ` in the `fromUrl` function in index.js. The affected regular expression exhibits polynomial worst-case time complexity.\r\n\r\n### PoC by Yeting Li\r\n```\r\nvar hostedGitInfo = require(\"hosted-git-info\")\r\nfunction build_attack(n) {\r\n    var ret = \"a:\"\r\n    for (var i = 0; i < n; i++) {\r\n        ret += \"a\"\r\n    }\r\n    return ret + \"!\";\r\n}\r\n\r\nfor(var i = 1; i <= 5000000; i++) {\r\n   if (i % 1000 == 0) {\r\n        var time = Date.now();\r\n        var attack_str = build_attack(i)\r\n       var parsedInfo = hostedGitInfo.fromUrl(attack_str)\r\n        var time_cost = Date.now() - time;\r\n        console.log(\"attack_str.length: \" + attack_str.length + \": \" + time_cost+\" ms\")\r\n}\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `hosted-git-info` to version 3.0.8, 2.8.9 or higher.\n## References\n- [GitHub Commit](https://github.com/npm/hosted-git-info/commit/bede0dc38e1785e732bf0a48ba6f81a4a908eba3)\n",
+        "disclosureTime": "2020-11-28T00:00:00Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "3.0.8",
+          "2.8.9"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-HOSTEDGITINFO-1088355",
+        "identifiers": {
+          "CVE": [
+            "CVE-2021-23362"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-43f8-2h32-f4cj"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2021-04-08T12:53:49.093606Z",
+        "moduleName": "hosted-git-info",
+        "packageManager": "npm",
+        "packageName": "hosted-git-info",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2021-03-23T17:13:24Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/npm/hosted-git-info/commit/bede0dc38e1785e732bf0a48ba6f81a4a908eba3"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            ">=3.0.0 <3.0.8",
+            "<2.8.9"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "SNYK-JS-INI-1048974": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P",
+        "alternativeIds": [],
+        "creationTime": "2020-12-08T15:34:07.743781Z",
+        "credit": [
+          "Eugene Lim",
+          "Government Technology Agency Cyber Security Group"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[ini](https://www.npmjs.org/package/ini) is an An ini encoder/decoder for node\n\nAffected versions of this package are vulnerable to Prototype Pollution. If an attacker submits a malicious INI file to an application that parses it with `ini.parse`, they will pollute the prototype on the application. This can be exploited further depending on the context.\r\n\r\n## PoC by Eugene Lim\r\n\r\npayload.ini\r\n```\r\n[__proto__]\r\npolluted = \"polluted\"\r\n```\r\n\r\npoc.js:\r\n```\r\nvar fs = require('fs')\r\nvar ini = require('ini')\r\n\r\nvar parsed = ini.parse(fs.readFileSync('./payload.ini', 'utf-8'))\r\nconsole.log(parsed)\r\nconsole.log(parsed.__proto__)\r\nconsole.log(polluted)\r\n```\r\n\r\n```\r\n> node poc.js\r\n{}\r\n{ polluted: 'polluted' }\r\n{ polluted: 'polluted' }\r\npolluted\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `ini` to version 1.3.6 or higher.\n## References\n- [Eugene Lim - Research Blog Post](https://medium.com/csg-govtech/supply-chain-pollution-discovering-a-16-million-download-week-node-js-2fa4d2c27cf7)\n- [GitHub Commit](https://github.com/npm/ini/commit/56d2805e07ccd94e2ba0984ac9240ff02d44b6f1)\n",
+        "disclosureTime": "2020-12-08T13:02:04Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "1.3.6"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-INI-1048974",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-7788"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-qqgx-2p2h-9c37"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-12-10T18:09:23.069283Z",
+        "moduleName": "ini",
+        "packageManager": "npm",
+        "packageName": "ini",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2020-12-10T18:08:38Z",
+        "references": [
+          {
+            "title": "Eugene Lim - Research Blog Post",
+            "url": "https://medium.com/csg-govtech/supply-chain-pollution-discovering-a-16-million-download-week-node-js-2fa4d2c27cf7"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/npm/ini/commit/56d2805e07ccd94e2ba0984ac9240ff02d44b6f1"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<1.3.6"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-ISMYJSONVALID-597165": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-08-02T12:09:52.577067Z",
+        "credit": [
+          "chalker"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n[is-my-json-valid](https://github.com/mafintosh/is-my-json-valid) is a JSONSchema / orderly validator that uses code generation to be extremely fast.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) via the `style` format. \r\n\r\n##PoC\r\n```\r\nconst imjv = require('is-my-json-valid')\r\nconst validate = imjv({ maxLength: 100, format: 'style' })\r\nconsole.log(validate(' '.repeat(1e4)))\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `is-my-json-valid` to version 2.20.2 or higher.\n## References\n- [GitHub Commit](https://github.com/mafintosh/is-my-json-valid/commit/c3fc04fc455d40e9b29537f8e2c73a28ce106edb)\n- [HackerOne Report](https://hackerone.com/reports/909757)\n",
+        "disclosureTime": "2020-07-31T17:13:38Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "2.20.2"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-ISMYJSONVALID-597165",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-02T15:04:47.420926Z",
+        "moduleName": "is-my-json-valid",
+        "packageManager": "npm",
+        "packageName": "is-my-json-valid",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-08-02T15:04:47.405171Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/mafintosh/is-my-json-valid/commit/c3fc04fc455d40e9b29537f8e2c73a28ce106edb"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/909757"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<2.20.2"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "SNYK-JS-ISMYJSONVALID-597167": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-08-02T12:14:47.006233Z",
+        "credit": [
+          "chalker"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[is-my-json-valid](https://github.com/mafintosh/is-my-json-valid) is a JSONSchema / orderly validator that uses code generation to be extremely fast.\n\nAffected versions of this package are vulnerable to Arbitrary Code Execution via the `formatName` function.\r\n\r\n##PoC\r\n```const validator = require('is-my-json-valid')\r\nconst schema = {\r\n  type: 'object',\r\n  properties: {\r\n    'x[console.log(process.mainModule.require(`child_process`).execSync(`cat /etc/passwd`).toString(`utf-8`))]': {\r\n      required: true,\r\n      type:'string'\r\n    }\r\n  },\r\n}\r\nvar validate = validator(schema);\r\nvalidate({})\r\n```\n## Remediation\nUpgrade `is-my-json-valid` to version 2.20.3 or higher.\n## References\n- [GitHub Commit](https://github.com/mafintosh/is-my-json-valid/commit/3419563687df463b4ca709a2b46be8e15d6a2b3d)\n- [HackerOne Report](https://hackerone.com/reports/894308)\n",
+        "disclosureTime": "2020-07-31T17:14:47Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "2.20.3"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-ISMYJSONVALID-597167",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-94"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-02T15:04:45.893491Z",
+        "moduleName": "is-my-json-valid",
+        "packageManager": "npm",
+        "packageName": "is-my-json-valid",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-08-02T15:04:45.880122Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/mafintosh/is-my-json-valid/commit/3419563687df463b4ca709a2b46be8e15d6a2b3d"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/894308"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<2.20.3"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Arbitrary Code Execution"
+      },
+      "SNYK-JS-JSONPOINTER-598804": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-08-17T15:07:51.732390Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 9.8,
+        "description": "## Overview\n[jsonpointer](https://www.npmjs.com/package/jsonpointer) is a Simple JSON Addressing.\n\nAffected versions of this package are vulnerable to Prototype Pollution via the `set` function.\r\n\r\n### POC by NerdJS\r\n```\r\nconst jsonpointer = require('jsonpointer');\r\njsonpointer.set({}, '/__proto__/polluted', true);\r\nconsole.log(polluted);\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `jsonpointer` to version 4.1.0 or higher.\n## References\n- [GitHub Commit](https://github.com/janl/node-jsonpointer/commit/234e3437019c6c07537ed2ad1e03b3e132b85e34)\n",
+        "disclosureTime": "2020-08-17T15:06:59Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.1.0"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-JSONPOINTER-598804",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-17T15:17:02.529823Z",
+        "moduleName": "jsonpointer",
+        "packageManager": "npm",
+        "packageName": "jsonpointer",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2020-08-17T15:17:02.764391Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/janl/node-jsonpointer/commit/234e3437019c6c07537ed2ad1e03b3e132b85e34"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.1.0"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "critical",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-JSYAML-173999": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/RL:O",
+        "alternativeIds": [],
+        "creationTime": "2019-03-24T09:59:28.172265Z",
+        "credit": [
+          "Shawn Rasheed",
+          "Jens DIetrich"
+        ],
+        "cvssScore": 5.9,
+        "description": "## Overview\n[js-yaml](https://www.npmjs.com/package/js-yaml) is a human-friendly data serialization language.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS). The parsing of a specially crafted YAML file may exhaust the system resources.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `js-yaml` to version 3.13.0 or higher.\n## References\n- [GitHub Commit](https://github.com/nodeca/js-yaml/commit/a567ef3c6e61eb319f0bfc2671d91061afb01235)\n- [GitHub Issue](https://github.com/nodeca/js-yaml/issues/475)\n",
+        "disclosureTime": "2019-03-18T21:29:08Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "3.13.0"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lib/js-yaml/loader.js",
+              "functionName": "storeMappingPair"
+            },
+            "version": [
+              ">=3.0.0 <3.13.0"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lib/js-yaml/loader.js",
+              "functionName": "storeMappingPair"
+            },
+            "version": [
+              ">=3.0.0 <3.13.0"
+            ]
+          }
+        ],
+        "id": "SNYK-JS-JSYAML-173999",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-2pr6-76vf-7546"
+          ],
+          "NSP": [
+            "788"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T14:36:55.564388Z",
+        "moduleName": "js-yaml",
+        "packageManager": "npm",
+        "packageName": "js-yaml",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2019-03-24T10:00:08Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/nodeca/js-yaml/commit/a567ef3c6e61eb319f0bfc2671d91061afb01235"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/nodeca/js-yaml/issues/475"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            ">=3.0.0 <3.13.0"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Denial of Service (DoS)"
+      },
+      "SNYK-JS-JSYAML-174129": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2019-04-07T11:15:19.826828Z",
+        "credit": [
+          "Alex Kocharin"
+        ],
+        "cvssScore": 8.1,
+        "description": "## Overview\n[js-yaml](https://www.npmjs.com/package/js-yaml) is a human-friendly data serialization language.\n\nAffected versions of this package are vulnerable to Arbitrary Code Execution. When an object with an executable `toString()` property used as a map key, it will execute that function. This happens only for `load()`, which should not be used with untrusted data anyway. `safeLoad()` is not affected because it can't parse functions.\n## Remediation\nUpgrade `js-yaml` to version 3.13.1 or higher.\n## References\n- [GitHub Commit](https://github.com/nodeca/js-yaml/pull/480/commits/e18afbf1edcafb7add2c4c7b22abc8d6ebc2fa61)\n- [GitHub PR](https://github.com/nodeca/js-yaml/pull/480)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/813)\n",
+        "disclosureTime": "2019-04-05T15:54:43Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "3.13.1"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lib/js-yaml/loader.js",
+              "functionName": "loadAll.storeMappingPair"
+            },
+            "version": [
+              ">1.0.3 <=2.1.3"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/js-yaml/loader.js",
+              "functionName": "storeMappingPair"
+            },
+            "version": [
+              ">2.1.3 <3.13.1"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lib/js-yaml/loader.js",
+              "functionName": "loadAll.storeMappingPair"
+            },
+            "version": [
+              ">1.0.3 <=2.1.3"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/js-yaml/loader.js",
+              "functionName": "storeMappingPair"
+            },
+            "version": [
+              ">2.1.3 <3.13.1"
+            ]
+          }
+        ],
+        "id": "SNYK-JS-JSYAML-174129",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-94"
+          ],
+          "GHSA": [
+            "GHSA-8j8c-7jfh-h6hx"
+          ],
+          "NSP": [
+            "813"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T14:37:01.431138Z",
+        "moduleName": "js-yaml",
+        "packageManager": "npm",
+        "packageName": "js-yaml",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2019-04-07T15:54:43Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/nodeca/js-yaml/pull/480/commits/e18afbf1edcafb7add2c4c7b22abc8d6ebc2fa61"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/nodeca/js-yaml/pull/480"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/813"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<3.13.1"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Arbitrary Code Execution"
+      },
+      "SNYK-JS-LODASH-1018905": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P",
+        "alternativeIds": [],
+        "creationTime": "2020-10-16T16:48:40.985673Z",
+        "credit": [
+          "Liyuan Chen"
+        ],
+        "cvssScore": 5.3,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) via the `toNumber`, `trim` and `trimEnd` functions.\r\n\r\n### POC\r\n```\r\nvar lo = require('lodash');\r\n\r\nfunction build_blank (n) {\r\nvar ret = \"1\"\r\nfor (var i = 0; i < n; i++) {\r\nret += \" \"\r\n}\r\n\r\nreturn ret + \"1\";\r\n}\r\n\r\nvar s = build_blank(50000)\r\nvar time0 = Date.now();\r\nlo.trim(s)\r\nvar time_cost0 = Date.now() - time0;\r\nconsole.log(\"time_cost0: \" + time_cost0)\r\n\r\nvar time1 = Date.now();\r\nlo.toNumber(s)\r\nvar time_cost1 = Date.now() - time1;\r\nconsole.log(\"time_cost1: \" + time_cost1)\r\n\r\nvar time2 = Date.now();\r\nlo.trimEnd(s)\r\nvar time_cost2 = Date.now() - time2;\r\nconsole.log(\"time_cost2: \" + time_cost2)\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `lodash` to version 4.17.21 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/c4847ebe7d14540bb28a8b932a9ce1b9ecbfee1a)\n- [GitHub Fix PR](https://github.com/lodash/lodash/pull/5065)\n",
+        "disclosureTime": "2020-10-16T16:47:34Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.17.21"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-LODASH-1018905",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-28500"
+          ],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2021-02-22T09:58:41.562106Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2021-02-15T11:50:49Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/lodash/lodash/commit/c4847ebe7d14540bb28a8b932a9ce1b9ecbfee1a"
+          },
+          {
+            "title": "GitHub Fix PR",
+            "url": "https://github.com/lodash/lodash/pull/5065"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.21"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "SNYK-JS-LODASH-1040724": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:P/RL:U/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-11-17T14:07:17.048472Z",
+        "credit": [
+          "Marc Hassan"
+        ],
+        "cvssScore": 7.2,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Command Injection via `template`.\r\n\r\n### PoC\r\n```\r\nvar _ = require('lodash');\r\n\r\n_.template('', { variable: '){console.log(process.env)}; with(obj' })()\r\n```\n## Remediation\nUpgrade `lodash` to version 4.17.21 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/3469357cff396a26c363f8c1b5a91dde28ba4b1c)\n- [Vulnerable Code](https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js#L14851)\n",
+        "disclosureTime": "2020-11-17T13:02:10Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.17.21"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-LODASH-1040724",
+        "identifiers": {
+          "CVE": [
+            "CVE-2021-23337"
+          ],
+          "CWE": [
+            "CWE-78"
+          ],
+          "GHSA": [
+            "GHSA-35jh-r3h4-6jhm"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2021-02-22T09:58:04.543992Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2021-02-15T11:50:50Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/lodash/lodash/commit/3469357cff396a26c363f8c1b5a91dde28ba4b1c"
+          },
+          {
+            "title": "Vulnerable Code",
+            "url": "https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js%23L14851"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.21"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Command Injection"
+      },
+      "SNYK-JS-LODASH-450202": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2019-06-19T12:04:21.040000Z",
+        "credit": [
+          "Snyk Security Team"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The function `defaultsDeep` could be tricked into adding or modifying properties of `Object.prototype` using a `constructor` payload.\r\n\r\n## PoC by Snyk\r\n```\r\nconst mergeFn = require('lodash').defaultsDeep;\r\nconst payload = '{\"constructor\": {\"prototype\": {\"a0\": true}}}'\r\n\r\nfunction check() {\r\n    mergeFn({}, JSON.parse(payload));\r\n    if (({})[`a0`] === true) {\r\n        console.log(`Vulnerable to Prototype Pollution via ${payload}`);\r\n    }\r\n  }\r\n\r\ncheck();\r\n```\r\n\r\nFor more information, check out our [blog post](https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/)\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.12 or higher.\n## References\n- [GitHub Issue](https://github.com/lodash/lodash/issues/4348)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4336)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4355)\n- [GitHub PR](https://github.com/sailshq/lodash/pull/1)\n- [Node Security Advisory](https://www.npmjs.com/advisories/1065)\n- [Snyk Blog](https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/)\n",
+        "disclosureTime": "2019-06-19T11:45:02Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.17.12"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.customDefaultsMerge"
+            },
+            "version": [
+              ">=4.17.3 <4.17.12"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.customDefaultsMerge"
+            },
+            "version": [
+              ">=4.17.3 <4.17.12"
+            ]
+          }
+        ],
+        "id": "SNYK-JS-LODASH-450202",
+        "identifiers": {
+          "CVE": [
+            "CVE-2019-10744"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-jf85-cpcp-j695"
+          ],
+          "NSP": [
+            "1065"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-24T08:59:58.227467Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:SNYK-JS-LODASH-450202:0",
+            "modificationTime": "2019-12-03T11:40:45.719849Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/lodash/20190702/lodash_20190702_0_0_1f8ea07746963a535385a5befc19fa687a627d2b.patch"
+            ],
+            "version": "=4.17.11"
+          }
+        ],
+        "proprietary": true,
+        "publicationTime": "2019-07-02T11:45:01Z",
+        "references": [
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/lodash/lodash/issues/4348"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4336"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4355"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/sailshq/lodash/pull/1"
+          },
+          {
+            "title": "Node Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1065"
+          },
+          {
+            "title": "Snyk Blog",
+            "url": "https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.12"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-LODASH-567746": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P/RL:U/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-04-28T14:32:13.683154Z",
+        "credit": [
+          "posix"
+        ],
+        "cvssScore": 6.3,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The function `zipObjectDeep` can be tricked into adding or modifying properties of the Object prototype. These properties will be present on all objects.\r\n\r\n## PoC\r\n```\r\nconst _ = require('lodash');\r\n_.zipObjectDeep(['__proto__.z'],[123])\r\nconsole.log(z) // 123\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.16 or higher.\n## References\n- [GitHub PR](https://github.com/lodash/lodash/pull/4759)\n- [HackerOne Report](https://hackerone.com/reports/712065)\n",
+        "disclosureTime": "2020-04-27T22:14:18Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.17.16"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-LODASH-567746",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-8203"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-p6mc-m468-83gw"
+          ],
+          "NSP": [
+            "1523"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-07-09T08:34:04.944267Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:SNYK-JS-LODASH-567746:0",
+            "modificationTime": "2020-04-30T14:28:46.729327Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/lodash/20200430/lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+            ],
+            "version": ">=4.14.2"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2020-04-28T14:59:14Z",
+        "references": [
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4759"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/712065"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.16"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-LODASH-590103": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2020-07-24T12:05:01.916784Z",
+        "credit": [
+          "reeser"
+        ],
+        "cvssScore": 9.8,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution in `zipObjectDeep` due to an incomplete fix for [CVE-2020-8203](https://snyk.io/vuln/SNYK-JS-LODASH-567746).\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.20 or higher.\n## References\n- [GitHub Issue](https://github.com/lodash/lodash/issues/4874)\n",
+        "disclosureTime": "2020-07-24T12:00:52Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "4.17.20"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-LODASH-590103",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-16T12:11:40.402299Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-08-16T13:09:06Z",
+        "references": [
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/lodash/lodash/issues/4874"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.20"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "critical",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-LODASH-608086": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-08-21T12:52:58.443440Z",
+        "credit": [
+          "awarau"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution via the `setWith` and `set` functions.\r\n\r\n### PoC by awarau\r\n* Create a JS file with this contents:\r\n```\r\nlod = require('lodash')\r\nlod.setWith({}, \"__proto__[test]\", \"123\")\r\nlod.set({}, \"__proto__[test2]\", \"456\")\r\nconsole.log(Object.prototype)\r\n```\r\n* Execute it with `node`\r\n* Observe that `test` and `test2` is now in the `Object.prototype`.\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.17 or higher.\n## References\n- [HackerOne Report](https://hackerone.com/reports/864701)\n",
+        "disclosureTime": "2020-08-21T10:34:29Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.17.17"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-LODASH-608086",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-27T16:44:20.914177Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-08-21T12:53:03Z",
+        "references": [
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/864701"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.17"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-LODASH-73638": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+        "alternativeIds": [],
+        "creationTime": "2019-02-03T09:06:37.726000Z",
+        "credit": [
+          "asgerf"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The functions `merge`, `mergeWith`, and `defaultsDeep` could be tricked into adding or modifying properties of `Object.prototype`. This is due to an incomplete fix to `CVE-2018-3721`.\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.11 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/380873)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1066)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1068)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1071)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/782)\n",
+        "disclosureTime": "2018-08-31T18:21:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "4.17.11"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "merge"
+            },
+            "version": [
+              ">=0.9.0 <1.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "dist/lodash.js",
+              "functionName": "merge"
+            },
+            "version": [
+              ">=1.0.0 <1.0.3"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "dist/lodash.js",
+              "functionName": "runInContext.merge"
+            },
+            "version": [
+              ">=1.1.0 <2.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.merge"
+            },
+            "version": [
+              ">=2.0.0 <3.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "runInContext.baseMerge"
+            },
+            "version": [
+              ">=3.0.0 <4.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "runInContext.baseMergeDeep"
+            },
+            "version": [
+              ">=3.0.0 <4.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.mergeDefaults"
+            },
+            "version": [
+              ">=4.0.0 <4.17.3"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.assignMergeValue"
+            },
+            "version": [
+              ">=4.0.0 <4.17.5"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.baseMerge"
+            },
+            "version": [
+              ">=4.0.0 <4.17.5"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.baseMergeDeep"
+            },
+            "version": [
+              ">=4.0.0 <4.17.5"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "safeGet"
+            },
+            "version": [
+              ">=4.17.5 <4.17.11"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "merge"
+            },
+            "version": [
+              ">=0.9.0 <1.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "dist/lodash.js",
+              "functionName": "merge"
+            },
+            "version": [
+              ">=1.0.0 <1.0.3"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "dist/lodash.js",
+              "functionName": "runInContext.merge"
+            },
+            "version": [
+              ">=1.1.0 <2.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.merge"
+            },
+            "version": [
+              ">=2.0.0 <3.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "runInContext.baseMerge"
+            },
+            "version": [
+              ">=3.0.0 <4.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "runInContext.baseMergeDeep"
+            },
+            "version": [
+              ">=3.0.0 <4.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.mergeDefaults"
+            },
+            "version": [
+              ">=4.0.0 <4.17.3"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.assignMergeValue"
+            },
+            "version": [
+              ">=4.0.0 <4.17.5"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.baseMerge"
+            },
+            "version": [
+              ">=4.0.0 <4.17.5"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.baseMergeDeep"
+            },
+            "version": [
+              ">=4.0.0 <4.17.5"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "safeGet"
+            },
+            "version": [
+              ">=4.17.5 <4.17.11"
+            ]
+          }
+        ],
+        "id": "SNYK-JS-LODASH-73638",
+        "identifiers": {
+          "CVE": [
+            "CVE-2018-16487"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-4xc9-xhrj-v574"
+          ],
+          "NSP": [
+            "1066",
+            "1068",
+            "1071",
+            "782"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-24T08:59:09.185738Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2019-02-01T18:21:00Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4337"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/380873"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1066"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1068"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1071"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/782"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.11"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-LODASH-73639": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:N/I:N/A:H",
+        "alternativeIds": [],
+        "creationTime": "2019-02-03T09:18:05.060741Z",
+        "credit": [
+          "cristianstaicu"
+        ],
+        "cvssScore": 4.4,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). It parses dates using regex strings, which may cause a slowdown of 2 seconds per 50k characters.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `lodash` to version 4.17.11 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/5c08f18d365b64063bfbfa686cbb97cdd6267347)\n- [GitHub Issue](https://github.com/lodash/lodash/issues/3359)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4450)\n",
+        "disclosureTime": "2017-09-05T09:14:29Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "4.17.11"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "hasUnicodeWord"
+            },
+            "version": [
+              ">=4.15.0 <4.17.11"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "hasUnicodeWord"
+            },
+            "version": [
+              ">=4.15.0 <4.17.11"
+            ]
+          }
+        ],
+        "id": "SNYK-JS-LODASH-73639",
+        "identifiers": {
+          "CVE": [
+            "CVE-2019-1010266"
+          ],
+          "CWE": [
+            "CWE-185"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T14:36:57.941198Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2019-04-05T09:14:22Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/lodash/lodash/commit/5c08f18d365b64063bfbfa686cbb97cdd6267347"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/lodash/lodash/issues/3359"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4450"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.11"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "SNYK-JS-LODASHDEFAULTSDEEP-450198": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P",
+        "alternativeIds": [],
+        "creationTime": "2019-06-19T11:41:45.817000Z",
+        "credit": [
+          "Olivier Arteau (HoLyVieR)"
+        ],
+        "cvssScore": 6.3,
+        "description": "## Overview\n[lodash.defaultsdeep](https://lodash.com/) is a Lodash method `_.defaultsDeep` exported as a Node.js module.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The utilities function allow modification of the `Object` prototype. If an attacker can control part of the structure passed to this function, they could add or modify an existing property.  \r\n\r\n## PoC by Olivier Arteau (HoLyVieR)\r\n```js\r\nvar _= require('lodash');\r\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\r\n\r\nvar a = {};\r\nconsole.log(\"Before : \" + a.oops);\r\n_.merge({}, JSON.parse(malicious_payload));\r\nconsole.log(\"After : \" + a.oops);\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash.defaultsdeep` to version 4.6.1 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/310443)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1067)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1069)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1070)\n",
+        "disclosureTime": "2018-01-30T22:28:27Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.6.1"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-LODASHDEFAULTSDEEP-450198",
+        "identifiers": {
+          "CVE": [
+            "CVE-2018-3721"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-2m96-9w4j-wgv7",
+            "GHSA-46fh-8fc5-xcwx",
+            "GHSA-5947-m4fg-xhqg",
+            "GHSA-fvqr-27wr-82fm"
+          ],
+          "NSP": [
+            "1067",
+            "1069",
+            "1070",
+            "577"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-25T09:41:03.215357Z",
+        "moduleName": "lodash.defaultsdeep",
+        "packageManager": "npm",
+        "packageName": "lodash.defaultsdeep",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2018-02-14T13:22:50Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4337"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/310443"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1067"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1069"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1070"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.6.1"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-LODASHDEFAULTSDEEP-450199": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+        "alternativeIds": [],
+        "creationTime": "2019-06-19T11:44:03.712000Z",
+        "credit": [
+          "asgerf"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[lodash.defaultsdeep](https://lodash.com/) is a Lodash method `_.defaultsDeep` exported as a Node.js module.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The functions `merge`, `mergeWith`, and `defaultsDeep` could be tricked into adding or modifying properties of `Object.prototype`. This is due to an incomplete fix to `CVE-2018-3721`.\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash.defaultsdeep` to version 4.6.1 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/380873)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1066)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1068)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1071)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/782)\n",
+        "disclosureTime": "2018-08-31T18:21:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "4.6.1"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-LODASHDEFAULTSDEEP-450199",
+        "identifiers": {
+          "CVE": [
+            "CVE-2018-16487"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-4xc9-xhrj-v574"
+          ],
+          "NSP": [
+            "1066",
+            "1068",
+            "1071",
+            "782"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-24T08:59:09.212950Z",
+        "moduleName": "lodash.defaultsdeep",
+        "packageManager": "npm",
+        "packageName": "lodash.defaultsdeep",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2019-02-01T18:21:00Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4337"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/380873"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1066"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1068"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1071"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/782"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.6.1"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-LODASHMERGEWITH-174136": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+        "alternativeIds": [],
+        "creationTime": "2019-04-08T14:32:04.805000Z",
+        "credit": [
+          "asgerf"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[lodash.mergewith](https://lodash.com/) is a Lodash method _.mergewith exported as a Node.js module.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The functions `merge`, `mergeWith`, and `defaultsDeep` could be tricked into adding or modifying properties of `Object.prototype`. This is due to an incomplete fix to `CVE-2018-3721`.\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash.mergewith` to version 4.6.2 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/380873)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1066)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1068)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1071)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/782)\n",
+        "disclosureTime": "2018-08-31T18:21:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "4.6.2"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "baseMerge"
+            },
+            "version": [
+              "*"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "baseMergeDeep"
+            },
+            "version": [
+              "*"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "baseMerge"
+            },
+            "version": [
+              "*"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "baseMergeDeep"
+            },
+            "version": [
+              "*"
+            ]
+          }
+        ],
+        "id": "SNYK-JS-LODASHMERGEWITH-174136",
+        "identifiers": {
+          "CVE": [
+            "CVE-2018-16487"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-4xc9-xhrj-v574"
+          ],
+          "NSP": [
+            "1066",
+            "1068",
+            "1071",
+            "782"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-24T08:59:09.204209Z",
+        "moduleName": "lodash.mergewith",
+        "packageManager": "npm",
+        "packageName": "lodash.mergewith",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2019-02-01T18:21:00Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4337"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/380873"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1066"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1068"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1071"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/782"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.6.2"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-LODASHMERGEWITH-174137": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P",
+        "alternativeIds": [],
+        "creationTime": "2019-04-08T14:35:02.142000Z",
+        "credit": [
+          "Olivier Arteau (HoLyVieR)"
+        ],
+        "cvssScore": 6.3,
+        "description": "## Overview\n[lodash.mergewith](https://lodash.com/) is a Lodash method _.mergewith exported as a Node.js module.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The utilities function allow modification of the `Object` prototype. If an attacker can control part of the structure passed to this function, they could add or modify an existing property.  \r\n\r\n## PoC by Olivier Arteau (HoLyVieR)\r\n```js\r\nvar _= require('lodash');\r\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\r\n\r\nvar a = {};\r\nconsole.log(\"Before : \" + a.oops);\r\n_.merge({}, JSON.parse(malicious_payload));\r\nconsole.log(\"After : \" + a.oops);\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash.mergewith` to version 4.6.1 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/310443)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1067)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1069)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1070)\n",
+        "disclosureTime": "2018-01-30T22:28:27Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.6.1"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "baseMerge"
+            },
+            "version": [
+              "<4.6.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "baseMergeDeep"
+            },
+            "version": [
+              "<4.6.1"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "baseMerge"
+            },
+            "version": [
+              "<4.6.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "baseMergeDeep"
+            },
+            "version": [
+              "<4.6.1"
+            ]
+          }
+        ],
+        "id": "SNYK-JS-LODASHMERGEWITH-174137",
+        "identifiers": {
+          "CVE": [
+            "CVE-2018-3721"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-2m96-9w4j-wgv7",
+            "GHSA-46fh-8fc5-xcwx",
+            "GHSA-5947-m4fg-xhqg",
+            "GHSA-fvqr-27wr-82fm"
+          ],
+          "NSP": [
+            "1067",
+            "1069",
+            "1070",
+            "577"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-25T09:41:03.208728Z",
+        "moduleName": "lodash.mergewith",
+        "packageManager": "npm",
+        "packageName": "lodash.mergewith",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2018-02-14T13:22:50Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4337"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/310443"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1067"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1069"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1070"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.6.1"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-MINIMIST-559764": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-03-11T08:25:47.093051Z",
+        "credit": [
+          "Snyk Security Team"
+        ],
+        "cvssScore": 5.6,
+        "description": "## Overview\n[minimist](https://www.npmjs.com/package/minimist) is a parse argument options module.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The library could be tricked into adding or modifying properties of `Object.prototype` using a `constructor` or `__proto__` payload.\r\n\r\n## PoC by Snyk\r\n```\r\nrequire('minimist')('--__proto__.injected0 value0'.split(' '));\r\nconsole.log(({}).injected0 === 'value0'); // true\r\n\r\nrequire('minimist')('--constructor.prototype.injected1 value1'.split(' '));\r\nconsole.log(({}).injected1 === 'value1'); // true\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `minimist` to version 0.2.1, 1.2.3 or higher.\n## References\n- [Command Injection PoC](https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a)\n- [GitHub Fix Commit #1](https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94)\n- [GitHub Fix Commit #2](https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab)\n- [Snyk Research Blog](https://snyk.io/blog/prototype-pollution-minimist/)\n",
+        "disclosureTime": "2020-03-10T08:22:24Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "0.2.1",
+          "1.2.3"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "setKey"
+            },
+            "version": [
+              "<0.2.1",
+              ">=1.0.0 <1.1.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports.setKey"
+            },
+            "version": [
+              "<0.2.1",
+              ">=1.1.1 <1.2.3"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "setKey"
+            },
+            "version": [
+              "<0.2.1",
+              ">=1.0.0 <1.1.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports.setKey"
+            },
+            "version": [
+              "<0.2.1",
+              ">=1.1.1 <1.2.3"
+            ]
+          }
+        ],
+        "id": "SNYK-JS-MINIMIST-559764",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-7598"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-vh95-rmgr-6w4m"
+          ],
+          "NSP": [
+            "1179"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-12-20T09:48:43.878574Z",
+        "moduleName": "minimist",
+        "packageManager": "npm",
+        "packageName": "minimist",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2020-03-11T08:22:19Z",
+        "references": [
+          {
+            "title": "Command Injection PoC",
+            "url": "https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a"
+          },
+          {
+            "title": "GitHub Fix Commit #1",
+            "url": "https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94"
+          },
+          {
+            "title": "GitHub Fix Commit #2",
+            "url": "https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab"
+          },
+          {
+            "title": "Snyk Research Blog",
+            "url": "https://snyk.io/blog/prototype-pollution-minimist/"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<0.2.1",
+            ">=1.0.0 <1.2.3"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-OPEN-174041": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/RL:O",
+        "alternativeIds": [],
+        "creationTime": "2019-03-31T10:27:47.709659Z",
+        "credit": [
+          "ChaLKer"
+        ],
+        "cvssScore": 9.8,
+        "description": "## Overview\n[open](https://www.npmjs.com/package/open) is a cross platform package that opens stuff like URLs, files, executables.\n\nAffected versions of this package are vulnerable to Arbitrary Code Injection when unsanitized user input is passed in.\r\n\r\nThe package does come with the following warning in the readme:\r\n\r\n```\r\nThe same care should be taken when calling open as if you were calling child_process.exec directly. If it is an executable it will run in a new shell.\r\n```\r\nThe package `open` is replacing the `opn` package, which is now deprecated. The older versions of `open` are vulnerable. \r\n\r\n**Note: Upgrading `open` to the last version will prevent this vulnerability but is also likely to have unwanted effects since it now has a very different API.**\n## Remediation\nUpgrade `open` to version 6.0.0 or higher.\n## References\n- [GitHub Issue](https://github.com/pwnall/node-open/issues/68)\n- [HackerOne Report](https://hackerone.com/reports/319473)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/663)\n",
+        "disclosureTime": "2018-05-16T19:36:39Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "6.0.0"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-OPEN-174041",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-94"
+          ],
+          "GHSA": [
+            "GHSA-28xh-wpgr-7fm8"
+          ],
+          "NSP": [
+            "663"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T14:36:55.653898Z",
+        "moduleName": "open",
+        "packageManager": "npm",
+        "packageName": "open",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2019-03-31T10:33:37Z",
+        "references": [
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/pwnall/node-open/issues/68"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/319473"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/663"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<6.0.0"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "critical",
+        "socialTrendAlert": false,
+        "title": "Arbitrary Code Injection"
+      },
+      "SNYK-JS-REQUEST-1314897": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N",
+        "alternativeIds": [],
+        "creationTime": "2021-06-29T09:27:06.371226Z",
+        "credit": [
+          "meandmax"
+        ],
+        "cvssScore": 3.7,
+        "description": "## Overview\n[request](https://www.npmjs.com/package/request) is a simplified http request client.\n\nAffected versions of this package are vulnerable to Insecure Encryption due to the usage of the insecure `sha1` cipher.\r\n\r\n**Note**: This library is deprecated.\n## Remediation\nA fix was pushed into the `master` branch but not yet published.\n## References\n- [GitHub Commit](https://github.com/request/request/pull/3385/commits/149e585d8f455b97c7c62df887c697f8045bb35d)\n- [GitHub PR](https://github.com/request/request/pull/3385)\n",
+        "disclosureTime": "2021-06-29T09:23:42Z",
+        "exploit": "Not Defined",
+        "fixedIn": [],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-REQUEST-1314897",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-326"
+          ]
+        },
+        "language": "js",
+        "modificationTime": "2021-06-29T15:26:06.017894Z",
+        "moduleName": "request",
+        "packageManager": "npm",
+        "packageName": "request",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2021-06-29T15:26:05.534835Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/request/request/pull/3385/commits/149e585d8f455b97c7c62df887c697f8045bb35d"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/request/request/pull/3385"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "*"
+          ]
+        },
+        "severity": "low",
+        "severityWithCritical": "low",
+        "title": "Insecure Encryption"
+      },
+      "SNYK-JS-UNDEFSAFE-548940": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-02-18T08:53:40.650407Z",
+        "credit": [
+          "JHU System Security Lab"
+        ],
+        "cvssScore": 6.3,
+        "description": "## Overview\n[undefsafe](https://www.npmjs.com/package/undefsafe) is a Simple function for retrieving deep object properties without getting \"Cannot read property 'X' of undefined\".\n\nAffected versions of this package are vulnerable to Prototype Pollution. The `a` function could be tricked into adding or modifying properties of `Object.prototype` using a `__proto__` payload.\r\n\r\n### PoC by JHU System Security Lab\r\n```js\r\nvar a = require(\"undefsafe\");\r\nvar payload = \"__proto__.toString\";\r\na({},payload,\"JHU\");\r\nconsole.log({}.toString);\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `undefsafe` to version 2.0.3 or higher.\n## References\n- [GitHub Commit](https://github.com/remy/undefsafe/commit/f272681b3a50e2c4cbb6a8533795e1453382c822)\n",
+        "disclosureTime": "2020-02-18T08:51:08Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "2.0.3"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-UNDEFSAFE-548940",
+        "identifiers": {
+          "CVE": [
+            "CVE-2019-10795"
+          ],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T14:36:59.362776Z",
+        "moduleName": "undefsafe",
+        "packageManager": "npm",
+        "packageName": "undefsafe",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2020-02-18T11:01:36Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/remy/undefsafe/commit/f272681b3a50e2c4cbb6a8533795e1453382c822"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<2.0.3"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-Y18N-1021887": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P",
+        "alternativeIds": [],
+        "creationTime": "2020-10-25T14:27:16.715665Z",
+        "credit": [
+          "po6ix"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[y18n](https://www.npmjs.com/package/y18n) is a the bare-bones internationalization library used by yargs\n\nAffected versions of this package are vulnerable to Prototype Pollution. PoC by po6ix:\r\n```\r\nconst y18n = require('y18n')();\r\n \r\ny18n.setLocale('__proto__');\r\ny18n.updateLocale({polluted: true});\r\n\r\nconsole.log(polluted); // true\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `y18n` to version 3.2.2, 4.0.1, 5.0.5 or higher.\n## References\n- [GitHub Issue](https://github.com/yargs/y18n/issues/96)\n- [GitHub PR](https://github.com/yargs/y18n/pull/108)\n",
+        "disclosureTime": "2020-10-25T14:24:22Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "3.2.2",
+          "4.0.1",
+          "5.0.5"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-Y18N-1021887",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-7774"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-c4w7-xm78-47vh"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2021-01-05T15:29:00.943111Z",
+        "moduleName": "y18n",
+        "packageManager": "npm",
+        "packageName": "y18n",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-11-10T15:27:28Z",
+        "references": [
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/yargs/y18n/issues/96"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/yargs/y18n/pull/108"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<3.2.2",
+            ">=4.0.0 <4.0.1",
+            ">=5.0.0 <5.0.5"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "npm:brace-expansion:20170302": {
+        "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "alternativeIds": [
+          "SNYK-JS-BRACEEXPANSION-10483"
+        ],
+        "creationTime": "2017-04-26T09:19:21.663000Z",
+        "credit": [
+          "kamael"
+        ],
+        "cvssScore": 6.2,
+        "description": "## Overview\r\n[`brace-expansion`](https://www.npmjs.com/package/brace-expansion) is a package that performs brace expansion as known from sh/bash.\r\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `brace-expansion` to version 1.1.7 or higher.\r\n\r\n## References\r\n- [GitHub PR](https://github.com/juliangruber/brace-expansion/pull/35)\r\n- [GitHub Issue](https://github.com/juliangruber/brace-expansion/issues/33)\r\n- [GitHub Commit](https://github.com/juliangruber/brace-expansion/pull/35/commits/b13381281cead487cbdbfd6a69fb097ea5e456c3)",
+        "disclosureTime": "2017-03-01T22:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "1.1.7"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "npm:brace-expansion:20170302",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-BRACEEXPANSION-10483"
+          ],
+          "CVE": [
+            "CVE-2017-18077"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-832h-xg76-4gv6"
+          ],
+          "NSP": [
+            "338"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2019-12-02T14:40:13.321868Z",
+        "moduleName": "brace-expansion",
+        "packageManager": "npm",
+        "packageName": "brace-expansion",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2017-04-26T09:19:21Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/juliangruber/brace-expansion/pull/35/commits/b13381281cead487cbdbfd6a69fb097ea5e456c3"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/juliangruber/brace-expansion/issues/33"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/juliangruber/brace-expansion/pull/35"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<1.1.7"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "npm:debug:20170905": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+        "alternativeIds": [
+          "SNYK-JS-DEBUG-10762"
+        ],
+        "creationTime": "2017-09-13T07:55:05.106000Z",
+        "credit": [
+          "Cristian-Alexandru Staicu"
+        ],
+        "cvssScore": 3.7,
+        "description": "## Overview\r\n[`debug`](https://www.npmjs.com/package/debug) is a JavaScript debugging utility modelled after Node.js core's debugging technique..\r\n\r\n`debug` uses [printf-style](https://wikipedia.org/wiki/Printf_format_string) formatting. Affected versions of this package are vulnerable to Regular expression Denial of Service (ReDoS) attacks via the the `%o` formatter (Pretty-print an Object all on a single line). It used a regular expression (`/\\s*\\n\\s*/g`) in order to strip whitespaces and replace newlines with spaces, in order to join the data into a single line. This can cause a very low impact of about 2 seconds matching time for data 50k characters long.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `debug` to version 2.6.9, 3.1.0 or higher.\r\n\r\n## References\r\n- [GitHub Issue](https://github.com/visionmedia/debug/issues/501)\r\n- [GitHub PR](https://github.com/visionmedia/debug/pull/504)",
+        "disclosureTime": "2017-09-05T21:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.6.9",
+          "3.1.0"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "src/node.js",
+              "functionName": "exports.formatters.o"
+            },
+            "version": [
+              ">= 2.5.0 <2.6.9",
+              ">=3.0.0 <3.1.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "node.js",
+              "functionName": "exports.formatters.o"
+            },
+            "version": [
+              ">=1.0.0 <2.5.0"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "src/node.js",
+              "functionName": "exports.formatters.o"
+            },
+            "version": [
+              ">= 2.5.0 <2.6.9",
+              ">=3.0.0 <3.1.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "node.js",
+              "functionName": "exports.formatters.o"
+            },
+            "version": [
+              ">=1.0.0 <2.5.0"
+            ]
+          }
+        ],
+        "id": "npm:debug:20170905",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-DEBUG-10762"
+          ],
+          "CVE": [
+            "CVE-2017-16137"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-gxpj-cx7g-858c"
+          ],
+          "NSP": [
+            "534"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2019-12-02T14:38:59.642834Z",
+        "moduleName": "debug",
+        "packageManager": "npm",
+        "packageName": "debug",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:debug:20170905:0",
+            "modificationTime": "2019-12-03T11:40:45.872397Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/debug/20170905/debug_20170905_0_0_c38a0166c266a679c8de012d4eaccec3f944e685.patch"
+            ],
+            "version": ">= 3.0.0 <=3.0.1"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:debug:20170905:1",
+            "modificationTime": "2019-12-03T11:40:45.873422Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/debug/20170905/debug_20170905_0_1_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+            ],
+            "version": ">=2.5.1 <2.6.9"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:debug:20170905:2",
+            "modificationTime": "2019-12-03T11:40:45.874399Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/debug/20170905/debug_20170905_0_2_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+            ],
+            "version": ">=2.4.0 <2.5.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:debug:20170905:3",
+            "modificationTime": "2019-12-03T11:40:45.875363Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/debug/20170905/debug_20170905_0_3_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+            ],
+            "version": ">=2.0.0 <2.4.0"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2017-09-26T03:55:05Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/visionmedia/debug/pull/504/commits/42a6ae0737f9243c80b6d3dbb08a69a7ae2a1061"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/visionmedia/debug/issues/501"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/visionmedia/debug/pull/504"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            ">=1.0.0 <2.6.9",
+            ">=3.0.0 <3.1.0"
+          ]
+        },
+        "severity": "low",
+        "severityWithCritical": "low",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "npm:deep-extend:20180409": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P",
+        "alternativeIds": [
+          "SNYK-JS-DEEPEXTEND-12120"
+        ],
+        "creationTime": "2018-04-15T20:11:17.552000Z",
+        "credit": [
+          "Olivier Arteau (HoLyVieR)"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[deep-extend](https://www.npmjs.com/package/deep-extend) is a library for Recursive object extending.\n\nAffected versions of this package are vulnerable to Prototype Pollution. Utilities function in all the listed modules can be tricked into modifying the prototype of \"Object\" when the attacker control part of the structure passed to these function. This can let an attacker add or modify existing property that will exist on all object.\r\n\r\n## PoC by HoLyVieR\r\n```js\r\nvar merge = require('deep-extend');\r\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\r\n\r\nvar a = {};\r\nconsole.log(\"Before : \" + a.oops);\r\nmerge({}, JSON.parse(malicious_payload));\r\nconsole.log(\"After : \" + a.oops);\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `deep-extend` to version 0.5.1 or higher.\n## References\n- [GitHub Commit](https://github.com/unclechu/node-deep-extend/commit/433ee51ed606f4e1867ece57b6ff5a47bebb492f)\n- [GitHub Issue](https://github.com/unclechu/node-deep-extend/issues/39)\n- [GitHub PR](https://github.com/unclechu/node-deep-extend/pull/40)\n- [HackerOne Report](https://hackerone.com/reports/311333)\n",
+        "disclosureTime": "2018-04-09T20:11:17Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "0.5.1"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports"
+            },
+            "version": [
+              "0.2.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "deepExtend"
+            },
+            "version": [
+              "<0.2.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports.deepExtend"
+            },
+            "version": [
+              ">=0.2.2 <0.2.5"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "deepExtend.module.exports"
+            },
+            "version": [
+              ">=0.2.5 <0.4.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/deep-extend.js",
+              "functionName": "cloneSpecificValue"
+            },
+            "version": [
+              ">=0.4.0 <0.5.1"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports"
+            },
+            "version": [
+              "0.2.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "deepExtend"
+            },
+            "version": [
+              "<0.2.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports.deepExtend"
+            },
+            "version": [
+              ">=0.2.2 <0.2.5"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "deepExtend.module.exports"
+            },
+            "version": [
+              ">=0.2.5 <0.4.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/deep-extend.js",
+              "functionName": "cloneSpecificValue"
+            },
+            "version": [
+              ">=0.4.0 <0.5.1"
+            ]
+          }
+        ],
+        "id": "npm:deep-extend:20180409",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-DEEPEXTEND-12120"
+          ],
+          "CVE": [
+            "CVE-2018-3750"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-hr2v-3952-633q"
+          ],
+          "NSP": [
+            "612"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T14:36:41.582307Z",
+        "moduleName": "deep-extend",
+        "packageManager": "npm",
+        "packageName": "deep-extend",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2018-04-25T07:45:48Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/unclechu/node-deep-extend/commit/433ee51ed606f4e1867ece57b6ff5a47bebb492f"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/unclechu/node-deep-extend/issues/39"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/unclechu/node-deep-extend/pull/40"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/311333"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<0.5.1"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "npm:extend:20180424": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+        "alternativeIds": [
+          "SNYK-JS-EXTEND-12179"
+        ],
+        "creationTime": "2018-07-23T17:51:10.908000Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[extend](https://www.npmjs.com/package/extend) is a port of the classic extend() method from jQuery.\n\nAffected versions of this package are vulnerable to Prototype Pollution. Utilities function can be tricked into modifying the prototype of \"Object\" when the attacker control part of the structure passed to these function. This can let an attacker add or modify existing property that will exist on all object.\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `extend` to version 2.0.2, 3.0.2 or higher.\n## References\n- [GitHub Commit](https://github.com/justmoon/node-extend/commit/0e68e71d93507fcc391e398bc84abd0666b28190)\n- [GitHub PR](https://github.com/justmoon/node-extend/pull/48#issuecomment-398261612)\n- [HackerOne Report](https://hackerone.com/reports/381185)\n",
+        "disclosureTime": "2018-04-24T17:51:10Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.0.2",
+          "3.0.2"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports"
+            },
+            "version": [
+              "<2.0.2",
+              ">=3.0.0 <3.0.2"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "module.exports"
+            },
+            "version": [
+              "<2.0.2",
+              ">=3.0.0 <3.0.2"
+            ]
+          }
+        ],
+        "id": "npm:extend:20180424",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-EXTEND-12179"
+          ],
+          "CVE": [
+            "CVE-2018-16492"
+          ],
+          "CWE": [
+            "CWE-1321"
+          ],
+          "GHSA": [
+            "GHSA-qrmc-fj45-qfc2"
+          ],
+          "NSP": [
+            "996"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2021-07-07T06:41:03.619163Z",
+        "moduleName": "extend",
+        "packageManager": "npm",
+        "packageName": "extend",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:extend:20180424:0",
+            "modificationTime": "2019-12-03T11:40:45.727650Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/extend/20180424/extend_20180424_0_0_0e68e71d93507fcc391e398bc84abd0666b28190.patch"
+            ],
+            "version": ">=3.0.0 <3.0.2"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2018-07-23T13:46:08Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/justmoon/node-extend/commit/0e68e71d93507fcc391e398bc84abd0666b28190"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/justmoon/node-extend/pull/48%23issuecomment-398261612"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/381185"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<2.0.2",
+            ">=3.0.0 <3.0.2"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "npm:hawk:20160119": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+        "alternativeIds": [
+          "SNYK-JS-HAWK-10080"
+        ],
+        "creationTime": "2016-01-19T23:24:51.834000Z",
+        "credit": [
+          "Adam Baldwin"
+        ],
+        "cvssScore": 3.7,
+        "description": "## Overview\r\n[`hawk`](https://www.npmjs.com/package/hawk) is an HTTP authentication scheme using a message authentication code (MAC) algorithm to provide partial HTTP request cryptographic verification.\r\n\r\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\nYou can read more about `Regular Expression Denial of Service (ReDoS)` on our [blog](https://snyk.io/blog/redos-and-catastrophic-backtracking/).\r\n\r\n## References\r\n- [GitHub Issue](https://github.com/hueniverse/hawk/issues/168)",
+        "disclosureTime": "2016-01-19T21:51:35Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "3.1.3",
+          "4.1.1"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lib/hawk.js",
+              "functionName": "exports.authenticate"
+            },
+            "version": [
+              "<=0.0.6"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/index.js",
+              "functionName": "exports.authenticate"
+            },
+            "version": [
+              ">=0.0.7 <0.10.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/server.js",
+              "functionName": "exports.authenticate"
+            },
+            "version": [
+              ">=0.10.0 <0.12.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/server.js",
+              "functionName": "exports.authenticateBewit"
+            },
+            "version": [
+              ">=0.12.1  <3.1.3",
+              ">=4.0.0 <4.1.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/utils.js",
+              "functionName": "exports.parseHost"
+            },
+            "version": [
+              ">=0.3.0 <3.1.3",
+              ">=4.0.0 <4.1.1"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lib/hawk.js",
+              "functionName": "exports.authenticate"
+            },
+            "version": [
+              "<=0.0.6"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/index.js",
+              "functionName": "exports.authenticate"
+            },
+            "version": [
+              ">=0.0.7 <0.10.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/server.js",
+              "functionName": "exports.authenticate"
+            },
+            "version": [
+              ">=0.10.0 <0.12.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/server.js",
+              "functionName": "exports.authenticateBewit"
+            },
+            "version": [
+              ">=0.12.1  <3.1.3",
+              ">=4.0.0 <4.1.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/utils.js",
+              "functionName": "exports.parseHost"
+            },
+            "version": [
+              ">=0.3.0 <3.1.3",
+              ">=4.0.0 <4.1.1"
+            ]
+          }
+        ],
+        "id": "npm:hawk:20160119",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-HAWK-10080"
+          ],
+          "CVE": [
+            "CVE-2016-2515"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-jcpv-g9rr-qxrc"
+          ],
+          "NSP": [
+            "77"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2019-04-29T17:06:31.778992Z",
+        "moduleName": "hawk",
+        "packageManager": "npm",
+        "packageName": "hawk",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:hawk:20160119:0",
+            "modificationTime": "2019-12-03T11:40:45.789189Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/hawk/20160119/hawk_20160119_0_0_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+            ],
+            "version": "<4.1.1 >=4.0.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:hawk:20160119:1",
+            "modificationTime": "2019-12-03T11:40:45.790286Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/hawk/20160119/hawk_20160119_0_1_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+            ],
+            "version": "<=3.1.2 >=3.0.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:hawk:20160119:2",
+            "modificationTime": "2019-12-03T11:40:45.791342Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/hawk/20160119/hawk_20160119_0_2_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+            ],
+            "version": "<= 2.3.1 >= 2.2.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:hawk:20160119:3",
+            "modificationTime": "2019-12-03T11:40:45.792397Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/hawk/20160119/hawk_20160119_0_3_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+            ],
+            "version": "<= 1.1.1 >= 1.0.0"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2016-01-19T23:24:51Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/hapijs/hawk/commit/0833f99ba64558525995a7e21d4093da1f3e15fa"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/hueniverse/hawk/issues/168"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<3.1.3",
+            ">=4.0.0 <4.1.1"
+          ]
+        },
+        "severity": "low",
+        "severityWithCritical": "low",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "npm:hoek:20180212": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P",
+        "alternativeIds": [
+          "SNYK-JS-HOEK-12061"
+        ],
+        "creationTime": "2018-02-12T22:28:27.612000Z",
+        "credit": [
+          "Olivier Arteau (HoLyVieR)"
+        ],
+        "cvssScore": 6.3,
+        "description": "## Overview\n[hoek](https://github.com/hapijs/hoek) is an Utility methods for the hapi ecosystem.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The utilities function allow modification of the `Object` prototype. If an attacker can control part of the structure passed to this function, they could add or modify an existing property.  \r\n\r\n## PoC by Olivier Arteau (HoLyVieR)\r\n```js\r\nvar Hoek = require('hoek');\r\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\r\n\r\nvar a = {};\r\nconsole.log(\"Before : \" + a.oops);\r\nHoek.merge({}, JSON.parse(malicious_payload));\r\nconsole.log(\"After : \" + a.oops);\r\n\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `hoek` to version 4.2.1, 5.0.3 or higher.\n## References\n- [GitHub Commit](https://github.com/hapijs/hoek/commit/32ed5c9413321fbc37da5ca81a7cbab693786dee)\n- [GitHub Commit](https://github.com/hapijs/hoek/commit/5aed1a8c4a3d55722d1c799f2368857bf418d6df)\n- [GitHub Issue](https://github.com/hapijs/hoek/issues/230)\n- [GitHub PR](https://github.com/hapijs/hoek/pull/227)\n- [HackerOne Report](https://hackerone.com/reports/310439)\n- [NPM Security Advisory](http://npmjs.com/advisories/566)\n",
+        "disclosureTime": "2018-02-12T22:28:27Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.2.1",
+          "5.0.3"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lib/hoek.js",
+              "functionName": "exports.merge"
+            },
+            "version": [
+              "<0.0.19"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/index.js",
+              "functionName": "exports.merge"
+            },
+            "version": [
+              ">0.0.18 <4.2.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/index.js",
+              "functionName": "exports.merge"
+            },
+            "version": [
+              ">=5.0.0 <5.0.3"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lib/hoek.js",
+              "functionName": "exports.merge"
+            },
+            "version": [
+              "<0.0.19"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/index.js",
+              "functionName": "exports.merge"
+            },
+            "version": [
+              ">0.0.18 <4.2.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/index.js",
+              "functionName": "exports.merge"
+            },
+            "version": [
+              ">=5.0.0 <5.0.3"
+            ]
+          }
+        ],
+        "id": "npm:hoek:20180212",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-HOEK-12061"
+          ],
+          "CVE": [
+            "CVE-2018-3728"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-jp4x-w63m-7wgm"
+          ],
+          "NSP": [
+            "566"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T14:36:45.981220Z",
+        "moduleName": "hoek",
+        "packageManager": "npm",
+        "packageName": "hoek",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:hoek:20180212:0",
+            "modificationTime": "2019-12-03T11:40:45.879582Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/hoek/20180212/20180212_0_0_hoek_5aed1a8c4a3d55722d1c799f2368857bf418d6df.patch"
+            ],
+            "version": "<4.2.1 >=4.1.0 || <3.0.4 >=3.0.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:hoek:20180212:1",
+            "modificationTime": "2019-12-03T11:40:45.880722Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/hoek/20180212/20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+            ],
+            "version": ">=2.0.0 <3.0.0"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2018-02-14T13:22:50Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/hapijs/hoek/commit/32ed5c9413321fbc37da5ca81a7cbab693786dee"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/hapijs/hoek/commit/5aed1a8c4a3d55722d1c799f2368857bf418d6df"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/hapijs/hoek/issues/230"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/hapijs/hoek/pull/227"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/310439"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "http://npmjs.com/advisories/566"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.2.1",
+            ">=5.0.0 <5.0.3"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "npm:http-signature:20150122": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+        "alternativeIds": [
+          "SNYK-JS-HTTPSIGNATURE-10664"
+        ],
+        "creationTime": "2017-06-28T13:07:29.691000Z",
+        "credit": [
+          "Alok Menghrajani"
+        ],
+        "cvssScore": 6.5,
+        "description": "## Overview\r\n[`http-signature`](https://www.npmjs.com/package/http-signature) is a reference implementation of Joyent's HTTP Signature scheme.\r\n\r\nAffected versions of the package are vulnerable to Timing Attacks due to time-variable comparison of signatures. \r\n\r\nThe library implemented a character to character comparison, similar to the built-in string comparison mechanism, `===`, and not a time constant string comparison. As a result, the comparison will fail faster when the first characters in the signature are incorrect.\r\nAn attacker can use this difference to perform a timing attack, essentially allowing them to guess the signature one character at a time.\r\n\r\nYou can read more about timing attacks in Node.js on the [Snyk blog](https://snyk.io/blog/node-js-timing-attack-ccc-ctf/).\r\n\r\n## Remediation\r\nUpgrade `http-signature` to version 1.0.0 or higher.\r\n\r\n## References\r\n- [Github PR](https://github.com/joyent/node-http-signature/pull/36)\r\n- [Github Commit](https://github.com/joyent/node-http-signature/commit/78ab1da232f31f695f5c362d863593a143aa8b56)",
+        "disclosureTime": "2015-01-21T22:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "1.0.0"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lib/verify.js",
+              "functionName": "module.exports.verifySignature"
+            },
+            "version": [
+              "<0.10.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/verify.js",
+              "functionName": "module.exports.verifyHMAC"
+            },
+            "version": [
+              ">=0.11.0 <1.0.0"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lib/verify.js",
+              "functionName": "module.exports.verifySignature"
+            },
+            "version": [
+              "<0.10.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/verify.js",
+              "functionName": "module.exports.verifyHMAC"
+            },
+            "version": [
+              ">=0.11.0 <1.0.0"
+            ]
+          }
+        ],
+        "id": "npm:http-signature:20150122",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-HTTPSIGNATURE-10664"
+          ],
+          "CVE": [],
+          "CWE": [
+            "CWE-310"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2019-04-29T15:44:53.819980Z",
+        "moduleName": "http-signature",
+        "packageManager": "npm",
+        "packageName": "http-signature",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:http-signature:20150122:0",
+            "modificationTime": "2019-12-03T11:40:45.867250Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/http-signature/20150122/20150122_0_0_http-signature_78ab1da232f31f695f5c362d863593a143aa8b56.patch"
+            ],
+            "version": "=0.10.1"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2017-06-28T13:07:29Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/joyent/node-http-signature/commit/78ab1da232f31f695f5c362d863593a143aa8b56"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/joyent/node-http-signature/pull/36"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<1.0.0"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Timing Attack"
+      },
+      "npm:is-my-json-valid:20180214": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L/E:F/RL:O/RC:C",
+        "alternativeIds": [
+          "SNYK-JS-ISMYJSONVALID-10887"
+        ],
+        "creationTime": "2018-02-15T14:36:50Z",
+        "credit": [
+          "Jamie Davis"
+        ],
+        "cvssScore": 3.7,
+        "description": "## Overview\r\n[`is-my-json-valid`](https://www.npmjs.com/package/is-my-json-valid) is a universal validation plugin.\r\n\r\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks. It used a regular expression (`/^\\S+@\\S+$/`) in order to validate emails. This can cause an impact of about 10 seconds matching time for data 90K characters long.\r\n\r\n## Disclosure Timeline\r\n* Feb 13th, 2018 - Initial Disclosure to package owner\r\n* Feb 14th, 2018 - Initial Response from package owner\r\n* Feb 14th, 2018 - Fix issued\r\n* Feb 15th, 2018 - Vulnerability published\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `is-my-json-valid` to version 2.17.2, 1.4.1 or higher.\r\n\r\n## References\r\n- [GitHub PR](https://github.com/mafintosh/is-my-json-valid/pull/159)\r\n- [GitHub Commit](https://github.com/mafintosh/is-my-json-valid/commit/b3051b277f7caa08cd2edc6f74f50aeda65d2976)",
+        "disclosureTime": "2018-02-13T20:39:06Z",
+        "exploit": "Functional",
+        "fixedIn": [
+          "1.4.1",
+          "2.17.2"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "npm:is-my-json-valid:20180214",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-ISMYJSONVALID-10887"
+          ],
+          "CVE": [
+            "CVE-2018-1107"
+          ],
+          "CWE": [
+            "CWE-185",
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-4x7c-cx64-49w8"
+          ],
+          "NSP": [
+            "572"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-09T09:57:45.620384Z",
+        "moduleName": "is-my-json-valid",
+        "packageManager": "npm",
+        "packageName": "is-my-json-valid",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2018-02-15T19:52:28Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/mafintosh/is-my-json-valid/commit/b3051b277f7caa08cd2edc6f74f50aeda65d2976"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/mafintosh/is-my-json-valid/pull/159"
+          },
+          {
+            "title": "Hackerone Report",
+            "url": "https://hackerone.com/reports/317548"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<1.4.1",
+            ">=2.0.0 <2.17.2"
+          ]
+        },
+        "severity": "low",
+        "severityWithCritical": "low",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "npm:lodash:20180130": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P",
+        "alternativeIds": [
+          "SNYK-JS-LODASH-174180"
+        ],
+        "creationTime": "2018-02-12T22:28:27.654000Z",
+        "credit": [
+          "Olivier Arteau (HoLyVieR)"
+        ],
+        "cvssScore": 6.3,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The utilities function allow modification of the `Object` prototype. If an attacker can control part of the structure passed to this function, they could add or modify an existing property.  \r\n\r\n## PoC by Olivier Arteau (HoLyVieR)\r\n```js\r\nvar _= require('lodash');\r\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\r\n\r\nvar a = {};\r\nconsole.log(\"Before : \" + a.oops);\r\n_.merge({}, JSON.parse(malicious_payload));\r\nconsole.log(\"After : \" + a.oops);\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.5 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/310443)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1067)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1069)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1070)\n",
+        "disclosureTime": "2018-01-30T22:28:27Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.17.5"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "dist/lodash.js",
+              "functionName": "merge"
+            },
+            "version": [
+              ">= 1.0.0 <1.0.3"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "merge"
+            },
+            "version": [
+              ">=0.9.0 <1.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "dist/lodash.js",
+              "functionName": "runInContext.merge"
+            },
+            "version": [
+              ">=1.1.0 <2.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.merge"
+            },
+            "version": [
+              ">=2.0.0 <3.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "runInContext.baseMergeDeep"
+            },
+            "version": [
+              ">=3.0.0 <4.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.baseMerge"
+            },
+            "version": [
+              ">=4.0.0 <4.17.5"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.baseMergeDeep"
+            },
+            "version": [
+              ">=4.0.0 <4.17.5"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "dist/lodash.js",
+              "functionName": "merge"
+            },
+            "version": [
+              ">= 1.0.0 <1.0.3"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "merge"
+            },
+            "version": [
+              ">=0.9.0 <1.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "dist/lodash.js",
+              "functionName": "runInContext.merge"
+            },
+            "version": [
+              ">=1.1.0 <2.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.merge"
+            },
+            "version": [
+              ">=2.0.0 <3.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "runInContext.baseMergeDeep"
+            },
+            "version": [
+              ">=3.0.0 <4.0.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.baseMerge"
+            },
+            "version": [
+              ">=4.0.0 <4.17.5"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lodash.js",
+              "functionName": "runInContext.baseMergeDeep"
+            },
+            "version": [
+              ">=4.0.0 <4.17.5"
+            ]
+          }
+        ],
+        "id": "npm:lodash:20180130",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-LODASH-174180"
+          ],
+          "CVE": [
+            "CVE-2018-3721"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-2m96-9w4j-wgv7",
+            "GHSA-46fh-8fc5-xcwx",
+            "GHSA-5947-m4fg-xhqg",
+            "GHSA-fvqr-27wr-82fm"
+          ],
+          "NSP": [
+            "1067",
+            "1069",
+            "1070",
+            "577"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-25T09:41:03.189638Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:lodash:20180130:0",
+            "modificationTime": "2019-12-03T11:40:45.883000Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/lodash/20180130/20180130_0_0_lodash_d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a.patch"
+            ],
+            "version": "=3.10.1"
+          }
+        ],
+        "proprietary": true,
+        "publicationTime": "2018-02-14T13:22:50Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4337"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/310443"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1067"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1069"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1070"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.5"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "npm:ms:20170412": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L",
+        "alternativeIds": [
+          "SNYK-JS-MS-10509"
+        ],
+        "creationTime": "2017-04-12T10:02:45.497000Z",
+        "credit": [
+          "Snyk Security Research Team"
+        ],
+        "cvssScore": 3.7,
+        "description": "## Overview\r\n[`ms`](https://www.npmjs.com/package/ms) is a tiny millisecond conversion utility.\r\n\r\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) due to an incomplete fix for previously reported vulnerability [npm:ms:20151024](https://snyk.io/vuln/npm:ms:20151024). The fix limited the length of accepted input string to 10,000 characters, and turned to be insufficient making it possible to block the event loop for 0.3 seconds (on a typical laptop) with a specially crafted string passed to `ms()` function.\r\n\r\n*Proof of concept*\r\n```js\r\nms = require('ms');\r\nms('1'.repeat(9998) + 'Q') // Takes about ~0.3s\r\n```\r\n\r\n**Note:** Snyk's patch for this vulnerability limits input length to 100 characters. This new limit was deemed to be a breaking change by the author.\r\nBased on user feedback, we believe the risk of breakage is _very_ low, while the value to your security is much greater, and therefore opted to still capture this change in a patch for earlier versions as well.  Whenever patching security issues, we always suggest to run tests on your code to validate that nothing has been broken.\r\n\r\nFor more information on `Regular Expression Denial of Service (ReDoS)` attacks, go to our [blog](https://snyk.io/blog/redos-and-catastrophic-backtracking/).\r\n\r\n## Disclosure Timeline\r\n- Feb 9th, 2017 - Reported the issue to package owner.\r\n- Feb 11th, 2017 - Issue acknowledged by package owner.\r\n- April 12th, 2017 - Fix PR opened by Snyk Security Team.\r\n- May 15th, 2017 - Vulnerability published.\r\n- May 16th, 2017 - Issue fixed and version `2.0.0` released.\r\n- May 21th, 2017 - Patches released for versions `>=0.7.1, <=1.0.0`.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `ms` to version 2.0.0 or higher.\r\n\r\n## References\r\n- [GitHub PR](https://github.com/zeit/ms/pull/89)\r\n- [GitHub Commit](https://github.com/zeit/ms/pull/89/commits/305f2ddcd4eff7cc7c518aca6bb2b2d2daad8fef)",
+        "disclosureTime": "2017-04-11T21:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.0.0"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "parse"
+            },
+            "version": [
+              ">=0.7.3 <2.0.0"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "parse"
+            },
+            "version": [
+              ">=0.7.3 <2.0.0"
+            ]
+          }
+        ],
+        "id": "npm:ms:20170412",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-MS-10509"
+          ],
+          "CVE": [],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-09T09:57:45.833759Z",
+        "moduleName": "ms",
+        "packageManager": "npm",
+        "packageName": "ms",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:ms:20170412:0",
+            "modificationTime": "2019-12-03T11:40:45.863964Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ms/20170412/ms_100.patch"
+            ],
+            "version": "=1.0.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:ms:20170412:1",
+            "modificationTime": "2019-12-03T11:40:45.865081Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ms/20170412/ms_072-073.patch"
+            ],
+            "version": "=0.7.2 || =0.7.3"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:ms:20170412:2",
+            "modificationTime": "2019-12-03T11:40:45.866206Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ms/20170412/ms_071.patch"
+            ],
+            "version": "=0.7.1"
+          }
+        ],
+        "proprietary": true,
+        "publicationTime": "2017-05-15T06:02:45Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/zeit/ms/pull/89/commits/305f2ddcd4eff7cc7c518aca6bb2b2d2daad8fef"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/zeit/ms/pull/89"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            ">=0.7.1 <2.0.0"
+          ]
+        },
+        "severity": "low",
+        "severityWithCritical": "low",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "npm:open:20180512": {
+        "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:O/RC:C",
+        "alternativeIds": [
+          "SNYK-JS-OPEN-12148"
+        ],
+        "creationTime": "2018-02-25T11:54:41.573000Z",
+        "credit": [
+          "ChALkeR"
+        ],
+        "cvssScore": 8.4,
+        "description": "## Overview\n[open](https://www.npmjs.com/package/open) is a cross platform package that opens stuff like URLs, files, executables.\n\nAffected versions of this package are vulnerable to Arbitrary Command Injection. Urls are not properly escaped before concatenating them into the command that is opened using `exec()`.\r\n\r\n**Note: Upgrading `open` to the last version will prevent this vulnerability but is also likely to have unwanted effects since it now has a very different API.**\n## Remediation\nUpgrade `open` to version 6.0.0 or higher.\n## References\n- [HackerOne Report](https://hackerone.com/reports/319473)\n",
+        "disclosureTime": "2018-05-12T11:54:41Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "6.0.0"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "npm:open:20180512",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-OPEN-12148"
+          ],
+          "CVE": [],
+          "CWE": [
+            "CWE-264"
+          ],
+          "NSP": [
+            "663"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T08:52:32.287783Z",
+        "moduleName": "open",
+        "packageManager": "npm",
+        "packageName": "open",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2018-05-13T14:26:27Z",
+        "references": [
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/319473"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<6.0.0"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Arbitrary Command Injection"
+      },
+      "npm:qs:20140806": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "alternativeIds": [
+          "SNYK-JS-QS-10019"
+        ],
+        "creationTime": "2014-08-06T06:10:22Z",
+        "credit": [
+          "Dustin Shiver"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n\n[qs](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.\n\n\nAffected versions of this package are vulnerable to Denial of Service (DoS).\nDuring parsing, the `qs` module may create a sparse area (an array where no elements are filled), and grow that array to the necessary size based on the indices used on it. An attacker can specify a high index value in a query string, thus making the server allocate a respectively big array. Truly large values can cause the server to run out of memory and cause it to crash - thus enabling a Denial-of-Service attack.\n\n## Remediation\n\nUpgrade `qs` to version 1.0.0 or higher.\n\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## References\n\n- [GitHub Commit](https://github.com/tj/node-querystring/pull/114/commits/43a604b7847e56bba49d0ce3e222fe89569354d8)\n\n- [GitHub Issue](https://github.com/visionmedia/node-querystring/issues/104)\n\n- [NVD](https://nvd.nist.gov/vuln/detail/CVE-2014-7191)\n",
+        "disclosureTime": "2014-08-06T06:10:22Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "1.0.0"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "compact"
+            },
+            "version": [
+              "<1.0.0"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "compact"
+            },
+            "version": [
+              "<1.0.0"
+            ]
+          }
+        ],
+        "id": "npm:qs:20140806",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-QS-10019"
+          ],
+          "CVE": [
+            "CVE-2014-7191"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-jjv7-qpx3-h62q",
+            "GHSA-gqgv-6jq5-jjj9"
+          ],
+          "NSP": [
+            "29"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2019-02-18T08:28:59.375824Z",
+        "moduleName": "qs",
+        "packageManager": "npm",
+        "packageName": "qs",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20140806:1",
+            "modificationTime": "2019-12-03T11:40:45.728930Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20140806/qs_20140806_0_1_snyk_npm.patch"
+            ],
+            "version": "=0.5.6"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20140806:0",
+            "modificationTime": "2019-12-03T11:40:45.741062Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20140806/qs_20140806_0_0_43a604b7847e56bba49d0ce3e222fe89569354d8_snyk.patch"
+            ],
+            "version": "<1.0.0 >=0.6.5"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2014-08-06T06:10:22Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/tj/node-querystring/pull/114/commits/43a604b7847e56bba49d0ce3e222fe89569354d8"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/visionmedia/node-querystring/issues/104"
+          },
+          {
+            "title": "NVD",
+            "url": "https://nvd.nist.gov/vuln/detail/CVE-2014-7191"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<1.0.0"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Denial of Service (DoS)"
+      },
+      "npm:qs:20140806-1": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+        "alternativeIds": [
+          "SNYK-JS-QS-10020"
+        ],
+        "creationTime": "2014-08-06T06:10:23Z",
+        "credit": [
+          "Tom Steele"
+        ],
+        "cvssScore": 6.5,
+        "description": "## Overview\n[qs](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS). When parsing a string representing a deeply nested object, qs will block the event loop for long periods of time. Such a delay may hold up the server's resources, keeping it from processing other requests in the meantime, thus enabling a Denial-of-Service attack.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `qs` to version 1.0.0 or higher.\n## References\n- [Node Security Advisory](https://nodesecurity.io/advisories/28)\n",
+        "disclosureTime": "2014-08-06T06:10:23Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "1.0.0"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "npm:qs:20140806-1",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-QS-10020"
+          ],
+          "CVE": [
+            "CVE-2014-10064"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-f9cm-p3w6-xvr3"
+          ],
+          "NSP": [
+            "28"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T14:36:44.334026Z",
+        "moduleName": "qs",
+        "packageManager": "npm",
+        "packageName": "qs",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20140806-1:0",
+            "modificationTime": "2019-12-03T11:40:45.742148Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20140806-1/qs_20140806-1_0_0_snyk.patch"
+            ],
+            "version": "<1.0.0 >=0.6.5"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20140806-1:1",
+            "modificationTime": "2019-12-03T11:40:45.744535Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20140806-1/qs_20140806-1_0_1_snyk.patch"
+            ],
+            "version": "=0.5.6"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2014-08-06T06:10:23Z",
+        "references": [
+          {
+            "title": "Node Security Advisory",
+            "url": "https://nodesecurity.io/advisories/28"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<1.0.0"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Denial of Service (DoS)"
+      },
+      "npm:qs:20170213": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "alternativeIds": [
+          "SNYK-JS-QS-10407"
+        ],
+        "creationTime": "2017-02-14T11:44:54.163000Z",
+        "credit": [
+          "Snyk Security Research Team"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n[qs](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.\n\nAffected versions of this package are vulnerable to Prototype Override Protection Bypass. By default `qs` protects against attacks that attempt to overwrite an object's existing prototype properties, such as `toString()`, `hasOwnProperty()`,etc.\r\n\r\nFrom [`qs` documentation](https://github.com/ljharb/qs):\r\n> By default parameters that would overwrite properties on the object prototype are ignored, if you wish to keep the data from those fields either use plainObjects as mentioned above, or set allowPrototypes to true which will allow user input to overwrite those properties. WARNING It is generally a bad idea to enable this option as it can cause problems when attempting to use the properties that have been overwritten. Always be careful with this option.\r\n\r\nOverwriting these properties can impact application logic, potentially allowing attackers to work around security controls, modify data, make the application unstable and more.\r\n\r\nIn versions of the package affected by this vulnerability, it is possible to circumvent this protection and overwrite prototype properties and functions by prefixing the name of the parameter with `[` or `]`. e.g. `qs.parse(\"]=toString\")` will return `{toString = true}`, as a result, calling `toString()` on the object will throw an exception.\r\n\r\n**Example:**\r\n```js\r\nqs.parse('toString=foo', { allowPrototypes: false })\r\n// {}\r\n\r\nqs.parse(\"]=toString\", { allowPrototypes: false })\r\n// {toString = true} <== prototype overwritten\r\n```\r\n\r\nFor more information, you can check out our [blog](https://snyk.io/blog/high-severity-vulnerability-qs/).\r\n\r\n## Disclosure Timeline\r\n- February 13th, 2017 - Reported the issue to package owner.\r\n- February 13th, 2017 - Issue acknowledged by package owner.\r\n- February 16th, 2017 - Partial fix released in versions `6.0.3`, `6.1.1`, `6.2.2`, `6.3.1`.\r\n- March 6th, 2017     - Final fix released in versions `6.4.0`,`6.3.2`, `6.2.3`, `6.1.2` and `6.0.4`\n## Remediation\nUpgrade `qs` to version 6.0.4, 6.1.2, 6.2.3, 6.3.2 or higher.\n## References\n- [GitHub Commit](https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d)\n- [GitHub Issue](https://github.com/ljharb/qs/issues/200)\n",
+        "disclosureTime": "2017-02-13T00:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "6.0.4",
+          "6.1.2",
+          "6.2.3",
+          "6.3.2"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lib/parse.js",
+              "functionName": "internals.parseObject"
+            },
+            "version": [
+              "<6.0.4"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/parse.js",
+              "functionName": "parseObject"
+            },
+            "version": [
+              ">=6.2.0 <6.2.3",
+              "6.3.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/parse.js",
+              "functionName": "parseObjectRecursive"
+            },
+            "version": [
+              ">=6.3.1 <6.3.2"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lib/parse.js",
+              "functionName": "internals.parseObject"
+            },
+            "version": [
+              "<6.0.4"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/parse.js",
+              "functionName": "parseObject"
+            },
+            "version": [
+              ">=6.2.0 <6.2.3",
+              "6.3.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/parse.js",
+              "functionName": "parseObjectRecursive"
+            },
+            "version": [
+              ">=6.3.1 <6.3.2"
+            ]
+          }
+        ],
+        "id": "npm:qs:20170213",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-QS-10407"
+          ],
+          "CVE": [
+            "CVE-2017-1000048"
+          ],
+          "CWE": [
+            "CWE-20"
+          ],
+          "GHSA": [
+            "GHSA-gqgv-6jq5-jjj9"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T14:36:53.880024Z",
+        "moduleName": "qs",
+        "packageManager": "npm",
+        "packageName": "qs",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:0",
+            "modificationTime": "2019-12-03T11:40:45.855245Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/630_632.patch"
+            ],
+            "version": "=6.3.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:1",
+            "modificationTime": "2019-12-03T11:40:45.856271Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/631_632.patch"
+            ],
+            "version": "=6.3.1"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:2",
+            "modificationTime": "2019-12-03T11:40:45.857318Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/621_623.patch"
+            ],
+            "version": "=6.2.1"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:3",
+            "modificationTime": "2019-12-03T11:40:45.858334Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/622_623.patch"
+            ],
+            "version": "=6.2.2"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:4",
+            "modificationTime": "2019-12-03T11:40:45.859411Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/610_612.patch"
+            ],
+            "version": "=6.1.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:5",
+            "modificationTime": "2019-12-03T11:40:45.860523Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/611_612.patch"
+            ],
+            "version": "=6.1.1"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:6",
+            "modificationTime": "2019-12-03T11:40:45.861504Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/602_604.patch"
+            ],
+            "version": "=6.0.2"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:7",
+            "modificationTime": "2019-12-03T11:40:45.862615Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/qs/20170213/603_604.patch"
+            ],
+            "version": "=6.0.3"
+          }
+        ],
+        "proprietary": true,
+        "publicationTime": "2017-03-01T10:00:54Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/ljharb/qs/issues/200"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<6.0.4",
+            ">=6.1.0 <6.1.2",
+            ">=6.2.0 <6.2.3",
+            ">=6.3.0 <6.3.2"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Override Protection Bypass"
+      },
+      "npm:request:20160119": {
+        "CVSSv3": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
+        "alternativeIds": [
+          "SNYK-JS-REQUEST-10088"
+        ],
+        "creationTime": "2016-03-22T12:00:05.158000Z",
+        "credit": [
+          "Feross Aboukhadijeh"
+        ],
+        "cvssScore": 5.1,
+        "description": "## Overview\n\n[request](https://www.npmjs.com/package/request) is a simplified http request client.\n\n\nAffected versions of this package are vulnerable to Remote Memory Exposure.\nA potential remote memory exposure vulnerability exists in `request`. If a `request` uses a multipart attachment and the _body type_ option is `number` with value X, then X bytes of uninitialized memory will be sent in the body of the request.\r\n\r\nNote that while the impact of this vulnerability is high (memory exposure), exploiting it is likely difficult, as the attacker needs to somehow control the body type of the request. One potential exploit scenario is when a request is composed based on JSON input, including the body type, allowing a malicious JSON to trigger the memory leak.\r\n\r\n## Details\r\nConstructing a `Buffer` class with integer `N` creates a `Buffer`\r\nof length `N` with non zero-ed out memory.\r\n**Example:**\r\n```js\r\nvar x = new Buffer(100); // uninitialized Buffer of length 100\r\n// vs\r\nvar x = new Buffer('100'); // initialized Buffer with value of '100'\r\n```\r\n\r\nInitializing a multipart body in such manner will cause uninitialized memory to be sent in the body of the request.\r\n\r\n#### Proof of concept\r\n```js\r\nvar http = require('http')\r\nvar request = require('request')\r\n\r\nhttp.createServer(function (req, res) {\r\n  var data = ''\r\n  req.setEncoding('utf8')\r\n  req.on('data', function (chunk) {\r\n    console.log('data')\r\n    data += chunk\r\n  })\r\n  req.on('end', function () {\r\n    // this will print uninitialized memory from the client\r\n    console.log('Client sent:\\n', data)\r\n  })\r\n  res.end()\r\n}).listen(8000)\r\n\r\nrequest({\r\n  method: 'POST',\r\n  uri: 'http://localhost:8000',\r\n  multipart: [{ body: 1000 }]\r\n},\r\nfunction (err, res, body) {\r\n  if (err) return console.error('upload failed:', err)\r\n  console.log('sent')\r\n})\r\n```\n\n## Remediation\n\nUpgrade `request` to version 2.68.0 or higher.\n\n\n## References\n\n- [Blog: Information about Buffer](https://github.com/ChALkeR/notes/blob/master/Buffer-knows-everything.md)\n\n- [Blog: Node Buffer API fix](https://github.com/ChALkeR/notes/blob/master/Lets-fix-Buffer-API.md#previous-materials)\n\n- [GitHub Commit](https://github.com/request/request/pull/2018/commits/3d31d4526fa4d4e4f59b89cabe194fb671063cdb)\n\n- [GitHub PR](https://github.com/request/request/pull/2018)\n",
+        "disclosureTime": "2016-01-19T04:57:05Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.68.0"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "Request.prototype.multipart"
+            },
+            "version": [
+              ">=2.16.0 <2.27.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "main.js",
+              "functionName": "Request.prototype.request"
+            },
+            "version": [
+              ">=2.2.6 <2.9.150"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "request.js",
+              "functionName": "Request.prototype.multipart"
+            },
+            "version": [
+              ">=2.27.0 <2.54.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/multipart.js",
+              "functionName": "Multipart.prototype.build.add"
+            },
+            "version": [
+              ">=2.54.0 <2.68.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "main.js",
+              "functionName": "Request.prototype.multipart"
+            },
+            "version": [
+              ">=2.9.150 <2.16.0"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "Request.prototype.multipart"
+            },
+            "version": [
+              ">=2.16.0 <2.27.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "main.js",
+              "functionName": "Request.prototype.request"
+            },
+            "version": [
+              ">=2.2.6 <2.9.150"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "request.js",
+              "functionName": "Request.prototype.multipart"
+            },
+            "version": [
+              ">=2.27.0 <2.54.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/multipart.js",
+              "functionName": "Multipart.prototype.build.add"
+            },
+            "version": [
+              ">=2.54.0 <2.68.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "main.js",
+              "functionName": "Request.prototype.multipart"
+            },
+            "version": [
+              ">=2.9.150 <2.16.0"
+            ]
+          }
+        ],
+        "id": "npm:request:20160119",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-REQUEST-10088"
+          ],
+          "CVE": [
+            "CVE-2017-16026"
+          ],
+          "CWE": [
+            "CWE-201"
+          ],
+          "GHSA": [
+            "GHSA-7xfp-9c55-5vqj"
+          ],
+          "NSP": [
+            "309"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2019-12-02T14:39:20.112971Z",
+        "moduleName": "request",
+        "packageManager": "npm",
+        "packageName": "request",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:request:20160119:0",
+            "modificationTime": "2019-12-03T11:40:45.805489Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/request/20160119/request_20160119_0_0_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+            ],
+            "version": "<2.68.0 >=2.54.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:request:20160119:1",
+            "modificationTime": "2019-12-03T11:40:45.806558Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/request/20160119/request_20160119_0_1_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+            ],
+            "version": "<2.54.0 >2.51.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:request:20160119:2",
+            "modificationTime": "2019-12-03T11:40:45.807612Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/request/20160119/request_20160119_0_2_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+            ],
+            "version": "<=2.51.0 >2.47.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:request:20160119:3",
+            "modificationTime": "2019-12-03T11:40:45.808645Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/request/20160119/request_20160119_0_3_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+            ],
+            "version": "=2.47.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:request:20160119:4",
+            "modificationTime": "2019-12-03T11:40:45.809647Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/request/20160119/request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+            ],
+            "version": "<2.47.0 >=2.27.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:request:20160119:5",
+            "modificationTime": "2019-12-03T11:40:45.810808Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/request/20160119/request_20160119_0_5_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+            ],
+            "version": "<2.27.0 >=2.16.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:request:20160119:6",
+            "modificationTime": "2019-12-03T11:40:45.811942Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/request/20160119/request_20160119_0_6_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+            ],
+            "version": "<2.16.0 >=2.9.150"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:request:20160119:7",
+            "modificationTime": "2019-12-03T11:40:45.813062Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/request/20160119/request_20160119_0_7_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+            ],
+            "version": "<2.9.150 >=2.9.3"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:request:20160119:8",
+            "modificationTime": "2019-12-03T11:40:45.814179Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/request/20160119/request_20160119_0_8_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+            ],
+            "version": "<2.9.3 >=2.2.6"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2016-03-22T12:00:05Z",
+        "references": [
+          {
+            "title": "Blog: Information about Buffer",
+            "url": "https://github.com/ChALkeR/notes/blob/master/Buffer-knows-everything.md"
+          },
+          {
+            "title": "Blog: Node Buffer API fix",
+            "url": "https://github.com/ChALkeR/notes/blob/master/Lets-fix-Buffer-API.md%23previous-materials"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/request/request/pull/2018/commits/3d31d4526fa4d4e4f59b89cabe194fb671063cdb"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/request/request/pull/2018"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            ">2.2.5 <2.68.0"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Remote Memory Exposure"
+      },
+      "npm:semver:20150403": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+        "alternativeIds": [
+          "SNYK-JS-SEMVER-10038"
+        ],
+        "creationTime": "2015-04-03T16:00:00Z",
+        "credit": [
+          "Adam Baldwin"
+        ],
+        "cvssScore": 5.3,
+        "description": "## Overview\n[semver](https://github.com/npm/node-semver) is a semantic version parser used by npm.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS).\n\n## Overview\r\n[npm](https://github.com/npm/npm) is a package manager for javascript.\r\n\r\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS).\r\nThe semver module uses regular expressions when parsing a version string. For a carefully crafted input, the time it takes to process these regular expressions is not linear to the length of the input. Since the semver module did not enforce a limit on the version string length, an attacker could provide a long string that would take up a large amount of resources, potentially taking a server down. This issue therefore enables a potential Denial of Service attack. This is a slightly differnt variant of a typical Regular Expression Denial of Service ([ReDoS](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS)) vulnerability.\r\n\r\n## Details\r\n<<ReDoS>>\r\n\r\n\r\n## Remediation\r\nUpdate to a version 4.3.2 or greater. From the issue description [2]: \"Package version can no longer be more than 256 characters long. This prevents a situation in which parsing the version number can use exponentially more time and memory to parse, leading to a potential denial of service.\"\r\n\r\n## References\r\n- [GitHub Release](https://github.com/npm/npm/releases/tag/v2.7.5)\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `semver` to version 4.3.2 or higher.\n## References\n- [GitHub Release](https://github.com/npm/npm/releases/tag/v2.7.5)\n",
+        "disclosureTime": "2015-04-03T16:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "4.3.2"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "npm:semver:20150403",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-SEMVER-10038"
+          ],
+          "CVE": [
+            "CVE-2015-8855"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-x6fg-f45m-jf5q"
+          ],
+          "NSP": [
+            "31"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-06-12T14:36:43.088858Z",
+        "moduleName": "semver",
+        "packageManager": "npm",
+        "packageName": "semver",
+        "patches": [
+          {
+            "comments": [
+              "https://github.com/npm/node-semver/commit/c80180d8341a8ada0236815c29a2be59864afd70.patch"
+            ],
+            "id": "patch:npm:semver:20150403:0",
+            "modificationTime": "2019-12-03T11:40:45.754335Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/semver/20150403/semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+            ],
+            "version": "<4.3.2 >= 2.0.2"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2015-04-03T16:00:00Z",
+        "references": [
+          {
+            "title": "GitHub Release",
+            "url": "https://github.com/npm/npm/releases/tag/v2.7.5"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.3.2"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "npm:sshpk:20180409": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P/RL:O/RC:C",
+        "alternativeIds": [
+          "SNYK-JS-SSHPK-12114"
+        ],
+        "creationTime": "2018-02-25T08:09:56.427000Z",
+        "credit": [
+          "ChALkeR"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\r\n[sshpk](https://www.npmjs.com/package/sshpk) is Parse, convert, fingerprint and use SSH keys in pure node.js.\r\n\r\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks when parsing crafted invalid public keys.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `sshpk` to version 1.13.2 or higher.\r\n\r\n## References\r\n- [HackerOne Report](https://hackerone.com/reports/319593)",
+        "disclosureTime": "2018-04-09T08:09:56Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "1.14.1"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lib/key.js",
+              "functionName": "Key.parse"
+            },
+            "version": [
+              "<1.14.1"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lib/key.js",
+              "functionName": "Key.parse"
+            },
+            "version": [
+              "<1.14.1"
+            ]
+          }
+        ],
+        "id": "npm:sshpk:20180409",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-SSHPK-12114"
+          ],
+          "CVE": [
+            "CVE-2018-3737"
+          ],
+          "CWE": [
+            "CWE-185"
+          ],
+          "GHSA": [
+            "GHSA-2m39-62fm-q8r3"
+          ],
+          "NSP": [
+            "606"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2019-12-31T10:17:09.068690Z",
+        "moduleName": "sshpk",
+        "packageManager": "npm",
+        "packageName": "sshpk",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2018-04-09T15:17:27Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/joyent/node-sshpk/commit/46065d38a5e6d1bccf86d3efb2fb83c14e3f9957"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/319593"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<1.14.1"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "npm:stringstream:20180511": {
+        "CVSSv3": "CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:H/E:F/RL:O/RC:C",
+        "alternativeIds": [
+          "SNYK-JS-STRINGSTREAM-12147"
+        ],
+        "creationTime": "2018-03-03T11:54:41.571000Z",
+        "credit": [
+          "ChALkeR"
+        ],
+        "cvssScore": 5.2,
+        "description": "## Overview\r\n[stringstream](https://www.npmjs.com/package/stringstream) Encode and decode streams into string streams in node.js.\r\n\r\nAffected versions of this package are vulnerable to Uninitialized Memory Exposure. An attacker could extract sensitive data from uninitialized memory or to cause a DoS by passing in a large number, in setups where typed user input can be passed to the stream (e.g. from JSON).\r\n\r\n## Details\r\nThe Buffer class on Node.js is a mutable array of binary data, and can be initialized with a string, array or number.\r\n```js\r\nconst buf1 = new Buffer([1,2,3]);\r\n// creates a buffer containing [01, 02, 03]\r\nconst buf2 = new Buffer('test');\r\n// creates a buffer containing ASCII bytes [74, 65, 73, 74]\r\nconst buf3 = new Buffer(10);\r\n// creates a buffer of length 10\r\n```\r\n\r\nThe first two variants simply create a binary representation of the value it received. The last one, however, pre-allocates a buffer of the specified size, making it a useful buffer, especially when reading data from a stream.\r\nWhen using the number constructor of Buffer, it will allocate the memory, but will not fill it with zeros. Instead, the allocated buffer will hold whatever was in memory at the time. If the buffer is not `zeroed` by using `buf.fill(0)`, it may leak sensitive information like keys, source code, and system info.\r\n\r\n\r\n**Note** This is vulnerable only for Node <=4\r\n\r\n## Remediation\r\nUpgrade `stringstream` to version 0.0.6 or higher.\n\n## References\n- [GitHub Commit](https://github.com/mhart/StringStream/commit/afbc7442220358419e330618e47f3a65fc265b1b)\n- [GitHub Issue](https://github.com/mhart/StringStream/issues/7)\n- [HAckerOne Report](https://hackerone.com/reports/321670)\n",
+        "disclosureTime": "2018-05-11T11:54:41Z",
+        "exploit": "Functional",
+        "fixedIn": [
+          "0.0.6"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "stringstream.js",
+              "functionName": "StringStream.prototype.write"
+            },
+            "version": [
+              ">0.0.0 <0.0.6"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "stringstream.js",
+              "functionName": "StringStream.prototype.write"
+            },
+            "version": [
+              ">0.0.0 <0.0.6"
+            ]
+          }
+        ],
+        "id": "npm:stringstream:20180511",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-STRINGSTREAM-12147"
+          ],
+          "CVE": [
+            "CVE-2018-21270"
+          ],
+          "CWE": [
+            "CWE-201",
+            "CWE-215"
+          ],
+          "GHSA": [
+            "GHSA-mf6x-7mm4-x2g7"
+          ],
+          "NSP": [
+            "664"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2019-03-05T12:06:41.274818Z",
+        "moduleName": "stringstream",
+        "packageManager": "npm",
+        "packageName": "stringstream",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:stringstream:20180511:0",
+            "modificationTime": "2019-12-03T11:40:45.881859Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/stringstream/20180511/20180511_0_0_stringstream_afbc7442220358419e330618e47f3a65fc265b1b.patch"
+            ],
+            "version": "<0.0.6 >=0.0.4"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2018-05-13T14:26:27Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/mhart/StringStream/commit/afbc7442220358419e330618e47f3a65fc265b1b"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/mhart/StringStream/issues/7"
+          },
+          {
+            "title": "HAckerOne Report",
+            "url": "https://hackerone.com/reports/321670"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<0.0.6"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Uninitialized Memory Exposure"
+      },
+      "npm:tough-cookie:20170905": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "alternativeIds": [
+          "SNYK-JS-TOUGHCOOKIE-10760"
+        ],
+        "creationTime": "2017-09-21T08:07:51.834000Z",
+        "credit": [
+          "Cristian-Alexandru Staicu"
+        ],
+        "cvssScore": 5.9,
+        "description": "## Overview\r\n[`tough-cookie`](https://www.npmjs.com/package/tough-cookie) is RFC6265 Cookies and Cookie Jar for node.js.\r\n\r\nAffected versions of this package are vulnerable to Regular expression Denial of Service (ReDoS) attacks. An attacker may pass a specially crafted cookie, causing the server to hang.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade to version `2.3.3` or newer.\r\n\r\n## References\r\n- [Github Issue](https://github.com/salesforce/tough-cookie/issues/92)",
+        "disclosureTime": "2017-09-07T21:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.3.3"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "lib/cookie.js",
+              "functionName": "parse"
+            },
+            "version": [
+              "<2.3.3"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "lib/cookie.js",
+              "functionName": "parse"
+            },
+            "version": [
+              "<2.3.3"
+            ]
+          }
+        ],
+        "id": "npm:tough-cookie:20170905",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-TOUGHCOOKIE-10760"
+          ],
+          "CVE": [
+            "CVE-2017-15010"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-g7q5-pjjr-gqvp"
+          ],
+          "NSP": [
+            "525"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2019-12-02T14:40:19.359490Z",
+        "moduleName": "tough-cookie",
+        "packageManager": "npm",
+        "packageName": "tough-cookie",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:tough-cookie:20170905:0",
+            "modificationTime": "2019-12-03T11:40:45.869349Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/tough-cookie/20170905/220_221.patch"
+            ],
+            "version": "=2.2.0 || =2.2.1"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:tough-cookie:20170905:1",
+            "modificationTime": "2019-12-03T11:40:45.870315Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/tough-cookie/20170905/222.patch"
+            ],
+            "version": "=2.2.2"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:tough-cookie:20170905:2",
+            "modificationTime": "2019-12-03T11:40:45.871421Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/tough-cookie/20170905/230_232.patch"
+            ],
+            "version": "=2.3.0 || =2.3.1 || =2.3.2"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2017-09-21T08:07:51Z",
+        "references": [
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/salesforce/tough-cookie/issues/92"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<2.3.3"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "npm:tunnel-agent:20170305": {
+        "CVSSv3": "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N/E:P/RL:O/RC:C",
+        "alternativeIds": [
+          "SNYK-JS-TUNNELAGENT-10672"
+        ],
+        "creationTime": "2017-07-05T07:23:57.738000Z",
+        "credit": [
+          "ChALkeR"
+        ],
+        "cvssScore": 5.1,
+        "description": "## Overview\r\n[`tunnel-agent`](https://www.npmjs.com/package/tunnel-agent) is HTTP proxy tunneling agent. Affected versions of the package are vulnerable to Uninitialized Memory Exposure. \r\n\r\nA possible memory disclosure vulnerability exists when a value of type `number` is used to set the _proxy.auth_ option of a request `request` and results in a possible uninitialized memory exposures in the request body.\r\n\r\nThis is a result of unobstructed use of the `Buffer` constructor, whose [insecure default constructor increases the odds of memory leakage](https://snyk.io/blog/exploiting-buffer/).\r\n\r\n## Details\r\nConstructing a `Buffer` class with integer `N` creates a `Buffer` of length `N` with raw (not \"zero-ed\") memory.\r\n\r\nIn the following example, the first call would allocate 100 bytes of memory, while the second example will allocate the memory needed for the string \"100\":\r\n```js\r\n// uninitialized Buffer of length 100\r\nx = new Buffer(100);\r\n// initialized Buffer with value of '100'\r\nx = new Buffer('100');\r\n```\r\n\r\n`tunnel-agent`'s `request` construction uses the default `Buffer` constructor as-is, making it easy to append uninitialized memory to an existing list. If the value of the buffer list is exposed to users, it may expose raw server side memory, potentially holding secrets, private data and code. This is a similar vulnerability to the infamous [`Heartbleed`](http://heartbleed.com/) flaw in OpenSSL.\r\n\r\n#### Proof of concept by ChALkeR\r\n```js\r\nrequire('request')({\r\n  method: 'GET',\r\n  uri: 'http://www.example.com',\r\n  tunnel: true,\r\n  proxy:{\r\n      protocol: 'http:',\r\n      host:\"127.0.0.1\",\r\n      port:8080,\r\n      auth:80\r\n  }\r\n});\r\n```\r\n\r\nYou can read more about the insecure `Buffer` behavior [on our blog](https://snyk.io/blog/exploiting-buffer/).\r\n\r\nSimilar vulnerabilities were discovered in [request](https://snyk.io/vuln/npm:request:20160119), [mongoose](https://snyk.io/vuln/npm:mongoose:20160116), [ws](https://snyk.io/vuln/npm:ws:20160104) and [sequelize](https://snyk.io/vuln/npm:sequelize:20160115).\r\n\r\n## Remediation\r\nUpgrade `tunnel-agent` to version 0.6.0 or higher.\r\n**Note** This is vulnerable only for Node <=4\n\n## References\n- [GitHub Commit](https://github.com/request/tunnel-agent/commit/9ca95ec7219daface8a6fc2674000653de0922c0)\n- [PoC by ChALkeR](https://gist.github.com/ChALkeR/fd6b2c445834244e7d440a043f9d2ff4)\n",
+        "disclosureTime": "2017-03-04T22:00:00Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "0.6.0"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "TunnelingAgent.prototype.createSocket"
+            },
+            "version": [
+              "<0.6.0"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "TunnelingAgent.prototype.createSocket"
+            },
+            "version": [
+              "<0.6.0"
+            ]
+          }
+        ],
+        "id": "npm:tunnel-agent:20170305",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-TUNNELAGENT-10672"
+          ],
+          "CVE": [],
+          "CWE": [
+            "CWE-201"
+          ],
+          "GHSA": [
+            "GHSA-xc7v-wxcw-j472"
+          ],
+          "NSP": [
+            "598"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2019-12-02T14:38:58.879097Z",
+        "moduleName": "tunnel-agent",
+        "packageManager": "npm",
+        "packageName": "tunnel-agent",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:tunnel-agent:20170305:0",
+            "modificationTime": "2019-12-03T11:40:45.868281Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/tunnel-agent/20170305/tunnel-agent_20170305_0_0_9ca95ec7219daface8a6fc2674000653de0922c0.patch"
+            ],
+            "version": "=0.4.3 || =0.5.0"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2017-07-05T14:05:50Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/request/tunnel-agent/commit/9ca95ec7219daface8a6fc2674000653de0922c0"
+          },
+          {
+            "title": "PoC by ChALkeR",
+            "url": "https://gist.github.com/ChALkeR/fd6b2c445834244e7d440a043f9d2ff4"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<0.6.0"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Uninitialized Memory Exposure"
+      }
+    },
+    "remediation": {
+      "unresolved": [
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:L/A:L/E:P",
+          "alternativeIds": [],
+          "creationTime": "2020-08-28T12:18:44.906258Z",
+          "credit": [
+            "chalker"
+          ],
+          "cvssScore": 7.7,
+          "description": "## Overview\n[bl](https://github.com/rvagg/bl) is a library that allows you to collect buffers and access with a standard readable buffer interface.\n\nAffected versions of this package are vulnerable to Remote Memory Exposure. If user input ends up in `consume()` argument and can become negative, BufferList state can be corrupted, tricking it into exposing uninitialized memory via regular `.slice()` calls.\r\n\r\n### PoC by chalker\r\n```\r\nconst { BufferList } = require('bl')\r\nconst secret = require('crypto').randomBytes(256)\r\nfor (let i = 0; i < 1e6; i++) {\r\n  const clone = Buffer.from(secret)\r\n  const bl = new BufferList()\r\n  bl.append(Buffer.from('a'))\r\n  bl.consume(-1024)\r\n  const buf = bl.slice(1)\r\n  if (buf.indexOf(clone) !== -1) {\r\n    console.error(`Match (at ${i})`, buf)\r\n  }\r\n}\r\n```\n## Remediation\nUpgrade `bl` to version 2.2.1, 3.0.1, 4.0.3, 1.2.3 or higher.\n## References\n- [Github Commit](https://github.com/rvagg/bl/commit/8a8c13c880e2bef519133ea43e0e9b78b5d0c91e)\n- [Github Commit](https://github.com/rvagg/bl/commit/d3e240e3b8ba4048d3c76ef5fb9dd1f8872d3190)\n- [Github Commit](https://github.com/rvagg/bl/commit/dacc4ac7d5fcd6201bcf26fbd886951be9537466)\n- [GitHub Commit](https://github.com/rvagg/bl/commit/0bd87ec97be399b129fc62feff2943ffa21bcc00)\n- [HackerOne Report](https://hackerone.com/reports/966347)\n",
+          "disclosureTime": "2020-08-27T15:16:42Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "2.2.1",
+            "3.0.1",
+            "4.0.3",
+            "1.2.3"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-BL-608877",
+          "identifiers": {
+            "CVE": [
+              "CVE-2020-8244"
+            ],
+            "CWE": [
+              "CWE-9"
+            ],
+            "GHSA": [
+              "GHSA-pp7h-53gx-mx7r"
+            ],
+            "NSP": [
+              "1555"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-09-04T12:31:03.817670Z",
+          "moduleName": "bl",
+          "packageManager": "npm",
+          "packageName": "bl",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2020-08-28T12:18:48Z",
+          "references": [
+            {
+              "title": "Github Commit",
+              "url": "https://github.com/rvagg/bl/commit/8a8c13c880e2bef519133ea43e0e9b78b5d0c91e"
+            },
+            {
+              "title": "Github Commit",
+              "url": "https://github.com/rvagg/bl/commit/d3e240e3b8ba4048d3c76ef5fb9dd1f8872d3190"
+            },
+            {
+              "title": "Github Commit",
+              "url": "https://github.com/rvagg/bl/commit/dacc4ac7d5fcd6201bcf26fbd886951be9537466"
+            },
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/rvagg/bl/commit/0bd87ec97be399b129fc62feff2943ffa21bcc00"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/966347"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              ">=2.2.0 <2.2.1",
+              ">=3.0.0 <3.0.1",
+              ">=4.0.0 <4.0.3",
+              "<1.2.3"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Remote Memory Exposure",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "bl@1.1.2"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.76.0"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "bl",
+          "version": "1.1.2"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2020-01-28T15:18:37.743372Z",
+          "credit": [
+            "aaron_costello"
+          ],
+          "cvssScore": 6.3,
+          "description": "## Overview\n[dot-prop](https://github.com/sindresorhus/dot-prop#readme) is a package to get, set, or delete a property from a nested object using a dot path.\n\nAffected versions of this package are vulnerable to Prototype Pollution. It is possible for a user to modify the prototype of a base object.\r\n\r\n## PoC by aaron_costello \r\n```\r\nvar dotProp = require(\"dot-prop\")\r\nconst object = {};\r\nconsole.log(\"Before \" + object.b); //Undefined\r\ndotProp.set(object, '__proto__.b', true);\r\nconsole.log(\"After \" + {}.b); //true\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `dot-prop` to version 4.2.1, 5.1.1 or higher.\n## References\n- [GitHub Commit](https://github.com/sindresorhus/dot-prop/commit/3039c8c07f6fdaa8b595ec869ae0895686a7a0f2)\n- [HackerOne Report](https://hackerone.com/reports/719856)\n",
+          "disclosureTime": "2020-01-28T10:17:51Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "4.2.1",
+            "5.1.1"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "module.exports.set"
+              },
+              "version": [
+                ">1.0.1 <5.1.1"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "module.exports.set"
+              },
+              "version": [
+                ">1.0.1 <5.1.1"
+              ]
+            }
+          ],
+          "id": "SNYK-JS-DOTPROP-543489",
+          "identifiers": {
+            "CVE": [
+              "CVE-2020-8116"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-ff7x-qrg7-qggm"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-27T08:47:24.715335Z",
+          "moduleName": "dot-prop",
+          "packageManager": "npm",
+          "packageName": "dot-prop",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2020-01-28T16:23:39Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/sindresorhus/dot-prop/commit/3039c8c07f6fdaa8b595ec869ae0895686a7a0f2"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/719856"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              ">1.0.1 <4.2.1",
+              ">=5.0.0 <5.1.1"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "update-notifier@0.6.3",
+            "configstore@2.0.0",
+            "dot-prop@2.4.0"
+          ],
+          "upgradePath": [],
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "dot-prop",
+          "version": "2.4.0"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P/RL:O/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2021-03-23T16:13:42.109692Z",
+          "credit": [
+            "Yeting Li"
+          ],
+          "cvssScore": 5.3,
+          "description": "## Overview\n[hosted-git-info](https://www.npmjs.org/package/hosted-git-info) is a Provides metadata and conversions from repository urls for Github, Bitbucket and Gitlab\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) via regular expression `shortcutMatch ` in the `fromUrl` function in index.js. The affected regular expression exhibits polynomial worst-case time complexity.\r\n\r\n### PoC by Yeting Li\r\n```\r\nvar hostedGitInfo = require(\"hosted-git-info\")\r\nfunction build_attack(n) {\r\n    var ret = \"a:\"\r\n    for (var i = 0; i < n; i++) {\r\n        ret += \"a\"\r\n    }\r\n    return ret + \"!\";\r\n}\r\n\r\nfor(var i = 1; i <= 5000000; i++) {\r\n   if (i % 1000 == 0) {\r\n        var time = Date.now();\r\n        var attack_str = build_attack(i)\r\n       var parsedInfo = hostedGitInfo.fromUrl(attack_str)\r\n        var time_cost = Date.now() - time;\r\n        console.log(\"attack_str.length: \" + attack_str.length + \": \" + time_cost+\" ms\")\r\n}\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `hosted-git-info` to version 3.0.8, 2.8.9 or higher.\n## References\n- [GitHub Commit](https://github.com/npm/hosted-git-info/commit/bede0dc38e1785e732bf0a48ba6f81a4a908eba3)\n",
+          "disclosureTime": "2020-11-28T00:00:00Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "3.0.8",
+            "2.8.9"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-HOSTEDGITINFO-1088355",
+          "identifiers": {
+            "CVE": [
+              "CVE-2021-23362"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-43f8-2h32-f4cj"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2021-04-08T12:53:49.093606Z",
+          "moduleName": "hosted-git-info",
+          "packageManager": "npm",
+          "packageName": "hosted-git-info",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2021-03-23T17:13:24Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/npm/hosted-git-info/commit/bede0dc38e1785e732bf0a48ba6f81a4a908eba3"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              ">=3.0.0 <3.0.8",
+              "<2.8.9"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Regular Expression Denial of Service (ReDoS)",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "yargs@4.8.1",
+            "read-pkg-up@1.0.1",
+            "read-pkg@1.1.0",
+            "normalize-package-data@2.3.5",
+            "hosted-git-info@2.1.5"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "yargs@4.8.1",
+            "read-pkg-up@1.0.1",
+            "read-pkg@1.1.0",
+            "normalize-package-data@2.3.5",
+            "hosted-git-info@2.8.9"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "hosted-git-info",
+          "version": "2.1.5"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P",
+          "alternativeIds": [],
+          "creationTime": "2020-12-08T15:34:07.743781Z",
+          "credit": [
+            "Eugene Lim",
+            "Government Technology Agency Cyber Security Group"
+          ],
+          "cvssScore": 7.3,
+          "description": "## Overview\n[ini](https://www.npmjs.org/package/ini) is an An ini encoder/decoder for node\n\nAffected versions of this package are vulnerable to Prototype Pollution. If an attacker submits a malicious INI file to an application that parses it with `ini.parse`, they will pollute the prototype on the application. This can be exploited further depending on the context.\r\n\r\n## PoC by Eugene Lim\r\n\r\npayload.ini\r\n```\r\n[__proto__]\r\npolluted = \"polluted\"\r\n```\r\n\r\npoc.js:\r\n```\r\nvar fs = require('fs')\r\nvar ini = require('ini')\r\n\r\nvar parsed = ini.parse(fs.readFileSync('./payload.ini', 'utf-8'))\r\nconsole.log(parsed)\r\nconsole.log(parsed.__proto__)\r\nconsole.log(polluted)\r\n```\r\n\r\n```\r\n> node poc.js\r\n{}\r\n{ polluted: 'polluted' }\r\n{ polluted: 'polluted' }\r\npolluted\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `ini` to version 1.3.6 or higher.\n## References\n- [Eugene Lim - Research Blog Post](https://medium.com/csg-govtech/supply-chain-pollution-discovering-a-16-million-download-week-node-js-2fa4d2c27cf7)\n- [GitHub Commit](https://github.com/npm/ini/commit/56d2805e07ccd94e2ba0984ac9240ff02d44b6f1)\n",
+          "disclosureTime": "2020-12-08T13:02:04Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "1.3.6"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-INI-1048974",
+          "identifiers": {
+            "CVE": [
+              "CVE-2020-7788"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-qqgx-2p2h-9c37"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-12-10T18:09:23.069283Z",
+          "moduleName": "ini",
+          "packageManager": "npm",
+          "packageName": "ini",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2020-12-10T18:08:38Z",
+          "references": [
+            {
+              "title": "Eugene Lim - Research Blog Post",
+              "url": "https://medium.com/csg-govtech/supply-chain-pollution-discovering-a-16-million-download-week-node-js-2fa4d2c27cf7"
+            },
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/npm/ini/commit/56d2805e07ccd94e2ba0984ac9240ff02d44b6f1"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<1.3.6"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "update-notifier@0.6.3",
+            "latest-version@2.0.0",
+            "package-json@2.3.3",
+            "registry-url@3.1.0",
+            "rc@1.1.6",
+            "ini@1.3.4"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "update-notifier@0.6.3",
+            "latest-version@2.0.0",
+            "package-json@2.3.3",
+            "registry-url@3.1.0",
+            "rc@1.1.6",
+            "ini@1.3.6"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "ini",
+          "version": "1.3.4"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P/RL:O/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2020-08-02T12:09:52.577067Z",
+          "credit": [
+            "chalker"
+          ],
+          "cvssScore": 7.5,
+          "description": "## Overview\n[is-my-json-valid](https://github.com/mafintosh/is-my-json-valid) is a JSONSchema / orderly validator that uses code generation to be extremely fast.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) via the `style` format. \r\n\r\n##PoC\r\n```\r\nconst imjv = require('is-my-json-valid')\r\nconst validate = imjv({ maxLength: 100, format: 'style' })\r\nconsole.log(validate(' '.repeat(1e4)))\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `is-my-json-valid` to version 2.20.2 or higher.\n## References\n- [GitHub Commit](https://github.com/mafintosh/is-my-json-valid/commit/c3fc04fc455d40e9b29537f8e2c73a28ce106edb)\n- [HackerOne Report](https://hackerone.com/reports/909757)\n",
+          "disclosureTime": "2020-07-31T17:13:38Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "2.20.2"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-ISMYJSONVALID-597165",
+          "identifiers": {
+            "CVE": [],
+            "CWE": [
+              "CWE-400"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-02T15:04:47.420926Z",
+          "moduleName": "is-my-json-valid",
+          "packageManager": "npm",
+          "packageName": "is-my-json-valid",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2020-08-02T15:04:47.405171Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/mafintosh/is-my-json-valid/commit/c3fc04fc455d40e9b29537f8e2c73a28ce106edb"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/909757"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<2.20.2"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Regular Expression Denial of Service (ReDoS)",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "har-validator@2.0.6",
+            "is-my-json-valid@2.13.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "har-validator@2.0.6",
+            "is-my-json-valid@2.20.2"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "is-my-json-valid",
+          "version": "2.13.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2020-08-02T12:14:47.006233Z",
+          "credit": [
+            "chalker"
+          ],
+          "cvssScore": 7.3,
+          "description": "## Overview\n[is-my-json-valid](https://github.com/mafintosh/is-my-json-valid) is a JSONSchema / orderly validator that uses code generation to be extremely fast.\n\nAffected versions of this package are vulnerable to Arbitrary Code Execution via the `formatName` function.\r\n\r\n##PoC\r\n```const validator = require('is-my-json-valid')\r\nconst schema = {\r\n  type: 'object',\r\n  properties: {\r\n    'x[console.log(process.mainModule.require(`child_process`).execSync(`cat /etc/passwd`).toString(`utf-8`))]': {\r\n      required: true,\r\n      type:'string'\r\n    }\r\n  },\r\n}\r\nvar validate = validator(schema);\r\nvalidate({})\r\n```\n## Remediation\nUpgrade `is-my-json-valid` to version 2.20.3 or higher.\n## References\n- [GitHub Commit](https://github.com/mafintosh/is-my-json-valid/commit/3419563687df463b4ca709a2b46be8e15d6a2b3d)\n- [HackerOne Report](https://hackerone.com/reports/894308)\n",
+          "disclosureTime": "2020-07-31T17:14:47Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "2.20.3"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-ISMYJSONVALID-597167",
+          "identifiers": {
+            "CVE": [],
+            "CWE": [
+              "CWE-94"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-02T15:04:45.893491Z",
+          "moduleName": "is-my-json-valid",
+          "packageManager": "npm",
+          "packageName": "is-my-json-valid",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2020-08-02T15:04:45.880122Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/mafintosh/is-my-json-valid/commit/3419563687df463b4ca709a2b46be8e15d6a2b3d"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/894308"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<2.20.3"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Arbitrary Code Execution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "har-validator@2.0.6",
+            "is-my-json-valid@2.13.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "har-validator@2.0.6",
+            "is-my-json-valid@2.20.3"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "is-my-json-valid",
+          "version": "2.13.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L/E:F/RL:O/RC:C",
+          "alternativeIds": [
+            "SNYK-JS-ISMYJSONVALID-10887"
+          ],
+          "creationTime": "2018-02-15T14:36:50Z",
+          "credit": [
+            "Jamie Davis"
+          ],
+          "cvssScore": 3.7,
+          "description": "## Overview\r\n[`is-my-json-valid`](https://www.npmjs.com/package/is-my-json-valid) is a universal validation plugin.\r\n\r\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks. It used a regular expression (`/^\\S+@\\S+$/`) in order to validate emails. This can cause an impact of about 10 seconds matching time for data 90K characters long.\r\n\r\n## Disclosure Timeline\r\n* Feb 13th, 2018 - Initial Disclosure to package owner\r\n* Feb 14th, 2018 - Initial Response from package owner\r\n* Feb 14th, 2018 - Fix issued\r\n* Feb 15th, 2018 - Vulnerability published\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `is-my-json-valid` to version 2.17.2, 1.4.1 or higher.\r\n\r\n## References\r\n- [GitHub PR](https://github.com/mafintosh/is-my-json-valid/pull/159)\r\n- [GitHub Commit](https://github.com/mafintosh/is-my-json-valid/commit/b3051b277f7caa08cd2edc6f74f50aeda65d2976)",
+          "disclosureTime": "2018-02-13T20:39:06Z",
+          "exploit": "Functional",
+          "fixedIn": [
+            "1.4.1",
+            "2.17.2"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "npm:is-my-json-valid:20180214",
+          "identifiers": {
+            "ALTERNATIVE": [
+              "SNYK-JS-ISMYJSONVALID-10887"
+            ],
+            "CVE": [
+              "CVE-2018-1107"
+            ],
+            "CWE": [
+              "CWE-185",
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-4x7c-cx64-49w8"
+            ],
+            "NSP": [
+              "572"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-06-09T09:57:45.620384Z",
+          "moduleName": "is-my-json-valid",
+          "packageManager": "npm",
+          "packageName": "is-my-json-valid",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2018-02-15T19:52:28Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/mafintosh/is-my-json-valid/commit/b3051b277f7caa08cd2edc6f74f50aeda65d2976"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/mafintosh/is-my-json-valid/pull/159"
+            },
+            {
+              "title": "Hackerone Report",
+              "url": "https://hackerone.com/reports/317548"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<1.4.1",
+              ">=2.0.0 <2.17.2"
+            ]
+          },
+          "severity": "low",
+          "severityWithCritical": "low",
+          "socialTrendAlert": false,
+          "title": "Regular Expression Denial of Service (ReDoS)",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "har-validator@2.0.6",
+            "is-my-json-valid@2.13.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "har-validator@2.0.6",
+            "is-my-json-valid@2.17.2"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "is-my-json-valid",
+          "version": "2.13.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:O/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2020-08-17T15:07:51.732390Z",
+          "credit": [
+            "Unknown"
+          ],
+          "cvssScore": 9.8,
+          "description": "## Overview\n[jsonpointer](https://www.npmjs.com/package/jsonpointer) is a Simple JSON Addressing.\n\nAffected versions of this package are vulnerable to Prototype Pollution via the `set` function.\r\n\r\n### POC by NerdJS\r\n```\r\nconst jsonpointer = require('jsonpointer');\r\njsonpointer.set({}, '/__proto__/polluted', true);\r\nconsole.log(polluted);\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `jsonpointer` to version 4.1.0 or higher.\n## References\n- [GitHub Commit](https://github.com/janl/node-jsonpointer/commit/234e3437019c6c07537ed2ad1e03b3e132b85e34)\n",
+          "disclosureTime": "2020-08-17T15:06:59Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "4.1.0"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-JSONPOINTER-598804",
+          "identifiers": {
+            "CVE": [],
+            "CWE": [
+              "CWE-400"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-17T15:17:02.529823Z",
+          "moduleName": "jsonpointer",
+          "packageManager": "npm",
+          "packageName": "jsonpointer",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2020-08-17T15:17:02.764391Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/janl/node-jsonpointer/commit/234e3437019c6c07537ed2ad1e03b3e132b85e34"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.1.0"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "critical",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "har-validator@2.0.6",
+            "is-my-json-valid@2.13.1",
+            "jsonpointer@2.0.0"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "har-validator@2.0.6",
+            "is-my-json-valid@2.15.0",
+            "jsonpointer@4.1.0"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "jsonpointer",
+          "version": "2.0.0"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/RL:O",
+          "alternativeIds": [],
+          "creationTime": "2019-03-24T09:59:28.172265Z",
+          "credit": [
+            "Shawn Rasheed",
+            "Jens DIetrich"
+          ],
+          "cvssScore": 5.9,
+          "description": "## Overview\n[js-yaml](https://www.npmjs.com/package/js-yaml) is a human-friendly data serialization language.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS). The parsing of a specially crafted YAML file may exhaust the system resources.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `js-yaml` to version 3.13.0 or higher.\n## References\n- [GitHub Commit](https://github.com/nodeca/js-yaml/commit/a567ef3c6e61eb319f0bfc2671d91061afb01235)\n- [GitHub Issue](https://github.com/nodeca/js-yaml/issues/475)\n",
+          "disclosureTime": "2019-03-18T21:29:08Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "3.13.0"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "lib/js-yaml/loader.js",
+                "functionName": "storeMappingPair"
+              },
+              "version": [
+                ">=3.0.0 <3.13.0"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "lib/js-yaml/loader.js",
+                "functionName": "storeMappingPair"
+              },
+              "version": [
+                ">=3.0.0 <3.13.0"
+              ]
+            }
+          ],
+          "id": "SNYK-JS-JSYAML-173999",
+          "identifiers": {
+            "CVE": [],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-2pr6-76vf-7546"
+            ],
+            "NSP": [
+              "788"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-06-12T14:36:55.564388Z",
+          "moduleName": "js-yaml",
+          "packageManager": "npm",
+          "packageName": "js-yaml",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2019-03-24T10:00:08Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/nodeca/js-yaml/commit/a567ef3c6e61eb319f0bfc2671d91061afb01235"
+            },
+            {
+              "title": "GitHub Issue",
+              "url": "https://github.com/nodeca/js-yaml/issues/475"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              ">=3.0.0 <3.13.0"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Denial of Service (DoS)",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-policy@1.5.2",
+            "js-yaml@3.6.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-policy@1.5.2",
+            "js-yaml@3.13.0"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "js-yaml",
+          "version": "3.6.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "alternativeIds": [],
+          "creationTime": "2019-04-07T11:15:19.826828Z",
+          "credit": [
+            "Alex Kocharin"
+          ],
+          "cvssScore": 8.1,
+          "description": "## Overview\n[js-yaml](https://www.npmjs.com/package/js-yaml) is a human-friendly data serialization language.\n\nAffected versions of this package are vulnerable to Arbitrary Code Execution. When an object with an executable `toString()` property used as a map key, it will execute that function. This happens only for `load()`, which should not be used with untrusted data anyway. `safeLoad()` is not affected because it can't parse functions.\n## Remediation\nUpgrade `js-yaml` to version 3.13.1 or higher.\n## References\n- [GitHub Commit](https://github.com/nodeca/js-yaml/pull/480/commits/e18afbf1edcafb7add2c4c7b22abc8d6ebc2fa61)\n- [GitHub PR](https://github.com/nodeca/js-yaml/pull/480)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/813)\n",
+          "disclosureTime": "2019-04-05T15:54:43Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "3.13.1"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "lib/js-yaml/loader.js",
+                "functionName": "loadAll.storeMappingPair"
+              },
+              "version": [
+                ">1.0.3 <=2.1.3"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lib/js-yaml/loader.js",
+                "functionName": "storeMappingPair"
+              },
+              "version": [
+                ">2.1.3 <3.13.1"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "lib/js-yaml/loader.js",
+                "functionName": "loadAll.storeMappingPair"
+              },
+              "version": [
+                ">1.0.3 <=2.1.3"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lib/js-yaml/loader.js",
+                "functionName": "storeMappingPair"
+              },
+              "version": [
+                ">2.1.3 <3.13.1"
+              ]
+            }
+          ],
+          "id": "SNYK-JS-JSYAML-174129",
+          "identifiers": {
+            "CVE": [],
+            "CWE": [
+              "CWE-94"
+            ],
+            "GHSA": [
+              "GHSA-8j8c-7jfh-h6hx"
+            ],
+            "NSP": [
+              "813"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-06-12T14:37:01.431138Z",
+          "moduleName": "js-yaml",
+          "packageManager": "npm",
+          "packageName": "js-yaml",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2019-04-07T15:54:43Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/nodeca/js-yaml/pull/480/commits/e18afbf1edcafb7add2c4c7b22abc8d6ebc2fa61"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/nodeca/js-yaml/pull/480"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/813"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<3.13.1"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Arbitrary Code Execution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-policy@1.5.2",
+            "js-yaml@3.6.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-policy@1.5.2",
+            "js-yaml@3.13.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "js-yaml",
+          "version": "3.6.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P",
+          "alternativeIds": [],
+          "creationTime": "2020-10-16T16:48:40.985673Z",
+          "credit": [
+            "Liyuan Chen"
+          ],
+          "cvssScore": 5.3,
+          "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) via the `toNumber`, `trim` and `trimEnd` functions.\r\n\r\n### POC\r\n```\r\nvar lo = require('lodash');\r\n\r\nfunction build_blank (n) {\r\nvar ret = \"1\"\r\nfor (var i = 0; i < n; i++) {\r\nret += \" \"\r\n}\r\n\r\nreturn ret + \"1\";\r\n}\r\n\r\nvar s = build_blank(50000)\r\nvar time0 = Date.now();\r\nlo.trim(s)\r\nvar time_cost0 = Date.now() - time0;\r\nconsole.log(\"time_cost0: \" + time_cost0)\r\n\r\nvar time1 = Date.now();\r\nlo.toNumber(s)\r\nvar time_cost1 = Date.now() - time1;\r\nconsole.log(\"time_cost1: \" + time_cost1)\r\n\r\nvar time2 = Date.now();\r\nlo.trimEnd(s)\r\nvar time_cost2 = Date.now() - time2;\r\nconsole.log(\"time_cost2: \" + time_cost2)\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `lodash` to version 4.17.21 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/c4847ebe7d14540bb28a8b932a9ce1b9ecbfee1a)\n- [GitHub Fix PR](https://github.com/lodash/lodash/pull/5065)\n",
+          "disclosureTime": "2020-10-16T16:47:34Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "4.17.21"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-LODASH-1018905",
+          "identifiers": {
+            "CVE": [
+              "CVE-2020-28500"
+            ],
+            "CWE": [
+              "CWE-400"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2021-02-22T09:58:41.562106Z",
+          "moduleName": "lodash",
+          "packageManager": "npm",
+          "packageName": "lodash",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2021-02-15T11:50:49Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/lodash/lodash/commit/c4847ebe7d14540bb28a8b932a9ce1b9ecbfee1a"
+            },
+            {
+              "title": "GitHub Fix PR",
+              "url": "https://github.com/lodash/lodash/pull/5065"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.17.21"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Regular Expression Denial of Service (ReDoS)",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "lodash@3.10.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.19.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash",
+          "version": "3.10.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:P/RL:U/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2020-11-17T14:07:17.048472Z",
+          "credit": [
+            "Marc Hassan"
+          ],
+          "cvssScore": 7.2,
+          "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Command Injection via `template`.\r\n\r\n### PoC\r\n```\r\nvar _ = require('lodash');\r\n\r\n_.template('', { variable: '){console.log(process.env)}; with(obj' })()\r\n```\n## Remediation\nUpgrade `lodash` to version 4.17.21 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/3469357cff396a26c363f8c1b5a91dde28ba4b1c)\n- [Vulnerable Code](https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js#L14851)\n",
+          "disclosureTime": "2020-11-17T13:02:10Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "4.17.21"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-LODASH-1040724",
+          "identifiers": {
+            "CVE": [
+              "CVE-2021-23337"
+            ],
+            "CWE": [
+              "CWE-78"
+            ],
+            "GHSA": [
+              "GHSA-35jh-r3h4-6jhm"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2021-02-22T09:58:04.543992Z",
+          "moduleName": "lodash",
+          "packageManager": "npm",
+          "packageName": "lodash",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2021-02-15T11:50:50Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/lodash/lodash/commit/3469357cff396a26c363f8c1b5a91dde28ba4b1c"
+            },
+            {
+              "title": "Vulnerable Code",
+              "url": "https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js%23L14851"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.17.21"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Command Injection",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "lodash@3.10.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.19.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash",
+          "version": "3.10.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2019-06-19T12:04:21.040000Z",
+          "credit": [
+            "Snyk Security Team"
+          ],
+          "cvssScore": 7.3,
+          "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The function `defaultsDeep` could be tricked into adding or modifying properties of `Object.prototype` using a `constructor` payload.\r\n\r\n## PoC by Snyk\r\n```\r\nconst mergeFn = require('lodash').defaultsDeep;\r\nconst payload = '{\"constructor\": {\"prototype\": {\"a0\": true}}}'\r\n\r\nfunction check() {\r\n    mergeFn({}, JSON.parse(payload));\r\n    if (({})[`a0`] === true) {\r\n        console.log(`Vulnerable to Prototype Pollution via ${payload}`);\r\n    }\r\n  }\r\n\r\ncheck();\r\n```\r\n\r\nFor more information, check out our [blog post](https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/)\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.12 or higher.\n## References\n- [GitHub Issue](https://github.com/lodash/lodash/issues/4348)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4336)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4355)\n- [GitHub PR](https://github.com/sailshq/lodash/pull/1)\n- [Node Security Advisory](https://www.npmjs.com/advisories/1065)\n- [Snyk Blog](https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/)\n",
+          "disclosureTime": "2019-06-19T11:45:02Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "4.17.12"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.customDefaultsMerge"
+              },
+              "version": [
+                ">=4.17.3 <4.17.12"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.customDefaultsMerge"
+              },
+              "version": [
+                ">=4.17.3 <4.17.12"
+              ]
+            }
+          ],
+          "id": "SNYK-JS-LODASH-450202",
+          "identifiers": {
+            "CVE": [
+              "CVE-2019-10744"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-jf85-cpcp-j695"
+            ],
+            "NSP": [
+              "1065"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-24T08:59:58.227467Z",
+          "moduleName": "lodash",
+          "packageManager": "npm",
+          "packageName": "lodash",
+          "patches": [
+            {
+              "comments": [],
+              "id": "patch:SNYK-JS-LODASH-450202:0",
+              "modificationTime": "2019-12-03T11:40:45.719849Z",
+              "urls": [
+                "https://snyk-patches.s3.amazonaws.com/npm/lodash/20190702/lodash_20190702_0_0_1f8ea07746963a535385a5befc19fa687a627d2b.patch"
+              ],
+              "version": "=4.17.11"
+            }
+          ],
+          "proprietary": true,
+          "publicationTime": "2019-07-02T11:45:01Z",
+          "references": [
+            {
+              "title": "GitHub Issue",
+              "url": "https://github.com/lodash/lodash/issues/4348"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/lodash/lodash/pull/4336"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/lodash/lodash/pull/4355"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/sailshq/lodash/pull/1"
+            },
+            {
+              "title": "Node Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1065"
+            },
+            {
+              "title": "Snyk Blog",
+              "url": "https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.17.12"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "lodash@3.10.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.19.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash",
+          "version": "3.10.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P/RL:U/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2020-04-28T14:32:13.683154Z",
+          "credit": [
+            "posix"
+          ],
+          "cvssScore": 6.3,
+          "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The function `zipObjectDeep` can be tricked into adding or modifying properties of the Object prototype. These properties will be present on all objects.\r\n\r\n## PoC\r\n```\r\nconst _ = require('lodash');\r\n_.zipObjectDeep(['__proto__.z'],[123])\r\nconsole.log(z) // 123\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.16 or higher.\n## References\n- [GitHub PR](https://github.com/lodash/lodash/pull/4759)\n- [HackerOne Report](https://hackerone.com/reports/712065)\n",
+          "disclosureTime": "2020-04-27T22:14:18Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "4.17.16"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-LODASH-567746",
+          "identifiers": {
+            "CVE": [
+              "CVE-2020-8203"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-p6mc-m468-83gw"
+            ],
+            "NSP": [
+              "1523"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-07-09T08:34:04.944267Z",
+          "moduleName": "lodash",
+          "packageManager": "npm",
+          "packageName": "lodash",
+          "patches": [
+            {
+              "comments": [],
+              "id": "patch:SNYK-JS-LODASH-567746:0",
+              "modificationTime": "2020-04-30T14:28:46.729327Z",
+              "urls": [
+                "https://snyk-patches.s3.amazonaws.com/npm/lodash/20200430/lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+              ],
+              "version": ">=4.14.2"
+            }
+          ],
+          "proprietary": false,
+          "publicationTime": "2020-04-28T14:59:14Z",
+          "references": [
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/lodash/lodash/pull/4759"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/712065"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.17.16"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "lodash@3.10.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.19.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash",
+          "version": "3.10.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "alternativeIds": [],
+          "creationTime": "2020-07-24T12:05:01.916784Z",
+          "credit": [
+            "reeser"
+          ],
+          "cvssScore": 9.8,
+          "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution in `zipObjectDeep` due to an incomplete fix for [CVE-2020-8203](https://snyk.io/vuln/SNYK-JS-LODASH-567746).\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.20 or higher.\n## References\n- [GitHub Issue](https://github.com/lodash/lodash/issues/4874)\n",
+          "disclosureTime": "2020-07-24T12:00:52Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "4.17.20"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-LODASH-590103",
+          "identifiers": {
+            "CVE": [],
+            "CWE": [
+              "CWE-400"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-16T12:11:40.402299Z",
+          "moduleName": "lodash",
+          "packageManager": "npm",
+          "packageName": "lodash",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2020-08-16T13:09:06Z",
+          "references": [
+            {
+              "title": "GitHub Issue",
+              "url": "https://github.com/lodash/lodash/issues/4874"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.17.20"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "critical",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "lodash@3.10.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.19.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash",
+          "version": "3.10.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2020-08-21T12:52:58.443440Z",
+          "credit": [
+            "awarau"
+          ],
+          "cvssScore": 7.3,
+          "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution via the `setWith` and `set` functions.\r\n\r\n### PoC by awarau\r\n* Create a JS file with this contents:\r\n```\r\nlod = require('lodash')\r\nlod.setWith({}, \"__proto__[test]\", \"123\")\r\nlod.set({}, \"__proto__[test2]\", \"456\")\r\nconsole.log(Object.prototype)\r\n```\r\n* Execute it with `node`\r\n* Observe that `test` and `test2` is now in the `Object.prototype`.\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.17 or higher.\n## References\n- [HackerOne Report](https://hackerone.com/reports/864701)\n",
+          "disclosureTime": "2020-08-21T10:34:29Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "4.17.17"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-LODASH-608086",
+          "identifiers": {
+            "CVE": [],
+            "CWE": [
+              "CWE-400"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-27T16:44:20.914177Z",
+          "moduleName": "lodash",
+          "packageManager": "npm",
+          "packageName": "lodash",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2020-08-21T12:53:03Z",
+          "references": [
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/864701"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.17.17"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "lodash@3.10.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.19.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash",
+          "version": "3.10.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+          "alternativeIds": [],
+          "creationTime": "2019-02-03T09:06:37.726000Z",
+          "credit": [
+            "asgerf"
+          ],
+          "cvssScore": 7.3,
+          "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The functions `merge`, `mergeWith`, and `defaultsDeep` could be tricked into adding or modifying properties of `Object.prototype`. This is due to an incomplete fix to `CVE-2018-3721`.\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.11 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/380873)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1066)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1068)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1071)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/782)\n",
+          "disclosureTime": "2018-08-31T18:21:00Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "4.17.11"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "merge"
+              },
+              "version": [
+                ">=0.9.0 <1.0.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "dist/lodash.js",
+                "functionName": "merge"
+              },
+              "version": [
+                ">=1.0.0 <1.0.3"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "dist/lodash.js",
+                "functionName": "runInContext.merge"
+              },
+              "version": [
+                ">=1.1.0 <2.0.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.merge"
+              },
+              "version": [
+                ">=2.0.0 <3.0.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "runInContext.baseMerge"
+              },
+              "version": [
+                ">=3.0.0 <4.0.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "runInContext.baseMergeDeep"
+              },
+              "version": [
+                ">=3.0.0 <4.0.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.mergeDefaults"
+              },
+              "version": [
+                ">=4.0.0 <4.17.3"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.assignMergeValue"
+              },
+              "version": [
+                ">=4.0.0 <4.17.5"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.baseMerge"
+              },
+              "version": [
+                ">=4.0.0 <4.17.5"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.baseMergeDeep"
+              },
+              "version": [
+                ">=4.0.0 <4.17.5"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "safeGet"
+              },
+              "version": [
+                ">=4.17.5 <4.17.11"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "merge"
+              },
+              "version": [
+                ">=0.9.0 <1.0.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "dist/lodash.js",
+                "functionName": "merge"
+              },
+              "version": [
+                ">=1.0.0 <1.0.3"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "dist/lodash.js",
+                "functionName": "runInContext.merge"
+              },
+              "version": [
+                ">=1.1.0 <2.0.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.merge"
+              },
+              "version": [
+                ">=2.0.0 <3.0.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "runInContext.baseMerge"
+              },
+              "version": [
+                ">=3.0.0 <4.0.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "runInContext.baseMergeDeep"
+              },
+              "version": [
+                ">=3.0.0 <4.0.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.mergeDefaults"
+              },
+              "version": [
+                ">=4.0.0 <4.17.3"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.assignMergeValue"
+              },
+              "version": [
+                ">=4.0.0 <4.17.5"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.baseMerge"
+              },
+              "version": [
+                ">=4.0.0 <4.17.5"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "runInContext.baseMergeDeep"
+              },
+              "version": [
+                ">=4.0.0 <4.17.5"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "safeGet"
+              },
+              "version": [
+                ">=4.17.5 <4.17.11"
+              ]
+            }
+          ],
+          "id": "SNYK-JS-LODASH-73638",
+          "identifiers": {
+            "CVE": [
+              "CVE-2018-16487"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-4xc9-xhrj-v574"
+            ],
+            "NSP": [
+              "1066",
+              "1068",
+              "1071",
+              "782"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-24T08:59:09.185738Z",
+          "moduleName": "lodash",
+          "packageManager": "npm",
+          "packageName": "lodash",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2019-02-01T18:21:00Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/lodash/lodash/pull/4337"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/380873"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1066"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1068"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1071"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/782"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.17.11"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "lodash@3.10.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.19.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash",
+          "version": "3.10.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:N/I:N/A:H",
+          "alternativeIds": [],
+          "creationTime": "2019-02-03T09:18:05.060741Z",
+          "credit": [
+            "cristianstaicu"
+          ],
+          "cvssScore": 4.4,
+          "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). It parses dates using regex strings, which may cause a slowdown of 2 seconds per 50k characters.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `lodash` to version 4.17.11 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/5c08f18d365b64063bfbfa686cbb97cdd6267347)\n- [GitHub Issue](https://github.com/lodash/lodash/issues/3359)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4450)\n",
+          "disclosureTime": "2017-09-05T09:14:29Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "4.17.11"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "hasUnicodeWord"
+              },
+              "version": [
+                ">=4.15.0 <4.17.11"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "lodash.js",
+                "functionName": "hasUnicodeWord"
+              },
+              "version": [
+                ">=4.15.0 <4.17.11"
+              ]
+            }
+          ],
+          "id": "SNYK-JS-LODASH-73639",
+          "identifiers": {
+            "CVE": [
+              "CVE-2019-1010266"
+            ],
+            "CWE": [
+              "CWE-185"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-06-12T14:36:57.941198Z",
+          "moduleName": "lodash",
+          "packageManager": "npm",
+          "packageName": "lodash",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2019-04-05T09:14:22Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/lodash/lodash/commit/5c08f18d365b64063bfbfa686cbb97cdd6267347"
+            },
+            {
+              "title": "GitHub Issue",
+              "url": "https://github.com/lodash/lodash/issues/3359"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/lodash/lodash/pull/4450"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.17.11"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Regular Expression Denial of Service (ReDoS)",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "lodash@3.10.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.19.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash",
+          "version": "3.10.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P",
+          "alternativeIds": [],
+          "creationTime": "2019-06-19T11:41:45.817000Z",
+          "credit": [
+            "Olivier Arteau (HoLyVieR)"
+          ],
+          "cvssScore": 6.3,
+          "description": "## Overview\n[lodash.defaultsdeep](https://lodash.com/) is a Lodash method `_.defaultsDeep` exported as a Node.js module.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The utilities function allow modification of the `Object` prototype. If an attacker can control part of the structure passed to this function, they could add or modify an existing property.  \r\n\r\n## PoC by Olivier Arteau (HoLyVieR)\r\n```js\r\nvar _= require('lodash');\r\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\r\n\r\nvar a = {};\r\nconsole.log(\"Before : \" + a.oops);\r\n_.merge({}, JSON.parse(malicious_payload));\r\nconsole.log(\"After : \" + a.oops);\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash.defaultsdeep` to version 4.6.1 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/310443)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1067)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1069)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1070)\n",
+          "disclosureTime": "2018-01-30T22:28:27Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "4.6.1"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-LODASHDEFAULTSDEEP-450198",
+          "identifiers": {
+            "CVE": [
+              "CVE-2018-3721"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-2m96-9w4j-wgv7",
+              "GHSA-46fh-8fc5-xcwx",
+              "GHSA-5947-m4fg-xhqg",
+              "GHSA-fvqr-27wr-82fm"
+            ],
+            "NSP": [
+              "1067",
+              "1069",
+              "1070",
+              "577"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-25T09:41:03.215357Z",
+          "moduleName": "lodash.defaultsdeep",
+          "packageManager": "npm",
+          "packageName": "lodash.defaultsdeep",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2018-02-14T13:22:50Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/lodash/lodash/pull/4337"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/310443"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1067"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1069"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1070"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.6.1"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "lodash.defaultsdeep@4.5.0"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "lodash.defaultsdeep@4.6.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash.defaultsdeep",
+          "version": "4.5.0"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+          "alternativeIds": [],
+          "creationTime": "2019-06-19T11:44:03.712000Z",
+          "credit": [
+            "asgerf"
+          ],
+          "cvssScore": 7.3,
+          "description": "## Overview\n[lodash.defaultsdeep](https://lodash.com/) is a Lodash method `_.defaultsDeep` exported as a Node.js module.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The functions `merge`, `mergeWith`, and `defaultsDeep` could be tricked into adding or modifying properties of `Object.prototype`. This is due to an incomplete fix to `CVE-2018-3721`.\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash.defaultsdeep` to version 4.6.1 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/380873)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1066)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1068)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1071)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/782)\n",
+          "disclosureTime": "2018-08-31T18:21:00Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "4.6.1"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-LODASHDEFAULTSDEEP-450199",
+          "identifiers": {
+            "CVE": [
+              "CVE-2018-16487"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-4xc9-xhrj-v574"
+            ],
+            "NSP": [
+              "1066",
+              "1068",
+              "1071",
+              "782"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-24T08:59:09.212950Z",
+          "moduleName": "lodash.defaultsdeep",
+          "packageManager": "npm",
+          "packageName": "lodash.defaultsdeep",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2019-02-01T18:21:00Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/lodash/lodash/pull/4337"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/380873"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1066"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1068"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1071"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/782"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.6.1"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "lodash.defaultsdeep@4.5.0"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "lodash.defaultsdeep@4.6.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash.defaultsdeep",
+          "version": "4.5.0"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+          "alternativeIds": [],
+          "creationTime": "2019-04-08T14:32:04.805000Z",
+          "credit": [
+            "asgerf"
+          ],
+          "cvssScore": 7.3,
+          "description": "## Overview\n[lodash.mergewith](https://lodash.com/) is a Lodash method _.mergewith exported as a Node.js module.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The functions `merge`, `mergeWith`, and `defaultsDeep` could be tricked into adding or modifying properties of `Object.prototype`. This is due to an incomplete fix to `CVE-2018-3721`.\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash.mergewith` to version 4.6.2 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/380873)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1066)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1068)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1071)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/782)\n",
+          "disclosureTime": "2018-08-31T18:21:00Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "4.6.2"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "baseMerge"
+              },
+              "version": [
+                "*"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "baseMergeDeep"
+              },
+              "version": [
+                "*"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "baseMerge"
+              },
+              "version": [
+                "*"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "baseMergeDeep"
+              },
+              "version": [
+                "*"
+              ]
+            }
+          ],
+          "id": "SNYK-JS-LODASHMERGEWITH-174136",
+          "identifiers": {
+            "CVE": [
+              "CVE-2018-16487"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-4xc9-xhrj-v574"
+            ],
+            "NSP": [
+              "1066",
+              "1068",
+              "1071",
+              "782"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-24T08:59:09.204209Z",
+          "moduleName": "lodash.mergewith",
+          "packageManager": "npm",
+          "packageName": "lodash.mergewith",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2019-02-01T18:21:00Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/lodash/lodash/pull/4337"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/380873"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1066"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1068"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1071"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/782"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.6.2"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "lodash.mergewith@4.5.0"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "lodash.mergewith@4.6.2"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash.mergewith",
+          "version": "4.5.0"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P",
+          "alternativeIds": [],
+          "creationTime": "2019-04-08T14:35:02.142000Z",
+          "credit": [
+            "Olivier Arteau (HoLyVieR)"
+          ],
+          "cvssScore": 6.3,
+          "description": "## Overview\n[lodash.mergewith](https://lodash.com/) is a Lodash method _.mergewith exported as a Node.js module.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The utilities function allow modification of the `Object` prototype. If an attacker can control part of the structure passed to this function, they could add or modify an existing property.  \r\n\r\n## PoC by Olivier Arteau (HoLyVieR)\r\n```js\r\nvar _= require('lodash');\r\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\r\n\r\nvar a = {};\r\nconsole.log(\"Before : \" + a.oops);\r\n_.merge({}, JSON.parse(malicious_payload));\r\nconsole.log(\"After : \" + a.oops);\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash.mergewith` to version 4.6.1 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a)\n- [GitHub PR](https://github.com/lodash/lodash/pull/4337)\n- [HackerOne Report](https://hackerone.com/reports/310443)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1067)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1069)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1070)\n",
+          "disclosureTime": "2018-01-30T22:28:27Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "4.6.1"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "baseMerge"
+              },
+              "version": [
+                "<4.6.1"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "baseMergeDeep"
+              },
+              "version": [
+                "<4.6.1"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "baseMerge"
+              },
+              "version": [
+                "<4.6.1"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "baseMergeDeep"
+              },
+              "version": [
+                "<4.6.1"
+              ]
+            }
+          ],
+          "id": "SNYK-JS-LODASHMERGEWITH-174137",
+          "identifiers": {
+            "CVE": [
+              "CVE-2018-3721"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-2m96-9w4j-wgv7",
+              "GHSA-46fh-8fc5-xcwx",
+              "GHSA-5947-m4fg-xhqg",
+              "GHSA-fvqr-27wr-82fm"
+            ],
+            "NSP": [
+              "1067",
+              "1069",
+              "1070",
+              "577"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-08-25T09:41:03.208728Z",
+          "moduleName": "lodash.mergewith",
+          "packageManager": "npm",
+          "packageName": "lodash.mergewith",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2018-02-14T13:22:50Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/lodash/lodash/pull/4337"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/310443"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1067"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1069"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1070"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<4.6.1"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "lodash.mergewith@4.5.0"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "lodash.mergewith@4.6.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "lodash.mergewith",
+          "version": "4.5.0"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2020-03-11T08:25:47.093051Z",
+          "credit": [
+            "Snyk Security Team"
+          ],
+          "cvssScore": 5.6,
+          "description": "## Overview\n[minimist](https://www.npmjs.com/package/minimist) is a parse argument options module.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The library could be tricked into adding or modifying properties of `Object.prototype` using a `constructor` or `__proto__` payload.\r\n\r\n## PoC by Snyk\r\n```\r\nrequire('minimist')('--__proto__.injected0 value0'.split(' '));\r\nconsole.log(({}).injected0 === 'value0'); // true\r\n\r\nrequire('minimist')('--constructor.prototype.injected1 value1'.split(' '));\r\nconsole.log(({}).injected1 === 'value1'); // true\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `minimist` to version 0.2.1, 1.2.3 or higher.\n## References\n- [Command Injection PoC](https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a)\n- [GitHub Fix Commit #1](https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94)\n- [GitHub Fix Commit #2](https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab)\n- [Snyk Research Blog](https://snyk.io/blog/prototype-pollution-minimist/)\n",
+          "disclosureTime": "2020-03-10T08:22:24Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "0.2.1",
+            "1.2.3"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "setKey"
+              },
+              "version": [
+                "<0.2.1",
+                ">=1.0.0 <1.1.1"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "module.exports.setKey"
+              },
+              "version": [
+                "<0.2.1",
+                ">=1.1.1 <1.2.3"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "setKey"
+              },
+              "version": [
+                "<0.2.1",
+                ">=1.0.0 <1.1.1"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "module.exports.setKey"
+              },
+              "version": [
+                "<0.2.1",
+                ">=1.1.1 <1.2.3"
+              ]
+            }
+          ],
+          "id": "SNYK-JS-MINIMIST-559764",
+          "identifiers": {
+            "CVE": [
+              "CVE-2020-7598"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-vh95-rmgr-6w4m"
+            ],
+            "NSP": [
+              "1179"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-12-20T09:48:43.878574Z",
+          "moduleName": "minimist",
+          "packageManager": "npm",
+          "packageName": "minimist",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2020-03-11T08:22:19Z",
+          "references": [
+            {
+              "title": "Command Injection PoC",
+              "url": "https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a"
+            },
+            {
+              "title": "GitHub Fix Commit #1",
+              "url": "https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94"
+            },
+            {
+              "title": "GitHub Fix Commit #2",
+              "url": "https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab"
+            },
+            {
+              "title": "Snyk Research Blog",
+              "url": "https://snyk.io/blog/prototype-pollution-minimist/"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<0.2.1",
+              ">=1.0.0 <1.2.3"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "update-notifier@0.6.3",
+            "latest-version@2.0.0",
+            "package-json@2.3.3",
+            "registry-url@3.1.0",
+            "rc@1.1.6",
+            "minimist@1.2.0"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "update-notifier@0.6.3",
+            "latest-version@2.0.0",
+            "package-json@2.3.3",
+            "registry-url@3.1.0",
+            "rc@1.1.6",
+            "minimist@1.2.3"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "minimist",
+          "version": "1.2.0"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/RL:O",
+          "alternativeIds": [],
+          "creationTime": "2019-03-31T10:27:47.709659Z",
+          "credit": [
+            "ChaLKer"
+          ],
+          "cvssScore": 9.8,
+          "description": "## Overview\n[open](https://www.npmjs.com/package/open) is a cross platform package that opens stuff like URLs, files, executables.\n\nAffected versions of this package are vulnerable to Arbitrary Code Injection when unsanitized user input is passed in.\r\n\r\nThe package does come with the following warning in the readme:\r\n\r\n```\r\nThe same care should be taken when calling open as if you were calling child_process.exec directly. If it is an executable it will run in a new shell.\r\n```\r\nThe package `open` is replacing the `opn` package, which is now deprecated. The older versions of `open` are vulnerable. \r\n\r\n**Note: Upgrading `open` to the last version will prevent this vulnerability but is also likely to have unwanted effects since it now has a very different API.**\n## Remediation\nUpgrade `open` to version 6.0.0 or higher.\n## References\n- [GitHub Issue](https://github.com/pwnall/node-open/issues/68)\n- [HackerOne Report](https://hackerone.com/reports/319473)\n- [NPM Security Advisory](https://www.npmjs.com/advisories/663)\n",
+          "disclosureTime": "2018-05-16T19:36:39Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "6.0.0"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-OPEN-174041",
+          "identifiers": {
+            "CVE": [],
+            "CWE": [
+              "CWE-94"
+            ],
+            "GHSA": [
+              "GHSA-28xh-wpgr-7fm8"
+            ],
+            "NSP": [
+              "663"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-06-12T14:36:55.653898Z",
+          "moduleName": "open",
+          "packageManager": "npm",
+          "packageName": "open",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2019-03-31T10:33:37Z",
+          "references": [
+            {
+              "title": "GitHub Issue",
+              "url": "https://github.com/pwnall/node-open/issues/68"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/319473"
+            },
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/663"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<6.0.0"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "critical",
+          "socialTrendAlert": false,
+          "title": "Arbitrary Code Injection",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "open@0.0.5"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.76.0"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "open",
+          "version": "0.0.5"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:O/RC:C",
+          "alternativeIds": [
+            "SNYK-JS-OPEN-12148"
+          ],
+          "creationTime": "2018-02-25T11:54:41.573000Z",
+          "credit": [
+            "ChALkeR"
+          ],
+          "cvssScore": 8.4,
+          "description": "## Overview\n[open](https://www.npmjs.com/package/open) is a cross platform package that opens stuff like URLs, files, executables.\n\nAffected versions of this package are vulnerable to Arbitrary Command Injection. Urls are not properly escaped before concatenating them into the command that is opened using `exec()`.\r\n\r\n**Note: Upgrading `open` to the last version will prevent this vulnerability but is also likely to have unwanted effects since it now has a very different API.**\n## Remediation\nUpgrade `open` to version 6.0.0 or higher.\n## References\n- [HackerOne Report](https://hackerone.com/reports/319473)\n",
+          "disclosureTime": "2018-05-12T11:54:41Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "6.0.0"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "npm:open:20180512",
+          "identifiers": {
+            "ALTERNATIVE": [
+              "SNYK-JS-OPEN-12148"
+            ],
+            "CVE": [],
+            "CWE": [
+              "CWE-264"
+            ],
+            "NSP": [
+              "663"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-06-12T08:52:32.287783Z",
+          "moduleName": "open",
+          "packageManager": "npm",
+          "packageName": "open",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2018-05-13T14:26:27Z",
+          "references": [
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/319473"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<6.0.0"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Arbitrary Command Injection",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "open@0.0.5"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.76.0"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "open",
+          "version": "0.0.5"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N",
+          "alternativeIds": [],
+          "creationTime": "2021-06-29T09:27:06.371226Z",
+          "credit": [
+            "meandmax"
+          ],
+          "cvssScore": 3.7,
+          "description": "## Overview\n[request](https://www.npmjs.com/package/request) is a simplified http request client.\n\nAffected versions of this package are vulnerable to Insecure Encryption due to the usage of the insecure `sha1` cipher.\r\n\r\n**Note**: This library is deprecated.\n## Remediation\nA fix was pushed into the `master` branch but not yet published.\n## References\n- [GitHub Commit](https://github.com/request/request/pull/3385/commits/149e585d8f455b97c7c62df887c697f8045bb35d)\n- [GitHub PR](https://github.com/request/request/pull/3385)\n",
+          "disclosureTime": "2021-06-29T09:23:42Z",
+          "exploit": "Not Defined",
+          "fixedIn": [],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-REQUEST-1314897",
+          "identifiers": {
+            "CVE": [],
+            "CWE": [
+              "CWE-326"
+            ]
+          },
+          "language": "js",
+          "modificationTime": "2021-06-29T15:26:06.017894Z",
+          "moduleName": "request",
+          "packageManager": "npm",
+          "packageName": "request",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2021-06-29T15:26:05.534835Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/request/request/pull/3385/commits/149e585d8f455b97c7c62df887c697f8045bb35d"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/request/request/pull/3385"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "*"
+            ]
+          },
+          "severity": "low",
+          "severityWithCritical": "low",
+          "title": "Insecure Encryption",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0"
+          ],
+          "upgradePath": [],
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "request",
+          "version": "2.74.0"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2020-02-18T08:53:40.650407Z",
+          "credit": [
+            "JHU System Security Lab"
+          ],
+          "cvssScore": 6.3,
+          "description": "## Overview\n[undefsafe](https://www.npmjs.com/package/undefsafe) is a Simple function for retrieving deep object properties without getting \"Cannot read property 'X' of undefined\".\n\nAffected versions of this package are vulnerable to Prototype Pollution. The `a` function could be tricked into adding or modifying properties of `Object.prototype` using a `__proto__` payload.\r\n\r\n### PoC by JHU System Security Lab\r\n```js\r\nvar a = require(\"undefsafe\");\r\nvar payload = \"__proto__.toString\";\r\na({},payload,\"JHU\");\r\nconsole.log({}.toString);\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `undefsafe` to version 2.0.3 or higher.\n## References\n- [GitHub Commit](https://github.com/remy/undefsafe/commit/f272681b3a50e2c4cbb6a8533795e1453382c822)\n",
+          "disclosureTime": "2020-02-18T08:51:08Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "2.0.3"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-UNDEFSAFE-548940",
+          "identifiers": {
+            "CVE": [
+              "CVE-2019-10795"
+            ],
+            "CWE": [
+              "CWE-400"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-06-12T14:36:59.362776Z",
+          "moduleName": "undefsafe",
+          "packageManager": "npm",
+          "packageName": "undefsafe",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2020-02-18T11:01:36Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/remy/undefsafe/commit/f272681b3a50e2c4cbb6a8533795e1453382c822"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<2.0.3"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "undefsafe@0.0.3"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.78.0",
+            "undefsafe@2.0.3"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "undefsafe",
+          "version": "0.0.3"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P",
+          "alternativeIds": [],
+          "creationTime": "2020-10-25T14:27:16.715665Z",
+          "credit": [
+            "po6ix"
+          ],
+          "cvssScore": 7.3,
+          "description": "## Overview\n[y18n](https://www.npmjs.com/package/y18n) is a the bare-bones internationalization library used by yargs\n\nAffected versions of this package are vulnerable to Prototype Pollution. PoC by po6ix:\r\n```\r\nconst y18n = require('y18n')();\r\n \r\ny18n.setLocale('__proto__');\r\ny18n.updateLocale({polluted: true});\r\n\r\nconsole.log(polluted); // true\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `y18n` to version 3.2.2, 4.0.1, 5.0.5 or higher.\n## References\n- [GitHub Issue](https://github.com/yargs/y18n/issues/96)\n- [GitHub PR](https://github.com/yargs/y18n/pull/108)\n",
+          "disclosureTime": "2020-10-25T14:24:22Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "3.2.2",
+            "4.0.1",
+            "5.0.5"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-Y18N-1021887",
+          "identifiers": {
+            "CVE": [
+              "CVE-2020-7774"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-c4w7-xm78-47vh"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2021-01-05T15:29:00.943111Z",
+          "moduleName": "y18n",
+          "packageManager": "npm",
+          "packageName": "y18n",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2020-11-10T15:27:28Z",
+          "references": [
+            {
+              "title": "GitHub Issue",
+              "url": "https://github.com/yargs/y18n/issues/96"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/yargs/y18n/pull/108"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<3.2.2",
+              ">=4.0.0 <4.0.1",
+              ">=5.0.0 <5.0.5"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "yargs@4.8.1",
+            "y18n@3.2.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "yargs@4.8.1",
+            "y18n@3.2.2"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "y18n",
+          "version": "3.2.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "alternativeIds": [
+            "SNYK-JS-BRACEEXPANSION-10483"
+          ],
+          "creationTime": "2017-04-26T09:19:21.663000Z",
+          "credit": [
+            "kamael"
+          ],
+          "cvssScore": 6.2,
+          "description": "## Overview\r\n[`brace-expansion`](https://www.npmjs.com/package/brace-expansion) is a package that performs brace expansion as known from sh/bash.\r\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `brace-expansion` to version 1.1.7 or higher.\r\n\r\n## References\r\n- [GitHub PR](https://github.com/juliangruber/brace-expansion/pull/35)\r\n- [GitHub Issue](https://github.com/juliangruber/brace-expansion/issues/33)\r\n- [GitHub Commit](https://github.com/juliangruber/brace-expansion/pull/35/commits/b13381281cead487cbdbfd6a69fb097ea5e456c3)",
+          "disclosureTime": "2017-03-01T22:00:00Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "1.1.7"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "npm:brace-expansion:20170302",
+          "identifiers": {
+            "ALTERNATIVE": [
+              "SNYK-JS-BRACEEXPANSION-10483"
+            ],
+            "CVE": [
+              "CVE-2017-18077"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-832h-xg76-4gv6"
+            ],
+            "NSP": [
+              "338"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2019-12-02T14:40:13.321868Z",
+          "moduleName": "brace-expansion",
+          "packageManager": "npm",
+          "packageName": "brace-expansion",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2017-04-26T09:19:21Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/juliangruber/brace-expansion/pull/35/commits/b13381281cead487cbdbfd6a69fb097ea5e456c3"
+            },
+            {
+              "title": "GitHub Issue",
+              "url": "https://github.com/juliangruber/brace-expansion/issues/33"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/juliangruber/brace-expansion/pull/35"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<1.1.7"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Regular Expression Denial of Service (ReDoS)",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-recursive-readdir@2.0.0",
+            "minimatch@3.0.2",
+            "brace-expansion@1.1.6"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-recursive-readdir@2.0.0",
+            "minimatch@3.0.2",
+            "brace-expansion@1.1.7"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "brace-expansion",
+          "version": "1.1.6"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P",
+          "alternativeIds": [
+            "SNYK-JS-DEEPEXTEND-12120"
+          ],
+          "creationTime": "2018-04-15T20:11:17.552000Z",
+          "credit": [
+            "Olivier Arteau (HoLyVieR)"
+          ],
+          "cvssScore": 7.3,
+          "description": "## Overview\n[deep-extend](https://www.npmjs.com/package/deep-extend) is a library for Recursive object extending.\n\nAffected versions of this package are vulnerable to Prototype Pollution. Utilities function in all the listed modules can be tricked into modifying the prototype of \"Object\" when the attacker control part of the structure passed to these function. This can let an attacker add or modify existing property that will exist on all object.\r\n\r\n## PoC by HoLyVieR\r\n```js\r\nvar merge = require('deep-extend');\r\nvar malicious_payload = '{\"__proto__\":{\"oops\":\"It works !\"}}';\r\n\r\nvar a = {};\r\nconsole.log(\"Before : \" + a.oops);\r\nmerge({}, JSON.parse(malicious_payload));\r\nconsole.log(\"After : \" + a.oops);\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `deep-extend` to version 0.5.1 or higher.\n## References\n- [GitHub Commit](https://github.com/unclechu/node-deep-extend/commit/433ee51ed606f4e1867ece57b6ff5a47bebb492f)\n- [GitHub Issue](https://github.com/unclechu/node-deep-extend/issues/39)\n- [GitHub PR](https://github.com/unclechu/node-deep-extend/pull/40)\n- [HackerOne Report](https://hackerone.com/reports/311333)\n",
+          "disclosureTime": "2018-04-09T20:11:17Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "0.5.1"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "module.exports"
+              },
+              "version": [
+                "0.2.1"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "deepExtend"
+              },
+              "version": [
+                "<0.2.1"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "module.exports.deepExtend"
+              },
+              "version": [
+                ">=0.2.2 <0.2.5"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "deepExtend.module.exports"
+              },
+              "version": [
+                ">=0.2.5 <0.4.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lib/deep-extend.js",
+                "functionName": "cloneSpecificValue"
+              },
+              "version": [
+                ">=0.4.0 <0.5.1"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "module.exports"
+              },
+              "version": [
+                "0.2.1"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "deepExtend"
+              },
+              "version": [
+                "<0.2.1"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "module.exports.deepExtend"
+              },
+              "version": [
+                ">=0.2.2 <0.2.5"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "index.js",
+                "functionName": "deepExtend.module.exports"
+              },
+              "version": [
+                ">=0.2.5 <0.4.0"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lib/deep-extend.js",
+                "functionName": "cloneSpecificValue"
+              },
+              "version": [
+                ">=0.4.0 <0.5.1"
+              ]
+            }
+          ],
+          "id": "npm:deep-extend:20180409",
+          "identifiers": {
+            "ALTERNATIVE": [
+              "SNYK-JS-DEEPEXTEND-12120"
+            ],
+            "CVE": [
+              "CVE-2018-3750"
+            ],
+            "CWE": [
+              "CWE-400"
+            ],
+            "GHSA": [
+              "GHSA-hr2v-3952-633q"
+            ],
+            "NSP": [
+              "612"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2020-06-12T14:36:41.582307Z",
+          "moduleName": "deep-extend",
+          "packageManager": "npm",
+          "packageName": "deep-extend",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2018-04-25T07:45:48Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/unclechu/node-deep-extend/commit/433ee51ed606f4e1867ece57b6ff5a47bebb492f"
+            },
+            {
+              "title": "GitHub Issue",
+              "url": "https://github.com/unclechu/node-deep-extend/issues/39"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/unclechu/node-deep-extend/pull/40"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/311333"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<0.5.1"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Prototype Pollution",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "update-notifier@0.6.3",
+            "latest-version@2.0.0",
+            "package-json@2.3.3",
+            "registry-url@3.1.0",
+            "rc@1.1.6",
+            "deep-extend@0.4.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "snyk-resolve-deps@1.7.0",
+            "clite@0.3.0",
+            "update-notifier@0.6.3",
+            "latest-version@2.0.0",
+            "package-json@2.3.3",
+            "registry-url@3.1.0",
+            "rc@1.2.7",
+            "deep-extend@0.5.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "deep-extend",
+          "version": "0.4.1"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+          "alternativeIds": [
+            "SNYK-JS-HTTPSIGNATURE-10664"
+          ],
+          "creationTime": "2017-06-28T13:07:29.691000Z",
+          "credit": [
+            "Alok Menghrajani"
+          ],
+          "cvssScore": 6.5,
+          "description": "## Overview\r\n[`http-signature`](https://www.npmjs.com/package/http-signature) is a reference implementation of Joyent's HTTP Signature scheme.\r\n\r\nAffected versions of the package are vulnerable to Timing Attacks due to time-variable comparison of signatures. \r\n\r\nThe library implemented a character to character comparison, similar to the built-in string comparison mechanism, `===`, and not a time constant string comparison. As a result, the comparison will fail faster when the first characters in the signature are incorrect.\r\nAn attacker can use this difference to perform a timing attack, essentially allowing them to guess the signature one character at a time.\r\n\r\nYou can read more about timing attacks in Node.js on the [Snyk blog](https://snyk.io/blog/node-js-timing-attack-ccc-ctf/).\r\n\r\n## Remediation\r\nUpgrade `http-signature` to version 1.0.0 or higher.\r\n\r\n## References\r\n- [Github PR](https://github.com/joyent/node-http-signature/pull/36)\r\n- [Github Commit](https://github.com/joyent/node-http-signature/commit/78ab1da232f31f695f5c362d863593a143aa8b56)",
+          "disclosureTime": "2015-01-21T22:00:00Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "1.0.0"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "lib/verify.js",
+                "functionName": "module.exports.verifySignature"
+              },
+              "version": [
+                "<0.10.1"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lib/verify.js",
+                "functionName": "module.exports.verifyHMAC"
+              },
+              "version": [
+                ">=0.11.0 <1.0.0"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "lib/verify.js",
+                "functionName": "module.exports.verifySignature"
+              },
+              "version": [
+                "<0.10.1"
+              ]
+            },
+            {
+              "functionId": {
+                "filePath": "lib/verify.js",
+                "functionName": "module.exports.verifyHMAC"
+              },
+              "version": [
+                ">=0.11.0 <1.0.0"
+              ]
+            }
+          ],
+          "id": "npm:http-signature:20150122",
+          "identifiers": {
+            "ALTERNATIVE": [
+              "SNYK-JS-HTTPSIGNATURE-10664"
+            ],
+            "CVE": [],
+            "CWE": [
+              "CWE-310"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2019-04-29T15:44:53.819980Z",
+          "moduleName": "http-signature",
+          "packageManager": "npm",
+          "packageName": "http-signature",
+          "patches": [
+            {
+              "comments": [],
+              "id": "patch:npm:http-signature:20150122:0",
+              "modificationTime": "2019-12-03T11:40:45.867250Z",
+              "urls": [
+                "https://snyk-patches.s3.amazonaws.com/npm/http-signature/20150122/20150122_0_0_http-signature_78ab1da232f31f695f5c362d863593a143aa8b56.patch"
+              ],
+              "version": "=0.10.1"
+            }
+          ],
+          "proprietary": false,
+          "publicationTime": "2017-06-28T13:07:29Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/joyent/node-http-signature/commit/78ab1da232f31f695f5c362d863593a143aa8b56"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/joyent/node-http-signature/pull/36"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<1.0.0"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "title": "Timing Attack",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "request@2.57.0",
+            "http-signature@0.11.0"
+          ],
+          "upgradePath": [],
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "http-signature",
+          "version": "0.11.0"
+        },
+        {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P/RL:O/RC:C",
+          "alternativeIds": [
+            "SNYK-JS-SSHPK-12114"
+          ],
+          "creationTime": "2018-02-25T08:09:56.427000Z",
+          "credit": [
+            "ChALkeR"
+          ],
+          "cvssScore": 7.5,
+          "description": "## Overview\r\n[sshpk](https://www.npmjs.com/package/sshpk) is Parse, convert, fingerprint and use SSH keys in pure node.js.\r\n\r\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks when parsing crafted invalid public keys.\r\n\r\n## Details\r\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\r\n\r\n\r\n## Remediation\r\nUpgrade `sshpk` to version 1.13.2 or higher.\r\n\r\n## References\r\n- [HackerOne Report](https://hackerone.com/reports/319593)",
+          "disclosureTime": "2018-04-09T08:09:56Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "1.14.1"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "filePath": "lib/key.js",
+                "functionName": "Key.parse"
+              },
+              "version": [
+                "<1.14.1"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "filePath": "lib/key.js",
+                "functionName": "Key.parse"
+              },
+              "version": [
+                "<1.14.1"
+              ]
+            }
+          ],
+          "id": "npm:sshpk:20180409",
+          "identifiers": {
+            "ALTERNATIVE": [
+              "SNYK-JS-SSHPK-12114"
+            ],
+            "CVE": [
+              "CVE-2018-3737"
+            ],
+            "CWE": [
+              "CWE-185"
+            ],
+            "GHSA": [
+              "GHSA-2m39-62fm-q8r3"
+            ],
+            "NSP": [
+              "606"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2019-12-31T10:17:09.068690Z",
+          "moduleName": "sshpk",
+          "packageManager": "npm",
+          "packageName": "sshpk",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2018-04-09T15:17:27Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/joyent/node-sshpk/commit/46065d38a5e6d1bccf86d3efb2fb83c14e3f9957"
+            },
+            {
+              "title": "HackerOne Report",
+              "url": "https://hackerone.com/reports/319593"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<1.14.1"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Regular Expression Denial of Service (ReDoS)",
+          "from": [
+            "qs-package@1.0.0",
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "http-signature@1.1.1",
+            "sshpk@1.9.1"
+          ],
+          "upgradePath": [
+            false,
+            "@remy/protect-test@1.0.13",
+            "snyk@1.17.4",
+            "request@2.74.0",
+            "http-signature@1.1.1",
+            "sshpk@1.14.1"
+          ],
+          "isUpgradable": true,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "sshpk",
+          "version": "1.9.1"
+        }
+      ],
+      "upgrade": {
+        "qs@0.6.6": {
+          "upgradeTo": "qs@6.0.4",
+          "upgrades": [
+            "qs@0.6.6",
+            "qs@0.6.6",
+            "qs@0.6.6"
+          ],
+          "vulns": [
+            "npm:qs:20170213",
+            "npm:qs:20140806",
+            "npm:qs:20140806-1"
+          ]
+        }
+      },
+      "patch": {
+        "npm:debug:20170905": {
+          "paths": [
+            {
+              "@remy/protect-test > snyk > debug": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-config > debug": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-module > debug": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve > debug": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-try-require > debug": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-policy > debug": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve-deps > debug": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-policy > snyk-module > debug": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve-deps > snyk-module > debug": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-policy > snyk-resolve > debug": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve-deps > snyk-resolve > debug": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-policy > snyk-try-require > debug": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve-deps > snyk-try-require > debug": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve-deps > clite > debug": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            }
+          ]
+        },
+        "npm:extend:20180424": {
+          "paths": [
+            {
+              "@remy/protect-test > snyk > request > extend": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            }
+          ]
+        },
+        "npm:hawk:20160119": {
+          "paths": [
+            {
+              "@remy/protect-test > request > hawk": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            }
+          ]
+        },
+        "npm:hoek:20180212": {
+          "paths": [
+            {
+              "@remy/protect-test > request > hawk > hoek": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > request > hawk > boom > hoek": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > request > hawk > sntp > hoek": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > request > hawk > hoek": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > request > hawk > cryptiles > boom > hoek": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > request > hawk > boom > hoek": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > request > hawk > sntp > hoek": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > request > hawk > cryptiles > boom > hoek": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            }
+          ]
+        },
+        "npm:lodash:20180130": {
+          "paths": [
+            {
+              "@remy/protect-test > snyk > lodash": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            }
+          ]
+        },
+        "npm:ms:20170412": {
+          "paths": [
+            {
+              "@remy/protect-test > snyk > debug > ms": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-config > debug > ms": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-module > debug > ms": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve > debug > ms": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-try-require > debug > ms": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-policy > debug > ms": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve-deps > debug > ms": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-policy > snyk-module > debug > ms": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve-deps > snyk-module > debug > ms": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-policy > snyk-resolve > debug > ms": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve-deps > snyk-resolve > debug > ms": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-policy > snyk-try-require > debug > ms": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve-deps > snyk-try-require > debug > ms": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > snyk-resolve-deps > clite > debug > ms": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            }
+          ]
+        },
+        "npm:qs:20170213": {
+          "paths": [
+            {
+              "@remy/protect-test > snyk > request > qs": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            }
+          ]
+        },
+        "npm:request:20160119": {
+          "paths": [
+            {
+              "@remy/protect-test > request": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            }
+          ]
+        },
+        "npm:stringstream:20180511": {
+          "paths": [
+            {
+              "@remy/protect-test > request > stringstream": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > request > stringstream": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            }
+          ]
+        },
+        "npm:tough-cookie:20170905": {
+          "paths": [
+            {
+              "@remy/protect-test > request > tough-cookie": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > request > tough-cookie": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            }
+          ]
+        },
+        "npm:tunnel-agent:20170305": {
+          "paths": [
+            {
+              "@remy/protect-test > request > tunnel-agent": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            },
+            {
+              "@remy/protect-test > snyk > request > tunnel-agent": {
+                "patched": "2021-09-03T19:51:05.773Z"
+              }
+            }
+          ]
+        }
+      },
+      "ignore": {},
+      "pin": {}
+    }
+  },
+  "meta": {
+    "isPrivate": true,
+    "isLicensesEnabled": true,
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.21.5\nignore: {}\n# patches apply the minimum changes required to fix a vulnerability\npatch:\n  'npm:semver:20150403':\n    - '@remy/protect-test@1.0.13 > semver@2.3.2':\n        patched: '2015-10-28T21:22:32.573Z'\n        from: '@remy/protect-test@1.0.13'\nsuggest:\n  'npm:hawk:20160119':\n    - '@remy/protect-test@1.0.13 > request > hawk':\n        reason: test trust policies\n        expires: '2116-03-19T17:42:05.690Z'\n        from: '@remy/protect-test@1.0.13'\n  'npm:request:20160119':\n    - '@remy/protect-test@1.0.13 > request':\n        reason: test trust policies\n        expires: '2116-03-19T17:42:05.690Z'\n        from: '@remy/protect-test@1.0.13'\n",
+    "ignoreSettings": null,
+    "org": "demo-applications",
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {
+        "AGPL-1.0": {
+          "licenseType": "AGPL-1.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "AGPL-3.0": {
+          "licenseType": "AGPL-3.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "Artistic-1.0": {
+          "licenseType": "Artistic-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "Artistic-2.0": {
+          "licenseType": "Artistic-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "CDDL-1.0": {
+          "licenseType": "CDDL-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "CPOL-1.02": {
+          "licenseType": "CPOL-1.02",
+          "severity": "high",
+          "instructions": ""
+        },
+        "EPL-1.0": {
+          "licenseType": "EPL-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "GPL-2.0": {
+          "licenseType": "GPL-2.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "GPL-3.0": {
+          "licenseType": "GPL-3.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "LGPL-2.0": {
+          "licenseType": "LGPL-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "LGPL-2.1": {
+          "licenseType": "LGPL-2.1",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "LGPL-3.0": {
+          "licenseType": "LGPL-3.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MPL-1.1": {
+          "licenseType": "MPL-1.1",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MPL-2.0": {
+          "licenseType": "MPL-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MS-RL": {
+          "licenseType": "MS-RL",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "SimPL-2.0": {
+          "licenseType": "SimPL-2.0",
+          "severity": "high",
+          "instructions": ""
+        }
+      }
+    }
+  }
+}

--- a/test/jest/acceptance/analytics.spec.ts
+++ b/test/jest/acceptance/analytics.spec.ts
@@ -106,8 +106,9 @@ describe('analytics module', () => {
     const project = await createProjectFromFixture(
       'npm/with-vulnerable-lodash-dep',
     );
-
-    server.setNextResponse(await project.read('test-dep-graph-result.json'));
+    server.depGraphResponse = await project.readJSON(
+      'test-dep-graph-result.json',
+    );
 
     const { code } = await runSnykCLI('test', {
       cwd: project.path(),

--- a/test/jest/acceptance/cli-json-file-output.spec.ts
+++ b/test/jest/acceptance/cli-json-file-output.spec.ts
@@ -40,9 +40,7 @@ describe('test --json-file-output ', () => {
 
     expect(code).toEqual(0);
     expect(stdout).toMatch('Organization:');
-
-    const jsonObj = JSON.parse(await project.read(outputPath));
-    expect(jsonObj).toMatchObject({ ok: true });
+    expect(await project.readJSON(outputPath)).toMatchObject({ ok: true });
   });
 
   it('test --json-file-output produces same JSON output as normal JSON output to stdout', async () => {

--- a/test/jest/acceptance/oauth-token.spec.ts
+++ b/test/jest/acceptance/oauth-token.spec.ts
@@ -12,7 +12,7 @@ describe('OAuth Token', () => {
     const apiPath = '/api/v1';
     const apiPort = process.env.PORT || process.env.SNYK_PORT || '12345';
     env = {
-      PATH: process.env.PATH || '',
+      ...process.env,
       SNYK_API: 'http://localhost:' + apiPort + apiPath,
       SNYK_OAUTH_TOKEN: 'oauth-jwt-token',
       SNYK_DISABLE_ANALYTICS: '1',

--- a/test/jest/acceptance/oauth-token.spec.ts
+++ b/test/jest/acceptance/oauth-token.spec.ts
@@ -32,8 +32,7 @@ describe('OAuth Token', () => {
 
   it('uses oauth token for authorised requests when testing projects', async () => {
     const project = await createProjectFromWorkspace('fail-on/no-vulns');
-    const jsonObj = JSON.parse(await project.read('vulns-result.json'));
-    server.setNextResponse(jsonObj);
+    server.depGraphResponse = await project.readJSON('vulns-result.json');
 
     const { code } = await runSnykCLI(`test --json`, {
       cwd: project.path(),
@@ -52,8 +51,7 @@ describe('OAuth Token', () => {
 
   it('uses oauth token for authorised requests when monitoring projects', async () => {
     const project = await createProjectFromWorkspace('fail-on/no-vulns');
-    const jsonObj = JSON.parse(await project.read('vulns-result.json'));
-    server.setNextResponse(jsonObj);
+    server.depGraphResponse = await project.readJSON('vulns-result.json');
 
     const { code } = await runSnykCLI(`monitor --json`, {
       cwd: project.path(),

--- a/test/jest/acceptance/proxy-behavior.spec.ts
+++ b/test/jest/acceptance/proxy-behavior.spec.ts
@@ -1,123 +1,83 @@
-import { exec } from 'child_process';
-import { sep } from 'path';
-const main = './bin/snyk'.replace(/\//g, sep);
+import { runSnykCLI } from '../util/runSnykCLI';
 
+const fakeServerPort = 12345;
 const SNYK_API_HTTPS = 'https://snyk.io/api/v1';
 const SNYK_API_HTTP = 'http://snyk.io/api/v1';
-const FAKE_HTTP_PROXY = 'http://localhost:12345';
-const testTimeout = 50000;
+const FAKE_HTTP_PROXY = `http://localhost:${fakeServerPort}`;
+
+jest.setTimeout(1000 * 60 * 1);
 
 describe('Proxy configuration behavior', () => {
   describe('*_PROXY against HTTPS host', () => {
-    it(
-      'tries to connect to the HTTPS_PROXY when HTTPS_PROXY is set',
-      (done) => {
-        exec(
-          `node ${main} woof -d`,
-          {
-            env: {
-              HTTPS_PROXY: FAKE_HTTP_PROXY,
-              SNYK_API: SNYK_API_HTTPS,
-            },
-          },
-          (err, stdout, stderr) => {
-            if (err) {
-              throw err;
-            }
+    it('tries to connect to the HTTPS_PROXY when HTTPS_PROXY is set', async () => {
+      const { code, stderr } = await runSnykCLI(`woof -d`, {
+        env: {
+          ...process.env,
+          HTTPS_PROXY: FAKE_HTTP_PROXY,
+          SNYK_API: SNYK_API_HTTPS,
+        },
+      });
 
-            // It will *attempt* to connect to a FAKE_HTTP_PROXY (and fails, because it's not a real proxy server)
-            expect(stderr).toContain(
-              `Error: connect ECONNREFUSED 127.0.0.1:${
-                FAKE_HTTP_PROXY.split(':')[2]
-              }`,
-            );
-            done();
-          },
-        );
-      },
-      testTimeout,
-    );
+      expect(code).toBe(0);
 
-    it(
-      'does not try to connect to the HTTP_PROXY when it is set',
-      (done) => {
-        exec(
-          `node ${main} woof -d`,
-          {
-            env: {
-              HTTP_PROXY: FAKE_HTTP_PROXY,
-              SNYK_API: SNYK_API_HTTPS,
-            },
-          },
-          (err, stdout, stderr) => {
-            if (err) {
-              throw err;
-            }
+      // It will *attempt* to connect to a FAKE_HTTP_PROXY (and fails, because it's not a real proxy server)
+      expect(stderr).toContain(
+        `Error: connect ECONNREFUSED 127.0.0.1:${fakeServerPort}`,
+      );
+    });
 
-            // It will *not attempt* to connect to a proxy and /analytics call won't fail
-            expect(stderr).not.toContain('ECONNREFUSED');
-            done();
-          },
-        );
-      },
-      testTimeout,
-    );
+    it('does not try to connect to the HTTP_PROXY when it is set', async () => {
+      const { code, stderr } = await runSnykCLI(`woof -d`, {
+        env: {
+          ...process.env,
+          HTTP_PROXY: FAKE_HTTP_PROXY,
+          SNYK_API: SNYK_API_HTTPS,
+        },
+      });
+
+      expect(code).toBe(0);
+
+      // It will *not attempt* to connect to a proxy and /analytics call won't fail
+      expect(stderr).not.toContain('ECONNREFUSED');
+    });
   });
 
   describe('*_PROXY against HTTP host', () => {
-    it(
-      'tries to connect to the HTTP_PROXY when HTTP_PROXY is set',
-      (done) => {
-        exec(
-          `node ${main} woof -d`,
-          {
-            env: {
-              HTTP_PROXY: FAKE_HTTP_PROXY,
-              SNYK_API: SNYK_API_HTTP,
-              SNYK_HTTP_PROTOCOL_UPGRADE: '0',
-            },
-          },
-          (err, stdout, stderr) => {
-            if (err) {
-              throw err;
-            }
+    it('tries to connect to the HTTP_PROXY when HTTP_PROXY is set', async () => {
+      const { code, stderr } = await runSnykCLI(`woof -d`, {
+        env: {
+          ...process.env,
+          HTTP_PROXY: FAKE_HTTP_PROXY,
+          SNYK_API: SNYK_API_HTTP,
+          SNYK_HTTP_PROTOCOL_UPGRADE: '0',
+        },
+      });
 
-            // It will *attempt* to connect to a FAKE_HTTP_PROXY (and fails, because it's not a real proxy server)
-            expect(stderr).toContain(
-              `Error: connect ECONNREFUSED 127.0.0.1:${
-                FAKE_HTTP_PROXY.split(':')[2]
-              }`,
-            );
-            done();
-          },
-        );
-      },
-      testTimeout,
-    );
+      expect(code).toBe(0);
 
-    it(
-      'does not try to connect to the HTTPS_PROXY when it is set',
-      (done) => {
-        exec(
-          `node ${main} woof -d`,
-          {
-            env: {
-              HTTPS_PROXY: FAKE_HTTP_PROXY,
-              SNYK_API: SNYK_API_HTTP,
-              SNYK_HTTP_PROTOCOL_UPGRADE: '0',
-            },
-          },
-          (err, stdout, stderr) => {
-            // TODO: incorrect behavior when Needle tries to upgrade connection after 301 http->https and the Agent option is set to a strict http/s protocol
-            // See lines with `keepAlive` in request.ts for more details
-            expect(stderr).toContain(
-              'TypeError [ERR_INVALID_PROTOCOL]: Protocol "https:" not supported. Expected "http:"',
-            );
-            done();
-          },
-        );
-      },
-      testTimeout,
-    );
+      // It will *attempt* to connect to a FAKE_HTTP_PROXY (and fails, because it's not a real proxy server)
+      expect(stderr).toContain(
+        `Error: connect ECONNREFUSED 127.0.0.1:${fakeServerPort}`,
+      );
+    });
+
+    it('does not try to connect to the HTTPS_PROXY when it is set', async () => {
+      const { code, stderr } = await runSnykCLI(`woof -d`, {
+        env: {
+          ...process.env,
+          HTTPS_PROXY: FAKE_HTTP_PROXY,
+          SNYK_API: SNYK_API_HTTP,
+          SNYK_HTTP_PROTOCOL_UPGRADE: '0',
+        },
+      });
+
+      expect(code).toBe(1);
+
+      // Incorrect behavior when Needle tries to upgrade connection after 301 http->https and the Agent option is set to a strict http/s protocol.
+      // See lines with `keepAlive` in request.ts for more details
+      expect(stderr).toContain(
+        'TypeError [ERR_INVALID_PROTOCOL]: Protocol "https:" not supported. Expected "http:"',
+      );
+    });
   });
 });

--- a/test/jest/acceptance/snyk-test-all-projects-exit-codes.spec.ts
+++ b/test/jest/acceptance/snyk-test-all-projects-exit-codes.spec.ts
@@ -39,8 +39,9 @@ describe('snyk test --all-projects with one project that has errors', () => {
       const project = await createProject(
         'snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error',
       );
-      const depGraphResStr = await project.read('test-dep-graph-result.json');
-      server.depGraphResponse = JSON.parse(depGraphResStr);
+      server.depGraphResponse = await project.readJSON(
+        'test-dep-graph-result.json',
+      );
       const { code, stderr } = await runSnykCLI(`test --all-projects`, {
         cwd: project.path(),
         env,
@@ -62,8 +63,9 @@ describe('snyk test --all-projects with one project that has errors', () => {
       const project = await createProject(
         'snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error',
       );
-      const depGraphResStr = await project.read('test-dep-graph-result.json');
-      server.depGraphResponse = JSON.parse(depGraphResStr);
+      server.depGraphResponse = await project.readJSON(
+        'test-dep-graph-result.json',
+      );
       server.setFeatureFlag('cliFailFast', true);
       const { code, stderr } = await runSnykCLI(`test --all-projects`, {
         cwd: project.path(),
@@ -79,8 +81,9 @@ describe('snyk test --all-projects with one project that has errors', () => {
       const project = await createProject(
         'snyk-test-all-projects-exit-codes/project-with-issues-and-project-with-error',
       );
-      const depGraphResStr = await project.read('test-dep-graph-result.json');
-      server.depGraphResponse = JSON.parse(depGraphResStr);
+      server.depGraphResponse = await project.readJSON(
+        'test-dep-graph-result.json',
+      );
       server.setFeatureFlag('cliFailFast', true);
       const { code, stderr } = await runSnykCLI(
         `test --all-projects --fail-fast`,

--- a/test/jest/acceptance/snyk-test/trust-policies.spec.ts
+++ b/test/jest/acceptance/snyk-test/trust-policies.spec.ts
@@ -36,8 +36,9 @@ describe('trust policies', () => {
 
   test('`snyk test` detects suggested ignore policies', async () => {
     const project = await createProject('qs-package');
-    const depGraphResStr = await project.read('test-dep-graph-result.json');
-    server.depGraphResponse = JSON.parse(depGraphResStr);
+    server.depGraphResponse = await project.readJSON(
+      'test-dep-graph-result.json',
+    );
 
     const { code, stdout } = await runSnykCLI('test', {
       cwd: project.path(),
@@ -54,10 +55,9 @@ describe('trust policies', () => {
 
   test('`snyk test --trust-policies` applies suggested ignore policies', async () => {
     const project = await createProject('qs-package');
-    const depGraphResStr = await project.read(
+    server.depGraphResponse = await project.readJSON(
       'test-dep-graph-result-trust-policies.json',
     );
-    server.depGraphResponse = JSON.parse(depGraphResStr);
 
     const { code, stdout } = await runSnykCLI('test --trust-policies', {
       cwd: project.path(),

--- a/test/jest/acceptance/snyk-test/trust-policies.spec.ts
+++ b/test/jest/acceptance/snyk-test/trust-policies.spec.ts
@@ -1,18 +1,44 @@
 import { createProject } from '../../util/createProject';
-import { requireSnykToken } from '../../util/requireSnykToken';
 import { runSnykCLI } from '../../util/runSnykCLI';
+import { fakeServer } from '../../../acceptance/fake-server';
 
 jest.setTimeout(1000 * 60);
 
 describe('trust policies', () => {
-  const env = {
-    ...process.env,
-    SNYK_TOKEN: requireSnykToken(),
-    SNYK_DISABLE_ANALYTICS: '1',
-  };
+  let server;
+  let env: Record<string, string>;
+
+  beforeAll((done) => {
+    const port = process.env.PORT || process.env.SNYK_PORT || '12345';
+    const baseApi = '/api/v1';
+    env = {
+      ...process.env,
+      SNYK_API: 'http://localhost:' + port + baseApi,
+      SNYK_HOST: 'http://localhost:' + port,
+      SNYK_TOKEN: '123456789',
+      SNYK_DISABLE_ANALYTICS: '1',
+    };
+    server = fakeServer(baseApi, env.SNYK_TOKEN);
+    server.listen(port, () => {
+      done();
+    });
+  });
+
+  afterEach(() => {
+    server.restore();
+  });
+
+  afterAll((done) => {
+    server.close(() => {
+      done();
+    });
+  });
 
   test('`snyk test` detects suggested ignore policies', async () => {
     const project = await createProject('qs-package');
+    const depGraphResStr = await project.read('test-dep-graph-result.json');
+    server.depGraphResponse = JSON.parse(depGraphResStr);
+
     const { code, stdout } = await runSnykCLI('test', {
       cwd: project.path(),
       env,
@@ -28,6 +54,11 @@ describe('trust policies', () => {
 
   test('`snyk test --trust-policies` applies suggested ignore policies', async () => {
     const project = await createProject('qs-package');
+    const depGraphResStr = await project.read(
+      'test-dep-graph-result-trust-policies.json',
+    );
+    server.depGraphResponse = JSON.parse(depGraphResStr);
+
     const { code, stdout } = await runSnykCLI('test --trust-policies', {
       cwd: project.path(),
       env,

--- a/test/jest/system/lib/commands/fix/fix.spec.ts
+++ b/test/jest/system/lib/commands/fix/fix.spec.ts
@@ -24,7 +24,7 @@ describe('snyk fix (system tests)', () => {
   );
 
   const env = {
-    PATH: process.env.PATH,
+    ...process.env,
     SNYK_TOKEN: apiKey,
     SNYK_API,
     SNYK_HOST,

--- a/test/jest/unit/cli/commands/types.spec.ts
+++ b/test/jest/unit/cli/commands/types.spec.ts
@@ -1,7 +1,7 @@
 import {
   CommandResult,
   TestCommandResult,
-} from '../../../src/cli/commands/types';
+} from '../../../../../src/cli/commands/types';
 
 test('createHumanReadableTestCommandResult', () => {
   const hrRes = TestCommandResult.createHumanReadableTestCommandResult(

--- a/test/jest/util/createProject.ts
+++ b/test/jest/util/createProject.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 type TestProject = {
   path: (filePath?: string) => string;
   read: (filePath: string) => Promise<string>;
+  readJSON: (filePath: string) => Promise<any>;
   remove: () => Promise<void>;
 };
 
@@ -33,6 +34,11 @@ const createProject = async (
     read: (filePath: string) => {
       const fullFilePath = path.resolve(projectPath, filePath);
       return fse.readFile(fullFilePath, 'utf-8');
+    },
+    readJSON: async (filePath: string) => {
+      const fullFilePath = path.resolve(projectPath, filePath);
+      const strJson = await fse.readFile(fullFilePath, 'utf-8');
+      return JSON.parse(strJson);
     },
     remove: () => {
       return fse.remove(tempFolder);


### PR DESCRIPTION
#### What does this PR do?

- Uses fake-server for the `test/jest/acceptance/snyk-test/trust-policies.spec.ts` acceptance tests to improve performance.
- use `runSnykCLI` in `test/jest/acceptance/proxy-behavior.spec.ts`
 - pass all env vars into CLI process in acceptance tests to so that we can debug through the process (if we only pass in the PATH (plus whatever other env vars might be required by the tests), it seems like we can't debug locally through the CLI process.
    - `test/jest/system/lib/commands/fix/fix.spec.ts`
    - `test/jest/acceptance/oauth-token.spec.ts`
- move wrongly classified test `test/jest/acceptance/cli-command-types.spec.ts` to a proper home at `test/jest/unit/cli/commands/types.spec.ts`
