### PR TITLE
feat(@snyk/fix): send more detailed error analytics

### DIFF
--- a/packages/snyk-fix/src/index.ts
+++ b/packages/snyk-fix/src/index.ts
@@ -18,7 +18,9 @@ import {
 import { convertErrorToUserMessage } from './lib/errors/error-to-user-message';
 import { getTotalIssueCount } from './lib/issues/total-issues-count';
 import { hasFixableIssues } from './lib/issues/fixable-issues';
-export { EntityToFix } from './types';
+
+export { FixHandlerResultByPlugin } from './plugins/types';
+export { EntityToFix, FixedMeta } from './types';
 
 const debug = debugLib('snyk-fix:main');
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
When projects fail we do not surface the full error in the summary,
it is shown to the user in the warning output.
make sure we send the error in analytics to help debug & improve the
plugin.


#### Where should the reviewer start?

https://github.com/snyk/snyk/compare/feat/snyk-fix-send-error-analytics?expand=1#diff-496e8bb7be43118118a857255a018b53e916cd7611050049ec55a6fba8a39d7aR70

#### How should this be manually tested?
run `snyk fix` on a project that fails & observe analytics 
