### PR TITLE
fix: exit code when IaC scans are empty

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,6 +30,7 @@ import {
   CustomError,
   NoSupportedSastFiles,
 } from '../lib/errors';
+import { IaCErrorCodes } from './commands/test/iac-local-execution/types';
 import stripAnsi from 'strip-ansi';
 import { ExcludeFlagInvalidInputError } from '../lib/errors/exclude-flag-invalid-input';
 import { modeValidation } from './modes';
@@ -96,8 +97,9 @@ async function handleError(args, error) {
     'Could not detect supported target files in',
   );
   const noSupportedSastFiles = error instanceof NoSupportedSastFiles;
+  const noSupportedIaCFiles = error.code === IaCErrorCodes.NoFilesToScanError;
   const noSupportedProjectsDetected =
-    noSupportedManifestsFound || noSupportedSastFiles;
+    noSupportedManifestsFound || noSupportedSastFiles || noSupportedIaCFiles;
 
   if (noSupportedProjectsDetected) {
     exitCode = EXIT_CODES.NO_SUPPORTED_PROJECTS_DETECTED;

--- a/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
@@ -61,7 +61,7 @@ Describe "Snyk iac local test command"
 
     It "ignores files with no recognised config types"
       When run snyk iac test ../fixtures/iac/kubernetes/pod-invalid.yaml
-      The status should equal 2
+      The status should equal 3
       The output should include "Could not find any valid infrastructure as code files."
     End
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

**fix: exit code when IaC scans are empty**

According to
https://support.snyk.io/hc/en-us/articles/360003812578#UUID-c88e66cf-431c-9ab1-d388-a8f82991c6e0,
the Snyk CLI should return 3 when there were no supported files in a
scan. This allows user to distinguish this situation from a complete
scan, and from when errors encountered during the scan.

We were actually returning 2, which is also returned when errors are
encountered during a scan.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?

See self-review comments.

#### What are the relevant tickets?

Customer issue: https://snyk.zendesk.com/agent/tickets/13733

#### Screenshots


#### Additional questions
