### PR TITLE
feat: support analytics from plugins

### DIFF
--- a/src/lib/ecosystems/plugin-analytics.ts
+++ b/src/lib/ecosystems/plugin-analytics.ts
@@ -1,0 +1,8 @@
+import { Analytics } from './types';
+import * as analytics from '../../lib/analytics';
+
+export function extractAndApplyPluginAnalytics(pluginAnalytics: Analytics[]) {
+  for (const { name, data } of pluginAnalytics) {
+    analytics.add(name, data);
+  }
+}

--- a/src/lib/ecosystems/resolve-test-facts.ts
+++ b/src/lib/ecosystems/resolve-test-facts.ts
@@ -2,6 +2,7 @@ import { Options } from '../types';
 import * as spinner from '../../lib/spinner';
 import { Ecosystem, ScanResult, TestResult } from './types';
 import { pollingWithTokenUntilDone, requestPollingToken } from './polling';
+import { extractAndApplyPluginAnalytics } from './plugin-analytics';
 
 export async function resolveAndTestFacts(
   ecosystem: Ecosystem,
@@ -17,6 +18,9 @@ export async function resolveAndTestFacts(
     await spinner(`Resolving and Testing fileSignatures in ${path}`);
     for (const scanResult of scanResults) {
       try {
+        if (scanResult.analytics) {
+          extractAndApplyPluginAnalytics(scanResult.analytics);
+        }
         const res = await requestPollingToken(options, true, scanResult);
         const { maxAttempts, pollInterval } = res.pollingTask;
         const attemptsCount = 0;

--- a/src/lib/ecosystems/types.ts
+++ b/src/lib/ecosystems/types.ts
@@ -24,6 +24,12 @@ export interface ScanResult {
   name?: string;
   policy?: string;
   target?: GitTarget | ContainerTarget;
+  analytics?: Analytics[];
+}
+
+export interface Analytics {
+  name: string;
+  data: unknown;
 }
 
 export interface Identity {

--- a/test/jest/unit/lib/ecosystems/fixtures/scan-results.ts
+++ b/test/jest/unit/lib/ecosystems/fixtures/scan-results.ts
@@ -29,6 +29,15 @@ export const scanResults = {
           remoteUrl: 'https://github.com/some-org/some-unmanaged-project.git',
           branch: 'master',
         },
+        analytics: [
+          {
+            data: {
+              totalFileSignatures: 3,
+              totalSecondsElapsedToGenerateFileSignatures: 0,
+            },
+            name: 'fileSignaturesAnalyticsContext',
+          },
+        ],
       },
     ],
   };

--- a/test/jest/unit/lib/ecosystems/resolve-test-facts.spec.ts
+++ b/test/jest/unit/lib/ecosystems/resolve-test-facts.spec.ts
@@ -2,6 +2,7 @@ import { Options } from '../../../../../src/lib/types';
 import * as polling from '../../../../../src/lib/ecosystems/polling';
 import { depGraphData, scanResults } from './fixtures/';
 import { resolveAndTestFacts } from '../../../../../src/lib/ecosystems/resolve-test-facts';
+import * as pluginAnalytics from '../../../../../src/lib/ecosystems/plugin-analytics';
 
 describe('resolve and test facts', () => {
   afterEach(() => jest.restoreAllMocks());
@@ -68,12 +69,18 @@ describe('resolve and test facts', () => {
       },
     });
 
+    const extractAndApplyPluginAnalyticsSpy = jest.spyOn(
+      pluginAnalytics,
+      'extractAndApplyPluginAnalytics',
+    );
+
     const [testResults, errors] = await resolveAndTestFacts(
       'cpp',
       scanResults,
       {} as Options,
     );
 
+    expect(extractAndApplyPluginAnalyticsSpy).toHaveBeenCalledTimes(1);
     expect(testResults).toEqual([
       {
         issuesData: {},


### PR DESCRIPTION
We are introducing the capability to allow the cli of receive analytics
data from plugins. In this initial interaction it's being added only for
async tests for the new unmanaged product line (c/c++ support) during
the `test` phase. See snyk-cpp-plugin pr https://github.com/snyk/snyk-cpp-plugin/pull/35