### PR TITLE
feat: track async requests analytics

### DIFF
--- a/src/lib/ecosystems/plugin-analytics.ts
+++ b/src/lib/ecosystems/plugin-analytics.ts
@@ -1,7 +1,13 @@
 import { Analytics } from './types';
 import * as analytics from '../../lib/analytics';
 
-export function extractAndApplyPluginAnalytics(pluginAnalytics: Analytics[]) {
+export function extractAndApplyPluginAnalytics(
+  pluginAnalytics: Analytics[],
+  asyncRequestToken?: string,
+): void {
+  if (asyncRequestToken) {
+    analytics.add('asyncRequestToken', asyncRequestToken);
+  }
   for (const { name, data } of pluginAnalytics) {
     analytics.add(name, data);
   }

--- a/src/lib/ecosystems/resolve-test-facts.ts
+++ b/src/lib/ecosystems/resolve-test-facts.ts
@@ -18,10 +18,10 @@ export async function resolveAndTestFacts(
     await spinner(`Resolving and Testing fileSignatures in ${path}`);
     for (const scanResult of scanResults) {
       try {
-        if (scanResult.analytics) {
-          extractAndApplyPluginAnalytics(scanResult.analytics);
-        }
         const res = await requestPollingToken(options, true, scanResult);
+        if (scanResult.analytics) {
+          extractAndApplyPluginAnalytics(scanResult.analytics, res.token);
+        }
         const { maxAttempts, pollInterval } = res.pollingTask;
         const attemptsCount = 0;
         const response = await pollingWithTokenUntilDone(

--- a/test/jest/unit/lib/ecosystems/resolve-test-facts.spec.ts
+++ b/test/jest/unit/lib/ecosystems/resolve-test-facts.spec.ts
@@ -3,6 +3,7 @@ import * as polling from '../../../../../src/lib/ecosystems/polling';
 import { depGraphData, scanResults } from './fixtures/';
 import { resolveAndTestFacts } from '../../../../../src/lib/ecosystems/resolve-test-facts';
 import * as pluginAnalytics from '../../../../../src/lib/ecosystems/plugin-analytics';
+import * as analytics from '../../../../../src/lib/analytics';
 
 describe('resolve and test facts', () => {
   afterEach(() => jest.restoreAllMocks());
@@ -74,6 +75,7 @@ describe('resolve and test facts', () => {
       'extractAndApplyPluginAnalytics',
     );
 
+    const addAnalyticsSpy = jest.spyOn(analytics, 'add');
     const [testResults, errors] = await resolveAndTestFacts(
       'cpp',
       scanResults,
@@ -81,6 +83,15 @@ describe('resolve and test facts', () => {
     );
 
     expect(extractAndApplyPluginAnalyticsSpy).toHaveBeenCalledTimes(1);
+    expect(addAnalyticsSpy).toHaveBeenCalledWith('asyncRequestToken', token);
+    expect(addAnalyticsSpy).toHaveBeenLastCalledWith(
+      'fileSignaturesAnalyticsContext',
+      {
+        totalFileSignatures: 3,
+        totalSecondsElapsedToGenerateFileSignatures: 0,
+      },
+    );
+    expect(addAnalyticsSpy).toHaveBeenCalledTimes(2);
     expect(testResults).toEqual([
       {
         issuesData: {},


### PR DESCRIPTION
This allow us of track async requests analytics through an ephemeral token used in
the unmanaged c/c++ product line.

It's safe to use as it does not contain any sensitive data.