### PR TITLE
feat: replace source cmd with unmanaged

### DIFF
--- a/src/cli/modes.ts
+++ b/src/cli/modes.ts
@@ -7,10 +7,10 @@ interface ModeData {
 }
 
 const modes: Record<string, ModeData> = {
-  source: {
+  unmanaged: {
     allowedCommands: ['test', 'monitor'],
     config: (args): [] => {
-      args['source'] = true;
+      args['unmanaged'] = true;
       return args;
     },
   },

--- a/src/lib/ecosystems/index.ts
+++ b/src/lib/ecosystems/index.ts
@@ -14,7 +14,7 @@ export { getPlugin } from './plugins';
  * hence this is in a separate function from getEcosystem().
  */
 export function getEcosystemForTest(options: Options): Ecosystem | null {
-  if (options.source) {
+  if (options.unmanaged) {
     return 'cpp';
   }
   if (options.code) {
@@ -24,7 +24,7 @@ export function getEcosystemForTest(options: Options): Ecosystem | null {
 }
 
 export function getEcosystem(options: Options): Ecosystem | null {
-  if (options.source) {
+  if (options.unmanaged) {
     return 'cpp';
   }
 

--- a/src/lib/plugins/get-extra-project-count.ts
+++ b/src/lib/plugins/get-extra-project-count.ts
@@ -8,7 +8,7 @@ export async function getExtraProjectCount(
   options: Options,
   inspectResult: pluginApi.InspectResult,
 ): Promise<number | undefined> {
-  if (options.docker || options.source) {
+  if (options.docker || options.unmanaged) {
     return undefined;
   }
   if (

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -52,7 +52,7 @@ export interface Options {
   docker?: boolean;
   iac?: boolean;
   code?: boolean;
-  source?: boolean; // C/C++ Ecosystem Support
+  unmanaged?: boolean; // C/C++ Ecosystem Support
   file?: string;
   policy?: string;
   json?: boolean;

--- a/test/jest/system/ecosystems-monitor-cpp.spec.ts
+++ b/test/jest/system/ecosystems-monitor-cpp.spec.ts
@@ -59,7 +59,7 @@ describe('monitorEcosystem cpp', () => {
       monitorResults,
       monitorErrors,
       {
-        source: true,
+        unmanaged: true,
       } as Options,
     );
 

--- a/test/jest/system/lib/commands/fix/fix.spec.ts
+++ b/test/jest/system/lib/commands/fix/fix.spec.ts
@@ -66,10 +66,10 @@ describe('snyk fix (system tests)', () => {
   );
 
   it(
-    '`shows error when called with --source`',
+    '`shows error when called with --unmanaged`',
     (done) => {
       exec(
-        `node ${main} fix --source`,
+        `node ${main} fix --unmanaged`,
         {
           env,
         },

--- a/test/jest/unit/all-projects-from-plugins.spec.ts
+++ b/test/jest/unit/all-projects-from-plugins.spec.ts
@@ -35,33 +35,13 @@ describe('Detect extra projects available that could be tested using --all-proje
     expect(actualResult).toBe(expectedResult);
   });
 
-  it('should return `undefined` when `source` command for cpp is being used', async () => {
+  it('should return `undefined` when `unmanaged` command for cpp is being used', async () => {
     const root = '';
     const inspectResult = {
       plugin: { meta: { allSubProjectNames: ['gradle-woof', 'npm-webapp'] } },
     } as pluginApi.InspectResult;
 
-    const options = { source: true } as Options;
-    const actualResult = await getExtraProjectCount(
-      root,
-      options,
-      inspectResult,
-    );
-    const expectedResult = undefined;
-    expect(actualResult).toBe(expectedResult);
-  });
-
-  it('should return `undefined` when `docker` command is being used', async () => {
-    const root = '';
-    const inspectResult = {
-      plugin: {
-        meta: {
-          allSubProjectNames: ['gradle-goof', 'npm-node', ['yarn-yarn']],
-        },
-      },
-    } as pluginApi.InspectResult;
-
-    const options = { source: true } as Options;
+    const options = { unmanaged: true } as Options;
     const actualResult = await getExtraProjectCount(
       root,
       options,

--- a/test/jest/unit/ecosystems.spec.ts
+++ b/test/jest/unit/ecosystems.spec.ts
@@ -18,18 +18,18 @@ describe('ecosystems', () => {
   });
 
   describe('getEcosystem', () => {
-    it('should return cpp ecosystem when options source is true', () => {
+    it('should return cpp ecosystem when options unmanaged is true', () => {
       const options: Options = {
-        source: true,
+        unmanaged: true,
         path: '',
       };
       const actual = ecosystems.getEcosystem(options);
       const expected = 'cpp';
       expect(actual).toBe(expected);
     });
-    it('should return null when options source is false', () => {
+    it('should return null when options unmanaged is false', () => {
       const options: Options = {
-        source: false,
+        unmanaged: false,
         path: '',
       };
       const actual = ecosystems.getEcosystem(options);

--- a/test/jest/unit/modes.spec.ts
+++ b/test/jest/unit/modes.spec.ts
@@ -138,13 +138,13 @@ describe('when have a valid mode and command', () => {
     expect(cliArgs['experimental']).toBeTruthy();
   });
 
-  it('"source test" should set source option and test command', () => {
+  it('"unmanaged test" should set unmanaged option and test command', () => {
     const expectedCommand = 'test';
     const expectedArgs = {
       _: [],
-      source: true,
+      unmanaged: true,
     };
-    const cliCommand = 'source';
+    const cliCommand = 'unmanaged';
     const cliArgs = {
       _: ['test'],
     };
@@ -152,16 +152,16 @@ describe('when have a valid mode and command', () => {
     const command = parseMode(cliCommand, cliArgs);
     expect(command).toBe(expectedCommand);
     expect(cliArgs).toEqual(expectedArgs);
-    expect(cliArgs['source']).toBeTruthy();
+    expect(cliArgs['unmanaged']).toBeTruthy();
   });
 
-  it('"source monitor" should set source option and monitor command', () => {
+  it('"unmanaged monitor" should set unmanaged option and monitor command', () => {
     const expectedCommand = 'monitor';
     const expectedArgs = {
       _: [],
-      source: true,
+      unmanaged: true,
     };
-    const cliCommand = 'source';
+    const cliCommand = 'unmanaged';
     const cliArgs = {
       _: ['monitor'],
     };
@@ -169,7 +169,7 @@ describe('when have a valid mode and command', () => {
     const command = parseMode(cliCommand, cliArgs);
     expect(command).toBe(expectedCommand);
     expect(cliArgs).toEqual(expectedArgs);
-    expect(cliArgs['source']).toBeTruthy();
+    expect(cliArgs['unmanaged']).toBeTruthy();
   });
 });
 

--- a/test/validate-fix-command-is-supported.spec.ts
+++ b/test/validate-fix-command-is-supported.spec.ts
@@ -36,14 +36,14 @@ describe('setDefaultTestOptions', () => {
     );
   });
 
-  it('fix is NOT supported for --source + enabled FF', async () => {
+  it('fix is NOT supported for --unmanaged + enabled FF', async () => {
     jest
       .spyOn(featureFlags, 'isFeatureFlagSupportedForOrg')
       .mockResolvedValue({ ok: true });
     const options = {
       path: '/',
       showVulnPaths: 'all' as ShowVulnPaths,
-      source: true,
+      unmanaged: true,
     };
     await expect(validateFixCommandIsSupported(options)).rejects.toThrowError(
       new FeatureNotSupportedByEcosystemError('snyk fix', 'cpp'),


### PR DESCRIPTION
BREAKING CHANGE: replacing `snyk source test` and `snyk source monitor`
commands with `snyk unmanaged test` and `snyk unmanaged monitor`
