### PR TITLE
feat: sequential fix

### DIFF
--- a/packages/snyk-fix/src/plugins/python/handlers/fail-if-no-updates-applied.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/fail-if-no-updates-applied.ts
@@ -6,7 +6,7 @@ import { isSuccessfulChange } from './attempted-changes-summary';
 
 const debug = debugLib('snyk-fix:python:ensure-changes-applied');
 
-export function ensureHasUpdates(changes: FixChangesSummary[]) {
+export function failIfNoUpdatesApplied(changes: FixChangesSummary[]) {
   if (!changes.length) {
     throw new NoFixesCouldBeAppliedError();
   }

--- a/packages/snyk-fix/src/plugins/python/handlers/pipenv-pipfile/update-dependencies/generate-upgrades.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pipenv-pipfile/update-dependencies/generate-upgrades.ts
@@ -1,0 +1,17 @@
+import { EntityToFix } from '../../../../../types';
+import { standardizePackageName } from '../../../standardize-package-name';
+import { validateRequiredData } from '../../validate-required-data';
+
+export function generateUpgrades(entity: EntityToFix): { upgrades: string[] } {
+  const { remediation } = validateRequiredData(entity);
+  const { pin: pins } = remediation;
+
+  const upgrades: string[] = [];
+  for (const pkgAtVersion of Object.keys(pins)) {
+    const pin = pins[pkgAtVersion];
+    const newVersion = pin.upgradeTo.split('@')[1];
+    const [pkgName] = pkgAtVersion.split('@');
+    upgrades.push(`${standardizePackageName(pkgName)}==${newVersion}`);
+  }
+  return { upgrades };
+}

--- a/packages/snyk-fix/src/plugins/python/handlers/pipenv-pipfile/update-dependencies/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pipenv-pipfile/update-dependencies/index.ts
@@ -7,7 +7,7 @@ import {
   FixOptions,
 } from '../../../../../types';
 
-import { ensureHasUpdates } from '../../ensure-has-updates';
+import { failIfNoUpdatesApplied } from '../../fail-if-no-updates-applied';
 import { NoFixesCouldBeAppliedError } from '../../../../../lib/errors/no-fixes-applied';
 import { generateUpgrades } from './generate-upgrades';
 import { pipenvAdd } from './pipenv-add';
@@ -53,7 +53,7 @@ async function fixAll(
       changes.push(...(await pipenvAdd(entity, options, upgrades)));
     }
 
-    ensureHasUpdates(changes);
+    failIfNoUpdatesApplied(changes);
     handlerResult.succeeded.push({
       original: entity,
       changes,
@@ -85,6 +85,8 @@ async function fixSequentially(
   // 1. parse the manifest and extract original requirements, version spec etc
   // 2. swap out only the version and retain original spec
   // 3. re-lock the lockfile
+  // at the moment we do not parse Pipfile and therefore can't tell the difference
+  // between prod & dev updates
   const changes: FixChangesSummary[] = [];
 
   try {
@@ -100,7 +102,7 @@ async function fixSequentially(
       }
     }
 
-    ensureHasUpdates(changes);
+    failIfNoUpdatesApplied(changes);
 
     handlerResult.succeeded.push({
       original: entity,

--- a/packages/snyk-fix/src/plugins/python/handlers/pipenv-pipfile/update-dependencies/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pipenv-pipfile/update-dependencies/index.ts
@@ -6,19 +6,23 @@ import {
   FixChangesSummary,
   FixOptions,
 } from '../../../../../types';
-import { NoFixesCouldBeAppliedError } from '../../../../../lib/errors/no-fixes-applied';
 
 import { ensureHasUpdates } from '../../ensure-has-updates';
-import { pipenvAdd } from './pipenv-add';
+import { NoFixesCouldBeAppliedError } from '../../../../../lib/errors/no-fixes-applied';
 import { generateUpgrades } from './generate-upgrades';
+import { pipenvAdd } from './pipenv-add';
 
 const debug = debugLib('snyk-fix:python:Pipfile');
+
+function chooseFixStrategy(options: FixOptions) {
+  return options.sequentialFix ? fixSequentially : fixAll;
+}
 
 export async function updateDependencies(
   entity: EntityToFix,
   options: FixOptions,
 ): Promise<PluginFixResponse> {
-  const handlerResult = await fixAll(entity, options);
+  const handlerResult = await chooseFixStrategy(options)(entity, options);
   return handlerResult;
 }
 
@@ -62,6 +66,54 @@ async function fixAll(
       original: entity,
       error,
       tip: error.tip,
+    });
+  }
+  return handlerResult;
+}
+
+async function fixSequentially(
+  entity: EntityToFix,
+  options: FixOptions,
+): Promise<PluginFixResponse> {
+  const handlerResult: PluginFixResponse = {
+    succeeded: [],
+    failed: [],
+    skipped: [],
+  };
+  const { upgrades } = await generateUpgrades(entity);
+  // TODO: for better support we need to:
+  // 1. parse the manifest and extract original requirements, version spec etc
+  // 2. swap out only the version and retain original spec
+  // 3. re-lock the lockfile
+  const changes: FixChangesSummary[] = [];
+
+  try {
+    if (!upgrades.length) {
+      throw new NoFixesCouldBeAppliedError(
+        'Failed to calculate package updates to apply',
+      );
+    }
+    // update prod dependencies first
+    if (upgrades.length) {
+      for (const upgrade of upgrades) {
+        changes.push(...(await pipenvAdd(entity, options, [upgrade])));
+      }
+    }
+
+    ensureHasUpdates(changes);
+
+    handlerResult.succeeded.push({
+      original: entity,
+      changes,
+    });
+  } catch (error) {
+    debug(
+      `Failed to fix ${entity.scanResult.identity.targetFile}.\nERROR: ${error}`,
+    );
+    handlerResult.failed.push({
+      original: entity,
+      tip: error.tip,
+      error,
     });
   }
   return handlerResult;

--- a/packages/snyk-fix/src/plugins/python/handlers/pipenv-pipfile/update-dependencies/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pipenv-pipfile/update-dependencies/index.ts
@@ -7,11 +7,10 @@ import {
   FixOptions,
 } from '../../../../../types';
 import { NoFixesCouldBeAppliedError } from '../../../../../lib/errors/no-fixes-applied';
-import { standardizePackageName } from '../../../standardize-package-name';
-import { validateRequiredData } from '../../validate-required-data';
 
 import { ensureHasUpdates } from '../../ensure-has-updates';
 import { pipenvAdd } from './pipenv-add';
+import { generateUpgrades } from './generate-upgrades';
 
 const debug = debugLib('snyk-fix:python:Pipfile');
 
@@ -21,20 +20,6 @@ export async function updateDependencies(
 ): Promise<PluginFixResponse> {
   const handlerResult = await fixAll(entity, options);
   return handlerResult;
-}
-
-export function generateUpgrades(entity: EntityToFix): { upgrades: string[] } {
-  const { remediation } = validateRequiredData(entity);
-  const { pin: pins } = remediation;
-
-  const upgrades: string[] = [];
-  for (const pkgAtVersion of Object.keys(pins)) {
-    const pin = pins[pkgAtVersion];
-    const newVersion = pin.upgradeTo.split('@')[1];
-    const [pkgName] = pkgAtVersion.split('@');
-    upgrades.push(`${standardizePackageName(pkgName)}==${newVersion}`);
-  }
-  return { upgrades };
 }
 
 async function fixAll(

--- a/packages/snyk-fix/src/plugins/python/handlers/pipenv-pipfile/update-dependencies/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pipenv-pipfile/update-dependencies/index.ts
@@ -31,14 +31,14 @@ async function fixAll(
     failed: [],
     skipped: [],
   };
-  const { upgrades } = await generateUpgrades(entity);
-  if (!upgrades.length) {
-    throw new NoFixesCouldBeAppliedError(
-      'Failed to calculate package updates to apply',
-    );
-  }
   const changes: FixChangesSummary[] = [];
   try {
+    const { upgrades } = await generateUpgrades(entity);
+    if (!upgrades.length) {
+      throw new NoFixesCouldBeAppliedError(
+        'Failed to calculate package updates to apply',
+      );
+    }
     // TODO: for better support we need to:
     // 1. parse the manifest and extract original requirements, version spec etc
     // 2. swap out only the version and retain original spec

--- a/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/generate-upgrades.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/generate-upgrades.ts
@@ -1,0 +1,70 @@
+import * as pathLib from 'path';
+import * as toml from 'toml';
+
+import * as debugLib from 'debug';
+
+import { EntityToFix } from '../../../../../types';
+
+import { validateRequiredData } from '../../validate-required-data';
+import { standardizePackageName } from '../../../standardize-package-name';
+
+const debug = debugLib('snyk-fix:python:Poetry');
+
+interface PyProjectToml {
+  tool: {
+    poetry: {
+      name: string;
+      version: string;
+      description: string;
+      authors: string[];
+      dependencies?: object;
+      'dev-dependencies'?: object;
+    };
+  };
+}
+
+export async function generateUpgrades(
+  entity: EntityToFix,
+): Promise<{ upgrades: string[]; devUpgrades: string[] }> {
+  const { remediation, targetFile } = validateRequiredData(entity);
+  const pins = remediation.pin;
+
+  const targetFilePath = pathLib.resolve(entity.workspace.path, targetFile);
+  const { dir } = pathLib.parse(targetFilePath);
+  const pyProjectTomlRaw = await entity.workspace.readFile(
+    pathLib.resolve(dir, 'pyproject.toml'),
+  );
+  const pyProjectToml: PyProjectToml = toml.parse(pyProjectTomlRaw);
+
+  const prodTopLevelDeps = Object.keys(
+    pyProjectToml.tool.poetry.dependencies ?? {},
+  ).map((dep) => standardizePackageName(dep));
+  const devTopLevelDeps = Object.keys(
+    pyProjectToml.tool.poetry['dev-dependencies'] ?? {},
+  ).map((dep) => standardizePackageName(dep));
+
+  const upgrades: string[] = [];
+  const devUpgrades: string[] = [];
+  for (const pkgAtVersion of Object.keys(pins)) {
+    const pin = pins[pkgAtVersion];
+    const newVersion = pin.upgradeTo.split('@')[1];
+    const [pkgName] = pkgAtVersion.split('@');
+
+    const upgrade = `${standardizePackageName(pkgName)}==${newVersion}`;
+
+    if (pin.isTransitive || prodTopLevelDeps.includes(pkgName)) {
+      // transitive and it could have come from a dev or prod dep
+      // since we can't tell right now let be pinned into production deps
+      upgrades.push(upgrade);
+    } else if (prodTopLevelDeps.includes(pkgName)) {
+      upgrades.push(upgrade);
+    } else if (entity.options.dev && devTopLevelDeps.includes(pkgName)) {
+      devUpgrades.push(upgrade);
+    } else {
+      debug(
+        `Could not determine what type of upgrade ${upgrade} is. When choosing between: transitive upgrade, production or dev direct upgrade. `,
+      );
+    }
+  }
+  return { upgrades, devUpgrades };
+}

--- a/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/index.ts
@@ -1,39 +1,19 @@
-import * as pathLib from 'path';
-import * as toml from 'toml';
-
 import * as debugLib from 'debug';
-import * as poetryFix from '@snyk/fix-poetry';
 
 import { PluginFixResponse } from '../../../../types';
 import {
   EntityToFix,
+  FixChangesError,
   FixChangesSummary,
   FixOptions,
 } from '../../../../../types';
 import { NoFixesCouldBeAppliedError } from '../../../../../lib/errors/no-fixes-applied';
-import { CommandFailedError } from '../../../../../lib/errors/command-failed-to-run-error';
-import { validateRequiredData } from '../../validate-required-data';
-import { standardizePackageName } from '../../../standardize-package-name';
-import {
-  generateFailedChanges,
-  generateSuccessfulChanges,
-} from '../../attempted-changes-summary';
+import { isSuccessfulChange } from '../../attempted-changes-summary';
+import { generateUpgrades } from './generate-upgrades';
+import { poetryAdd } from './poetry-add';
 import { ensureHasUpdates } from '../../ensure-has-updates';
 
 const debug = debugLib('snyk-fix:python:Poetry');
-
-interface PyProjectToml {
-  tool: {
-    poetry: {
-      name: string;
-      version: string;
-      description: string;
-      authors: string[];
-      dependencies?: object;
-      'dev-dependencies'?: object;
-    };
-  };
-}
 
 function chooseFixStrategy(options: FixOptions) {
   return options.sequentialFix ? fixSequentially : fixAll;
@@ -45,81 +25,6 @@ export async function updateDependencies(
 ): Promise<PluginFixResponse> {
   const handlerResult = await chooseFixStrategy(options)(entity, options);
   return handlerResult;
-}
-
-export async function generateUpgrades(
-  entity: EntityToFix,
-): Promise<{ upgrades: string[]; devUpgrades: string[] }> {
-  const { remediation, targetFile } = validateRequiredData(entity);
-  const pins = remediation.pin;
-
-  const targetFilePath = pathLib.resolve(entity.workspace.path, targetFile);
-  const { dir } = pathLib.parse(targetFilePath);
-  const pyProjectTomlRaw = await entity.workspace.readFile(
-    pathLib.resolve(dir, 'pyproject.toml'),
-  );
-  const pyProjectToml: PyProjectToml = toml.parse(pyProjectTomlRaw);
-
-  const prodTopLevelDeps = Object.keys(
-    pyProjectToml.tool.poetry.dependencies ?? {},
-  ).map((dep) => standardizePackageName(dep));
-  const devTopLevelDeps = Object.keys(
-    pyProjectToml.tool.poetry['dev-dependencies'] ?? {},
-  ).map((dep) => standardizePackageName(dep));
-
-  const upgrades: string[] = [];
-  const devUpgrades: string[] = [];
-  for (const pkgAtVersion of Object.keys(pins)) {
-    const pin = pins[pkgAtVersion];
-    const newVersion = pin.upgradeTo.split('@')[1];
-    const [pkgName] = pkgAtVersion.split('@');
-
-    const upgrade = `${standardizePackageName(pkgName)}==${newVersion}`;
-
-    if (pin.isTransitive || prodTopLevelDeps.includes(pkgName)) {
-      // transitive and it could have come from a dev or prod dep
-      // since we can't tell right now let be pinned into production deps
-      upgrades.push(upgrade);
-    } else if (prodTopLevelDeps.includes(pkgName)) {
-      upgrades.push(upgrade);
-    } else if (entity.options.dev && devTopLevelDeps.includes(pkgName)) {
-      devUpgrades.push(upgrade);
-    } else {
-      debug(
-        `Could not determine what type of upgrade ${upgrade} is. When choosing between: transitive upgrade, production or dev direct upgrade. `,
-      );
-    }
-  }
-  return { upgrades, devUpgrades };
-}
-
-function throwPoetryError(stderr: string, command?: string) {
-  const ALREADY_UP_TO_DATE = 'No dependencies to install or update';
-  const INCOMPATIBLE_PYTHON = new RegExp(
-    /Python requirement (.*) is not compatible/g,
-    'gm',
-  );
-  const SOLVER_PROBLEM = /SolverProblemError(.* version solving failed)/gms;
-
-  const incompatiblePythonError = INCOMPATIBLE_PYTHON.exec(stderr);
-  if (incompatiblePythonError) {
-    throw new CommandFailedError(
-      `The current project's Python requirement ${incompatiblePythonError[1]} is not compatible with some of the required packages`,
-      command,
-    );
-  }
-  const solverProblemError = SOLVER_PROBLEM.exec(stderr);
-  if (solverProblemError) {
-    throw new CommandFailedError(solverProblemError[0].trim(), command);
-  }
-
-  if (stderr.includes(ALREADY_UP_TO_DATE)) {
-    throw new CommandFailedError(
-      'No dependencies could be updated as they seem to be at the correct versions. Make sure installed dependencies in the environment match those in the lockfile by running `poetry update`',
-      command,
-    );
-  }
-  throw new NoFixesCouldBeAppliedError();
 }
 
 async function fixAll(
@@ -231,35 +136,4 @@ async function fixSequentially(
     });
   }
   return handlerResult;
-}
-
-async function poetryAdd(
-  entity: EntityToFix,
-  options: FixOptions,
-  upgrades: string[],
-  dev?: boolean,
-): Promise<FixChangesSummary[]> {
-  const changes: FixChangesSummary[] = [];
-  let poetryCommand;
-  const { remediation, targetFile } = validateRequiredData(entity);
-  try {
-    const targetFilePath = pathLib.resolve(entity.workspace.path, targetFile);
-    const { dir } = pathLib.parse(targetFilePath);
-    if (!options.dryRun && upgrades.length) {
-      const res = await poetryFix.poetryAdd(dir, upgrades, {
-        dev,
-        python: entity.options.command ?? undefined,
-      });
-      if (res.exitCode !== 0) {
-        poetryCommand = res.command;
-        throwPoetryError(res.stderr ? res.stderr : res.stdout, res.command);
-      }
-    }
-    changes.push(...generateSuccessfulChanges(upgrades, remediation.pin));
-  } catch (error) {
-    changes.push(
-      ...generateFailedChanges(upgrades, remediation.pin, error, poetryCommand),
-    );
-  }
-  return changes;
 }

--- a/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/index.ts
@@ -8,8 +8,8 @@ import {
 } from '../../../../../types';
 import { generateUpgrades } from './generate-upgrades';
 import { poetryAdd } from './poetry-add';
-import { ensureHasUpdates } from '../../ensure-has-updates';
 import { NoFixesCouldBeAppliedError } from '../../../../../lib/errors/no-fixes-applied';
+import { failIfNoUpdatesApplied } from '../../fail-if-no-updates-applied';
 
 const debug = debugLib('snyk-fix:python:Poetry');
 
@@ -60,7 +60,7 @@ async function fixAll(
       );
     }
 
-    ensureHasUpdates(changes);
+    failIfNoUpdatesApplied(changes);
     handlerResult.succeeded.push({
       original: entity,
       changes,
@@ -115,7 +115,7 @@ async function fixSequentially(
         );
       }
     }
-    ensureHasUpdates(changes);
+    failIfNoUpdatesApplied(changes);
     handlerResult.succeeded.push({
       original: entity,
       changes,

--- a/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/index.ts
@@ -38,17 +38,17 @@ async function fixAll(
   };
   const { upgrades, devUpgrades } = await generateUpgrades(entity);
 
-  if (![...upgrades, ...devUpgrades].length) {
-    throw new NoFixesCouldBeAppliedError(
-      'Failed to calculate package updates to apply',
-    );
-  }
   // TODO: for better support we need to:
   // 1. parse the manifest and extract original requirements, version spec etc
   // 2. swap out only the version and retain original spec
   // 3. re-lock the lockfile
   const changes: FixChangesSummary[] = [];
   try {
+    if (![...upgrades, ...devUpgrades].length) {
+      throw new NoFixesCouldBeAppliedError(
+        'Failed to calculate package updates to apply',
+      );
+    }
     // update prod dependencies first
     if (upgrades.length) {
       changes.push(...(await poetryAdd(entity, options, upgrades)));
@@ -114,13 +114,7 @@ async function fixSequentially(
       }
     }
 
-    if (!changes.length || !changes.some((c) => isSuccessfulChange(c))) {
-      debug('Manifest has not changed as no changes got applied!');
-      // throw the first error tip since 100% failed, they all failed with the same
-      // error
-      const { reason, tip } = changes[0] as FixChangesError;
-      throw new NoFixesCouldBeAppliedError(reason, tip);
-    }
+    ensureHasUpdates(changes);
     handlerResult.succeeded.push({
       original: entity,
       changes,

--- a/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/index.ts
@@ -6,10 +6,10 @@ import {
   FixChangesSummary,
   FixOptions,
 } from '../../../../../types';
-import { NoFixesCouldBeAppliedError } from '../../../../../lib/errors/no-fixes-applied';
 import { generateUpgrades } from './generate-upgrades';
 import { poetryAdd } from './poetry-add';
 import { ensureHasUpdates } from '../../ensure-has-updates';
+import { NoFixesCouldBeAppliedError } from '../../../../../lib/errors/no-fixes-applied';
 
 const debug = debugLib('snyk-fix:python:Poetry');
 

--- a/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/poetry-add.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/poetry-add.ts
@@ -1,0 +1,76 @@
+import * as pathLib from 'path';
+
+import * as poetryFix from '@snyk/fix-poetry';
+
+import {
+  EntityToFix,
+  FixChangesSummary,
+  FixOptions,
+} from '../../../../../types';
+import { validateRequiredData } from '../../validate-required-data';
+import {
+  generateFailedChanges,
+  generateSuccessfulChanges,
+} from '../../attempted-changes-summary';
+import { CommandFailedError } from '../../../../../lib/errors/command-failed-to-run-error';
+import { NoFixesCouldBeAppliedError } from '../../../../../lib/errors/no-fixes-applied';
+
+export async function poetryAdd(
+  entity: EntityToFix,
+  options: FixOptions,
+  upgrades: string[],
+  dev?: boolean,
+): Promise<FixChangesSummary[]> {
+  const changes: FixChangesSummary[] = [];
+  let poetryCommand;
+  const { remediation, targetFile } = validateRequiredData(entity);
+  try {
+    const targetFilePath = pathLib.resolve(entity.workspace.path, targetFile);
+    const { dir } = pathLib.parse(targetFilePath);
+    if (!options.dryRun && upgrades.length) {
+      const res = await poetryFix.poetryAdd(dir, upgrades, {
+        dev,
+        python: entity.options.command ?? undefined,
+      });
+      if (res.exitCode !== 0) {
+        poetryCommand = res.command;
+        throwPoetryError(res.stderr ? res.stderr : res.stdout, res.command);
+      }
+    }
+    changes.push(...generateSuccessfulChanges(upgrades, remediation.pin));
+  } catch (error) {
+    changes.push(
+      ...generateFailedChanges(upgrades, remediation.pin, error, poetryCommand),
+    );
+  }
+  return changes;
+}
+
+function throwPoetryError(stderr: string, command?: string) {
+  const ALREADY_UP_TO_DATE = 'No dependencies to install or update';
+  const INCOMPATIBLE_PYTHON = new RegExp(
+    /Python requirement (.*) is not compatible/g,
+    'gm',
+  );
+  const SOLVER_PROBLEM = /SolverProblemError(.* version solving failed)/gms;
+
+  const incompatiblePythonError = INCOMPATIBLE_PYTHON.exec(stderr);
+  if (incompatiblePythonError) {
+    throw new CommandFailedError(
+      `The current project's Python requirement ${incompatiblePythonError[1]} is not compatible with some of the required packages`,
+      command,
+    );
+  }
+  const solverProblemError = SOLVER_PROBLEM.exec(stderr);
+  if (solverProblemError) {
+    throw new CommandFailedError(solverProblemError[0].trim(), command);
+  }
+
+  if (stderr.includes(ALREADY_UP_TO_DATE)) {
+    throw new CommandFailedError(
+      'No dependencies could be updated as they seem to be at the correct versions. Make sure installed dependencies in the environment match those in the lockfile by running `poetry update`',
+      command,
+    );
+  }
+  throw new NoFixesCouldBeAppliedError();
+}

--- a/packages/snyk-fix/src/types.ts
+++ b/packages/snyk-fix/src/types.ts
@@ -239,6 +239,7 @@ export interface FixOptions {
   dryRun?: boolean;
   quiet?: boolean;
   stripAnsi?: boolean;
+  sequentialFix?: boolean;
 }
 
 export interface FixedMeta {

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/pipenv-pipfile/update-dependencies.spec.ts
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/pipenv-pipfile/update-dependencies.spec.ts
@@ -176,13 +176,13 @@ describe('fix Pipfile Python projects', () => {
     );
     expect(result.fixSummary).toContain('✖ No successful fixes');
     expect(pipenvPipfileFixStub).toHaveBeenCalledTimes(1);
-    expect(pipenvPipfileFixStub.mock.calls[0]).toEqual([
+    expect(pipenvPipfileFixStub).toHaveBeenCalledWith(
       pathLib.resolve(workspacesPath, 'with-dev-deps'),
       ['django==2.0.1', 'transitive==1.1.1'],
       {
         python: 'python3',
       },
-    ]);
+    );
   });
 
   it('applies expected changes to Pipfile when install fails', async () => {
@@ -259,13 +259,13 @@ describe('fix Pipfile Python projects', () => {
     );
     expect(result.fixSummary).toContain('✖ No successful fixes');
     expect(pipenvPipfileFixStub).toHaveBeenCalledTimes(1);
-    expect(pipenvPipfileFixStub.mock.calls[0]).toEqual([
+    expect(pipenvPipfileFixStub).toHaveBeenCalledWith(
       pathLib.resolve(workspacesPath, 'with-dev-deps'),
       ['django==2.0.1', 'transitive==1.1.1'],
       {
         python: 'python3',
       },
-    ]);
+    );
   });
 
   it('applies expected changes to Pipfile (100% success)', async () => {
@@ -333,13 +333,13 @@ describe('fix Pipfile Python projects', () => {
     expect(result.fixSummary).toContain('1 items were successfully fixed');
     expect(result.fixSummary).toContain('1 issues were successfully fixed');
     expect(pipenvPipfileFixStub).toHaveBeenCalledTimes(1);
-    expect(pipenvPipfileFixStub.mock.calls[0]).toEqual([
+    expect(pipenvPipfileFixStub).toHaveBeenCalledWith(
       pathLib.resolve(workspacesPath, 'with-django-upgrade'),
       ['django==2.0.1'],
       {
         python: 'python3',
       },
-    ]);
+    );
   });
 
   it('passes down custom --python if the project was tested with this (--command) from CLI', async () => {
@@ -377,13 +377,457 @@ describe('fix Pipfile Python projects', () => {
 
     // Assert
     expect(pipenvPipfileFixStub).toHaveBeenCalledTimes(1);
-    expect(pipenvPipfileFixStub.mock.calls[0]).toEqual([
+    expect(pipenvPipfileFixStub).toHaveBeenCalledWith(
       pathLib.resolve(workspacesPath, 'with-django-upgrade'),
       ['django==2.0.1'],
       {
         python: 'python2',
       },
-    ]);
+    );
+
+    expect(result).toMatchObject({
+      exceptions: {},
+      results: {
+        python: {
+          failed: [],
+          skipped: [],
+          succeeded: [
+            {
+              original: entityToFix,
+              changes: [
+                {
+                  success: true,
+                  userMessage: 'Upgraded django from 1.6.1 to 2.0.1',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    expect(result.fixSummary).toContain(
+      '✔ Upgraded django from 1.6.1 to 2.0.1',
+    );
+    expect(result.fixSummary).toContain('1 items were successfully fixed');
+    expect(result.fixSummary).toContain('1 issues were successfully fixed');
+  });
+});
+
+describe('fix Pipfile Python projects (fix sequentially)', () => {
+  let pipenvPipfileFixStub: jest.SpyInstance;
+  beforeAll(() => {
+    jest.spyOn(pipenvPipfileFix, 'isPipenvSupportedVersion').mockReturnValue({
+      supported: true,
+      versions: ['123.123.123'],
+    });
+    jest.spyOn(pipenvPipfileFix, 'isPipenvInstalled').mockResolvedValue({
+      version: '123.123.123',
+    });
+  });
+
+  beforeEach(() => {
+    pipenvPipfileFixStub = jest.spyOn(pipenvPipfileFix, 'pipenvInstall');
+  });
+
+  afterEach(() => {
+    pipenvPipfileFixStub.mockClear();
+  });
+
+  const workspacesPath = pathLib.resolve(__dirname, 'workspaces');
+
+  it('shows expected changes with lockfile in --dry-run mode', async () => {
+    jest.spyOn(pipenvPipfileFix, 'pipenvInstall').mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      command: 'pipenv install',
+      duration: 123,
+    });
+    // Arrange
+    const targetFile = 'with-dev-deps/Pipfile';
+
+    const testResult = {
+      ...generateTestResult(),
+      remediation: {
+        unresolved: [],
+        upgrade: {},
+        patch: {},
+        ignore: {},
+        pin: {
+          'django@1.6.1': {
+            upgradeTo: 'django@2.0.1',
+            vulns: [],
+            isTransitive: false,
+          },
+          'transitive@1.0.0': {
+            upgradeTo: 'transitive@1.1.1',
+            vulns: [],
+            isTransitive: true,
+          },
+        },
+      },
+    };
+
+    const entityToFix = generateEntityToFixWithFileReadWrite(
+      workspacesPath,
+      targetFile,
+      testResult,
+    );
+
+    // Act
+    const result = await snykFix.fix([entityToFix], {
+      quiet: true,
+      stripAnsi: true,
+      dryRun: true,
+      sequentialFix: true,
+    });
+    // Assert
+    expect(result).toMatchObject({
+      exceptions: {},
+      results: {
+        python: {
+          failed: [],
+          skipped: [],
+          succeeded: [
+            {
+              original: entityToFix,
+              changes: [
+                {
+                  success: true,
+                  userMessage: 'Upgraded django from 1.6.1 to 2.0.1',
+                },
+                {
+                  success: true,
+                  userMessage: 'Pinned transitive from 1.0.0 to 1.1.1',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    expect(pipenvPipfileFixStub).toHaveBeenCalledTimes(0);
+  });
+
+  // FYI: on later pipenv versions the Pipfile changes are also not present of locking failed
+  it('applies expected changes to Pipfile when locking fails', async () => {
+    jest.spyOn(pipenvPipfileFix, 'pipenvInstall').mockResolvedValueOnce({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'Locking failed',
+      command: 'pipenv install django==2.0.1',
+      duration: 123,
+    });
+
+    jest.spyOn(pipenvPipfileFix, 'pipenvInstall').mockResolvedValueOnce({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      command: 'poetry install transitive==1.1.1',
+      duration: 123,
+    });
+    // Arrange
+    const targetFile = 'with-dev-deps/Pipfile';
+    const testResult = {
+      ...generateTestResult(),
+      remediation: {
+        unresolved: [],
+        upgrade: {},
+        patch: {},
+        ignore: {},
+        pin: {
+          'django@1.6.1': {
+            upgradeTo: 'django@2.0.1',
+            vulns: ['vuln-id'],
+            isTransitive: false,
+          },
+          'transitive@1.0.0': {
+            upgradeTo: 'transitive@1.1.1',
+            vulns: [],
+            isTransitive: true,
+          },
+        },
+      },
+    };
+
+    const entityToFix = generateEntityToFixWithFileReadWrite(
+      workspacesPath,
+      targetFile,
+      testResult,
+    );
+
+    // Act
+    const result = await snykFix.fix([entityToFix], {
+      quiet: true,
+      stripAnsi: true,
+      sequentialFix: true,
+    });
+    // Assert
+    expect(result).toMatchObject({
+      exceptions: {},
+      results: {
+        python: {
+          failed: [],
+          skipped: [],
+          succeeded: [
+            {
+              original: entityToFix,
+              changes: [
+                {
+                  from: 'django@1.6.1',
+                  issueIds: ['vuln-id'],
+                  reason: 'Locking failed',
+                  success: false,
+                  tip: 'Try running `pipenv install django==2.0.1`',
+                  to: 'django@2.0.1',
+                  userMessage: 'Failed to upgrade django from 1.6.1 to 2.0.1',
+                },
+                {
+                  from: 'transitive@1.0.0',
+                  issueIds: [],
+                  success: true,
+                  to: 'transitive@1.1.1',
+                  userMessage: 'Pinned transitive from 1.0.0 to 1.1.1',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    expect(result.fixSummary).toContain('Locking failed');
+    expect(result.fixSummary).toContain(
+      'Tip:     Try running `pipenv install django==2.0.1`',
+    );
+    expect(result.fixSummary).toContain(
+      '✔ Pinned transitive from 1.0.0 to 1.1.1',
+    );
+    expect(pipenvPipfileFixStub).toHaveBeenCalledTimes(2);
+    expect(pipenvPipfileFixStub).toHaveBeenCalledWith(
+      pathLib.resolve(workspacesPath, 'with-dev-deps'),
+      ['django==2.0.1'],
+      {
+        python: 'python3',
+      },
+    );
+    expect(pipenvPipfileFixStub).toHaveBeenCalledWith(
+      pathLib.resolve(workspacesPath, 'with-dev-deps'),
+      ['transitive==1.1.1'],
+      {
+        python: 'python3',
+      },
+    );
+  });
+
+  it('applies expected changes to Pipfile when install fails', async () => {
+    jest.spyOn(pipenvPipfileFix, 'pipenvInstall').mockResolvedValue({
+      exitCode: 1,
+      stdout: '',
+      stderr: `Updating dependenciesResolving dependencies... (1.1s)
+
+      SolverProblemError
+
+      Because django (2.6) depends on numpy (>=1.19)and tensorflow (2.2.1) depends on numpy (>=1.16.0,<1.19.0), django (2.6) is incompatible with tensorflow (2.2.1).So, because pillow depends on both tensorflow (2.2.1) and django (2.6), version solving failed.`,
+      command: 'pipenv install django==2.0.1 transitive==1.1.1',
+      duration: 123,
+    });
+
+    // Arrange
+    const targetFile = 'with-dev-deps/Pipfile';
+    const testResult = {
+      ...generateTestResult(),
+      remediation: {
+        unresolved: [],
+        upgrade: {},
+        patch: {},
+        ignore: {},
+        pin: {
+          'django@1.6.1': {
+            upgradeTo: 'django@2.0.1',
+            vulns: ['vuln-id'],
+            isTransitive: false,
+          },
+          'transitive@1.0.0': {
+            upgradeTo: 'transitive@1.1.1',
+            vulns: [],
+            isTransitive: true,
+          },
+        },
+      },
+    };
+
+    const entityToFix = generateEntityToFixWithFileReadWrite(
+      workspacesPath,
+      targetFile,
+      testResult,
+    );
+
+    // Act
+    const result = await snykFix.fix([entityToFix], {
+      quiet: true,
+      stripAnsi: true,
+      sequentialFix: true,
+    });
+    // Assert
+    expect(result).toMatchObject({
+      exceptions: {},
+      results: {
+        python: {
+          failed: [
+            {
+              original: entityToFix,
+              error: expect.objectContaining({
+                name: 'NoFixesCouldBeAppliedError',
+              }),
+              tip:
+                'Try running `pipenv install django==2.0.1 transitive==1.1.1`',
+            },
+          ],
+          skipped: [],
+          succeeded: [],
+        },
+      },
+    });
+    expect(result.fixSummary).toContain('version solving failed');
+    expect(result.fixSummary).toContain(
+      'Tip:     Try running `pipenv install django==2.0.1 transitive==1.1.1`',
+    );
+    expect(result.fixSummary).toContain('✖ No successful fixes');
+    expect(pipenvPipfileFixStub).toHaveBeenCalledTimes(2);
+    expect(pipenvPipfileFixStub).toHaveBeenCalledWith(
+      pathLib.resolve(workspacesPath, 'with-dev-deps'),
+      ['django==2.0.1'],
+      {
+        python: 'python3',
+      },
+    );
+    expect(pipenvPipfileFixStub).toHaveBeenCalledWith(
+      pathLib.resolve(workspacesPath, 'with-dev-deps'),
+      ['transitive==1.1.1'],
+      {
+        python: 'python3',
+      },
+    );
+  });
+
+  it('applies expected changes to Pipfile (100% success)', async () => {
+    jest.spyOn(pipenvPipfileFix, 'pipenvInstall').mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      command: 'pipenv install django==2.0.1',
+      duration: 123,
+    });
+    // Arrange
+    const targetFile = 'with-django-upgrade/Pipfile';
+    const testResult = {
+      ...generateTestResult(),
+      remediation: {
+        unresolved: [],
+        upgrade: {},
+        patch: {},
+        ignore: {},
+        pin: {
+          'django@1.6.1': {
+            upgradeTo: 'django@2.0.1',
+            vulns: ['vuln-id'],
+            isTransitive: false,
+          },
+        },
+      },
+    };
+
+    const entityToFix = generateEntityToFixWithFileReadWrite(
+      workspacesPath,
+      targetFile,
+      testResult,
+    );
+
+    // Act
+    const result = await snykFix.fix([entityToFix], {
+      quiet: true,
+      stripAnsi: true,
+      sequentialFix: true,
+    });
+    // Assert
+    expect(result).toMatchObject({
+      exceptions: {},
+      results: {
+        python: {
+          failed: [],
+          skipped: [],
+          succeeded: [
+            {
+              original: entityToFix,
+              changes: [
+                {
+                  success: true,
+                  userMessage: 'Upgraded django from 1.6.1 to 2.0.1',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    expect(result.fixSummary).toContain(
+      '✔ Upgraded django from 1.6.1 to 2.0.1',
+    );
+    expect(result.fixSummary).toContain('1 items were successfully fixed');
+    expect(result.fixSummary).toContain('1 issues were successfully fixed');
+    expect(pipenvPipfileFixStub).toHaveBeenCalledTimes(1);
+    expect(pipenvPipfileFixStub).toHaveBeenCalledWith(
+      pathLib.resolve(workspacesPath, 'with-django-upgrade'),
+      ['django==2.0.1'],
+      {
+        python: 'python3',
+      },
+    );
+  });
+
+  it('passes down custom --python if the project was tested with this (--command) from CLI', async () => {
+    // Arrange
+    const targetFile = 'with-django-upgrade/Pipfile';
+    const testResult = {
+      ...generateTestResult(),
+      remediation: {
+        unresolved: [],
+        upgrade: {},
+        patch: {},
+        ignore: {},
+        pin: {
+          'django@1.6.1': {
+            upgradeTo: 'django@2.0.1',
+            vulns: ['vuln-id'],
+            isTransitive: false,
+          },
+        },
+      },
+    };
+
+    const entityToFix = generateEntityToFixWithFileReadWrite(
+      workspacesPath,
+      targetFile,
+      testResult,
+    );
+
+    entityToFix.options.command = 'python2';
+    // Act
+    const result = await snykFix.fix([entityToFix], {
+      quiet: true,
+      stripAnsi: true,
+      sequentialFix: true,
+    });
+
+    // Assert
+    expect(pipenvPipfileFixStub).toHaveBeenCalledTimes(1);
+    expect(pipenvPipfileFixStub).toHaveBeenCalledWith(
+      pathLib.resolve(workspacesPath, 'with-django-upgrade'),
+      ['django==2.0.1'],
+      {
+        python: 'python2',
+      },
+    );
 
     expect(result).toMatchObject({
       exceptions: {},

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/update-dependencies.spec.ts
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/update-dependencies.spec.ts
@@ -683,7 +683,9 @@ describe('fix Poetry Python projects fix sequentially', () => {
           failed: [
             {
               original: entityToFix,
-              error: expect.objectContaining({ name: 'NoFixesCouldBeAppliedError' }),
+              error: expect.objectContaining({
+                name: 'NoFixesCouldBeAppliedError',
+              }),
               tip: 'Try running `poetry install six==2.0.1 transitive==1.1.1`',
             },
           ],

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/update-dependencies.spec.ts
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/update-dependencies.spec.ts
@@ -181,13 +181,13 @@ describe('fix Poetry Python projects', () => {
     );
     expect(result.fixSummary).toContain('✖ No successful fixes');
     expect(poetryFixStub).toHaveBeenCalledTimes(1);
-    expect(poetryFixStub.mock.calls[0]).toEqual([
+    expect(poetryFixStub).toHaveBeenCalledWith(
       pathLib.resolve(workspacesPath, 'simple'),
       ['six==2.0.1', 'transitive==1.1.1'],
       {
         python: 'python3',
       },
-    ]);
+    );
   });
 
   it('Calls the plugin with expected parameters (upgrade & pin)', async () => {
@@ -260,13 +260,13 @@ describe('fix Poetry Python projects', () => {
       },
     });
     expect(poetryFixStub.mock.calls).toHaveLength(1);
-    expect(poetryFixStub.mock.calls[0]).toEqual([
+    expect(poetryFixStub).toHaveBeenCalledWith(
       pathLib.resolve(workspacesPath, 'simple'),
       ['six==2.0.1', 'transitive==1.1.1'],
       {
         python: 'python3',
       },
-    ]);
+    );
   });
 
   it('Calls the plugin with expected parameters with --dev (upgrade & pin)', async () => {
@@ -361,18 +361,18 @@ describe('fix Poetry Python projects', () => {
       },
     });
     expect(poetryFixStub.mock.calls).toHaveLength(2);
-    expect(poetryFixStub.mock.calls[0]).toEqual([
+    expect(poetryFixStub).toHaveBeenCalledWith(
       pathLib.resolve(workspacesPath, 'simple'),
       ['six==2.0.1', 'transitive==1.1.1'],
       {},
-    ]);
-    expect(poetryFixStub.mock.calls[1]).toEqual([
+    );
+    expect(poetryFixStub).toHaveBeenCalledWith(
       pathLib.resolve(workspacesPath, 'simple'),
       ['json-api==0.1.22'],
       {
         dev: true,
       },
-    ]);
+    );
   });
   it('pins a transitive dep with custom python interpreter via --command', async () => {
     jest.spyOn(poetryFix, 'poetryAdd').mockResolvedValue({
@@ -438,13 +438,13 @@ describe('fix Poetry Python projects', () => {
       },
     });
     expect(poetryFixStub.mock.calls).toHaveLength(1);
-    expect(poetryFixStub.mock.calls[0]).toEqual([
+    expect(poetryFixStub).toHaveBeenCalledWith(
       pathLib.resolve(workspacesPath, 'simple'),
       ['markupsafe==2.1.0'],
       {
         python: 'python2',
       },
-    ]);
+    );
   });
   it('shows expected changes when updating a dev dep', async () => {
     jest.spyOn(poetryFix, 'poetryAdd').mockResolvedValue({
@@ -510,13 +510,553 @@ describe('fix Poetry Python projects', () => {
       },
     });
     expect(poetryFixStub.mock.calls).toHaveLength(1);
-    expect(poetryFixStub.mock.calls[0]).toEqual([
+    expect(poetryFixStub).toHaveBeenCalledWith(
       pathLib.resolve(workspacesPath, 'with-dev-deps'),
       ['json-api==0.1.22'],
       {
         dev: true,
       },
-    ]);
+    );
+  });
+
+  it.todo(
+    'upgrade fails since the env already has the right versions (full failure)',
+  );
+
+  it.todo('upgrade of dev deps fails (partial failure)');
+});
+
+describe('fix Poetry Python projects fix sequentially', () => {
+  let poetryFixStub: jest.SpyInstance;
+  beforeAll(() => {
+    jest.spyOn(poetryFix, 'isPoetrySupportedVersion').mockReturnValue({
+      supported: true,
+      versions: ['1.1.1'],
+    });
+    jest.spyOn(poetryFix, 'isPoetryInstalled').mockResolvedValue({
+      version: '1.1.1',
+    });
+  });
+
+  beforeEach(() => {
+    poetryFixStub = jest.spyOn(poetryFix, 'poetryAdd');
+  });
+
+  afterEach(() => {
+    poetryFixStub.mockClear();
+  });
+
+  const workspacesPath = pathLib.resolve(__dirname, 'workspaces');
+
+  it('shows expected changes with lockfile in --dry-run mode', async () => {
+    jest.spyOn(poetryFix, 'poetryAdd').mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      command: 'poetry install',
+      duration: 123,
+    });
+    // Arrange
+    const targetFile = 'simple/pyproject.toml';
+
+    const testResult = {
+      ...generateTestResult(),
+      remediation: {
+        unresolved: [],
+        upgrade: {},
+        patch: {},
+        ignore: {},
+        pin: {
+          'six@1.1.6': {
+            upgradeTo: 'six@2.0.1',
+            vulns: ['VULN-six'],
+            isTransitive: false,
+          },
+          'transitive@1.0.0': {
+            upgradeTo: 'transitive@1.1.1',
+            vulns: [],
+            isTransitive: true,
+          },
+        },
+      },
+    };
+
+    const entityToFix = generateEntityToFixWithFileReadWrite(
+      workspacesPath,
+      targetFile,
+      testResult,
+    );
+
+    // Act
+    const result = await snykFix.fix([entityToFix], {
+      quiet: true,
+      stripAnsi: true,
+      dryRun: true,
+      sequentialFix: true,
+    });
+    // Assert
+    expect(result).toMatchObject({
+      exceptions: {},
+      results: {
+        python: {
+          failed: [],
+          skipped: [],
+          succeeded: [
+            {
+              original: entityToFix,
+              changes: [
+                {
+                  success: true,
+                  userMessage: 'Upgraded six from 1.1.6 to 2.0.1',
+                },
+                {
+                  success: true,
+                  userMessage: 'Pinned transitive from 1.0.0 to 1.1.1',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    expect(poetryFixStub.mock.calls).toHaveLength(0);
+  });
+
+  it('error is bubbled up', async () => {
+    jest.spyOn(poetryFix, 'poetryAdd').mockResolvedValue({
+      exitCode: 1,
+      stdout: '',
+      stderr: `Resolving dependencies... (1.7s)
+
+      SolverProblemError
+
+      Because package-A (2.6) depends on package-B (>=1.19)
+      and package-C (2.2.1) depends on package-B (>=1.16.0,<1.19.0), package-D (2.6) is incompatible with package-C (2.2.1).
+      So, because package-Z depends on both  package-C (2.2.1) and package-D (2.6), version solving failed.`,
+      command: 'poetry install six==2.0.1 transitive==1.1.1',
+      duration: 123,
+    });
+
+    // Arrange
+    const targetFile = 'simple/pyproject.toml';
+
+    const testResult = {
+      ...generateTestResult(),
+      remediation: {
+        unresolved: [],
+        upgrade: {},
+        patch: {},
+        ignore: {},
+        pin: {
+          'six@1.1.6': {
+            upgradeTo: 'six@2.0.1',
+            vulns: ['VULN-six'],
+            isTransitive: false,
+          },
+          'transitive@1.0.0': {
+            upgradeTo: 'transitive@1.1.1',
+            vulns: [],
+            isTransitive: true,
+          },
+        },
+      },
+    };
+
+    const entityToFix = generateEntityToFixWithFileReadWrite(
+      workspacesPath,
+      targetFile,
+      testResult,
+    );
+
+    // Act
+    const result = await snykFix.fix([entityToFix], {
+      quiet: true,
+      stripAnsi: true,
+      dryRun: false,
+      sequentialFix: true,
+    });
+    // Assert
+    expect(result).toMatchObject({
+      exceptions: {},
+      results: {
+        python: {
+          failed: [
+            {
+              original: entityToFix,
+              error: expect.objectContaining({ name: 'NoFixesCouldBeAppliedError' }),
+              tip: 'Try running `poetry install six==2.0.1 transitive==1.1.1`',
+            },
+          ],
+          skipped: [],
+          succeeded: [],
+        },
+      },
+    });
+    expect(result.fixSummary).toContain('✖ SolverProblemError');
+    expect(result.fixSummary).toContain(
+      'Tip:     Try running `poetry install six==2.0.1 transitive==1.1.1`',
+    );
+    expect(result.fixSummary).toContain('✖ No successful fixes');
+    expect(poetryFixStub).toHaveBeenCalledTimes(2);
+    expect(poetryFixStub).toHaveBeenCalledWith(
+      pathLib.resolve(workspacesPath, 'simple'),
+      ['six==2.0.1'],
+      {
+        python: 'python3',
+      },
+    );
+    expect(poetryFixStub).toHaveBeenCalledWith(
+      pathLib.resolve(workspacesPath, 'simple'),
+      ['transitive==1.1.1'],
+      {
+        python: 'python3',
+      },
+    );
+  });
+
+  it('Calls the plugin with expected parameters (upgrade & pin)', async () => {
+    jest.spyOn(poetryFix, 'poetryAdd').mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      command: 'poetry install',
+      duration: 123,
+    });
+    // Arrange
+    const targetFile = 'simple/pyproject.toml';
+
+    const testResult = {
+      ...generateTestResult(),
+      remediation: {
+        unresolved: [],
+        upgrade: {},
+        patch: {},
+        ignore: {},
+        pin: {
+          'six@1.1.6': {
+            upgradeTo: 'six@2.0.1',
+            vulns: ['VULN-six'],
+            isTransitive: false,
+          },
+          'transitive@1.0.0': {
+            upgradeTo: 'transitive@1.1.1',
+            vulns: [],
+            isTransitive: true,
+          },
+        },
+      },
+    };
+
+    const entityToFix = generateEntityToFixWithFileReadWrite(
+      workspacesPath,
+      targetFile,
+      testResult,
+    );
+
+    // Act
+    const result = await snykFix.fix([entityToFix], {
+      quiet: true,
+      stripAnsi: true,
+      sequentialFix: true,
+    });
+    // Assert
+    expect(result).toMatchObject({
+      exceptions: {},
+      results: {
+        python: {
+          failed: [],
+          skipped: [],
+          succeeded: [
+            {
+              original: entityToFix,
+              changes: [
+                {
+                  success: true,
+                  userMessage: 'Upgraded six from 1.1.6 to 2.0.1',
+                },
+                {
+                  success: true,
+                  userMessage: 'Pinned transitive from 1.0.0 to 1.1.1',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    expect(poetryFixStub.mock.calls).toHaveLength(2);
+    expect(poetryFixStub).toHaveBeenCalledWith(
+      pathLib.resolve(workspacesPath, 'simple'),
+      ['six==2.0.1'],
+      {
+        python: 'python3',
+      },
+    );
+    expect(poetryFixStub).toHaveBeenCalledWith(
+      pathLib.resolve(workspacesPath, 'simple'),
+      ['transitive==1.1.1'],
+      {
+        python: 'python3',
+      },
+    );
+  });
+
+  it('Calls the plugin with expected parameters with --dev (upgrade & pin)', async () => {
+    jest.spyOn(poetryFix, 'poetryAdd').mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      command: 'poetry install',
+      duration: 123,
+    });
+    // Arrange
+    const targetFile = 'simple/pyproject.toml';
+
+    const testResult = {
+      ...generateTestResult(),
+      remediation: {
+        unresolved: [],
+        upgrade: {},
+        patch: {},
+        ignore: {},
+        pin: {
+          'six@1.1.6': {
+            upgradeTo: 'six@2.0.1',
+            vulns: ['VULN-six'],
+            isTransitive: false,
+          },
+          'transitive@1.0.0': {
+            upgradeTo: 'transitive@1.1.1',
+            vulns: ['vuln-transitive'],
+            isTransitive: true,
+          },
+          'json-api@0.1.21': {
+            upgradeTo: 'json-api@0.1.22',
+            vulns: ['SNYK-1'],
+            isTransitive: false,
+          },
+        },
+      },
+    };
+
+    const entityToFix = generateEntityToFixWithFileReadWrite(
+      workspacesPath,
+      targetFile,
+      testResult,
+      {
+        dev: true,
+      },
+    );
+
+    // Act
+    const result = await snykFix.fix([entityToFix], {
+      quiet: true,
+      stripAnsi: true,
+      sequentialFix: true,
+    });
+
+    // Assert
+    expect(result).toMatchObject({
+      exceptions: {},
+      results: {
+        python: {
+          failed: [],
+          skipped: [],
+          succeeded: [
+            {
+              original: entityToFix,
+              changes: [
+                {
+                  from: 'six@1.1.6',
+                  to: 'six@2.0.1',
+                  issueIds: ['VULN-six'],
+                  success: true,
+                  userMessage: 'Upgraded six from 1.1.6 to 2.0.1',
+                },
+                {
+                  from: 'transitive@1.0.0',
+                  to: 'transitive@1.1.1',
+                  issueIds: ['vuln-transitive'],
+                  success: true,
+                  userMessage: 'Pinned transitive from 1.0.0 to 1.1.1',
+                },
+                {
+                  from: 'json-api@0.1.21',
+                  to: 'json-api@0.1.22',
+                  issueIds: ['SNYK-1'],
+                  success: true,
+                  userMessage: 'Upgraded json-api from 0.1.21 to 0.1.22',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    expect(poetryFixStub.mock.calls).toHaveLength(3);
+    expect(poetryFixStub).toHaveBeenCalledWith(
+      pathLib.resolve(workspacesPath, 'simple'),
+      ['transitive==1.1.1'],
+      {},
+    );
+    expect(poetryFixStub).toHaveBeenCalledWith(
+      pathLib.resolve(workspacesPath, 'simple'),
+      ['six==2.0.1'],
+      {},
+    );
+    expect(poetryFixStub).toHaveBeenCalledWith(
+      pathLib.resolve(workspacesPath, 'simple'),
+      ['json-api==0.1.22'],
+      {
+        dev: true,
+      },
+    );
+  });
+  it('pins a transitive dep with custom python interpreter via --command', async () => {
+    jest.spyOn(poetryFix, 'poetryAdd').mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      command: 'poetry install',
+      duration: 123,
+    });
+    // Arrange
+    const targetFile = 'simple/poetry.lock';
+
+    const testResult = {
+      ...generateTestResult(),
+      remediation: {
+        unresolved: [],
+        upgrade: {},
+        patch: {},
+        ignore: {},
+        pin: {
+          'markupsafe@2.0.1': {
+            upgradeTo: 'markupsafe@2.1.0',
+            vulns: ['SNYK-1'],
+            isTransitive: true,
+          },
+        },
+      },
+    };
+
+    const entityToFix = generateEntityToFixWithFileReadWrite(
+      workspacesPath,
+      targetFile,
+      testResult,
+      {
+        command: 'python2',
+      },
+    );
+
+    // Act
+    const result = await snykFix.fix([entityToFix], {
+      quiet: true,
+      stripAnsi: true,
+      sequentialFix: true,
+    });
+    // Assert
+    expect(result).toMatchObject({
+      exceptions: {},
+      results: {
+        python: {
+          failed: [],
+          skipped: [],
+          succeeded: [
+            {
+              original: entityToFix,
+              changes: [
+                {
+                  success: true,
+                  userMessage: 'Pinned markupsafe from 2.0.1 to 2.1.0',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    expect(poetryFixStub.mock.calls).toHaveLength(1);
+    expect(poetryFixStub).toHaveBeenCalledWith(
+      pathLib.resolve(workspacesPath, 'simple'),
+      ['markupsafe==2.1.0'],
+      {
+        python: 'python2',
+      },
+    );
+  });
+  it('shows expected changes when updating a dev dep', async () => {
+    jest.spyOn(poetryFix, 'poetryAdd').mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      command: 'poetry install',
+      duration: 123,
+    });
+    // Arrange
+    const targetFile = 'with-dev-deps/pyproject.toml';
+
+    const testResult = {
+      ...generateTestResult(),
+      remediation: {
+        unresolved: [],
+        upgrade: {},
+        patch: {},
+        ignore: {},
+        pin: {
+          'json-api@0.1.21': {
+            upgradeTo: 'json-api@0.1.22',
+            vulns: ['SNYK-1'],
+            isTransitive: false,
+          },
+        },
+      },
+    };
+
+    const entityToFix = generateEntityToFixWithFileReadWrite(
+      workspacesPath,
+      targetFile,
+      testResult,
+      {
+        dev: true,
+      },
+    );
+
+    // Act
+    const result = await snykFix.fix([entityToFix], {
+      quiet: true,
+      stripAnsi: true,
+      sequentialFix: true,
+    });
+    // Assert
+    expect(result).toMatchObject({
+      exceptions: {},
+      results: {
+        python: {
+          failed: [],
+          skipped: [],
+          succeeded: [
+            {
+              original: entityToFix,
+              changes: [
+                {
+                  success: true,
+                  userMessage: 'Upgraded json-api from 0.1.21 to 0.1.22',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    expect(poetryFixStub.mock.calls).toHaveLength(1);
+    expect(poetryFixStub).toHaveBeenCalledWith(
+      pathLib.resolve(workspacesPath, 'with-dev-deps'),
+      ['json-api==0.1.22'],
+      {
+        dev: true,
+      },
+    );
   });
 
   it.todo(

--- a/packages/snyk-fix/test/unit/plugins/python/handlers/poetry/generate-upgrades.spec.ts
+++ b/packages/snyk-fix/test/unit/plugins/python/handlers/poetry/generate-upgrades.spec.ts
@@ -1,4 +1,4 @@
-import { generateUpgrades } from '../../../../../../src/plugins/python/handlers/poetry/update-dependencies';
+import { generateUpgrades } from '../../../../../../src/plugins/python/handlers/poetry/update-dependencies/generate-upgrades';
 import { generateEntityToFix } from '../../../../../helpers/generate-entity-to-fix';
 describe('generateUpgrades', () => {
   it('returns empty if no upgrades could be generated', async () => {

--- a/packages/snyk-fix/test/unit/plugins/python/handlers/poetry/generate-upgrades.spec.ts
+++ b/packages/snyk-fix/test/unit/plugins/python/handlers/poetry/generate-upgrades.spec.ts
@@ -25,8 +25,7 @@ describe('generateUpgrades', () => {
       manifestContents,
     );
 
-    // @ts-ignore: for test purpose need specific remediation
-    entityToFix.testResult.remediation = {
+    (entityToFix.testResult as any).remediation = {
       ignore: {},
       patch: {},
       pin: {},
@@ -70,12 +69,10 @@ describe('generateUpgrades', () => {
       'pyproject.toml',
       manifestContents,
     );
-    // @ts-ignore: for test purpose need specific remediation
-    entityToFix.options = {
+    (entityToFix as any).options = {
       dev: true,
     };
-    // @ts-ignore: for test purpose need specific remediation
-    entityToFix.testResult.remediation = {
+    (entityToFix.testResult as any).remediation = {
       ignore: {},
       patch: {},
       pin: {
@@ -120,8 +117,7 @@ describe('generateUpgrades', () => {
       'pyproject.toml',
       manifestContents,
     );
-    // @ts-ignore: for test purpose need specific remediation
-    entityToFix.testResult.remediation = {
+    (entityToFix.testResult as any).remediation = {
       ignore: {},
       patch: {},
       pin: {
@@ -165,8 +161,7 @@ describe('generateUpgrades', () => {
       'pyproject.toml',
       manifestContents,
     );
-    // @ts-ignore: for test purpose need specific remediation
-    entityToFix.testResult.remediation = {
+    (entityToFix.testResult as any).remediation = {
       ignore: {},
       patch: {},
       pin: {
@@ -212,12 +207,10 @@ describe('generateUpgrades', () => {
       'pyproject.toml',
       manifestContents,
     );
-    // @ts-ignore: for test purpose need specific remediation
-    entityToFix.options = {
+    (entityToFix as any).options = {
       dev: true,
     };
-    // @ts-ignore: for test purpose need specific remediation
-    entityToFix.testResult.remediation = {
+    (entityToFix.testResult as any).remediation = {
       ignore: {},
       patch: {},
       pin: {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,7 +1,7 @@
 import * as abbrev from 'abbrev';
 import { MethodResult } from './commands/types';
 
-import debugModule = require('debug');
+import * as debugModule from 'debug';
 import { parseMode, displayModeHelp } from './modes';
 import {
   SupportedCliCommands,
@@ -218,7 +218,7 @@ export function args(rawArgv: string[]): Args {
     'integration-version',
     'prune-repeated-subdependencies',
     'dry-run',
-    'update-sequentially',
+    'sequential',
   ];
   for (const dashedArg of argumentsToTransform) {
     if (argv[dashedArg]) {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -218,6 +218,7 @@ export function args(rawArgv: string[]): Args {
     'integration-version',
     'prune-repeated-subdependencies',
     'dry-run',
+    'update-sequentially',
   ];
   for (const dashedArg of argumentsToTransform) {
     if (argv[dashedArg]) {

--- a/src/cli/commands/fix/index.ts
+++ b/src/cli/commands/fix/index.ts
@@ -25,6 +25,7 @@ const snykFixFeatureFlag = 'cliSnykFix';
 interface FixOptions {
   dryRun?: boolean;
   quiet?: boolean;
+  updateSequentially?: boolean;
 }
 export default async function fix(...args: MethodArgs): Promise<string> {
   const { options: rawOptions, paths } = await processCommandArgs<FixOptions>(
@@ -44,12 +45,13 @@ export default async function fix(...args: MethodArgs): Promise<string> {
   const vulnerableResults = results.filter(
     (res) => Object.keys(res.testResult.issues).length,
   );
-  const { dryRun, quiet } = options;
+  const { dryRun, quiet, updateSequentially: sequentialFix } = options;
   const { fixSummary, meta, results: resultsByPlugin } = await snykFix.fix(
     results,
     {
       dryRun,
       quiet,
+      sequentialFix,
     },
   );
 

--- a/src/cli/commands/fix/index.ts
+++ b/src/cli/commands/fix/index.ts
@@ -25,7 +25,7 @@ const snykFixFeatureFlag = 'cliSnykFix';
 interface FixOptions {
   dryRun?: boolean;
   quiet?: boolean;
-  updateSequentially?: boolean;
+  sequential?: boolean;
 }
 export default async function fix(...args: MethodArgs): Promise<string> {
   const { options: rawOptions, paths } = await processCommandArgs<FixOptions>(
@@ -45,7 +45,7 @@ export default async function fix(...args: MethodArgs): Promise<string> {
   const vulnerableResults = results.filter(
     (res) => Object.keys(res.testResult.issues).length,
   );
-  const { dryRun, quiet, updateSequentially: sequentialFix } = options;
+  const { dryRun, quiet, sequential: sequentialFix } = options;
   const { fixSummary, meta, results: resultsByPlugin } = await snykFix.fix(
     results,
     {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -163,7 +163,7 @@ export type SupportedUserReachableFacingCliArgs =
   | 'detection-depth'
   | 'docker'
   | 'dry-run'
-  | 'update-sequentially'
+  | 'sequential'
   | 'fail-on'
   | 'file'
   | 'gradle-sub-project'

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -163,6 +163,7 @@ export type SupportedUserReachableFacingCliArgs =
   | 'detection-depth'
   | 'docker'
   | 'dry-run'
+  | 'update-sequentially'
   | 'fail-on'
   | 'file'
   | 'gradle-sub-project'


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Support optionally upgrading 1 package at a time, this
is much slower but can provide better success in upgrading
vulnerable package versions
#### Any background context you want to provide?
Some combination of package upgraded might not be compatible, allow upgrading 1 at a time to increase the % of fixed issues. This is much slower 🐌 

`snyk fix --sequential` will trigger the behavior to try applying package upgrades via `poetry` and `pipenv` 1 by 1.

#### Screenshots
Can't see a difference in the screenshot unless one of the upgrades fails. See the added test to show what to expect.

Actual project run
<img width="751" alt="CleanShot 2021-09-14 at 13 32 06@2x" src="https://user-images.githubusercontent.com/2911613/133258037-a3c044dd-07ac-465f-aa02-76eaec93243b.png">

From a test that crafts the right scenario, when running with `--sequential-fix` the whole fix does not fail.
<img width="987" alt="CleanShot 2021-09-14 at 13 34 45@2x" src="https://user-images.githubusercontent.com/2911613/133258446-07f3b1db-ee96-4ea5-8043-c6df0e39b4f2.png">
