### PR TITLE
feat: support print-deps cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "rimraf": "^2.6.3",
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
-    "snyk-cpp-plugin": "2.8.0",
+    "snyk-cpp-plugin": "2.9.0",
     "snyk-docker-plugin": "4.24.0",
     "snyk-go-plugin": "1.17.0",
     "snyk-gradle-plugin": "3.16.1",

--- a/src/lib/ecosystems/resolve-test-facts.ts
+++ b/src/lib/ecosystems/resolve-test-facts.ts
@@ -39,6 +39,7 @@ export async function resolveAndTestFacts(
           issues: response?.issues,
           issuesData: response?.issuesData,
           depGraphData: response?.depGraphData,
+          depsFilePaths: response?.depsFilePaths,
         });
       } catch (error) {
         const hasStatusCodeError = error.code >= 400 && error.code <= 500;

--- a/src/lib/ecosystems/types.ts
+++ b/src/lib/ecosystems/types.ts
@@ -75,10 +75,15 @@ export interface IssuesData {
   };
 }
 
+export interface DepsFilePaths {
+  [pkgKey: string]: string[];
+}
+
 export interface TestResult {
   issues: Issue[];
   issuesData: IssuesData;
   depGraphData: DepGraphData;
+  depsFilePaths?: DepsFilePaths;
   remediation?: RemediationChanges;
 }
 

--- a/src/lib/polling/polling-test.ts
+++ b/src/lib/polling/polling-test.ts
@@ -55,8 +55,8 @@ export async function pollingTestWithTokenUntilDone(
   const response = await makeRequest<ResolveAndTestFactsResponse>(payload);
 
   if (response.result) {
-    const { issues, issuesData, depGraphData } = response.result;
-    return { issues, issuesData, depGraphData };
+    const { issues, issuesData, depGraphData, depsFilePaths } = response.result;
+    return { issues, issuesData, depGraphData, depsFilePaths };
   }
 
   await delayNextStep(attemptsCount, maxAttempts, pollInterval);

--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -1,6 +1,6 @@
 const values = require('lodash.values');
 import * as depGraphLib from '@snyk/dep-graph';
-import { ScanResult } from '../ecosystems/types';
+import { DepsFilePaths, ScanResult } from '../ecosystems/types';
 import { SupportedPackageManagers } from '../package-managers';
 import { Options, SupportedProjectTypes, TestOptions } from '../types';
 import { SEVERITIES } from './common';
@@ -249,6 +249,7 @@ export interface TestDependenciesResult {
     binariesVulns: TestDepGraphResult;
   };
   remediation?: RemediationChanges;
+  depsFilePaths?: DepsFilePaths;
   depGraphData: depGraphLib.DepGraphData;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -69,6 +69,7 @@ export interface Options {
   severityThreshold?: SEVERITY;
   dev?: boolean;
   'print-deps'?: boolean;
+  'print-dep-paths'?: boolean;
   'remote-repo-url'?: string;
   scanAllUnmanaged?: boolean;
   allProjects?: boolean;
@@ -96,6 +97,7 @@ export interface MonitorOptions {
   allSubProjects?: boolean;
   'project-name'?: string;
   'print-deps'?: boolean;
+  'print-dep-paths'?: boolean;
   scanAllUnmanaged?: boolean;
   allProjects?: boolean;
   // An experimental flag to allow monitoring of bigtrees (with degraded deps info and remediation advice).


### PR DESCRIPTION
Support `--print-dep-paths` and `print-deps` args

To allow the user of have different kind of UI outputs

`--print-dep-paths`: includes the  dependencies that have been identified
and the each dependency filePaths in the test result output

`--print-deps`: includes the dependencies that have been identified in
the test result output

Also introducing depsFilePaths type for `unmanaged c/c++` product line

See https://github.com/snyk/snyk-cpp-plugin/pull/37

<img width="1204" alt="Screen Shot 2021-09-14 at 21 19 55" src="https://user-images.githubusercontent.com/40601533/133317488-8ed28c17-054e-47cb-82f3-018d44d7290c.png">
