### PR TITLE
feat: replace YAML parser with library call [CC-1012]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "dependencies": {
         "@open-policy-agent/opa-wasm": "^1.2.0",
         "@snyk/cli-interface": "2.11.0",
-        "@snyk/cloud-config-parser": "^1.10.2",
+        "@snyk/cloud-config-parser": "^1.11.0",
         "@snyk/code-client": "^4.2.3",
         "@snyk/dep-graph": "^1.27.1",
         "@snyk/fix": "file:packages/snyk-fix",
@@ -80,8 +80,7 @@
         "tar": "^6.1.2",
         "tempy": "^1.0.1",
         "uuid": "^8.3.2",
-        "wrap-ansi": "^5.1.0",
-        "yaml": "^1.10.2"
+        "wrap-ansi": "^5.1.0"
       },
       "bin": {
         "snyk": "bin/snyk"
@@ -4904,12 +4903,13 @@
       }
     },
     "node_modules/@snyk/cloud-config-parser": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.10.2.tgz",
-      "integrity": "sha512-ovA6iX59jLOVMfZr6rsqYNcOIjZTYAbm34bn41m3hRbCPuZkxe3JNKxjsEFCFkZQBnGSebrbz8TGoe81y0L2Cw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.11.0.tgz",
+      "integrity": "sha512-L3SnkPkc1nocvrELYHhjlkFB0nHUXXLJUL3MxF2p8Xp6R+Tm9LJ4JMOovmzZ60OR4z7t/Ypp+y5O4mEfqTF6xA==",
       "dependencies": {
         "esprima": "^4.0.1",
         "tslib": "^1.10.0",
+        "yaml": "^1.10.2",
         "yaml-js": "^0.3.0"
       },
       "engines": {
@@ -30082,12 +30082,13 @@
       }
     },
     "@snyk/cloud-config-parser": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.10.2.tgz",
-      "integrity": "sha512-ovA6iX59jLOVMfZr6rsqYNcOIjZTYAbm34bn41m3hRbCPuZkxe3JNKxjsEFCFkZQBnGSebrbz8TGoe81y0L2Cw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.11.0.tgz",
+      "integrity": "sha512-L3SnkPkc1nocvrELYHhjlkFB0nHUXXLJUL3MxF2p8Xp6R+Tm9LJ4JMOovmzZ60OR4z7t/Ypp+y5O4mEfqTF6xA==",
       "requires": {
         "esprima": "^4.0.1",
         "tslib": "^1.10.0",
+        "yaml": "^1.10.2",
         "yaml-js": "^0.3.0"
       }
     },
@@ -43494,7 +43495,7 @@
         "@open-policy-agent/opa-wasm": "^1.2.0",
         "@snyk/cli-alert": "file:packages/cli-alert",
         "@snyk/cli-interface": "2.11.0",
-        "@snyk/cloud-config-parser": "^1.10.2",
+        "@snyk/cloud-config-parser": "^1.11.0",
         "@snyk/code-client": "^4.2.3",
         "@snyk/dep-graph": "^1.27.1",
         "@snyk/fix": "file:packages/snyk-fix",
@@ -43602,8 +43603,7 @@
         "webpack-cli": "^4.6.0",
         "webpack-license-plugin": "^4.2.0",
         "webpack-merge": "^5.8.0",
-        "wrap-ansi": "^5.1.0",
-        "yaml": "^1.10.2"
+        "wrap-ansi": "^5.1.0"
       },
       "dependencies": {
         "@arcanis/slice-ansi": {
@@ -47511,12 +47511,13 @@
           }
         },
         "@snyk/cloud-config-parser": {
-          "version": "1.10.2",
-          "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.10.2.tgz",
-          "integrity": "sha512-ovA6iX59jLOVMfZr6rsqYNcOIjZTYAbm34bn41m3hRbCPuZkxe3JNKxjsEFCFkZQBnGSebrbz8TGoe81y0L2Cw==",
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.11.0.tgz",
+          "integrity": "sha512-L3SnkPkc1nocvrELYHhjlkFB0nHUXXLJUL3MxF2p8Xp6R+Tm9LJ4JMOovmzZ60OR4z7t/Ypp+y5O4mEfqTF6xA==",
           "requires": {
             "esprima": "^4.0.1",
             "tslib": "^1.10.0",
+            "yaml": "^1.10.2",
             "yaml-js": "^0.3.0"
           }
         },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "@open-policy-agent/opa-wasm": "^1.2.0",
     "@snyk/cli-interface": "2.11.0",
-    "@snyk/cloud-config-parser": "^1.10.2",
+    "@snyk/cloud-config-parser": "^1.11.0",
     "@snyk/code-client": "^4.2.3",
     "@snyk/dep-graph": "^1.27.1",
     "@snyk/fix": "file:packages/snyk-fix",
@@ -137,8 +137,7 @@
     "tar": "^6.1.2",
     "tempy": "^1.0.1",
     "uuid": "^8.3.2",
-    "wrap-ansi": "^5.1.0",
-    "yaml": "^1.10.2"
+    "wrap-ansi": "^5.1.0"
   },
   "devDependencies": {
     "@types/cross-spawn": "^6.0.2",

--- a/src/cli/commands/test/iac-local-execution/yaml-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/yaml-parser.ts
@@ -1,11 +1,11 @@
-import * as YAML from 'yaml';
 import { CustomError } from '../../../../lib/errors';
 import { getErrorStringCode } from './error-utils';
 import { IaCErrorCodes, IacFileData } from './types';
+import { parseFileContent } from '@snyk/cloud-config-parser';
 
 export function parseYAMLOrJSONFileData(fileData: IacFileData): any[] {
   try {
-    return parseYAMLOrJSON(fileData.fileContent);
+    return parseFileContent(fileData.fileContent);
   } catch (e) {
     if (fileData.fileType === 'json') {
       throw new InvalidJsonFileError(fileData.filePath);
@@ -13,47 +13,6 @@ export function parseYAMLOrJSONFileData(fileData: IacFileData): any[] {
       throw new InvalidYamlFileError(fileData.filePath);
     }
   }
-}
-
-const errorsToSkip = [
-  'Insufficient indentation in flow collection',
-  'Map keys must be unique',
-];
-// the YAML Parser is more strict than the Golang one in Policy Engine,
-// so we decided to skip specific errors in order to be consistent.
-// this function checks if the current error is one them
-export function shouldThrowErrorFor(doc: YAML.Document.Parsed) {
-  return (
-    doc.errors.length !== 0 &&
-    !errorsToSkip.some((e) => doc.errors[0].message.includes(e))
-  );
-}
-
-const warningsToInclude = [
-  'Keys with collection values will be stringified as YAML due to JS Object restrictions. Use mapAsMap: true to avoid this.',
-];
-// The YAML Parser is less strict than the Golang one when it comes to templating directives
-// instead it returns them as warnings
-// which we now throw on
-function shouldThrowWarningFor(doc: YAML.Document.Parsed) {
-  return (
-    doc.warnings.length !== 0 &&
-    warningsToInclude.some((e) => doc.warnings[0].message.includes(e))
-  );
-}
-
-export function parseYAMLOrJSON(fileContent: string): any[] {
-  // the YAML library can parse both YAML and JSON content, as well as content with singe/multiple YAMLs
-  // by using this library we don't have to disambiguate between these different contents ourselves
-  return YAML.parseAllDocuments(fileContent).map((doc) => {
-    if (shouldThrowErrorFor(doc)) {
-      throw doc.errors[0];
-    }
-    if (shouldThrowWarningFor(doc)) {
-      throw doc.warnings[0];
-    }
-    return doc.toJSON();
-  });
 }
 
 export class InvalidJsonFileError extends CustomError {

--- a/src/lib/iac/iac-parser.ts
+++ b/src/lib/iac/iac-parser.ts
@@ -1,5 +1,6 @@
 //TODO(orka): take out into a new lib
 import * as debugLib from 'debug';
+import { parseFileContent as parseYAMLOrJSON } from '@snyk/cloud-config-parser';
 import {
   IllegalIacFileErrorMsg,
   InternalServerError,
@@ -13,7 +14,6 @@ import {
   IacValidateTerraformResponse,
   IacValidationResponse,
 } from './constants';
-import { parseYAMLOrJSON } from '../../cli/commands/test/iac-local-execution/yaml-parser';
 
 const debug = debugLib('snyk-detect');
 


### PR DESCRIPTION
#### What does this PR do?
This PR replaces the `yaml` library with a call to `@snyk/cloud-config-parser`, where we have moved our customised YAML parsing logic. This way when we have parsing issues that we need to fix, we can fix them in just one place.

#### How should this be manually tested?
Run:
1. `npm run build`
2. ` snyk-dev iac test ./test/fixtures/iac/kubernetes/pod-privileged.yaml`
3. `snyk-dev iac test ./test/fixtures/iac/kubernetes/pod-valid.json`

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CC-1012


#### Screenshots

<img width="819" alt="Screenshot 2021-09-16 at 16 45 45" src="https://user-images.githubusercontent.com/81559517/133623604-2bb20dfb-834b-4c5f-ad6c-52e7b7571f25.png">
<img width="732" alt="Screenshot 2021-09-16 at 16 45 49" src="https://user-images.githubusercontent.com/81559517/133623612-85b9a84a-645d-41cc-9ee2-ff3b8540f673.png">
