### PR TITLE
chore: upgrade to snyk-docker-plugin v4.25.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.9.0",
-        "snyk-docker-plugin": "4.25.1",
+        "snyk-docker-plugin": "4.25.2",
         "snyk-go-plugin": "1.17.0",
         "snyk-gradle-plugin": "3.16.1",
         "snyk-module": "3.1.0",
@@ -22009,9 +22009,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "4.25.1",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.25.1.tgz",
-      "integrity": "sha512-MSZI2zU5sVvmaFMalPrEumtDjGZrO2zgyGwjU6pO39ceTEC1B73YGZYs1tUYfuHLzsqFKpWTFwH9MwOWFmNMvQ==",
+      "version": "4.25.2",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.25.2.tgz",
+      "integrity": "sha512-ncajarsvczCbEtxMRFqc8JuqOr0s/oReeSXtXodPut3+CjkbILxR3WQciE4I1HPf5PdnGf7cZ1AoMXP+D0DkkQ==",
       "dependencies": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/rpm-parser": "^2.0.0",
@@ -43634,7 +43634,7 @@
         "snyk": "file:",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.9.0",
-        "snyk-docker-plugin": "4.25.1",
+        "snyk-docker-plugin": "4.25.2",
         "snyk-go-plugin": "1.17.0",
         "snyk-gradle-plugin": "3.16.1",
         "snyk-module": "3.1.0",
@@ -61089,9 +61089,9 @@
           }
         },
         "snyk-docker-plugin": {
-          "version": "4.25.1",
-          "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.25.1.tgz",
-          "integrity": "sha512-MSZI2zU5sVvmaFMalPrEumtDjGZrO2zgyGwjU6pO39ceTEC1B73YGZYs1tUYfuHLzsqFKpWTFwH9MwOWFmNMvQ==",
+          "version": "4.25.2",
+          "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.25.2.tgz",
+          "integrity": "sha512-ncajarsvczCbEtxMRFqc8JuqOr0s/oReeSXtXodPut3+CjkbILxR3WQciE4I1HPf5PdnGf7cZ1AoMXP+D0DkkQ==",
           "requires": {
             "@snyk/dep-graph": "^1.28.0",
             "@snyk/rpm-parser": "^2.0.0",
@@ -64418,9 +64418,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "4.25.1",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.25.1.tgz",
-      "integrity": "sha512-MSZI2zU5sVvmaFMalPrEumtDjGZrO2zgyGwjU6pO39ceTEC1B73YGZYs1tUYfuHLzsqFKpWTFwH9MwOWFmNMvQ==",
+      "version": "4.25.2",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.25.2.tgz",
+      "integrity": "sha512-ncajarsvczCbEtxMRFqc8JuqOr0s/oReeSXtXodPut3+CjkbILxR3WQciE4I1HPf5PdnGf7cZ1AoMXP+D0DkkQ==",
       "requires": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/rpm-parser": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "snyk",
       "version": "1.0.0-monorepo",
       "license": "Apache-2.0",
       "workspaces": [
@@ -62,7 +61,7 @@
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.9.0",
-        "snyk-docker-plugin": "4.24.0",
+        "snyk-docker-plugin": "4.25.0",
         "snyk-go-plugin": "1.17.0",
         "snyk-gradle-plugin": "3.16.1",
         "snyk-module": "3.1.0",
@@ -2277,6 +2276,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -2352,6 +2354,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -2577,6 +2582,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -2859,6 +2867,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3035,6 +3046,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3097,6 +3111,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3245,6 +3262,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3297,6 +3317,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3497,6 +3520,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -4100,6 +4126,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -4171,6 +4200,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -4291,6 +4323,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -4341,6 +4376,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -7767,6 +7805,12 @@
       "engines": [
         "node >=0.10.0"
       ],
+      "dependencies": {
+        "dtrace-provider": "~0.8",
+        "moment": "^2.19.3",
+        "mv": "~2",
+        "safe-json-stringify": "~1"
+      },
       "bin": {
         "bunyan": "bin/bunyan"
       },
@@ -8119,6 +8163,7 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -10291,7 +10336,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -12922,6 +12968,7 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -14926,6 +14973,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^27.0.6",
         "jest-serializer": "^27.0.6",
@@ -16335,6 +16383,7 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -21058,6 +21107,7 @@
         "assert-plus": "^1.0.0",
         "bunyan": "^1.8.12",
         "csv": "^5.1.1",
+        "dtrace-provider": "^0.8.1",
         "escape-regexp-component": "^1.0.2",
         "ewma": "^2.0.1",
         "find-my-way": "^2.0.1",
@@ -21095,7 +21145,8 @@
       "dependencies": {
         "@netflix/nerror": "^1.0.0",
         "assert-plus": "^1.0.0",
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.15",
+        "safe-json-stringify": "^1.0.4"
       },
       "optionalDependencies": {
         "safe-json-stringify": "^1.0.4"
@@ -21805,8 +21856,8 @@
       "dev": true
     },
     "node_modules/snyk": {
-      "resolved": "",
-      "link": true
+      "link": true,
+      "resolved": ""
     },
     "node_modules/snyk-config": {
       "version": "4.0.0",
@@ -21946,9 +21997,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.24.0.tgz",
-      "integrity": "sha512-BmTZaRy1l0S05dWqqenBP6sSBWBIaNvbKvV0Y2yowV4JkDRFiLeS/KNs1mp/u6kvAfec8mslY5fAtxu6bqQdkw==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.25.0.tgz",
+      "integrity": "sha512-JxnN5dcDJ3U3qMrstKqbx7rzrYEBFfS92De+o3yq/D5KujYhEsyG/pI1GBLszyQN0Gat7F+MWynSCYO8xCnLrg==",
       "dependencies": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/rpm-parser": "^2.0.0",
@@ -21970,7 +22021,7 @@
         "uuid": "^8.2.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14"
       }
     },
     "node_modules/snyk-docker-plugin/node_modules/argparse": {
@@ -23639,6 +23690,7 @@
         "escape-string-regexp": "^1.0.3",
         "glob": "^7.0.5",
         "js-yaml": "^3.3.1",
+        "readable-stream": "^2.1.5",
         "tap-parser": "^5.1.0",
         "unicode-length": "^1.0.0"
       },
@@ -23713,7 +23765,8 @@
       "dev": true,
       "dependencies": {
         "events-to-array": "^1.0.1",
-        "js-yaml": "^3.2.7"
+        "js-yaml": "^3.2.7",
+        "readable-stream": "^2"
       },
       "bin": {
         "tap-parser": "bin/cmd.js"
@@ -43574,7 +43627,7 @@
         "snyk": "file:",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.9.0",
-        "snyk-docker-plugin": "4.24.0",
+        "snyk-docker-plugin": "4.25.0",
         "snyk-go-plugin": "1.17.0",
         "snyk-gradle-plugin": "3.16.1",
         "snyk-module": "3.1.0",
@@ -61021,9 +61074,9 @@
           }
         },
         "snyk-docker-plugin": {
-          "version": "4.24.0",
-          "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.24.0.tgz",
-          "integrity": "sha512-BmTZaRy1l0S05dWqqenBP6sSBWBIaNvbKvV0Y2yowV4JkDRFiLeS/KNs1mp/u6kvAfec8mslY5fAtxu6bqQdkw==",
+          "version": "4.25.0",
+          "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.25.0.tgz",
+          "integrity": "sha512-JxnN5dcDJ3U3qMrstKqbx7rzrYEBFfS92De+o3yq/D5KujYhEsyG/pI1GBLszyQN0Gat7F+MWynSCYO8xCnLrg==",
           "requires": {
             "@snyk/dep-graph": "^1.28.0",
             "@snyk/rpm-parser": "^2.0.0",
@@ -64362,9 +64415,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.24.0.tgz",
-      "integrity": "sha512-BmTZaRy1l0S05dWqqenBP6sSBWBIaNvbKvV0Y2yowV4JkDRFiLeS/KNs1mp/u6kvAfec8mslY5fAtxu6bqQdkw==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.25.0.tgz",
+      "integrity": "sha512-JxnN5dcDJ3U3qMrstKqbx7rzrYEBFfS92De+o3yq/D5KujYhEsyG/pI1GBLszyQN0Gat7F+MWynSCYO8xCnLrg==",
       "requires": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/rpm-parser": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.9.0",
-        "snyk-docker-plugin": "4.25.0",
+        "snyk-docker-plugin": "4.25.1",
         "snyk-go-plugin": "1.17.0",
         "snyk-gradle-plugin": "3.16.1",
         "snyk-module": "3.1.0",
@@ -9106,6 +9106,19 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/cpu-features": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.2.tgz",
+      "integrity": "sha512-/2yieBqvMcRj8McNzkycjW2v3OIUOibBfd2dLEJ0nWts8NobAxwiyw9phVNS6oDL8x8tz9F7uNVFEVpJncQpeA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "nan": "^2.14.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -9920,14 +9933,14 @@
       }
     },
     "node_modules/docker-modem": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-2.1.3.tgz",
-      "integrity": "sha512-cwaRptBmYZwu/FyhGcqBm2MzXA77W2/E6eVkpOZVDk6PkI9Bjj84xPrXiHMA+OWjzNy+DFjgKh8Q+1hMR7/OHg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-3.0.3.tgz",
+      "integrity": "sha512-Tgkn2a+yiNP9FoZgMa/D9Wk+D2Db///0KOyKSYZRJa8w4+DzKyzQMkczKSdR/adQ0x46BOpeNkoyEOKjPhCzjw==",
       "dependencies": {
         "debug": "^4.1.1",
         "readable-stream": "^3.5.0",
         "split-ca": "^1.0.1",
-        "ssh2": "^0.8.7"
+        "ssh2": "^1.4.0"
       },
       "engines": {
         "node": ">= 8.0"
@@ -18090,7 +18103,6 @@
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
       "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
-      "dev": true,
       "optional": true
     },
     "node_modules/nanoid": {
@@ -21997,9 +22009,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.25.0.tgz",
-      "integrity": "sha512-JxnN5dcDJ3U3qMrstKqbx7rzrYEBFfS92De+o3yq/D5KujYhEsyG/pI1GBLszyQN0Gat7F+MWynSCYO8xCnLrg==",
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.25.1.tgz",
+      "integrity": "sha512-MSZI2zU5sVvmaFMalPrEumtDjGZrO2zgyGwjU6pO39ceTEC1B73YGZYs1tUYfuHLzsqFKpWTFwH9MwOWFmNMvQ==",
       "dependencies": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/rpm-parser": "^2.0.0",
@@ -22007,7 +22019,7 @@
         "adm-zip": "^0.5.5",
         "chalk": "^2.4.2",
         "debug": "^4.1.1",
-        "docker-modem": "2.1.3",
+        "docker-modem": "3.0.3",
         "dockerfile-ast": "0.2.1",
         "elfy": "^1.0.0",
         "event-loop-spinner": "^2.0.0",
@@ -23021,27 +23033,22 @@
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "node_modules/ssh2": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.9.tgz",
-      "integrity": "sha512-GmoNPxWDMkVpMFa9LVVzQZHF6EW3WKmBwL+4/GeILf2hFmix5Isxm7Amamo8o7bHiU0tC+wXsGcUXOxp8ChPaw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.4.0.tgz",
+      "integrity": "sha512-XvXwcXKvS452DyQvCa6Ct+chpucwc/UyxgliYz+rWXJ3jDHdtBb9xgmxJdMmnIn5bpgGAEV3KaEsH98ZGPHqwg==",
+      "hasInstallScript": true,
       "dependencies": {
-        "ssh2-streams": "~0.4.10"
-      },
-      "engines": {
-        "node": ">=5.2.0"
-      }
-    },
-    "node_modules/ssh2-streams": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.10.tgz",
-      "integrity": "sha512-8pnlMjvnIZJvmTzUIIA5nT4jr2ZWNNVHwyXfMGdRJbug9TpI3kd99ffglgfSWqujVv/0gxwMsDn9j9RVst8yhQ==",
-      "dependencies": {
-        "asn1": "~0.2.0",
+        "asn1": "^0.2.4",
         "bcrypt-pbkdf": "^1.0.2",
-        "streamsearch": "~0.1.2"
+        "cpu-features": "0.0.2",
+        "nan": "^2.15.0"
       },
       "engines": {
-        "node": ">=5.2.0"
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "0.0.2",
+        "nan": "^2.15.0"
       }
     },
     "node_modules/sshpk": {
@@ -23268,14 +23275,6 @@
       "dev": true,
       "dependencies": {
         "mixme": "^0.5.0"
-      }
-    },
-    "node_modules/streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/strict-uri-encode": {
@@ -33554,6 +33553,15 @@
         }
       }
     },
+    "cpu-features": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.2.tgz",
+      "integrity": "sha512-/2yieBqvMcRj8McNzkycjW2v3OIUOibBfd2dLEJ0nWts8NobAxwiyw9phVNS6oDL8x8tz9F7uNVFEVpJncQpeA==",
+      "optional": true,
+      "requires": {
+        "nan": "^2.14.1"
+      }
+    },
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -34195,14 +34203,14 @@
       }
     },
     "docker-modem": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-2.1.3.tgz",
-      "integrity": "sha512-cwaRptBmYZwu/FyhGcqBm2MzXA77W2/E6eVkpOZVDk6PkI9Bjj84xPrXiHMA+OWjzNy+DFjgKh8Q+1hMR7/OHg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-3.0.3.tgz",
+      "integrity": "sha512-Tgkn2a+yiNP9FoZgMa/D9Wk+D2Db///0KOyKSYZRJa8w4+DzKyzQMkczKSdR/adQ0x46BOpeNkoyEOKjPhCzjw==",
       "requires": {
         "debug": "^4.1.1",
         "readable-stream": "^3.5.0",
         "split-ca": "^1.0.1",
-        "ssh2": "^0.8.7"
+        "ssh2": "^1.4.0"
       }
     },
     "dockerfile-ast": {
@@ -40581,7 +40589,6 @@
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
       "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
-      "dev": true,
       "optional": true
     },
     "nanoid": {
@@ -43627,7 +43634,7 @@
         "snyk": "file:",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.9.0",
-        "snyk-docker-plugin": "4.25.0",
+        "snyk-docker-plugin": "4.25.1",
         "snyk-go-plugin": "1.17.0",
         "snyk-gradle-plugin": "3.16.1",
         "snyk-module": "3.1.0",
@@ -50983,6 +50990,15 @@
             }
           }
         },
+        "cpu-features": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.2.tgz",
+          "integrity": "sha512-/2yieBqvMcRj8McNzkycjW2v3OIUOibBfd2dLEJ0nWts8NobAxwiyw9phVNS6oDL8x8tz9F7uNVFEVpJncQpeA==",
+          "optional": true,
+          "requires": {
+            "nan": "^2.14.1"
+          }
+        },
         "create-require": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -51624,14 +51640,14 @@
           }
         },
         "docker-modem": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-2.1.3.tgz",
-          "integrity": "sha512-cwaRptBmYZwu/FyhGcqBm2MzXA77W2/E6eVkpOZVDk6PkI9Bjj84xPrXiHMA+OWjzNy+DFjgKh8Q+1hMR7/OHg==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-3.0.3.tgz",
+          "integrity": "sha512-Tgkn2a+yiNP9FoZgMa/D9Wk+D2Db///0KOyKSYZRJa8w4+DzKyzQMkczKSdR/adQ0x46BOpeNkoyEOKjPhCzjw==",
           "requires": {
             "debug": "^4.1.1",
             "readable-stream": "^3.5.0",
             "split-ca": "^1.0.1",
-            "ssh2": "^0.8.7"
+            "ssh2": "^1.4.0"
           }
         },
         "dockerfile-ast": {
@@ -58010,7 +58026,6 @@
           "version": "2.15.0",
           "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
           "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
-          "dev": true,
           "optional": true
         },
         "nanoid": {
@@ -61074,9 +61089,9 @@
           }
         },
         "snyk-docker-plugin": {
-          "version": "4.25.0",
-          "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.25.0.tgz",
-          "integrity": "sha512-JxnN5dcDJ3U3qMrstKqbx7rzrYEBFfS92De+o3yq/D5KujYhEsyG/pI1GBLszyQN0Gat7F+MWynSCYO8xCnLrg==",
+          "version": "4.25.1",
+          "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.25.1.tgz",
+          "integrity": "sha512-MSZI2zU5sVvmaFMalPrEumtDjGZrO2zgyGwjU6pO39ceTEC1B73YGZYs1tUYfuHLzsqFKpWTFwH9MwOWFmNMvQ==",
           "requires": {
             "@snyk/dep-graph": "^1.28.0",
             "@snyk/rpm-parser": "^2.0.0",
@@ -61084,7 +61099,7 @@
             "adm-zip": "^0.5.5",
             "chalk": "^2.4.2",
             "debug": "^4.1.1",
-            "docker-modem": "2.1.3",
+            "docker-modem": "3.0.3",
             "dockerfile-ast": "0.2.1",
             "elfy": "^1.0.0",
             "event-loop-spinner": "^2.0.0",
@@ -61943,21 +61958,14 @@
           "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
         },
         "ssh2": {
-          "version": "0.8.9",
-          "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.9.tgz",
-          "integrity": "sha512-GmoNPxWDMkVpMFa9LVVzQZHF6EW3WKmBwL+4/GeILf2hFmix5Isxm7Amamo8o7bHiU0tC+wXsGcUXOxp8ChPaw==",
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.4.0.tgz",
+          "integrity": "sha512-XvXwcXKvS452DyQvCa6Ct+chpucwc/UyxgliYz+rWXJ3jDHdtBb9xgmxJdMmnIn5bpgGAEV3KaEsH98ZGPHqwg==",
           "requires": {
-            "ssh2-streams": "~0.4.10"
-          }
-        },
-        "ssh2-streams": {
-          "version": "0.4.10",
-          "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.10.tgz",
-          "integrity": "sha512-8pnlMjvnIZJvmTzUIIA5nT4jr2ZWNNVHwyXfMGdRJbug9TpI3kd99ffglgfSWqujVv/0gxwMsDn9j9RVst8yhQ==",
-          "requires": {
-            "asn1": "~0.2.0",
+            "asn1": "^0.2.4",
             "bcrypt-pbkdf": "^1.0.2",
-            "streamsearch": "~0.1.2"
+            "cpu-features": "0.0.2",
+            "nan": "^2.15.0"
           }
         },
         "sshpk": {
@@ -62151,11 +62159,6 @@
           "requires": {
             "mixme": "^0.5.0"
           }
-        },
-        "streamsearch": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-          "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
         },
         "strict-uri-encode": {
           "version": "2.0.0",
@@ -64415,9 +64418,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.25.0.tgz",
-      "integrity": "sha512-JxnN5dcDJ3U3qMrstKqbx7rzrYEBFfS92De+o3yq/D5KujYhEsyG/pI1GBLszyQN0Gat7F+MWynSCYO8xCnLrg==",
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.25.1.tgz",
+      "integrity": "sha512-MSZI2zU5sVvmaFMalPrEumtDjGZrO2zgyGwjU6pO39ceTEC1B73YGZYs1tUYfuHLzsqFKpWTFwH9MwOWFmNMvQ==",
       "requires": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/rpm-parser": "^2.0.0",
@@ -64425,7 +64428,7 @@
         "adm-zip": "^0.5.5",
         "chalk": "^2.4.2",
         "debug": "^4.1.1",
-        "docker-modem": "2.1.3",
+        "docker-modem": "3.0.3",
         "dockerfile-ast": "0.2.1",
         "elfy": "^1.0.0",
         "event-loop-spinner": "^2.0.0",
@@ -65284,21 +65287,14 @@
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "ssh2": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.9.tgz",
-      "integrity": "sha512-GmoNPxWDMkVpMFa9LVVzQZHF6EW3WKmBwL+4/GeILf2hFmix5Isxm7Amamo8o7bHiU0tC+wXsGcUXOxp8ChPaw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.4.0.tgz",
+      "integrity": "sha512-XvXwcXKvS452DyQvCa6Ct+chpucwc/UyxgliYz+rWXJ3jDHdtBb9xgmxJdMmnIn5bpgGAEV3KaEsH98ZGPHqwg==",
       "requires": {
-        "ssh2-streams": "~0.4.10"
-      }
-    },
-    "ssh2-streams": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.10.tgz",
-      "integrity": "sha512-8pnlMjvnIZJvmTzUIIA5nT4jr2ZWNNVHwyXfMGdRJbug9TpI3kd99ffglgfSWqujVv/0gxwMsDn9j9RVst8yhQ==",
-      "requires": {
-        "asn1": "~0.2.0",
+        "asn1": "^0.2.4",
         "bcrypt-pbkdf": "^1.0.2",
-        "streamsearch": "~0.1.2"
+        "cpu-features": "0.0.2",
+        "nan": "^2.15.0"
       }
     },
     "sshpk": {
@@ -65492,11 +65488,6 @@
       "requires": {
         "mixme": "^0.5.0"
       }
-    },
-    "streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
     "strict-uri-encode": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.9.0",
-    "snyk-docker-plugin": "4.25.0",
+    "snyk-docker-plugin": "4.25.1",
     "snyk-go-plugin": "1.17.0",
     "snyk-gradle-plugin": "3.16.1",
     "snyk-module": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.9.0",
-    "snyk-docker-plugin": "4.25.1",
+    "snyk-docker-plugin": "4.25.2",
     "snyk-go-plugin": "1.17.0",
     "snyk-gradle-plugin": "3.16.1",
     "snyk-module": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.9.0",
-    "snyk-docker-plugin": "4.24.0",
+    "snyk-docker-plugin": "4.25.0",
     "snyk-go-plugin": "1.17.0",
     "snyk-gradle-plugin": "3.16.1",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Upgrades the `snyk-docker-plugin` dependency to [v4.25.2](https://github.com/snyk/snyk-docker-plugin/releases/tag/v4.25.2)

#### Where should the reviewer start?
The `package-lock.json` file is probably the best place to look for any potential issues with this PR.  It was auto-generated by `npm install --also=dev` on my local machine.  Hopefully it's fine, but generating canonical, reproducible dependency lockfiles can seem more difficult than it should be in many package-management systems.

Edits: (version updates, and not talking about myself in the third-person!)

#### How should this be manually tested?
Existing tests should continue to pass.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
N/A

#### Screenshots
N/A

#### Additional questions
N/A