### PR TITLE
fix: update yaml parser to fix parsing [CC-1175]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4903,9 +4903,9 @@
       }
     },
     "node_modules/@snyk/cloud-config-parser": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.11.0.tgz",
-      "integrity": "sha512-L3SnkPkc1nocvrELYHhjlkFB0nHUXXLJUL3MxF2p8Xp6R+Tm9LJ4JMOovmzZ60OR4z7t/Ypp+y5O4mEfqTF6xA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.11.1.tgz",
+      "integrity": "sha512-x6reqkw2RetrpxZdn/jm26L2dpdsR6mPU6lmQGbPkJc1DDmmI5eyhBQyKzwMJxdVc7axL88xgUefTXAuDBzzLA==",
       "dependencies": {
         "esprima": "^4.0.1",
         "tslib": "^1.10.0",
@@ -30082,9 +30082,9 @@
       }
     },
     "@snyk/cloud-config-parser": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.11.0.tgz",
-      "integrity": "sha512-L3SnkPkc1nocvrELYHhjlkFB0nHUXXLJUL3MxF2p8Xp6R+Tm9LJ4JMOovmzZ60OR4z7t/Ypp+y5O4mEfqTF6xA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.11.1.tgz",
+      "integrity": "sha512-x6reqkw2RetrpxZdn/jm26L2dpdsR6mPU6lmQGbPkJc1DDmmI5eyhBQyKzwMJxdVc7axL88xgUefTXAuDBzzLA==",
       "requires": {
         "esprima": "^4.0.1",
         "tslib": "^1.10.0",
@@ -47511,9 +47511,9 @@
           }
         },
         "@snyk/cloud-config-parser": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.11.0.tgz",
-          "integrity": "sha512-L3SnkPkc1nocvrELYHhjlkFB0nHUXXLJUL3MxF2p8Xp6R+Tm9LJ4JMOovmzZ60OR4z7t/Ypp+y5O4mEfqTF6xA==",
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.11.1.tgz",
+          "integrity": "sha512-x6reqkw2RetrpxZdn/jm26L2dpdsR6mPU6lmQGbPkJc1DDmmI5eyhBQyKzwMJxdVc7axL88xgUefTXAuDBzzLA==",
           "requires": {
             "esprima": "^4.0.1",
             "tslib": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "@open-policy-agent/opa-wasm": "^1.2.0",
     "@snyk/cli-interface": "2.11.0",
-    "@snyk/cloud-config-parser": "^1.11.0",
+    "@snyk/cloud-config-parser": "^1.11.1",
     "@snyk/code-client": "^4.2.3",
     "@snyk/dep-graph": "^1.27.1",
     "@snyk/fix": "file:packages/snyk-fix",


### PR DESCRIPTION
#### What does this PR do?

This PR updates the version of `@snyk/cloud-config-parser` in order to fix a parsing inconsistency where `\/` doesn't fail parsing in the YAML JavaScript parser.

#### How should this be manually tested?
I've tested this locally by importing a repo that has an IaC YAML file where one of they keys has a value like `"\/"Test\/""`

#### Any background context you want to provide?
This will hopefully reduce the number of error logs that cause this alert to hit us every day: https://snyk.slack.com/archives/C023NA9FQCU/p1632279068000600

#### What are the relevant tickets?
- [Jira ticket CC-1175](https://snyksec.atlassian.net/browse/CC-1175)

#### Screenshots
We can see a comparison of the before (`snyk-dev`) and after (`snyk`).
<img width="1503" alt="Screenshot 2021-09-22 at 09 11 49" src="https://user-images.githubusercontent.com/81559517/134292368-e31b88aa-e899-4087-9004-d6ab443c5660.png">

Now, the fail correctly isn't considered valid YAML and the CLI scanning is consistent with the SCM import as per https://github.com/snyk/registry/pull/23716.
