### PR TITLE
feat: support project attributes via CLI

### DIFF
--- a/help/commands-md/snyk-monitor.md
+++ b/help/commands-md/snyk-monitor.md
@@ -82,6 +82,15 @@ For advanced usage, we offer language and context specific flags, listed further
   (only in `monitor` command)
   A reference to separate this project from other scans of the same project. For example, a branch name or version. Projects using the same reference can be used for grouping. [More information](https://snyk.info/3B0vTPs).
 
+- `--environment`=<ENVIRONMENT>[,<ENVIRONMENT>]...>:
+  Set the project environment to one or more values (comma-separated). Allowed values: frontend, backend, internal, external, mobile, saas, onprem, hosted, distributed
+
+- `--lifecycle`=<LIFECYCLE>[,<LIFECYCLE>]...>:
+  Set the project lifecycle to one or more values (comma-separated). Allowed values: production, development, sandbox
+
+- `--business-criticality`=<BUSINESS_CRITICALITY>[,<BUSINESS_CRITICALITY>]...>:
+  Set the project business criticality to one or more values (comma-separated). Allowed values: critical, high, medium, low
+
 - `--policy-path`=<PATH_TO_POLICY_FILE>`:
   Manually pass a path to a snyk policy file.
 

--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -356,7 +356,7 @@ function getProjectAttribute<T>(
   return values;
 }
 
-function generateProjectAttributes(options: Options): ProjectAttributes {
+export function generateProjectAttributes(options): ProjectAttributes {
   return {
     criticality: getProjectAttribute(
       'business-criticality',
@@ -382,7 +382,7 @@ function generateProjectAttributes(options: Options): ProjectAttributes {
  * @param options CLI options
  * @returns List of parsed tags or undefined if they are to be left untouched.
  */
-function generateTags(options): Tag[] | undefined {
+export function generateTags(options): Tag[] | undefined {
   if (options.tags === undefined) {
     return undefined;
   }

--- a/src/lib/monitor/index.ts
+++ b/src/lib/monitor/index.ts
@@ -18,6 +18,7 @@ import {
   Options,
   Contributor,
   ProjectAttributes,
+  Tag,
 } from '../types';
 import * as projectMetadata from '../project-metadata';
 import {
@@ -92,6 +93,7 @@ export async function monitor(
   targetFileRelativePath?: string,
   contributors?: Contributor[],
   projectAttributes?: ProjectAttributes,
+  tags?: Tag[],
 ): Promise<MonitorResult> {
   apiOrOAuthTokenExists();
 
@@ -109,6 +111,7 @@ export async function monitor(
       targetFileRelativePath,
       contributors,
       projectAttributes,
+      tags,
     );
   }
 
@@ -122,6 +125,7 @@ export async function monitor(
       targetFileRelativePath,
       contributors,
       projectAttributes,
+      tags,
     );
   }
 
@@ -134,6 +138,7 @@ export async function monitor(
     targetFileRelativePath,
     contributors,
     projectAttributes,
+    tags,
   );
 }
 
@@ -146,6 +151,7 @@ async function monitorDepTree(
   targetFileRelativePath?: string,
   contributors?: Contributor[],
   projectAttributes?: ProjectAttributes,
+  tags?: Tag[],
 ): Promise<MonitorResult> {
   let treeMissingDeps: string[] = [];
 
@@ -287,6 +293,7 @@ async function monitorDepTree(
       targetReference: meta.targetReference,
       contributors,
       projectAttributes,
+      tags,
     } as MonitorBody,
     gzip: true,
     method: 'PUT',
@@ -319,6 +326,7 @@ export async function monitorDepGraph(
   targetFileRelativePath?: string,
   contributors?: Contributor[],
   projectAttributes?: ProjectAttributes,
+  tags?: Tag[],
 ): Promise<MonitorResult> {
   const packageManager = meta.packageManager;
   analytics.add('monitorDepGraph', true);
@@ -434,6 +442,7 @@ export async function monitorDepGraph(
       contributors,
       callGraph: callGraphPayload,
       projectAttributes,
+      tags,
     } as MonitorBody,
     gzip: true,
     method: 'PUT',
@@ -466,6 +475,7 @@ async function monitorDepGraphFromDepTree(
   targetFileRelativePath?: string,
   contributors?: Contributor[],
   projectAttributes?: ProjectAttributes,
+  tags?: Tag[],
 ): Promise<MonitorResult> {
   const packageManager = meta.packageManager;
 
@@ -566,6 +576,7 @@ async function monitorDepGraphFromDepTree(
       targetReference: meta.targetReference,
       contributors,
       projectAttributes,
+      tags,
     } as MonitorBody,
     gzip: true,
     method: 'PUT',

--- a/src/lib/monitor/index.ts
+++ b/src/lib/monitor/index.ts
@@ -17,6 +17,7 @@ import {
   MonitorOptions,
   Options,
   Contributor,
+  ProjectAttributes,
 } from '../types';
 import * as projectMetadata from '../project-metadata';
 import {
@@ -90,6 +91,7 @@ export async function monitor(
   pluginMeta: PluginMetadata,
   targetFileRelativePath?: string,
   contributors?: Contributor[],
+  projectAttributes?: ProjectAttributes,
 ): Promise<MonitorResult> {
   apiOrOAuthTokenExists();
 
@@ -106,6 +108,7 @@ export async function monitor(
       options,
       targetFileRelativePath,
       contributors,
+      projectAttributes,
     );
   }
 
@@ -118,6 +121,7 @@ export async function monitor(
       options,
       targetFileRelativePath,
       contributors,
+      projectAttributes,
     );
   }
 
@@ -129,6 +133,7 @@ export async function monitor(
     options,
     targetFileRelativePath,
     contributors,
+    projectAttributes,
   );
 }
 
@@ -140,6 +145,7 @@ async function monitorDepTree(
   options: MonitorOptions & PolicyOptions,
   targetFileRelativePath?: string,
   contributors?: Contributor[],
+  projectAttributes?: ProjectAttributes,
 ): Promise<MonitorResult> {
   let treeMissingDeps: string[] = [];
 
@@ -280,6 +286,7 @@ async function monitorDepTree(
       targetFileRelativePath,
       targetReference: meta.targetReference,
       contributors,
+      projectAttributes,
     } as MonitorBody,
     gzip: true,
     method: 'PUT',
@@ -311,6 +318,7 @@ export async function monitorDepGraph(
   options: MonitorOptions & PolicyOptions,
   targetFileRelativePath?: string,
   contributors?: Contributor[],
+  projectAttributes?: ProjectAttributes,
 ): Promise<MonitorResult> {
   const packageManager = meta.packageManager;
   analytics.add('monitorDepGraph', true);
@@ -425,6 +433,7 @@ export async function monitorDepGraph(
       targetReference: meta.targetReference,
       contributors,
       callGraph: callGraphPayload,
+      projectAttributes,
     } as MonitorBody,
     gzip: true,
     method: 'PUT',
@@ -456,6 +465,7 @@ async function monitorDepGraphFromDepTree(
   options: MonitorOptions & PolicyOptions,
   targetFileRelativePath?: string,
   contributors?: Contributor[],
+  projectAttributes?: ProjectAttributes,
 ): Promise<MonitorResult> {
   const packageManager = meta.packageManager;
 
@@ -555,6 +565,7 @@ async function monitorDepGraphFromDepTree(
       targetFileRelativePath,
       targetReference: meta.targetReference,
       contributors,
+      projectAttributes,
     } as MonitorBody,
     gzip: true,
     method: 'PUT',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -71,6 +71,7 @@ export interface Options {
   'print-deps'?: boolean;
   'print-dep-paths'?: boolean;
   'remote-repo-url'?: string;
+  criticality?: string;
   scanAllUnmanaged?: boolean;
   allProjects?: boolean;
   detectionDepth?: number;
@@ -121,6 +122,37 @@ export interface MonitorMeta {
   prune: boolean;
   'remote-repo-url'?: string;
   targetReference?: string;
+}
+
+export interface ProjectAttributes {
+  criticality?: PROJECT_CRITICALITY[];
+  environment?: PROJECT_ENVIRONMENT[];
+  lifecycle?: PROJECT_LIFECYCLE[];
+}
+
+export enum PROJECT_CRITICALITY {
+  CRITICAL = 'critical',
+  HIGH = 'high',
+  MEDIUM = 'medium',
+  LOW = 'low',
+}
+
+export enum PROJECT_ENVIRONMENT {
+  FRONTEND = 'frontend',
+  BACKEND = 'backend',
+  INTERNAL = 'internal',
+  EXTERNAL = 'external',
+  MOBILE = 'mobile',
+  SAAS = 'saas',
+  ONPREM = 'onprem',
+  HOSTED = 'hosted',
+  DISTRIBUTED = 'distributed',
+}
+
+export enum PROJECT_LIFECYCLE {
+  PRODUCTION = 'production',
+  DEVELOPMENT = 'development',
+  SANDBOX = 'sandbox',
 }
 
 export interface PackageJson {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -86,6 +86,7 @@ export interface Options {
   'group-issues'?: boolean;
   quiet?: boolean;
   'fail-fast'?: boolean;
+  tags?: string;
 }
 
 // TODO(kyegupov): catch accessing ['undefined-properties'] via noImplicitAny
@@ -122,6 +123,11 @@ export interface MonitorMeta {
   prune: boolean;
   'remote-repo-url'?: string;
   targetReference?: string;
+}
+
+export interface Tag {
+  key: string;
+  value: string;
 }
 
 export interface ProjectAttributes {

--- a/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
+++ b/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
@@ -517,6 +517,18 @@ if (!isWindows) {
     ]);
   });
 
+  test('`monitor npm-package with --tags`', async (t) => {
+    chdirWorkspaces();
+    await cli.monitor('npm-package', {
+      tags: 'department=finance,team=outbound-payments',
+    });
+    const req = server.popRequest();
+    t.deepEqual(req.body.tags, [
+      { key: 'department', value: 'finance' },
+      { key: 'team', value: 'outbound-payments' },
+    ]);
+  });
+
   test('`monitor npm-package with custom --remote-repo-url`', async (t) => {
     chdirWorkspaces();
     await cli.monitor('npm-package', {
@@ -714,6 +726,20 @@ if (!isWindows) {
     });
     const req = server.popRequest();
     t.deepEqual(req.body.projectAttributes.criticality, ['high', 'medium']);
+  });
+
+  test('`monitor maven-multi-app with --tags`', async (t) => {
+    chdirWorkspaces();
+    stubExec(t, 'maven-multi-app/mvn-dep-tree-stdout.txt');
+    await cli.monitor('maven-multi-app', {
+      file: 'pom.xml',
+      tags: 'department=finance,team=outbound-payments',
+    });
+    const req = server.popRequest();
+    t.deepEqual(req.body.tags, [
+      { key: 'department', value: 'finance' },
+      { key: 'team', value: 'outbound-payments' },
+    ]);
   });
 
   test('`monitor maven-multi-app with --environment`', async (t) => {

--- a/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
+++ b/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
@@ -484,6 +484,39 @@ if (!isWindows) {
     t.equal(req.body.meta.projectName, 'custom-project-name');
   });
 
+  test('`monitor npm-package with --business-criticality`', async (t) => {
+    chdirWorkspaces();
+    await cli.monitor('npm-package', {
+      'business-criticality': 'high,medium',
+    });
+    const req = server.popRequest();
+    t.deepEqual(req.body.projectAttributes.criticality, ['high', 'medium']);
+  });
+
+  test('`monitor npm-package with --environment`', async (t) => {
+    chdirWorkspaces();
+    await cli.monitor('npm-package', {
+      environment: 'frontend,backend',
+    });
+    const req = server.popRequest();
+    t.deepEqual(req.body.projectAttributes.environment, [
+      'frontend',
+      'backend',
+    ]);
+  });
+
+  test('`monitor npm-package with --lifecycle`', async (t) => {
+    chdirWorkspaces();
+    await cli.monitor('npm-package', {
+      lifecycle: 'production,sandbox',
+    });
+    const req = server.popRequest();
+    t.deepEqual(req.body.projectAttributes.lifecycle, [
+      'production',
+      'sandbox',
+    ]);
+  });
+
   test('`monitor npm-package with custom --remote-repo-url`', async (t) => {
     chdirWorkspaces();
     await cli.monitor('npm-package', {
@@ -670,6 +703,45 @@ if (!isWindows) {
       pkg.dependencies['com.mycompany.app:simple-child'].from,
       'no "from" array on dep',
     );
+  });
+
+  test('`monitor maven-multi-app with --business-criticality`', async (t) => {
+    chdirWorkspaces();
+    stubExec(t, 'maven-multi-app/mvn-dep-tree-stdout.txt');
+    await cli.monitor('maven-multi-app', {
+      file: 'pom.xml',
+      'business-criticality': 'high,medium',
+    });
+    const req = server.popRequest();
+    t.deepEqual(req.body.projectAttributes.criticality, ['high', 'medium']);
+  });
+
+  test('`monitor maven-multi-app with --environment`', async (t) => {
+    chdirWorkspaces();
+    stubExec(t, 'maven-multi-app/mvn-dep-tree-stdout.txt');
+    await cli.monitor('maven-multi-app', {
+      file: 'pom.xml',
+      environment: 'frontend,backend',
+    });
+    const req = server.popRequest();
+    t.deepEqual(req.body.projectAttributes.environment, [
+      'frontend',
+      'backend',
+    ]);
+  });
+
+  test('`monitor maven-multi-app with --lifecycle`', async (t) => {
+    chdirWorkspaces();
+    stubExec(t, 'maven-multi-app/mvn-dep-tree-stdout.txt');
+    await cli.monitor('maven-multi-app', {
+      file: 'pom.xml',
+      lifecycle: 'production,sandbox',
+    });
+    const req = server.popRequest();
+    t.deepEqual(req.body.projectAttributes.lifecycle, [
+      'production',
+      'sandbox',
+    ]);
   });
 
   test('`monitor maven-app-with-jars --file=example.jar` sends package info', async (t) => {

--- a/test/jest/acceptance/cli-args.spec.ts
+++ b/test/jest/acceptance/cli-args.spec.ts
@@ -278,6 +278,117 @@ describe('cli args', () => {
     });
   });
 
+  test('snyk monitor --business-criticality without an = returns the correct error', async () => {
+    const { code, stdout } = await runSnykCLI(
+      `monitor --business-criticality`,
+      {
+        env,
+      },
+    );
+    expect(stdout).toMatch(
+      "--business-criticality must contain an '=' with a comma-separated list of values. To clear all existing values, pass no values i.e. --business-criticality=",
+    );
+    expect(code).toEqual(2);
+  });
+
+  test('snyk monitor --business-criticality with a single invalid value returns the correct error', async () => {
+    const { code, stdout } = await runSnykCLI(
+      `monitor --business-criticality=high,invalid`,
+      {
+        env,
+      },
+    );
+    expect(stdout).toMatch(
+      '1 invalid business-criticality: invalid. Possible values are: critical, high, medium, low',
+    );
+    expect(code).toEqual(2);
+  });
+
+  test('snyk monitor --business-criticality with a multiple invalid values returns the correct error', async () => {
+    const { code, stdout } = await runSnykCLI(
+      `monitor --business-criticality=invalid1,invalid2`,
+      {
+        env,
+      },
+    );
+    expect(stdout).toMatch(
+      '2 invalid business-criticality: invalid1, invalid2. Possible values are: critical, high, medium, low',
+    );
+    expect(code).toEqual(2);
+  });
+
+  test('snyk monitor --environment without an = returns the correct error', async () => {
+    const { code, stdout } = await runSnykCLI(`monitor --environment`, {
+      env,
+    });
+    expect(stdout).toMatch(
+      "--environment must contain an '=' with a comma-separated list of values. To clear all existing values, pass no values i.e. --environment=",
+    );
+    expect(code).toEqual(2);
+  });
+
+  test('snyk monitor --environment with an invalid value returns the correct error', async () => {
+    const { code, stdout } = await runSnykCLI(
+      `monitor --environment=frontend,invalid`,
+      {
+        env,
+      },
+    );
+    expect(stdout).toMatch(
+      '1 invalid environment: invalid. Possible values are: frontend, backend, internal, external, mobile, saas, onprem, hosted, distributed',
+    );
+    expect(code).toEqual(2);
+  });
+
+  test('snyk monitor --environment with a multiple invalid values returns the correct error', async () => {
+    const { code, stdout } = await runSnykCLI(
+      `monitor --environment=invalid1,invalid2`,
+      {
+        env,
+      },
+    );
+    expect(stdout).toMatch(
+      '2 invalid environment: invalid1, invalid2. Possible values are: frontend, backend, internal, external, mobile, saas, onprem, hosted, distributed',
+    );
+    expect(code).toEqual(2);
+  });
+
+  test('snyk monitor --lifecycle without an = returns the correct error', async () => {
+    const { code, stdout } = await runSnykCLI(`monitor --lifecycle`, {
+      env,
+    });
+    expect(stdout).toMatch(
+      "--lifecycle must contain an '=' with a comma-separated list of values. To clear all existing values, pass no values i.e. --lifecycle=",
+    );
+    expect(code).toEqual(2);
+  });
+
+  test('snyk monitor --lifecycle with an invalid value returns the correct error', async () => {
+    const { code, stdout } = await runSnykCLI(
+      `monitor --lifecycle=production,invalid`,
+      {
+        env,
+      },
+    );
+    expect(stdout).toMatch(
+      '1 invalid lifecycle: invalid. Possible values are: production, development, sandbox',
+    );
+    expect(code).toEqual(2);
+  });
+
+  test('snyk monitor --lifecycle with a multiple invalid values returns the correct error', async () => {
+    const { code, stdout } = await runSnykCLI(
+      `monitor --lifecycle=invalid1,invalid2`,
+      {
+        env,
+      },
+    );
+    expect(stdout).toMatch(
+      '2 invalid lifecycle: invalid1, invalid2. Possible values are: production, development, sandbox',
+    );
+    expect(code).toEqual(2);
+  });
+
   const optionsToTest = [
     '--json-file-output',
     '--json-file-output=',

--- a/test/jest/acceptance/cli-args.spec.ts
+++ b/test/jest/acceptance/cli-args.spec.ts
@@ -278,7 +278,7 @@ describe('cli args', () => {
     });
   });
 
-  test('snyk monitor --business-criticality without an = returns the correct error', async () => {
+  test('project attributes are implemented (--business-criticality, --lifecycle, --environment)', async () => {
     const { code, stdout } = await runSnykCLI(
       `monitor --business-criticality`,
       {
@@ -291,123 +291,12 @@ describe('cli args', () => {
     expect(code).toEqual(2);
   });
 
-  test('snyk monitor --business-criticality with a single invalid value returns the correct error', async () => {
-    const { code, stdout } = await runSnykCLI(
-      `monitor --business-criticality=high,invalid`,
-      {
-        env,
-      },
-    );
-    expect(stdout).toMatch(
-      '1 invalid business-criticality: invalid. Possible values are: critical, high, medium, low',
-    );
-    expect(code).toEqual(2);
-  });
-
-  test('snyk monitor --business-criticality with a multiple invalid values returns the correct error', async () => {
-    const { code, stdout } = await runSnykCLI(
-      `monitor --business-criticality=invalid1,invalid2`,
-      {
-        env,
-      },
-    );
-    expect(stdout).toMatch(
-      '2 invalid business-criticality: invalid1, invalid2. Possible values are: critical, high, medium, low',
-    );
-    expect(code).toEqual(2);
-  });
-
-  test('snyk monitor --environment without an = returns the correct error', async () => {
-    const { code, stdout } = await runSnykCLI(`monitor --environment`, {
-      env,
-    });
-    expect(stdout).toMatch(
-      "--environment must contain an '=' with a comma-separated list of values. To clear all existing values, pass no values i.e. --environment=",
-    );
-    expect(code).toEqual(2);
-  });
-
-  test('snyk monitor --environment with an invalid value returns the correct error', async () => {
-    const { code, stdout } = await runSnykCLI(
-      `monitor --environment=frontend,invalid`,
-      {
-        env,
-      },
-    );
-    expect(stdout).toMatch(
-      '1 invalid environment: invalid. Possible values are: frontend, backend, internal, external, mobile, saas, onprem, hosted, distributed',
-    );
-    expect(code).toEqual(2);
-  });
-
-  test('snyk monitor --environment with a multiple invalid values returns the correct error', async () => {
-    const { code, stdout } = await runSnykCLI(
-      `monitor --environment=invalid1,invalid2`,
-      {
-        env,
-      },
-    );
-    expect(stdout).toMatch(
-      '2 invalid environment: invalid1, invalid2. Possible values are: frontend, backend, internal, external, mobile, saas, onprem, hosted, distributed',
-    );
-    expect(code).toEqual(2);
-  });
-
-  test('snyk monitor --lifecycle without an = returns the correct error', async () => {
-    const { code, stdout } = await runSnykCLI(`monitor --lifecycle`, {
-      env,
-    });
-    expect(stdout).toMatch(
-      "--lifecycle must contain an '=' with a comma-separated list of values. To clear all existing values, pass no values i.e. --lifecycle=",
-    );
-    expect(code).toEqual(2);
-  });
-
-  test('snyk monitor --lifecycle with an invalid value returns the correct error', async () => {
-    const { code, stdout } = await runSnykCLI(
-      `monitor --lifecycle=production,invalid`,
-      {
-        env,
-      },
-    );
-    expect(stdout).toMatch(
-      '1 invalid lifecycle: invalid. Possible values are: production, development, sandbox',
-    );
-    expect(code).toEqual(2);
-  });
-
-  test('snyk monitor --lifecycle with a multiple invalid values returns the correct error', async () => {
-    const { code, stdout } = await runSnykCLI(
-      `monitor --lifecycle=invalid1,invalid2`,
-      {
-        env,
-      },
-    );
-    expect(stdout).toMatch(
-      '2 invalid lifecycle: invalid1, invalid2. Possible values are: production, development, sandbox',
-    );
-    expect(code).toEqual(2);
-  });
-
-  test('snyk monitor --tags without an = returns the correct error', async () => {
+  test('snyk monitor --tags is implemented', async () => {
     const { code, stdout } = await runSnykCLI(`monitor --tags`, {
       env,
     });
     expect(stdout).toMatch(
       "--tags must contain an '=' with a comma-separated list of pairs (also separated with an '='). To clear all existing values, pass no values i.e. --tags=",
-    );
-    expect(code).toEqual(2);
-  });
-
-  test('snyk monitor --tags with an invalid value returns the correct error', async () => {
-    const { code, stdout } = await runSnykCLI(
-      `monitor --tags=invalidAsOnlyAKeyWasSpecified`,
-      {
-        env,
-      },
-    );
-    expect(stdout).toMatch(
-      'The tag "invalidAsOnlyAKeyWasSpecified" does not have an "=" separating the key and value.',
     );
     expect(code).toEqual(2);
   });

--- a/test/jest/acceptance/cli-args.spec.ts
+++ b/test/jest/acceptance/cli-args.spec.ts
@@ -389,6 +389,29 @@ describe('cli args', () => {
     expect(code).toEqual(2);
   });
 
+  test('snyk monitor --tags without an = returns the correct error', async () => {
+    const { code, stdout } = await runSnykCLI(`monitor --tags`, {
+      env,
+    });
+    expect(stdout).toMatch(
+      "--tags must contain an '=' with a comma-separated list of pairs (also separated with an '='). To clear all existing values, pass no values i.e. --tags=",
+    );
+    expect(code).toEqual(2);
+  });
+
+  test('snyk monitor --tags with an invalid value returns the correct error', async () => {
+    const { code, stdout } = await runSnykCLI(
+      `monitor --tags=invalidAsOnlyAKeyWasSpecified`,
+      {
+        env,
+      },
+    );
+    expect(stdout).toMatch(
+      'The tag "invalidAsOnlyAKeyWasSpecified" does not have an "=" separating the key and value.',
+    );
+    expect(code).toEqual(2);
+  });
+
   const optionsToTest = [
     '--json-file-output',
     '--json-file-output=',

--- a/test/jest/acceptance/snyk-monitor/project-attributes.spec.ts
+++ b/test/jest/acceptance/snyk-monitor/project-attributes.spec.ts
@@ -1,0 +1,56 @@
+import { generateProjectAttributes } from '../../../../src/cli/commands/monitor';
+import {
+  PROJECT_CRITICALITY,
+  PROJECT_ENVIRONMENT,
+  PROJECT_LIFECYCLE,
+} from '../../../../src/lib/types';
+
+describe('project attributes (--lifecycle, --environment, --business-criticality)', () => {
+  it('returns undefined when they are all missing, for each option', () => {
+    expect(generateProjectAttributes({})).toStrictEqual({
+      criticality: undefined,
+      lifecycle: undefined,
+      environment: undefined,
+    });
+  });
+
+  it('parses the options correctly when they are valid', () => {
+    expect(
+      generateProjectAttributes({
+        'business-criticality': 'critical,high',
+        lifecycle: 'development,sandbox',
+        environment: 'backend,frontend',
+      }),
+    ).toStrictEqual({
+      criticality: [PROJECT_CRITICALITY.CRITICAL, PROJECT_CRITICALITY.HIGH],
+      lifecycle: [PROJECT_LIFECYCLE.DEVELOPMENT, PROJECT_LIFECYCLE.SANDBOX],
+      environment: [PROJECT_ENVIRONMENT.BACKEND, PROJECT_ENVIRONMENT.FRONTEND],
+    });
+  });
+
+  it('raises the correct error with an invalid business criticality', () => {
+    expect(() =>
+      generateProjectAttributes({ 'business-criticality': 'invalid' }),
+    ).toThrow(
+      '1 invalid business-criticality: invalid. Possible values are: critical, high, medium, low',
+    );
+  });
+
+  it('raises the correct error with an invalid lifecycle', () => {
+    expect(() => generateProjectAttributes({ lifecycle: 'invalid' })).toThrow(
+      '1 invalid lifecycle: invalid. Possible values are: production, development, sandbox',
+    );
+  });
+
+  it('raises the correct error with an invalid environment', () => {
+    expect(() => generateProjectAttributes({ environment: 'invalid' })).toThrow(
+      '1 invalid environment: invalid. Possible values are: frontend, backend, internal, external, mobile, saas, onprem, hosted, distributed',
+    );
+  });
+
+  it('raises the correct error with multiple invalid attributes', () => {
+    expect(() =>
+      generateProjectAttributes({ lifecycle: 'invalid1,invalid2' }),
+    ).toThrow(/2 invalid lifecycle: invalid1, invalid2/);
+  });
+});

--- a/test/jest/acceptance/snyk-monitor/tags.spec.ts
+++ b/test/jest/acceptance/snyk-monitor/tags.spec.ts
@@ -1,0 +1,47 @@
+import { generateTags } from '../../../../src/cli/commands/monitor/index';
+
+describe('--tags', () => {
+  it('raises the correct error when passed as --tags (i.e. missing the =)', () => {
+    expect(() => generateTags({ tags: true })).toThrow(
+      /must contain.*comma-separated/,
+    );
+  });
+
+  it('returns an empty set of tags when passed as --tags=', () => {
+    expect(generateTags({ tags: '' })).toStrictEqual([]);
+  });
+
+  it('returns undefined when --tags is not passed', () => {
+    expect(generateTags({ someOtherArg: true })).toBeUndefined();
+  });
+
+  it('raises the correct error when a key is supplied with no value', () => {
+    expect(() =>
+      generateTags({ tags: 'invalidAsOnlyAKeyWasSpecified' }),
+    ).toThrow(/does not have an "="/);
+  });
+
+  it('parses a single key/value pair into the correct data structure', () => {
+    expect(generateTags({ tags: 'team=rhino' })).toStrictEqual([
+      {
+        key: 'team',
+        value: 'rhino',
+      },
+    ]);
+  });
+
+  it('parses multiple key/value pairs into the correct data structure', () => {
+    expect(
+      generateTags({ tags: 'team=rhino,department=finance' }),
+    ).toStrictEqual([
+      {
+        key: 'team',
+        value: 'rhino',
+      },
+      {
+        key: 'department',
+        value: 'finance',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

(First CLI PR! Welcome all feedback.)

This PR adds 3 new flags for setting project attributes from the CLI:

* business criticality (set via `--business-criticality`)
* environment (set via `--environment`)
* lifecycle (set via `--lifecycle`)

Each one can only have a value from the documentation (this is validated locally). They map to these fields in the UI:

![image](https://user-images.githubusercontent.com/4825223/134392722-f364675f-6b31-43e3-a91a-5dee3050ea76.png)

The values that can be used are the same set that the UI allows you to select from. No free-form values are allowed for any of these 3 fields.

#### Where should the reviewer start?

Start with the docs and tests, this should explain the expected behaviour.

#### How should this be manually tested?

Use `snyk monitor` and pass each of the flags as above. If a flag is not provided, it is not updated on the project. If it is provided, the entire list provided (including an empty list) will overwrite what is already set - no merging occurs.

#### Any background context you want to provide?


#### What are the relevant tickets?

`RHINO-237`

#### Screenshots

Inlined above.

#### Additional questions
