### PR TITLE
chore: bump gradle plugin version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "snyk-cpp-plugin": "2.9.0",
         "snyk-docker-plugin": "4.24.0",
         "snyk-go-plugin": "1.18.0",
-        "snyk-gradle-plugin": "3.16.1",
+        "snyk-gradle-plugin": "3.16.2",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.26.2",
         "snyk-nodejs-lockfile-parser": "1.37.0",
@@ -23222,19 +23222,47 @@
       }
     },
     "node_modules/snyk-gradle-plugin": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.16.1.tgz",
-      "integrity": "sha512-ii+W544+vCsRe+I4FdmhnYwGq5ZZYacEkUswJoUYmj1sIkkN1G0iUyas/r9mX+ERjQlvzyN4diptZe9OeaTaaA==",
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.16.2.tgz",
+      "integrity": "sha512-0EFZ3yHwnn4BwuG9sSm5F4MPMLimJVtNr7A+NYohZabw951l+rm2jXj84/Any1WUrnpGi2TXTV4LreUnrwN/Qg==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.0",
         "@snyk/dep-graph": "^1.28.0",
-        "@snyk/java-call-graph-builder": "1.23.1",
+        "@snyk/java-call-graph-builder": "1.23.2",
         "@types/debug": "^4.1.4",
         "chalk": "^3.0.0",
         "debug": "^4.1.1",
         "tmp": "0.2.1",
         "tslib": "^2.0.0"
       }
+    },
+    "node_modules/snyk-gradle-plugin/node_modules/@snyk/java-call-graph-builder": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@snyk/java-call-graph-builder/-/java-call-graph-builder-1.23.2.tgz",
+      "integrity": "sha512-m66K9SHNuCSMnY2hItNSL+8dlj0KRyjiHBy8XuYv3fifGWwhYLQANl3uIkPx3tUTjqFzW7yHNeo8pqP4dTM9Jg==",
+      "dependencies": {
+        "@snyk/graphlib": "2.1.9-patch.3",
+        "ci-info": "^2.0.0",
+        "debug": "^4.1.1",
+        "glob": "^7.1.6",
+        "jszip": "^3.7.0",
+        "needle": "^2.3.3",
+        "progress": "^2.0.3",
+        "snyk-config": "^4.0.0-rc.2",
+        "source-map-support": "^0.5.7",
+        "temp-dir": "^2.0.0",
+        "tmp": "^0.2.1",
+        "tslib": "^1.9.3",
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/snyk-gradle-plugin/node_modules/@snyk/java-call-graph-builder/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/snyk-gradle-plugin/node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -23261,6 +23289,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/snyk-gradle-plugin/node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
     },
     "node_modules/snyk-gradle-plugin/node_modules/color-convert": {
       "version": "2.0.1",
@@ -45620,7 +45653,7 @@
         "ora": "5.4.0",
         "os-name": "^3.0.0",
         "pegjs": "^0.10.0",
-        "pkg": "*",
+        "pkg": "^5.3.2",
         "prettier": "^1.18.2",
         "promise-queue": "^2.2.5",
         "proxy-from-env": "^1.0.0",
@@ -45634,7 +45667,7 @@
         "snyk-cpp-plugin": "2.9.0",
         "snyk-docker-plugin": "4.24.0",
         "snyk-go-plugin": "1.18.0",
-        "snyk-gradle-plugin": "3.16.1",
+        "snyk-gradle-plugin": "3.16.2",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.26.2",
         "snyk-nodejs-lockfile-parser": "1.37.0",
@@ -64082,13 +64115,13 @@
           }
         },
         "snyk-gradle-plugin": {
-          "version": "3.16.1",
-          "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.16.1.tgz",
-          "integrity": "sha512-ii+W544+vCsRe+I4FdmhnYwGq5ZZYacEkUswJoUYmj1sIkkN1G0iUyas/r9mX+ERjQlvzyN4diptZe9OeaTaaA==",
+          "version": "3.16.2",
+          "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.16.2.tgz",
+          "integrity": "sha512-0EFZ3yHwnn4BwuG9sSm5F4MPMLimJVtNr7A+NYohZabw951l+rm2jXj84/Any1WUrnpGi2TXTV4LreUnrwN/Qg==",
           "requires": {
             "@snyk/cli-interface": "2.11.0",
             "@snyk/dep-graph": "^1.28.0",
-            "@snyk/java-call-graph-builder": "1.23.1",
+            "@snyk/java-call-graph-builder": "1.23.2",
             "@types/debug": "^4.1.4",
             "chalk": "^3.0.0",
             "debug": "^4.1.1",
@@ -64096,6 +64129,33 @@
             "tslib": "^2.0.0"
           },
           "dependencies": {
+            "@snyk/java-call-graph-builder": {
+              "version": "1.23.2",
+              "resolved": "https://registry.npmjs.org/@snyk/java-call-graph-builder/-/java-call-graph-builder-1.23.2.tgz",
+              "integrity": "sha512-m66K9SHNuCSMnY2hItNSL+8dlj0KRyjiHBy8XuYv3fifGWwhYLQANl3uIkPx3tUTjqFzW7yHNeo8pqP4dTM9Jg==",
+              "requires": {
+                "@snyk/graphlib": "2.1.9-patch.3",
+                "ci-info": "^2.0.0",
+                "debug": "^4.1.1",
+                "glob": "^7.1.6",
+                "jszip": "^3.7.0",
+                "needle": "^2.3.3",
+                "progress": "^2.0.3",
+                "snyk-config": "^4.0.0-rc.2",
+                "source-map-support": "^0.5.7",
+                "temp-dir": "^2.0.0",
+                "tmp": "^0.2.1",
+                "tslib": "^1.9.3",
+                "xml-js": "^1.6.11"
+              },
+              "dependencies": {
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+              }
+            },
             "ansi-styles": {
               "version": "4.3.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -64112,6 +64172,11 @@
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
               }
+            },
+            "ci-info": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+              "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
             },
             "color-convert": {
               "version": "2.0.1",
@@ -67516,13 +67581,13 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.16.1.tgz",
-      "integrity": "sha512-ii+W544+vCsRe+I4FdmhnYwGq5ZZYacEkUswJoUYmj1sIkkN1G0iUyas/r9mX+ERjQlvzyN4diptZe9OeaTaaA==",
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.16.2.tgz",
+      "integrity": "sha512-0EFZ3yHwnn4BwuG9sSm5F4MPMLimJVtNr7A+NYohZabw951l+rm2jXj84/Any1WUrnpGi2TXTV4LreUnrwN/Qg==",
       "requires": {
         "@snyk/cli-interface": "2.11.0",
         "@snyk/dep-graph": "^1.28.0",
-        "@snyk/java-call-graph-builder": "1.23.1",
+        "@snyk/java-call-graph-builder": "1.23.2",
         "@types/debug": "^4.1.4",
         "chalk": "^3.0.0",
         "debug": "^4.1.1",
@@ -67530,6 +67595,33 @@
         "tslib": "^2.0.0"
       },
       "dependencies": {
+        "@snyk/java-call-graph-builder": {
+          "version": "1.23.2",
+          "resolved": "https://registry.npmjs.org/@snyk/java-call-graph-builder/-/java-call-graph-builder-1.23.2.tgz",
+          "integrity": "sha512-m66K9SHNuCSMnY2hItNSL+8dlj0KRyjiHBy8XuYv3fifGWwhYLQANl3uIkPx3tUTjqFzW7yHNeo8pqP4dTM9Jg==",
+          "requires": {
+            "@snyk/graphlib": "2.1.9-patch.3",
+            "ci-info": "^2.0.0",
+            "debug": "^4.1.1",
+            "glob": "^7.1.6",
+            "jszip": "^3.7.0",
+            "needle": "^2.3.3",
+            "progress": "^2.0.3",
+            "snyk-config": "^4.0.0-rc.2",
+            "source-map-support": "^0.5.7",
+            "temp-dir": "^2.0.0",
+            "tmp": "^0.2.1",
+            "tslib": "^1.9.3",
+            "xml-js": "^1.6.11"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -67546,6 +67638,11 @@
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
           }
+        },
+        "ci-info": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
         },
         "color-convert": {
           "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "snyk-cpp-plugin": "2.9.0",
     "snyk-docker-plugin": "4.24.0",
     "snyk-go-plugin": "1.18.0",
-    "snyk-gradle-plugin": "3.16.1",
+    "snyk-gradle-plugin": "3.16.2",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.26.2",
     "snyk-nodejs-lockfile-parser": "1.37.0",


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Bumps version of `snyk-gradle-plugin` to 3.16.2 to include this fix (presented through `java-call-graph-builder`): https://github.com/snyk/java-call-graph-builder/pull/57

Use temporary file copied to the local filesystem to ensure the separate process that reads init.gradle can find it in binary releases.
