### PR TITLE
feat: Analytics for IaC Custom Rules

### DIFF
--- a/src/cli/commands/test/iac-local-execution/math-utils.ts
+++ b/src/cli/commands/test/iac-local-execution/math-utils.ts
@@ -1,0 +1,10 @@
+/**
+ * Calculate percentage from relative and total amounts.
+ * @param relativeValue The relative amount.
+ * @param totalValue  The total amount.
+ * @returns The calculated precentage.
+ */
+export const calculatePercentage = (
+  relativeValue: number,
+  totalValue: number,
+): number => +(totalValue ? (relativeValue / totalValue) * 100 : 0).toFixed(2);

--- a/src/cli/commands/test/iac-local-execution/results-formatter.ts
+++ b/src/cli/commands/test/iac-local-execution/results-formatter.ts
@@ -55,6 +55,7 @@ function formatScanResult(
   options: IaCTestFlags,
 ): FormattedResult {
   const fileType = getFileTypeForParser(scanResult.fileType);
+  const isGeneratedByCustomRule = scanResult.engineType === EngineType.Custom;
   let treeByDocId: MapsDocIdToTree;
   try {
     treeByDocId = getTrees(fileType, scanResult.fileContent);
@@ -88,6 +89,7 @@ function formatScanResult(
       severity: policy.severity,
       lineNumber,
       documentation: `https://snyk.io/security-rules/${policy.publicId}`,
+      isGeneratedByCustomRule,
     };
   });
 

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -72,6 +72,7 @@ export interface IacOrgSettings {
   meta: TestMeta;
   customPolicies: IacCustomPolicies;
 }
+
 export interface TestMeta {
   isPrivate: boolean;
   isLicensesEnabled: boolean;
@@ -105,6 +106,7 @@ export interface PolicyMetadata {
   subType: string;
   title: string;
   documentation?: string; // e.g. "https://snyk.io/security-rules/SNYK-CC-K8S-2",
+  isGeneratedByCustomRule?: boolean;
   // Legacy field, still included in WASM eval output, but not in use.
   description: string;
   severity: SEVERITY | 'none'; // the 'null' value can be provided by the backend

--- a/src/lib/snyk-test/iac-test-result.ts
+++ b/src/lib/snyk-test/iac-test-result.ts
@@ -11,6 +11,7 @@ export interface AnnotatedIacIssue {
   subType: string;
   path?: string[];
   documentation?: string;
+  isGeneratedByCustomRule?: boolean;
   // Legacy fields from Registry, unused.
   name?: string;
   from?: string[];

--- a/test/jest/unit/iac-unit-tests/math-utils.spec.ts
+++ b/test/jest/unit/iac-unit-tests/math-utils.spec.ts
@@ -1,0 +1,50 @@
+import { calculatePercentage } from '../../../../src/cli/commands/test/iac-local-execution/math-utils';
+
+describe('Math Utils', function() {
+  describe('calculatePercentage', function() {
+    it('correctly calculates that 5 is 50% of 10', function() {
+      const [relativeValue, totalValue] = [5, 10];
+      const expectedResult = 50;
+
+      const result = calculatePercentage(relativeValue, totalValue);
+
+      expect(result).toBe(expectedResult);
+    });
+
+    it('correctly calculates that 1 is 4.35% of 23', function() {
+      const [relativeValue, totalValue] = [1, 23];
+      const expectedResult = 4.35;
+
+      const result = calculatePercentage(relativeValue, totalValue);
+
+      expect(result).toBe(expectedResult);
+    });
+
+    it('correctly calculates that 45 is 300% of 15', function() {
+      const [relativeValue, totalValue] = [45, 15];
+      const expectedResult = 300;
+
+      const result = calculatePercentage(relativeValue, totalValue);
+
+      expect(result).toBe(expectedResult);
+    });
+
+    it('returns that 0 is 0% of 1000', function() {
+      const [relativeValue, totalValue] = [0, 1000];
+      const expectedResult = 0;
+
+      const result = calculatePercentage(relativeValue, totalValue);
+
+      expect(result).toBe(expectedResult);
+    });
+
+    it('returns 0% when the total value is 0', function() {
+      const [relativeValue, totalValue] = [1000, 0];
+      const expectedResult = 0;
+
+      const result = calculatePercentage(relativeValue, totalValue);
+
+      expect(result).toBe(expectedResult);
+    });
+  });
+});

--- a/test/jest/unit/iac-unit-tests/results-formatter.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/results-formatter.fixtures.ts
@@ -46,14 +46,16 @@ const yetAnotherPolicyStub: PolicyMetadata = {
 const relativeFilePath = 'dont-care.yaml';
 const absoluteFilePath = path.resolve(relativeFilePath, '.');
 
-export function generateScanResults(): Array<IacFileScanResult> {
+export function generateScanResults({
+  engineType = EngineType.Kubernetes,
+} = {}): Array<IacFileScanResult> {
   return [
     {
       violatedPolicies: [{ ...policyStub }],
       jsonContent: { dontCare: null },
       docId: 0,
       projectType: IacProjectType.K8S,
-      engineType: EngineType.Kubernetes,
+      engineType,
       fileContent: 'dont-care',
       filePath: relativeFilePath,
       fileType: 'yaml',
@@ -63,7 +65,7 @@ export function generateScanResults(): Array<IacFileScanResult> {
       jsonContent: { dontCare: null },
       docId: 0,
       projectType: IacProjectType.K8S,
-      engineType: EngineType.Kubernetes,
+      engineType,
       fileContent: 'dont-care',
       filePath: relativeFilePath,
       fileType: 'yaml',
@@ -73,7 +75,7 @@ export function generateScanResults(): Array<IacFileScanResult> {
       jsonContent: { dontCare: null },
       docId: 1,
       projectType: IacProjectType.K8S,
-      engineType: EngineType.Kubernetes,
+      engineType,
       fileContent: 'dont-care',
       filePath: relativeFilePath,
       fileType: 'yaml',
@@ -87,9 +89,10 @@ export const meta: TestMeta = {
   org: 'org-name',
 };
 
-export function generateCloudConfigResults(
+export function generateCloudConfigResults({
   withLineNumber = true,
-): AnnotatedIacIssue[] {
+  isGeneratedByCustomRule = false,
+} = {}): AnnotatedIacIssue[] {
   return [
     {
       ...anotherPolicyStub,
@@ -105,6 +108,7 @@ export function generateCloudConfigResults(
       severity: anotherPolicyStub.severity,
       lineNumber: withLineNumber ? 3 : -1,
       documentation: 'https://snyk.io/security-rules/SNYK-CC-K8S-2',
+      isGeneratedByCustomRule,
     },
     {
       ...yetAnotherPolicyStub,
@@ -122,18 +126,21 @@ export function generateCloudConfigResults(
       severity: yetAnotherPolicyStub.severity,
       lineNumber: withLineNumber ? 3 : -1,
       documentation: 'https://snyk.io/security-rules/SNYK-CC-K8S-3',
+      isGeneratedByCustomRule,
     },
   ];
 }
 
-function generateFormattedResults(withLineNumber = true) {
+function generateFormattedResults(options) {
   return {
     result: {
-      cloudConfigResults: generateCloudConfigResults(withLineNumber),
+      cloudConfigResults: generateCloudConfigResults(
+        options.cloudConfigResultsOptions ?? {},
+      ),
       projectType: 'k8sconfig',
     },
     isPrivate: true,
-    packageManager: IacProjectType.K8S,
+    packageManager: options.packageManager ?? IacProjectType.K8S,
     targetFile: relativeFilePath,
     targetFilePath: absoluteFilePath,
     vulnerabilities: [],
@@ -152,9 +159,23 @@ function generateFormattedResults(withLineNumber = true) {
   };
 }
 
-export const expectedFormattedResultsWithLineNumber = generateFormattedResults(
-  true,
-);
+export const expectedFormattedResultsWithLineNumber = generateFormattedResults({
+  cloudConfigResultsOptions: {
+    withLineNumber: true,
+  },
+});
 export const expectedFormattedResultsWithoutLineNumber = generateFormattedResults(
-  false,
+  {
+    cloudConfigResultsOptions: {
+      withLineNumber: false,
+    },
+  },
+);
+export const expectedFormattedResultsGeneratedByCustomRules = generateFormattedResults(
+  {
+    cloudConfigResultsOptions: {
+      isGeneratedByCustomRule: true,
+    },
+    packageManager: IacProjectType.CUSTOM,
+  },
 );

--- a/test/jest/unit/iac-unit-tests/results-formatter.spec.ts
+++ b/test/jest/unit/iac-unit-tests/results-formatter.spec.ts
@@ -9,9 +9,13 @@ import {
   meta,
   policyStub,
   generateScanResults,
+  expectedFormattedResultsGeneratedByCustomRules,
 } from './results-formatter.fixtures';
 import * as cloudConfigParserModule from '@snyk/cloud-config-parser';
-import { PolicyMetadata } from '../../../../src/cli/commands/test/iac-local-execution/types';
+import {
+  EngineType,
+  PolicyMetadata,
+} from '../../../../src/cli/commands/test/iac-local-execution/types';
 
 jest.mock('@snyk/cloud-config-parser', () => ({
   ...jest.requireActual('@snyk/cloud-config-parser'),
@@ -20,24 +24,52 @@ const validTree = { '0': { nodes: [] } };
 describe('formatScanResults', () => {
   it.each([
     [
-      { severityThreshold: SEVERITY.HIGH },
+      {
+        formatOptions: { severityThreshold: SEVERITY.HIGH },
+        generateOptions: {},
+      },
       expectedFormattedResultsWithLineNumber,
     ],
     [
-      { severityThreshold: SEVERITY.HIGH, sarif: true },
+      {
+        formatOptions: { severityThreshold: SEVERITY.HIGH, sarif: true },
+        generateOptions: {},
+      },
       expectedFormattedResultsWithLineNumber,
     ],
     [
-      { severityThreshold: SEVERITY.HIGH, json: true },
+      {
+        formatOptions: { severityThreshold: SEVERITY.HIGH, json: true },
+        generateOptions: {},
+      },
       expectedFormattedResultsWithLineNumber,
     ],
     [
-      { severityThreshold: SEVERITY.HIGH, 'sarif-file-output': 'output.sarif' },
+      {
+        formatOptions: {
+          severityThreshold: SEVERITY.HIGH,
+          'sarif-file-output': 'output.sarif',
+        },
+        generateOptions: {},
+      },
       expectedFormattedResultsWithLineNumber,
     ],
     [
-      { severityThreshold: SEVERITY.HIGH, 'json-file-output': 'output.json' },
+      {
+        formatOptions: {
+          severityThreshold: SEVERITY.HIGH,
+          'json-file-output': 'output.json',
+        },
+        generateOptions: {},
+      },
       expectedFormattedResultsWithLineNumber,
+    ],
+    [
+      {
+        formatOptions: { severityThreshold: SEVERITY.HIGH },
+        generateOptions: { engineType: EngineType.Custom },
+      },
+      expectedFormattedResultsGeneratedByCustomRules,
     ],
   ])(
     'given %p options object, returns the expected results',
@@ -47,8 +79,8 @@ describe('formatScanResults', () => {
         .mockReturnValue(validTree);
       jest.spyOn(cloudConfigParserModule, 'getLineNumber').mockReturnValue(3);
       const formattedResults = formatScanResults(
-        generateScanResults(),
-        optionsObject,
+        generateScanResults(optionsObject.generateOptions),
+        optionsObject.formatOptions,
         meta,
       );
 

--- a/test/jest/unit/lib/formatters/format-test-meta.spec.ts
+++ b/test/jest/unit/lib/formatters/format-test-meta.spec.ts
@@ -21,7 +21,9 @@ describe('formatTestMeta', () => {
         policy: '',
       },
       result: {
-        cloudConfigResults: generateCloudConfigResults(false),
+        cloudConfigResults: generateCloudConfigResults({
+          withLineNumber: false,
+        }),
         projectType: 'k8sconfig',
       },
       ok: true,


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- For users that have provided us with custom rules,  it adds IaC custom-rules-based metrics to the analytics sent to `registry`.

#### Where should the reviewer start?
```
src/cli/commands/test/iac-local-execution/index.ts:test
```

#### How should this be manually tested?
- Generate a custom rules tarball with the [IaC custom rules bundles generator CLI](https://github.com/snyk/snyk-iac-rules)
- In the Snyk CLI, run the following command to test an IaC file in debug mode: 
```
snyk iac test -d --rules=<path-to-generated-tarball> <path-to-iac-file-to-test>
```
- In the logged analytics, the following analytics have been added:
    - `iac-issues-from-custom-rules-count`
    - `iac-issues-from-custom-rules-percentage`
    - `iac-custom-rules-utilized-count`

#### Any background context you want to provide?
The Snyk CLI can provide us with built-in analytics for the `--rules` flag (where customers would be providing their bundles).
We'd like to ensure we capture as much analytics about the utilization of custom rules as possible.

#### What are the relevant tickets?
- [Ticket CFG-322](https://snyksec.atlassian.net/browse/CFG-322)

#### Additional information
- [Related PR in snyk/registry repository](https://github.com/snyk/registry/pull/23877)