### PR TITLE
feat: Pull remote OCI Artifact with custom rules [CFG-1039]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@snyk/cloud-config-parser": "^1.11.1",
         "@snyk/code-client": "^4.4.0",
         "@snyk/dep-graph": "^1.27.1",
+        "@snyk/docker-registry-v2-client": "^2.4.0",
         "@snyk/fix": "file:packages/snyk-fix",
         "@snyk/gemfile": "1.2.0",
         "@snyk/graphlib": "^2.1.9-patch.3",
@@ -5068,9 +5069,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@snyk/docker-registry-v2-client": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.3.0.tgz",
-      "integrity": "sha512-VYQe/1SuIdQ8C7bA6nzfcEeafsqG1cHaZDFaIt1uYGwI1TI0OWzUIvGRkfgkMkwFBVLRqS1hFczSoxGTT7OMfA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.4.0.tgz",
+      "integrity": "sha512-4vRXn1ZaYCsvKNyRKPL3wskM2TiBnwH6A9pC+nqmtfwjps1OPXXTjRZhZWfLnZGEAY3SJERdqHUorTk3VQEzfw==",
       "dependencies": {
         "needle": "^2.5.0",
         "parse-link-header": "^1.0.1",
@@ -31425,9 +31426,9 @@
       }
     },
     "@snyk/docker-registry-v2-client": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.3.0.tgz",
-      "integrity": "sha512-VYQe/1SuIdQ8C7bA6nzfcEeafsqG1cHaZDFaIt1uYGwI1TI0OWzUIvGRkfgkMkwFBVLRqS1hFczSoxGTT7OMfA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.4.0.tgz",
+      "integrity": "sha512-4vRXn1ZaYCsvKNyRKPL3wskM2TiBnwH6A9pC+nqmtfwjps1OPXXTjRZhZWfLnZGEAY3SJERdqHUorTk3VQEzfw==",
       "requires": {
         "needle": "^2.5.0",
         "parse-link-header": "^1.0.1",
@@ -45563,6 +45564,7 @@
         "@snyk/cloud-config-parser": "^1.11.1",
         "@snyk/code-client": "4.4.0",
         "@snyk/dep-graph": "^1.27.1",
+        "@snyk/docker-registry-v2-client": "^2.4.0",
         "@snyk/fix": "file:packages/snyk-fix",
         "@snyk/gemfile": "1.2.0",
         "@snyk/graphlib": "^2.1.9-patch.3",
@@ -49715,9 +49717,9 @@
           }
         },
         "@snyk/docker-registry-v2-client": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.3.0.tgz",
-          "integrity": "sha512-VYQe/1SuIdQ8C7bA6nzfcEeafsqG1cHaZDFaIt1uYGwI1TI0OWzUIvGRkfgkMkwFBVLRqS1hFczSoxGTT7OMfA==",
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.4.0.tgz",
+          "integrity": "sha512-4vRXn1ZaYCsvKNyRKPL3wskM2TiBnwH6A9pC+nqmtfwjps1OPXXTjRZhZWfLnZGEAY3SJERdqHUorTk3VQEzfw==",
           "requires": {
             "needle": "^2.5.0",
             "parse-link-header": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@snyk/cloud-config-parser": "^1.11.1",
     "@snyk/code-client": "^4.4.0",
     "@snyk/dep-graph": "^1.27.1",
+    "@snyk/docker-registry-v2-client": "^2.4.0",
     "@snyk/fix": "file:packages/snyk-fix",
     "@snyk/gemfile": "1.2.0",
     "@snyk/graphlib": "^2.1.9-patch.3",

--- a/src/cli/commands/test/iac-local-execution/file-utils.ts
+++ b/src/cli/commands/test/iac-local-execution/file-utils.ts
@@ -36,10 +36,7 @@ export function extractBundle(response: NodeJS.ReadableStream): Promise<void> {
 export function isValidBundle(wasmPath: string, dataPath: string): boolean {
   try {
     // verify that the correct files were generated, since this is user input
-    if (!fs.existsSync(wasmPath) || !fs.existsSync(dataPath)) {
-      return false;
-    }
-    return true;
+    return !(!fs.existsSync(wasmPath) || !fs.existsSync(dataPath));
   } catch {
     return false;
   }

--- a/src/cli/commands/test/iac-local-execution/local-cache.ts
+++ b/src/cli/commands/test/iac-local-execution/local-cache.ts
@@ -56,7 +56,7 @@ export function assertNever(value: never): never {
   );
 }
 
-export function getLocalCachePath(engineType: EngineType) {
+export function getLocalCachePath(engineType: EngineType): string[] {
   switch (engineType) {
     case EngineType.Kubernetes:
       return [

--- a/src/cli/commands/test/iac-local-execution/measurable-methods.ts
+++ b/src/cli/commands/test/iac-local-execution/measurable-methods.ts
@@ -7,6 +7,7 @@ import { cleanLocalCache, initLocalCache } from './local-cache';
 import { applyCustomSeverities } from './org-settings/apply-custom-severities';
 import { getIacOrgSettings } from './org-settings/get-iac-org-settings';
 import { test } from './index';
+import { pull } from './oci-pull';
 import {
   PerformanceAnalyticsKey,
   performanceAnalyticsObject,
@@ -98,6 +99,11 @@ const measurableLocalTest = asyncPerformanceAnalyticsDecorator(
   PerformanceAnalyticsKey.Total,
 );
 
+const measurableOciPull = asyncPerformanceAnalyticsDecorator(
+  pull,
+  PerformanceAnalyticsKey.Total,
+);
+
 export {
   measurableInitLocalCache as initLocalCache,
   measurableLoadFiles as loadFiles,
@@ -109,4 +115,5 @@ export {
   measurableTrackUsage as trackUsage,
   measurableCleanLocalCache as cleanLocalCache,
   measurableLocalTest as localTest,
+  measurableOciPull as pull,
 };

--- a/src/cli/commands/test/iac-local-execution/oci-pull.ts
+++ b/src/cli/commands/test/iac-local-execution/oci-pull.ts
@@ -1,0 +1,126 @@
+import * as registryClient from '@snyk/docker-registry-v2-client';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import {
+  IaCErrorCodes,
+  ImageManifest,
+  ManifestConfig,
+  OCIPullOptions,
+  OciUrl,
+} from './types';
+import { CustomError } from '../../../../lib/errors';
+import { getErrorStringCode } from './error-utils';
+import { LOCAL_POLICY_ENGINE_DIR } from './local-cache';
+import * as Debug from 'debug';
+import { initLocalCache } from './measurable-methods';
+import { createIacDir } from './file-utils';
+const debug = Debug('iac-oci-pull');
+
+export function extractURLComponents(OCIRegistryURL: string): OciUrl {
+  try {
+    const url = OCIRegistryURL.split('://')[1];
+    const [registryBase, accountName, repoWithTag] = url.split('/');
+    const [repoName, tag] = repoWithTag.split(':');
+    const repo = accountName + '/' + repoName;
+    return { registryBase, repo, tag };
+  } catch {
+    throw new InvalidRemoteRegistryURLError();
+  }
+}
+
+/**
+ * Downloads an OCI Artifact from a remote OCI Registry and writes it to the disk.
+ * The artifact here is a custom rules bundle stored in a remote registry.
+ * In order to do that, it calls an external docker registry v2 client to get the manifests, the layers and then builds the artifact.
+ * Example: https://github.com/opencontainers/image-spec/blob/main/manifest.md#example-image-manifest
+ * @param OCIRegistryURL - the URL where the custom rules bundle is stored
+ * @param opt????? (optional) - object that holds the credentials and other metadata required for the registry-v2-client
+ **/
+export async function pull(
+  OCIRegistryURL: string,
+  opt?: OCIPullOptions,
+): Promise<void> {
+  if (!isValidURL(OCIRegistryURL)) {
+    throw new InvalidRemoteRegistryURLError();
+  }
+  const { registryBase, repo, tag } = extractURLComponents(OCIRegistryURL);
+  const manifest: ImageManifest = await registryClient.getManifest(
+    registryBase,
+    repo,
+    tag,
+    opt?.username,
+    opt?.password,
+    opt?.reqOptions,
+  );
+
+  if (manifest.schemaVersion !== 2) {
+    throw new InvalidManifestSchemaVersionError(
+      manifest.schemaVersion.toString(),
+    );
+  }
+  const manifestLayers: ManifestConfig[] = manifest.layers;
+  // We assume that we will always have an artifact of a single layer
+  if (manifestLayers.length > 1) {
+    debug('There were more than one layers found in the OCI Artifact.');
+  }
+
+  const blob = await registryClient.getLayer(
+    registryBase,
+    repo,
+    manifestLayers[0].digest,
+    opt?.username,
+    opt?.password,
+    opt?.reqOptions,
+  );
+
+  try {
+    const downloadPath: string = path.join(
+      LOCAL_POLICY_ENGINE_DIR,
+      'custom-bundle.tar.gz',
+    );
+    createIacDir();
+    await fs.writeFile(downloadPath, blob);
+    await initLocalCache({ customRulesPath: downloadPath });
+  } catch (err) {
+    throw new FailedToBuildOCIArtifactError();
+  }
+}
+
+function isValidURL(string) {
+  let url;
+  try {
+    url = new URL(string);
+  } catch (e) {
+    return false;
+  }
+  return url.protocol === 'http:' || url.protocol === 'https:';
+}
+
+export class FailedToBuildOCIArtifactError extends CustomError {
+  constructor(message?: string) {
+    super(message || 'Could not build OCI Artifact');
+    this.code = IaCErrorCodes.FailedToBuildOCIArtifactError;
+    this.strCode = getErrorStringCode(this.code);
+    this.userMessage =
+      'We were unable to build the remote OCI Artifact locally, please ensure that the local directory is writeable.';
+  }
+}
+
+export class InvalidRemoteRegistryURLError extends CustomError {
+  constructor(message?: string) {
+    super(message || 'Invalid URL for Remote Registry');
+    this.code = IaCErrorCodes.InvalidRemoteRegistryURLError;
+    this.strCode = getErrorStringCode(this.code);
+    this.userMessage =
+      'The Remote Registry URL is invalid, or does not include a http/https protocol. Please check it again.';
+  }
+}
+
+export class InvalidManifestSchemaVersionError extends CustomError {
+  constructor(message?: string) {
+    super(message || 'Invalid manifest schema version');
+    this.code = IaCErrorCodes.InvalidRemoteRegistryURLError;
+    this.strCode = getErrorStringCode(this.code);
+    this.userMessage = `Invalid manifest schema version: ${message}. We currently support Image Manifest Version 2, Schema 2`;
+  }
+}

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -269,9 +269,53 @@ export enum IaCErrorCodes {
   // assert-iac-options-flag
   FlagError = 1090,
   FlagValueError = 1091,
+
+  // oci-pull errors
+  FailedToExecuteCustomRulesError = 1100,
+  FailedToPullCustomBundleError = 1101,
+  FailedToBuildOCIArtifactError = 1102,
+  InvalidRemoteRegistryURLError = 1103,
+  InvalidManifestSchemaVersionError = 1104,
 }
 
 export interface TestReturnValue {
   results: TestResult | TestResult[];
   failures?: IacFileInDirectory[];
 }
+
+// https://github.com/opencontainers/image-spec/blob/main/manifest.md#image-manifest
+export interface ImageManifest {
+  schemaVersion: number;
+  mediaType: string;
+  config: ManifestConfig;
+  layers: ManifestConfig[];
+}
+
+export interface ManifestConfig {
+  mediaType: string;
+  size: number;
+  digest: string; // unique content identifier
+}
+
+export interface Layer {
+  config: ManifestConfig;
+  blob: Buffer;
+}
+
+export interface OCIPullOptions {
+  username?: string;
+  password?: string;
+  // weak typing on the client
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reqOptions?: { accept?: string; indexContentType?: string };
+  imageSavePath?: string;
+}
+
+export interface OciUrl {
+  registryBase: string;
+  repo: string;
+  tag: string;
+}
+
+export const manifestContentType = 'application/vnd.oci.image.manifest.v1+json';
+export const layerContentType = 'application/vnd.oci.image.layer.v1.tar+gzip';

--- a/test/jest/unit/iac-unit-tests/oci-pull.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/oci-pull.fixtures.ts
@@ -1,0 +1,33 @@
+export const config = {
+  mediaType: '',
+  size: 50,
+  digest:
+    'sha256:db5t678c2946ae8c52553519a93bf5bc09c2df3e7f48cfb28acb258c91c67ee1',
+};
+
+export const manifest = {
+  schemaVersion: 2,
+  mediaType: 'la',
+  config,
+  layers: [
+    {
+      mediaType: 'application/vnd.oci.image.layer.v1.tar+gzip',
+      digest: '',
+      size: 50000,
+    },
+  ],
+};
+
+export const opt = {
+  username: 'username',
+  password: 'password',
+  reqOptions: {},
+};
+
+const blob = Buffer.from('text');
+export const layers = [
+  {
+    config,
+    blob,
+  },
+];


### PR DESCRIPTION
#### What does this PR do?

We currently allow users to specify the path of a local custom rules bundle and use their own security rules written in Rego to scan their files, along with our own Security Rules. We now want to allow users to write their own security rules and use them. Users can store their bundles in a remote Registry repository, which they will provide to us and we are then going to download their rules, evaluate them and scan files against them.

This PR implements the "pull" functionality of an OCI Artifact. 

When running `snyk iac test` (if the right credentials are provided), we will try to download a remote OCI artifact.

#### Where should the reviewer start?
- `index.ts` in the iac-local-execution directory does the checks for the credentials and handles errors, then calls the `pull()` from `oci-pull.ts`.
- `oci-pull.ts` handles the calls to the `docker-registry-v2-client` to get the layers and the manifests for the specified artifact. Then, we write the blob to a tarball, extract it as usual and follow the normal flow of evaluating rules and test them.

#### For non-IaC files:
- The `package-lock.json` and `package.json` have been updated to include the new version of the `docker-registry-v2-client`

#### How should this be manually tested?
Locally:
export OCI_REGISTRY_URL= url
export OCI_REGISTRY_USERNAME= username
export OCI_REGISTRY_PASSWORD = password

This PR is also dependent on the contentType extension of the docker-registry-client library: https://github.com/snyk/docker-registry-v2-client/pull/77. This is already merged and the new version is included in the `package.json` file.

Then running `snyk-dev iac test file.tf` should work and get all the custom rules from the OCI Registry.

#### Any background context you want to provide?

OCI registries are typically used for container images, but it’s actually possible to use them for storing and distributing other types of data. There are a couple techniques for doing this, and one of them is commonly referred to as “OCI Artifacts”.

Info on OCI Artifacts: https://www.notion.so/snyk/OCI-Artifacts-2aca3ef2d1ce45c3915c828bff50f468

#### What are the relevant tickets?
[CFG-1039]

#### Screenshots
![image](https://user-images.githubusercontent.com/6989529/136351447-95fa5b73-de9e-4f36-b485-b69f644028bb.png)


#### Additional questions
- Acceptance tests have to be completed and pass the env vars to the job in circleCI - currenty on draft

[CFG-1039]: https://snyksec.atlassian.net/browse/CFG-1039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ