### PR TITLE
feat: use the new `snyk fix` docs url

### DIFF
--- a/src/cli/commands/fix/validate-fix-command-is-supported.ts
+++ b/src/cli/commands/fix/validate-fix-command-is-supported.ts
@@ -41,7 +41,7 @@ export async function validateFixCommandIsSupported(
           options.org ? ` for org '${options.org}'` : ''
         }.`,
       ) +
-      '\nSee documentation on how to enable this beta feature: https://support.snyk.io/hc/en-us/articles/4403417279505-Automatic-remediation-with-snyk-fix';
+      '\nSee documentation on how to enable this beta feature: https://docs.snyk.io/features/snyk-cli/fix-vulnerabilities-from-the-cli/automatic-remediation-with-snyk-fix';
     const unsupportedError = new Error(snykFixErrorMessage);
     throw unsupportedError;
   }

--- a/src/lib/formatters/show-fix-tip.ts
+++ b/src/lib/formatters/show-fix-tip.ts
@@ -26,7 +26,7 @@ export function showFixTip(
       )} to address these issues.${chalk.bold(
         '`snyk fix`',
       )} is a new CLI command in that aims to automatically apply the recommended updates for supported ecosystems.` +
-      '\nSee documentation on how to enable this beta feature: https://support.snyk.io/hc/en-us/articles/4403417279505-Automatic-remediation-with-snyk-fix'
+      '\nSee documentation on how to enable this beta feature: https://docs.snyk.io/features/snyk-cli/fix-vulnerabilities-from-the-cli/automatic-remediation-with-snyk-fix'
     );
   }
 

--- a/test/acceptance/workspaces/pip-app-transitive-vuln/cli-output-actionable-remediation.txt
+++ b/test/acceptance/workspaces/pip-app-transitive-vuln/cli-output-actionable-remediation.txt
@@ -30,4 +30,4 @@ Open source:       no
 Project path:      pip-app-transitive-vuln
 
 Tip: Try `snyk fix` to address these issues.`snyk fix` is a new CLI command in that aims to automatically apply the recommended updates for supported ecosystems.
-See documentation on how to enable this beta feature: https://support.snyk.io/hc/en-us/articles/4403417279505-Automatic-remediation-with-snyk-fix
+See documentation on how to enable this beta feature: https://docs.snyk.io/features/snyk-cli/fix-vulnerabilities-from-the-cli/automatic-remediation-with-snyk-fix

--- a/test/acceptance/workspaces/pip-app-transitive-vuln/cli-output.txt
+++ b/test/acceptance/workspaces/pip-app-transitive-vuln/cli-output.txt
@@ -45,4 +45,4 @@ Project path:      pip-app-transitive-vuln
 Tested 6 dependencies for known vulnerabilities, found 4 vulnerabilities, 4 vulnerable paths.
 
 Tip: Try `snyk fix` to address these issues.`snyk fix` is a new CLI command in that aims to automatically apply the recommended updates for supported ecosystems.
-See documentation on how to enable this beta feature: https://support.snyk.io/hc/en-us/articles/4403417279505-Automatic-remediation-with-snyk-fix
+See documentation on how to enable this beta feature: https://docs.snyk.io/features/snyk-cli/fix-vulnerabilities-from-the-cli/automatic-remediation-with-snyk-fix

--- a/test/jest/system/lib/commands/fix/fix.spec.ts
+++ b/test/jest/system/lib/commands/fix/fix.spec.ts
@@ -48,7 +48,7 @@ describe('snyk fix (system tests)', () => {
     });
     expect(code).toEqual(2);
     expect(stdout).toMatch(
-      "`snyk fix` is not supported for org 'no-flag'.\nSee documentation on how to enable this beta feature: https://support.snyk.io/hc/en-us/articles/4403417279505-Automatic-remediation-with-snyk-fix",
+      "`snyk fix` is not supported for org 'no-flag'.\nSee documentation on how to enable this beta feature: https://docs.snyk.io/features/snyk-cli/fix-vulnerabilities-from-the-cli/automatic-remediation-with-snyk-fix",
     );
     expect(stderr).toBe('');
   });

--- a/test/jest/unit/lib/formatters/show-fix-tip.spec.ts
+++ b/test/jest/unit/lib/formatters/show-fix-tip.spec.ts
@@ -46,7 +46,7 @@ describe('showFixTip', () => {
       ),
     ).toBe(
       'Tip: Try `snyk fix` to address these issues.`snyk fix` is a new CLI command in that aims to automatically apply the recommended updates for supported ecosystems.\n' +
-        'See documentation on how to enable this beta feature: https://support.snyk.io/hc/en-us/articles/4403417279505-Automatic-remediation-with-snyk-fix',
+        'See documentation on how to enable this beta feature: https://docs.snyk.io/features/snyk-cli/fix-vulnerabilities-from-the-cli/automatic-remediation-with-snyk-fix',
     );
   });
 

--- a/test/jest/unit/lib/formatters/test/__snapshots__/display-result.spec.ts.snap
+++ b/test/jest/unit/lib/formatters/test/__snapshots__/display-result.spec.ts.snap
@@ -150,7 +150,7 @@ Project path:      src
 Licenses:          enabled
 
 Tip: Try \`snyk fix\` to address these issues.\`snyk fix\` is a new CLI command in that aims to automatically apply the recommended updates for supported ecosystems.
-See documentation on how to enable this beta feature: https://support.snyk.io/hc/en-us/articles/4403417279505-Automatic-remediation-with-snyk-fix
+See documentation on how to enable this beta feature: https://docs.snyk.io/features/snyk-cli/fix-vulnerabilities-from-the-cli/automatic-remediation-with-snyk-fix
 
 Tip: Detected multiple supported manifests (3), use --all-projects to scan all of them at once."
 `;


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Migrate the `snyk fix` urls to the new docs.snyk.io urls.

