### PR TITLE
docs: fix typo in docs for --project-tags

### DIFF
--- a/help/commands-docs/_SNYK_COMMAND_OPTIONS.md
+++ b/help/commands-docs/_SNYK_COMMAND_OPTIONS.md
@@ -85,7 +85,7 @@ For advanced usage, we offer language and context specific flags, listed further
 
 - `--project-tags`=<TAG>[,<TAG>]...>:
   (only in `monitor` command)
-  Set the project tags to one or more values (comma-separated key value pairs with an "=" separator). e.g. --tags=department=finance,team=alpha
+  Set the project tags to one or more values (comma-separated key value pairs with an "=" separator). e.g. --project-tags=department=finance,team=alpha
 
 - `--policy-path`=<PATH_TO_POLICY_FILE>`:
   Manually pass a path to a snyk policy file.

--- a/help/commands-man/snyk-monitor.1
+++ b/help/commands-man/snyk-monitor.1
@@ -78,7 +78,7 @@ Specify a custom Snyk project name\.
 (only in \fBmonitor\fR command) Set the project business criticality to one or more values (comma\-separated)\. Allowed values: critical, high, medium, low
 .TP
 \fB\-\-project\-tags\fR=\fITAG\fR[,\fITAG\fR]\|\.\|\.\|\.>
-(only in \fBmonitor\fR command) Set the project tags to one or more values (comma\-separated key value pairs with an "=" separator)\. e\.g\. \-\-tags=department=finance,team=alpha
+(only in \fBmonitor\fR command) Set the project tags to one or more values (comma\-separated key value pairs with an "=" separator)\. e\.g\. \-\-project\-tags=department=finance,team=alpha
 .TP
 \fB\-\-policy\-path\fR=\fIPATH_TO_POLICY_FILE\fR`
 Manually pass a path to a snyk policy file\.

--- a/help/commands-man/snyk-test.1
+++ b/help/commands-man/snyk-test.1
@@ -78,7 +78,7 @@ Specify a custom Snyk project name\.
 (only in \fBmonitor\fR command) Set the project business criticality to one or more values (comma\-separated)\. Allowed values: critical, high, medium, low
 .TP
 \fB\-\-project\-tags\fR=\fITAG\fR[,\fITAG\fR]\|\.\|\.\|\.>
-(only in \fBmonitor\fR command) Set the project tags to one or more values (comma\-separated key value pairs with an "=" separator)\. e\.g\. \-\-tags=department=finance,team=alpha
+(only in \fBmonitor\fR command) Set the project tags to one or more values (comma\-separated key value pairs with an "=" separator)\. e\.g\. \-\-project\-tags=department=finance,team=alpha
 .TP
 \fB\-\-policy\-path\fR=\fIPATH_TO_POLICY_FILE\fR`
 Manually pass a path to a snyk policy file\.

--- a/help/commands-man/snyk.1
+++ b/help/commands-man/snyk.1
@@ -123,7 +123,7 @@ Specify a custom Snyk project name\.
 (only in \fBmonitor\fR command) Set the project business criticality to one or more values (comma\-separated)\. Allowed values: critical, high, medium, low
 .TP
 \fB\-\-project\-tags\fR=\fITAG\fR[,\fITAG\fR]\|\.\|\.\|\.>
-(only in \fBmonitor\fR command) Set the project tags to one or more values (comma\-separated key value pairs with an "=" separator)\. e\.g\. \-\-tags=department=finance,team=alpha
+(only in \fBmonitor\fR command) Set the project tags to one or more values (comma\-separated key value pairs with an "=" separator)\. e\.g\. \-\-project\-tags=department=finance,team=alpha
 .TP
 \fB\-\-policy\-path\fR=\fIPATH_TO_POLICY_FILE\fR`
 Manually pass a path to a snyk policy file\.

--- a/help/commands-md/snyk-monitor.md
+++ b/help/commands-md/snyk-monitor.md
@@ -96,7 +96,7 @@ For advanced usage, we offer language and context specific flags, listed further
 
 - `--project-tags`=<TAG>[,<TAG>]...>:
   (only in `monitor` command)
-  Set the project tags to one or more values (comma-separated key value pairs with an "=" separator). e.g. --tags=department=finance,team=alpha
+  Set the project tags to one or more values (comma-separated key value pairs with an "=" separator). e.g. --project-tags=department=finance,team=alpha
 
 - `--policy-path`=<PATH_TO_POLICY_FILE>`:
   Manually pass a path to a snyk policy file.

--- a/help/commands-md/snyk-test.md
+++ b/help/commands-md/snyk-test.md
@@ -96,7 +96,7 @@ For advanced usage, we offer language and context specific flags, listed further
 
 - `--project-tags`=<TAG>[,<TAG>]...>:
   (only in `monitor` command)
-  Set the project tags to one or more values (comma-separated key value pairs with an "=" separator). e.g. --tags=department=finance,team=alpha
+  Set the project tags to one or more values (comma-separated key value pairs with an "=" separator). e.g. --project-tags=department=finance,team=alpha
 
 - `--policy-path`=<PATH_TO_POLICY_FILE>`:
   Manually pass a path to a snyk policy file.

--- a/help/commands-md/snyk.md
+++ b/help/commands-md/snyk.md
@@ -141,7 +141,7 @@ For advanced usage, we offer language and context specific flags, listed further
 
 - `--project-tags`=<TAG>[,<TAG>]...>:
   (only in `monitor` command)
-  Set the project tags to one or more values (comma-separated key value pairs with an "=" separator). e.g. --tags=department=finance,team=alpha
+  Set the project tags to one or more values (comma-separated key value pairs with an "=" separator). e.g. --project-tags=department=finance,team=alpha
 
 - `--policy-path`=<PATH_TO_POLICY_FILE>`:
   Manually pass a path to a snyk policy file.

--- a/help/commands-txt/snyk-monitor.txt
+++ b/help/commands-txt/snyk-monitor.txt
@@ -121,7 +121,7 @@
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mt[0m[1ma[0m[1mg[0m[1ms[0m=[4mT[0m[4mA[0m[4mG[0m[,[4mT[0m[4mA[0m[4mG[0m]...>
               (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project tags to  one  or  more
               values  (comma-separated key value pairs with an "=" separator).
-              e.g. --tags=department=finance,team=alpha
+              e.g. --project-tags=department=finance,team=alpha
 
        [1m-[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m=[4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m`
               Manually pass a path to a snyk policy file.

--- a/help/commands-txt/snyk-test.txt
+++ b/help/commands-txt/snyk-test.txt
@@ -121,7 +121,7 @@
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mt[0m[1ma[0m[1mg[0m[1ms[0m=[4mT[0m[4mA[0m[4mG[0m[,[4mT[0m[4mA[0m[4mG[0m]...>
               (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project tags to  one  or  more
               values  (comma-separated key value pairs with an "=" separator).
-              e.g. --tags=department=finance,team=alpha
+              e.g. --project-tags=department=finance,team=alpha
 
        [1m-[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m=[4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m`
               Manually pass a path to a snyk policy file.

--- a/help/commands-txt/snyk.txt
+++ b/help/commands-txt/snyk.txt
@@ -166,7 +166,7 @@
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mt[0m[1ma[0m[1mg[0m[1ms[0m=[4mT[0m[4mA[0m[4mG[0m[,[4mT[0m[4mA[0m[4mG[0m]...>
               (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project tags to  one  or  more
               values  (comma-separated key value pairs with an "=" separator).
-              e.g. --tags=department=finance,team=alpha
+              e.g. --project-tags=department=finance,team=alpha
 
        [1m-[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m=[4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m`
               Manually pass a path to a snyk policy file.


### PR DESCRIPTION
#### What does this PR do?

Fixes a typo in the suggested usage of `--project-tags` which referred to `--tags` in error.

#### Where should the reviewer start?

`snyk monitor --help` after building the docs
