### PR TITLE
feat: Use OCI registry URL from /org-iac-settings endpoint. [CFG-1072]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -22,6 +22,7 @@ import {
   initLocalCache,
   loadFiles,
   parseFiles,
+  pull,
   scanFiles,
   trackUsage,
 } from './measurable-methods';
@@ -29,7 +30,6 @@ import { isFeatureFlagSupportedForOrg } from '../../../../lib/feature-flags';
 import { FlagError } from './assert-iac-options-flag';
 import config from '../../../../lib/config';
 import { findAndLoadPolicy } from '../../../../lib/policy';
-import { pull } from './oci-pull';
 import { CustomError } from '../../../../lib/errors';
 import { getErrorStringCode } from './error-utils';
 
@@ -44,7 +44,11 @@ export async function test(
     const iacOrgSettings = await getIacOrgSettings(org);
     const customRulesPath = await customRulesPathForOrg(options.rules, org);
 
-    const OCIRegistryURL = process.env.OCI_REGISTRY_URL;
+    const OCIRegistryURL = iacOrgSettings.customRules?.ociRegistryURL
+      ? `${iacOrgSettings.customRules?.ociRegistryURL}:${iacOrgSettings
+          .customRules?.ociRegistryTag || 'latest'}`
+      : process.env.OCI_REGISTRY_URL;
+
     if (OCIRegistryURL && customRulesPath) {
       throw new FailedToExecuteCustomRulesError();
     }

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -68,9 +68,16 @@ export type FormattedResult = {
 
 export type IacCustomPolicies = Record<string, { severity?: string }>;
 
+export interface IaCCustomRulesConfigs {
+  isEnabled?: boolean;
+  ociRegistryURL?: string;
+  ociRegistryTag?: string;
+}
+
 export interface IacOrgSettings {
   meta: TestMeta;
   customPolicies: IacCustomPolicies;
+  customRules?: IaCCustomRulesConfigs;
 }
 
 export interface TestMeta {

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -365,6 +365,7 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
         org: req.query.org || 'test-org',
       },
       customPolicies: {},
+      customRules: {},
     });
   });
 

--- a/test/jest/unit/iac-unit-tests/index.spec.ts
+++ b/test/jest/unit/iac-unit-tests/index.spec.ts
@@ -56,6 +56,7 @@ jest.mock(
         org: 'org-name',
       },
       customPolicies: {},
+      customRules: {},
     }),
   }),
 );

--- a/test/jest/unit/iac-unit-tests/oci-pull.spec.ts
+++ b/test/jest/unit/iac-unit-tests/oci-pull.spec.ts
@@ -2,7 +2,6 @@ import * as OCIPull from '../../../../src/cli/commands/test/iac-local-execution/
 import {
   extractURLComponents,
   FailedToBuildOCIArtifactError,
-  InvalidRemoteRegistryURLError,
 } from '../../../../src/cli/commands/test/iac-local-execution/oci-pull';
 import * as registryClient from '@snyk/docker-registry-v2-client';
 import { layers, manifest, opt } from './oci-pull.fixtures';
@@ -56,7 +55,11 @@ describe('pull', () => {
     jest.spyOn(fileUtilsModule, 'createIacDir').mockImplementation(() => null);
 
     await OCIPull.pull(
-      'https://registry-1.docker.io/accountName/custom-bundle-repo:latest',
+      {
+        registryBase: 'registry-1.docker.io',
+        repo: 'accountName/custom-bundle-repo',
+        tag: 'latest',
+      },
       opt,
     );
 
@@ -89,7 +92,11 @@ describe('pull', () => {
     });
 
     const pullResult = OCIPull.pull(
-      'https://registry-1.docker.io/accountName/custom-bundle-repo:latest',
+      {
+        registryBase: 'registry-1.docker.io',
+        repo: 'accountName/custom-bundle-repo',
+        tag: 'latest',
+      },
       opt,
     );
 
@@ -98,10 +105,14 @@ describe('pull', () => {
 
   it('throws an error if URL is invalid', async () => {
     const pullResult = OCIPull.pull(
-      'registry-1.docker.io/accountName/custom-bundle-repo:latest',
+      {
+        registryBase: 'registry-1.docker.io',
+        repo: 'accountName/custom-bundle-repo',
+        tag: 'latest',
+      },
       opt,
     );
 
-    await expect(pullResult).rejects.toThrow(InvalidRemoteRegistryURLError);
+    await expect(pullResult).rejects.toThrow(FailedToBuildOCIArtifactError);
   });
 });


### PR DESCRIPTION
#### What does this PR do?

- Replaces the OCI registry URL env variable with the URL retrieved from the `/org-iac-settings` endpoint.

#### Where should the reviewer start?
`src/cli/commands/test/iac-local-execution/index.ts`

#### How should this be manually tested?

1. Prepare a custom-rules bundle generated by the [Snyk custom-rules bundles generator](https://github.com/snyk/snyk-iac-rules). 
2. Store the generated bundle in your preferred OCI registry.
3. Export the following env variables:
- `OCI_REGISTRY_USERNAME`: The username for the desired registry.
- `OCI_REGISTRY_PASSWORD`: The password for the desired registry.

4. Make sure your user has the `iacCustomRules` and the `infrastructureAsCode` feature flags.
5. Make sure your user has the following org permission: `READ`, `IAC_SETTINGS_READ` `IAC_SETTINGS_EDIT`.
6. Navigate to the custom-rules configurations section in the org IaC settings page on `/org/ofekatr/manage/cloud-config`.
7. Update the OCI registry URL and tag for the desired custom-rules bundle.
8. In the Snyk CLI, run `snyk-dev iac test <file>`.
9. Verify that:
- No errors were thrown.
- The bundle was pulled successfully into the `.iac-data` directory.
- The defined custom-rules generated the expected issues successfully.

#### Any background context you want to provide?

Nowadays, when using the Snyk CLI to pull custom-rules bundles from OCI registry hubs, we either use a URL provided as an argument, or use one that is stored as an environment variable. We would like to get the stored OCI registry URL and tag that are stored in `org.cloudConfigSettings.customRules`, and use them instead. To do that, we added these to the existing org IaC settings endpoint.

#### What are the relevant tickets?

- [Jira ticket CFG-1072](https://snyksec.atlassian.net/browse/CFG-1072)
- [Related PR in snyk/registry](https://github.com/snyk/registry/pull/24236)