### PR TITLE
Auth command waits 3 minutes instead of 30 seconds

### DIFF
--- a/src/cli/commands/auth/index.ts
+++ b/src/cli/commands/auth/index.ts
@@ -23,7 +23,7 @@ const debug = Debug('snyk-auth');
 let attemptsLeft = 0;
 
 function resetAttempts() {
-  attemptsLeft = isDocker() ? 60 : 30;
+  attemptsLeft = isDocker() ? 60 : 3 * 60;
 }
 
 type AuthCliCommands = 'wizard' | 'ignore';


### PR DESCRIPTION
`snyk auth` now gives you more time to actually signup or login to snyk.io