### PR TITLE
[RUN-1824] fix: upgrade snyk docker plugin to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,8 +62,8 @@
         "rimraf": "^2.6.3",
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.12.2",
-        "snyk-docker-plugin": "4.25.2",
+        "snyk-cpp-plugin": "2.12.3",
+        "snyk-docker-plugin": "4.26.0",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.16.2",
         "snyk-module": "3.1.0",
@@ -22905,9 +22905,9 @@
       }
     },
     "node_modules/snyk-cpp-plugin": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.12.2.tgz",
-      "integrity": "sha512-Z+qrpjtshBU/0LX2McFNcIj1kDscDfnlz+lfCSB6WZL+MsG3936A3jKbKnzGfwUHk9JnkIPYDgyUbTmsf6++Bg==",
+      "version": "2.12.3",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.12.3.tgz",
+      "integrity": "sha512-LjtYEJmc0RcqQAv4qmwvE+iUASi0gaIkec78C1GlIy1kUxUF+YlBLIFrnik6Yf/FHlJCekvr3SvxAS2qNdEBLg==",
       "dependencies": {
         "@snyk/dep-graph": "^1.19.3",
         "chalk": "^4.1.0",
@@ -23031,9 +23031,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "4.25.2",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.25.2.tgz",
-      "integrity": "sha512-ncajarsvczCbEtxMRFqc8JuqOr0s/oReeSXtXodPut3+CjkbILxR3WQciE4I1HPf5PdnGf7cZ1AoMXP+D0DkkQ==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.26.0.tgz",
+      "integrity": "sha512-qnu9eZjPTu3wTHb3V0rUJJL6iAVq9Zm3EHtuODpIc5ni/pumGwkajBOQZf4zsJ7YPkAkcTEc5K/RsvEhrZSWkQ==",
       "dependencies": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/rpm-parser": "^2.0.0",
@@ -45562,7 +45562,7 @@
         "@snyk/cli-alert": "file:packages/cli-alert",
         "@snyk/cli-interface": "2.11.0",
         "@snyk/cloud-config-parser": "^1.11.1",
-        "@snyk/code-client": "4.4.0",
+        "@snyk/code-client": "^4.4.0",
         "@snyk/dep-graph": "^1.27.1",
         "@snyk/docker-registry-v2-client": "^2.4.0",
         "@snyk/fix": "file:packages/snyk-fix",
@@ -45645,8 +45645,8 @@
         "sinon": "^4.0.0",
         "snyk": "file:",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.12.2",
-        "snyk-docker-plugin": "4.25.2",
+        "snyk-cpp-plugin": "2.12.3",
+        "snyk-docker-plugin": "4.26.0",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.16.2",
         "snyk-module": "3.1.0",
@@ -63858,9 +63858,9 @@
           }
         },
         "snyk-cpp-plugin": {
-          "version": "2.12.2",
-          "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.12.2.tgz",
-          "integrity": "sha512-Z+qrpjtshBU/0LX2McFNcIj1kDscDfnlz+lfCSB6WZL+MsG3936A3jKbKnzGfwUHk9JnkIPYDgyUbTmsf6++Bg==",
+          "version": "2.12.3",
+          "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.12.3.tgz",
+          "integrity": "sha512-LjtYEJmc0RcqQAv4qmwvE+iUASi0gaIkec78C1GlIy1kUxUF+YlBLIFrnik6Yf/FHlJCekvr3SvxAS2qNdEBLg==",
           "requires": {
             "@snyk/dep-graph": "^1.19.3",
             "chalk": "^4.1.0",
@@ -63950,9 +63950,9 @@
           }
         },
         "snyk-docker-plugin": {
-          "version": "4.25.2",
-          "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.25.2.tgz",
-          "integrity": "sha512-ncajarsvczCbEtxMRFqc8JuqOr0s/oReeSXtXodPut3+CjkbILxR3WQciE4I1HPf5PdnGf7cZ1AoMXP+D0DkkQ==",
+          "version": "4.26.0",
+          "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.26.0.tgz",
+          "integrity": "sha512-qnu9eZjPTu3wTHb3V0rUJJL6iAVq9Zm3EHtuODpIc5ni/pumGwkajBOQZf4zsJ7YPkAkcTEc5K/RsvEhrZSWkQ==",
           "requires": {
             "@snyk/dep-graph": "^1.28.0",
             "@snyk/rpm-parser": "^2.0.0",
@@ -67312,9 +67312,9 @@
       }
     },
     "snyk-cpp-plugin": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.12.2.tgz",
-      "integrity": "sha512-Z+qrpjtshBU/0LX2McFNcIj1kDscDfnlz+lfCSB6WZL+MsG3936A3jKbKnzGfwUHk9JnkIPYDgyUbTmsf6++Bg==",
+      "version": "2.12.3",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.12.3.tgz",
+      "integrity": "sha512-LjtYEJmc0RcqQAv4qmwvE+iUASi0gaIkec78C1GlIy1kUxUF+YlBLIFrnik6Yf/FHlJCekvr3SvxAS2qNdEBLg==",
       "requires": {
         "@snyk/dep-graph": "^1.19.3",
         "chalk": "^4.1.0",
@@ -67404,9 +67404,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "4.25.2",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.25.2.tgz",
-      "integrity": "sha512-ncajarsvczCbEtxMRFqc8JuqOr0s/oReeSXtXodPut3+CjkbILxR3WQciE4I1HPf5PdnGf7cZ1AoMXP+D0DkkQ==",
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.26.0.tgz",
+      "integrity": "sha512-qnu9eZjPTu3wTHb3V0rUJJL6iAVq9Zm3EHtuODpIc5ni/pumGwkajBOQZf4zsJ7YPkAkcTEc5K/RsvEhrZSWkQ==",
       "requires": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/rpm-parser": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.12.3",
-    "snyk-docker-plugin": "4.25.2",
+    "snyk-docker-plugin": "4.26.0",
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.16.2",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

We have recently added imageID info for application project in snyk-docker-plugin. By upgrading to the latest plugin version, it helps to populate the scanResults with the this new entry.

#### Where should the reviewer start?

https://github.com/snyk/snyk-docker-plugin/pull/376
package.json

#### What are the relevant tickets?

- [Jira ticket RUN-1824](https://snyksec.atlassian.net/browse/RUN-1824)
