### PR TITLE
fix: disable custom rules settings

### DIFF
--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -49,7 +49,8 @@ export async function test(
     const customRulesPath = await customRulesPathForOrg(options.rules, org);
 
     const OCIRegistryURL =
-      iacOrgSettings.customRules?.ociRegistryURL ||
+      (iacOrgSettings.customRules?.isEnabled &&
+        iacOrgSettings.customRules?.ociRegistryURL) ||
       process.env.OCI_REGISTRY_URL;
 
     if (OCIRegistryURL && customRulesPath) {


### PR DESCRIPTION
#### What does this PR do?
Makes sure to not use the configured custom rules settings if they're disabled.

#### How should this be manually tested?
1. Enable `iacCustomRules` flag and `iacCustomRulesEntitlement` entitlement
2. Configure the custom rules settings in either the group-level or org-level Infrastructure as Code settings with a fake oCI registry URL, it doesn't matter if it's real or not
3. Run the `snyk iac test` command on any file and see that we fail because we can't pull the bundle from the OCI registry URL
4. Disable the custom rules settings from before\
5. Run the `snyk iac test` command on the same file and see that it doesn't fail anymore
