### PR TITLE
feat: add --gradle-accept-legacy-config-roles flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "snyk-cpp-plugin": "2.12.3",
         "snyk-docker-plugin": "4.26.1",
         "snyk-go-plugin": "1.18.0",
-        "snyk-gradle-plugin": "3.16.2",
+        "snyk-gradle-plugin": "3.17.0",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.26.2",
         "snyk-nodejs-lockfile-parser": "1.37.1",
@@ -23219,9 +23219,9 @@
       }
     },
     "node_modules/snyk-gradle-plugin": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.16.2.tgz",
-      "integrity": "sha512-0EFZ3yHwnn4BwuG9sSm5F4MPMLimJVtNr7A+NYohZabw951l+rm2jXj84/Any1WUrnpGi2TXTV4LreUnrwN/Qg==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.17.0.tgz",
+      "integrity": "sha512-Pl83SPh5xrdPGJiY/iuE29igiER5MIuM30N/ywIoUy54bpjxpsUu63PmUtEy1A40d59r9kxECtESoyfqT9K7TQ==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.0",
         "@snyk/dep-graph": "^1.28.0",
@@ -45648,7 +45648,7 @@
         "snyk-cpp-plugin": "2.12.3",
         "snyk-docker-plugin": "4.26.1",
         "snyk-go-plugin": "1.18.0",
-        "snyk-gradle-plugin": "3.16.2",
+        "snyk-gradle-plugin": "3.17.0",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.26.2",
         "snyk-nodejs-lockfile-parser": "1.37.1",
@@ -64095,9 +64095,9 @@
           }
         },
         "snyk-gradle-plugin": {
-          "version": "3.16.2",
-          "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.16.2.tgz",
-          "integrity": "sha512-0EFZ3yHwnn4BwuG9sSm5F4MPMLimJVtNr7A+NYohZabw951l+rm2jXj84/Any1WUrnpGi2TXTV4LreUnrwN/Qg==",
+          "version": "3.17.0",
+          "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.17.0.tgz",
+          "integrity": "sha512-Pl83SPh5xrdPGJiY/iuE29igiER5MIuM30N/ywIoUy54bpjxpsUu63PmUtEy1A40d59r9kxECtESoyfqT9K7TQ==",
           "requires": {
             "@snyk/cli-interface": "2.11.0",
             "@snyk/dep-graph": "^1.28.0",
@@ -67549,9 +67549,9 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.16.2.tgz",
-      "integrity": "sha512-0EFZ3yHwnn4BwuG9sSm5F4MPMLimJVtNr7A+NYohZabw951l+rm2jXj84/Any1WUrnpGi2TXTV4LreUnrwN/Qg==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.17.0.tgz",
+      "integrity": "sha512-Pl83SPh5xrdPGJiY/iuE29igiER5MIuM30N/ywIoUy54bpjxpsUu63PmUtEy1A40d59r9kxECtESoyfqT9K7TQ==",
       "requires": {
         "@snyk/cli-interface": "2.11.0",
         "@snyk/dep-graph": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "snyk-cpp-plugin": "2.12.3",
     "snyk-docker-plugin": "4.26.1",
     "snyk-go-plugin": "1.18.0",
-    "snyk-gradle-plugin": "3.16.2",
+    "snyk-gradle-plugin": "3.17.0",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.26.2",
     "snyk-nodejs-lockfile-parser": "1.37.1",

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -203,6 +203,7 @@ export function args(rawArgv: string[]): Args {
     'all-sub-projects',
     'sub-project',
     'gradle-sub-project',
+    'gradle-accept-legacy-config-roles',
     'skip-unresolved',
     'scan-all-unmanaged',
     'fail-on',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,6 +22,7 @@ export interface TestOptions {
   initScript?: string;
   yarnWorkspaces?: boolean;
   gradleSubProject?: boolean;
+  gradleAcceptLegacyConfigRoles?: boolean;
   command?: string; // python interpreter to use for python tests
   testDepGraphDockerEndpoint?: string | null;
   isDockerUser?: boolean;
@@ -208,6 +209,7 @@ export type SupportedUserReachableFacingCliArgs =
   | 'sequential'
   | 'fail-on'
   | 'file'
+  | 'gradle-accept-legacy-config-roles'
   | 'gradle-sub-project'
   | 'ignore-policy'
   | 'init-script'

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -24,6 +24,10 @@ module.exports = {
           to: '../bin',
         },
         {
+          from: 'node_modules/snyk-gradle-plugin/lib/legacy-init.gradle',
+          to: '../lib',
+        },
+        {
           from: 'node_modules/snyk-gradle-plugin/lib/init.gradle',
           to: '../lib',
         },


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This patch adds the `--gradle-accept-legacy-config-roles` flag, and uses a version of the Gradle plugin that accepts it. When set by the user, the plugin will use a more permissive dependency resolution process.

See https://github.com/snyk/snyk-gradle-plugin/pull/191/files for more details.