### PR TITLE
support tags/attributes in Docker projects & alias --project-tags to --tags

### DIFF
--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -393,10 +393,13 @@ export function generateTags(options): Tag[] | undefined {
   }
 
   if (options['project-tags'] !== undefined && options['tags'] !== undefined) {
-    throw new ValidationError('Only one of --tags or --project-tags may be specified, not both');
+    throw new ValidationError(
+      'Only one of --tags or --project-tags may be specified, not both',
+    );
   }
 
-  const rawTags = options['tags'] === undefined ? options['project-tags'] : options['tags'];
+  const rawTags =
+    options['tags'] === undefined ? options['project-tags'] : options['tags'];
 
   if (rawTags === '') {
     return [];

--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -388,23 +388,29 @@ export function generateProjectAttributes(options): ProjectAttributes {
  * @returns List of parsed tags or undefined if they are to be left untouched.
  */
 export function generateTags(options): Tag[] | undefined {
-  if (options['project-tags'] === undefined) {
+  if (options['project-tags'] === undefined && options['tags'] === undefined) {
     return undefined;
   }
 
-  if (options['project-tags'] === '') {
+  if (options['project-tags'] !== undefined && options['tags'] !== undefined) {
+    throw new ValidationError('Only one of --tags or --project-tags may be specified, not both');
+  }
+
+  const rawTags = options['tags'] === undefined ? options['project-tags'] : options['tags'];
+
+  if (rawTags === '') {
     return [];
   }
 
   // When it's specified without the =, we raise an explicit error to avoid
   // accidentally clearing the existing tags;
-  if (options['project-tags'] === true) {
+  if (rawTags === true) {
     throw new ValidationError(
       `--project-tags must contain an '=' with a comma-separated list of pairs (also separated with an '='). To clear all existing values, pass no values i.e. --project-tags=`,
     );
   }
 
-  const keyEqualsValuePairs = options['project-tags'].split(',');
+  const keyEqualsValuePairs = rawTags.split(',');
 
   const tags: Tag[] = [];
   for (const keyEqualsValue of keyEqualsValuePairs) {

--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -357,6 +357,12 @@ function getProjectAttribute<T>(
   return values;
 }
 
+export function validateProjectAttributes(options): void {
+  // The validation is deep within the parsing, so call the generate but throw away the return for simplicity.
+  // Using this method makes it much clearer what the intent is of the caller.
+  generateProjectAttributes(options);
+}
+
 export function generateProjectAttributes(options): ProjectAttributes {
   return {
     criticality: getProjectAttribute(
@@ -430,6 +436,12 @@ export function generateTags(options): Tag[] | undefined {
   }
 
   return tags;
+}
+
+export function validateTags(options): void {
+  // The validation is deep within the parsing, so call the generate but throw away the return for simplicity.
+  // Using this method makes it much clearer what the intent is of the caller.
+  generateTags(options);
 }
 
 function validateMonitorPath(path: string, isDocker?: boolean): void {

--- a/src/lib/ecosystems/types.ts
+++ b/src/lib/ecosystems/types.ts
@@ -1,7 +1,7 @@
 import { DepGraphData } from '@snyk/dep-graph';
 import { SEVERITY } from '../snyk-test/common';
 import { RemediationChanges } from '../snyk-test/legacy';
-import { Options } from '../types';
+import { Options, ProjectAttributes, Tag } from '../types';
 
 export type Ecosystem = 'cpp' | 'docker' | 'code';
 
@@ -133,4 +133,6 @@ export interface MonitorDependenciesRequest {
   projectName?: string;
   policy?: string;
   method?: 'cli';
+  tags?: Tag[];
+  attributes?: ProjectAttributes;
 }

--- a/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
+++ b/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
@@ -1740,6 +1740,7 @@ if (!isWindows) {
           },
           facts: [{ type: 'depGraph', data: {} }],
         },
+        attributes: {},
       },
       'sends correct payload',
     );
@@ -1808,6 +1809,7 @@ if (!isWindows) {
             { type: 'dockerfileAnalysis', data: {} },
           ],
         },
+        attributes: {},
       },
       'sends correct payload',
     );
@@ -1867,6 +1869,7 @@ if (!isWindows) {
             facts: [{ type: 'depGraph', data: {} }],
           },
         ],
+        attributes: {},
       },
       t,
     );
@@ -1936,6 +1939,7 @@ if (!isWindows) {
           },
           facts: [{ type: 'depGraph', data: {} }],
         },
+        attributes: {},
       },
       'sends correct payload',
     );

--- a/test/jest/acceptance/cli-args.spec.ts
+++ b/test/jest/acceptance/cli-args.spec.ts
@@ -301,6 +301,19 @@ describe('cli args', () => {
     expect(code).toEqual(2);
   });
 
+  test('snyk container monitor --project-tags is implemented', async () => {
+    const { code, stdout } = await runSnykCLI(
+      `container monitor alpine --project-tags`,
+      {
+        env,
+      },
+    );
+    expect(stdout).toMatch(
+      "--project-tags must contain an '=' with a comma-separated list of pairs (also separated with an '='). To clear all existing values, pass no values i.e. --project-tags=",
+    );
+    expect(code).toEqual(2);
+  });
+
   const optionsToTest = [
     '--json-file-output',
     '--json-file-output=',

--- a/test/jest/system/ecosystems-monitor-docker.spec.ts
+++ b/test/jest/system/ecosystems-monitor-docker.spec.ts
@@ -65,6 +65,7 @@ describe('monitorEcosystem docker/container', () => {
         docker: true,
         'app-vulns': true,
         org: 'my-org',
+        tags: 'keyone=valueone',
       },
     );
 
@@ -116,6 +117,8 @@ describe('monitorEcosystem docker/container', () => {
         },
         projectName: undefined,
         method: 'cli',
+        attributes: {},
+        tags: [{ key: 'keyone', value: 'valueone' }],
       },
       qs: {
         org: 'my-org',


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR adds support for `snyk container monitor` to use `--project-tags` (and now `--tags`) as well as the project attributes (`--project-lifecycle`, `--project-business-criticality`, `--project-environment`).

#### Where should the reviewer start?


#### How should this be manually tested?

Example command line:

```
snyk container monitor alpine:3.14 --tags=container2=monitor5 --project-lifecycle=sandbox --project-environment=backend --project-business-criticality=critical
```

#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
