### PR TITLE
fix: match package.json to workspace definition

### DIFF
--- a/test/acceptance/cli-test/cli-test.acceptance.test.ts
+++ b/test/acceptance/cli-test/cli-test.acceptance.test.ts
@@ -74,113 +74,106 @@ import * as ecoSystemPlugins from '../../../src/lib/ecosystems/plugins';
   - Jakub
 */
 
-const isWindows =
-  require('os-name')()
-    .toLowerCase()
-    .indexOf('windows') === 0;
+// @later: remove this config stuff.
+// Was copied straight from ../src/cli-server.js
+before('setup', async (t) => {
+  versionNumber = await getVersion();
 
-if (!isWindows) {
-  // @later: remove this config stuff.
-  // Was copied straight from ../src/cli-server.js
-  before('setup', async (t) => {
-    versionNumber = await getVersion();
+  t.plan(3);
+  let key = await cli.config('get', 'api');
+  oldkey = key;
+  t.pass('existing user config captured');
 
-    t.plan(3);
-    let key = await cli.config('get', 'api');
-    oldkey = key;
-    t.pass('existing user config captured');
+  key = await cli.config('get', 'endpoint');
+  oldendpoint = key;
+  t.pass('existing user endpoint captured');
 
-    key = await cli.config('get', 'endpoint');
-    oldendpoint = key;
-    t.pass('existing user endpoint captured');
+  await new Promise((resolve) => {
+    server.listen(port, resolve);
+  });
+  t.pass('started demo server');
+  t.end();
+});
 
-    await new Promise((resolve) => {
-      server.listen(port, resolve);
+// @later: remove this config stuff.
+// Was copied straight from ../src/cli-server.js
+before('prime config', async (t) => {
+  await cli.config('set', 'api=' + apiKey);
+  t.pass('api token set');
+  await cli.config('unset', 'endpoint');
+  t.pass('endpoint removed');
+  t.end();
+});
+
+test(GenericTests.language, async (t) => {
+  for (const testName of Object.keys(GenericTests.tests)) {
+    t.test(
+      testName,
+      GenericTests.tests[testName](
+        { server, versionNumber, cli },
+        { chdirWorkspaces },
+      ),
+    );
+  }
+});
+
+test(AllProjectsTests.language, async (t) => {
+  for (const testName of Object.keys(AllProjectsTests.tests)) {
+    t.test(
+      testName,
+      AllProjectsTests.tests[testName](
+        { server, versionNumber, cli, plugins },
+        { chdirWorkspaces },
+      ),
+    );
+  }
+});
+
+test('Languages', async (t) => {
+  for (const languageTest of languageTests) {
+    t.test(languageTest.language, async (tt) => {
+      for (const testName of Object.keys(languageTest.tests)) {
+        tt.test(
+          testName,
+          languageTest.tests[testName](
+            { server, plugins, ecoSystemPlugins, versionNumber, cli },
+            { chdirWorkspaces },
+          ),
+        );
+        server.restore();
+      }
     });
-    t.pass('started demo server');
+  }
+});
+
+// TODO: try and remove this config stuff
+// Was copied straight from ../src/cli-server.js
+after('teardown', async (t) => {
+  t.plan(4);
+
+  delete process.env.SNYK_API;
+  delete process.env.SNYK_HOST;
+  delete process.env.SNYK_PORT;
+  t.notOk(process.env.SNYK_PORT, 'fake env values cleared');
+
+  await new Promise((resolve) => {
+    server.close(resolve);
+  });
+  t.pass('server shutdown');
+  let key = 'set';
+  let value = 'api=' + oldkey;
+  if (!oldkey) {
+    key = 'unset';
+    value = 'api';
+  }
+  await cli.config(key, value);
+  t.pass('user config restored');
+  if (oldendpoint) {
+    await cli.config('endpoint', oldendpoint);
+    t.pass('user endpoint restored');
     t.end();
-  });
-
-  // @later: remove this config stuff.
-  // Was copied straight from ../src/cli-server.js
-  before('prime config', async (t) => {
-    await cli.config('set', 'api=' + apiKey);
-    t.pass('api token set');
-    await cli.config('unset', 'endpoint');
-    t.pass('endpoint removed');
+  } else {
+    t.pass('no endpoint');
     t.end();
-  });
-
-  test(GenericTests.language, async (t) => {
-    for (const testName of Object.keys(GenericTests.tests)) {
-      t.test(
-        testName,
-        GenericTests.tests[testName](
-          { server, versionNumber, cli },
-          { chdirWorkspaces },
-        ),
-      );
-    }
-  });
-
-  test(AllProjectsTests.language, async (t) => {
-    for (const testName of Object.keys(AllProjectsTests.tests)) {
-      t.test(
-        testName,
-        AllProjectsTests.tests[testName](
-          { server, versionNumber, cli, plugins },
-          { chdirWorkspaces },
-        ),
-      );
-    }
-  });
-
-  test('Languages', async (t) => {
-    for (const languageTest of languageTests) {
-      t.test(languageTest.language, async (tt) => {
-        for (const testName of Object.keys(languageTest.tests)) {
-          tt.test(
-            testName,
-            languageTest.tests[testName](
-              { server, plugins, ecoSystemPlugins, versionNumber, cli },
-              { chdirWorkspaces },
-            ),
-          );
-          server.restore();
-        }
-      });
-    }
-  });
-
-  // TODO: try and remove this config stuff
-  // Was copied straight from ../src/cli-server.js
-  after('teardown', async (t) => {
-    t.plan(4);
-
-    delete process.env.SNYK_API;
-    delete process.env.SNYK_HOST;
-    delete process.env.SNYK_PORT;
-    t.notOk(process.env.SNYK_PORT, 'fake env values cleared');
-
-    await new Promise((resolve) => {
-      server.close(resolve);
-    });
-    t.pass('server shutdown');
-    let key = 'set';
-    let value = 'api=' + oldkey;
-    if (!oldkey) {
-      key = 'unset';
-      value = 'api';
-    }
-    await cli.config(key, value);
-    t.pass('user config restored');
-    if (oldendpoint) {
-      await cli.config('endpoint', oldendpoint);
-      t.pass('user endpoint restored');
-      t.end();
-    } else {
-      t.pass('no endpoint');
-      t.end();
-    }
-  });
-}
+  }
+});

--- a/test/jest/unit/lib/plugins/yarn-workspaces-parser.spec.ts
+++ b/test/jest/unit/lib/plugins/yarn-workspaces-parser.spec.ts
@@ -1,0 +1,151 @@
+import { packageJsonBelongsToWorkspace } from '../../../../../src/lib/plugins/nodejs-plugin/yarn-workspaces-parser';
+
+const yarnWorkspacesMap = {
+  'snyk/test/acceptance/workspaces/yarn-workspace-out-of-sync/package.json': {
+    workspaces: ['packages/*'],
+  },
+  'snyk/test/acceptance/workspaces/yarn-workspace/package.json': {
+    workspaces: ['libs/*/**', 'tools/*'],
+  },
+};
+
+const yarnWorkspacesMapWindows = {
+  'C:\\snyk\\test\\acceptance\\workspaces\\yarn-workspace-out-of-sync\\package.json': {
+    workspaces: ['packages'],
+  },
+  'C:\\snyk\\test\\acceptance\\workspaces\\yarn-workspace\\package.json': {
+    workspaces: ['libs/*/**', 'tools/*'],
+  },
+  'C:\\snyk\\yarn-workspace\\package.json': {
+    workspaces: ['libs\\*\\**', 'tools\\*'],
+  },
+};
+describe('packageJsonBelongsToWorkspace', () => {
+  test('does not match workspace root', () => {
+    const packageJsonFileName =
+      'snyk/test/acceptance/workspaces/yarn-workspace-out-of-sync/package.json';
+    const workspaceRoot =
+      'snyk/test/acceptance/workspaces/yarn-workspace-out-of-sync/package.json';
+    expect(
+      packageJsonBelongsToWorkspace(
+        packageJsonFileName,
+        yarnWorkspacesMap,
+        workspaceRoot,
+      ),
+    ).toBeFalsy();
+  });
+  test('correctly matches a workspace with /* globs (meaning all folders)', () => {
+    // docs: https://yarnpkg.com/features/workspaces#how-to-declare-a-worktree
+    const packageJsonFileName =
+      'snyk/test/acceptance/workspaces/yarn-workspace-out-of-sync/packages/apple/package.json';
+    const workspaceRoot =
+      'snyk/test/acceptance/workspaces/yarn-workspace-out-of-sync/package.json';
+    expect(
+      packageJsonBelongsToWorkspace(
+        packageJsonFileName,
+        yarnWorkspacesMap,
+        workspaceRoot,
+      ),
+    ).toBeTruthy();
+  });
+
+  test('correctly matches a workspace with /*/** globs', () => {
+    const packageJsonFileName =
+      'snyk/test/acceptance/workspaces/yarn-workspace/libs/a/package.json';
+    const workspaceRoot =
+      'snyk/test/acceptance/workspaces/yarn-workspace/package.json';
+    expect(
+      packageJsonBelongsToWorkspace(
+        packageJsonFileName,
+        yarnWorkspacesMap,
+        workspaceRoot,
+      ),
+    ).toBeTruthy();
+  });
+
+  test('does not match a workspace outside declared globs', () => {
+    const packageJsonFileName =
+      'snyk/test/acceptance/workspaces/yarn-workspace/packages/a/package.json';
+    const workspaceRoot =
+      'snyk/test/acceptance/workspaces/yarn-workspace/package.json';
+    expect(
+      packageJsonBelongsToWorkspace(
+        packageJsonFileName,
+        yarnWorkspacesMap,
+        workspaceRoot,
+      ),
+    ).toBeFalsy();
+  });
+});
+
+describe('packageJsonBelongsToWorkspace Windows', () => {
+  test('does not match workspace root', () => {
+    const packageJsonFileName =
+      'C:\\snyk\\test\\acceptance\\workspaces\\yarn-workspace-out-of-sync\\package.json';
+    const workspaceRoot =
+      'C:\\snyk\\test\\acceptance\\workspaces\\yarn-workspace-out-of-sync\\package.json';
+    expect(
+      packageJsonBelongsToWorkspace(
+        packageJsonFileName,
+        yarnWorkspacesMapWindows,
+        workspaceRoot,
+      ),
+    ).toBeFalsy();
+  });
+  test('correctly matches a workspace with /* globs (meaning all folders)', () => {
+    // docs: https://yarnpkg.com/features/workspaces#how-to-declare-a-worktree
+    const packageJsonFileName =
+      'C:\\snyk\\test\\acceptance\\workspaces\\yarn-workspace-out-of-sync\\packages\\apple\\package.json';
+    const workspaceRoot =
+      'C:\\snyk\\test\\acceptance\\workspaces\\yarn-workspace-out-of-sync\\package.json';
+    expect(
+      packageJsonBelongsToWorkspace(
+        packageJsonFileName,
+        yarnWorkspacesMapWindows,
+        workspaceRoot,
+      ),
+    ).toBeTruthy();
+  });
+
+  test('correctly matches a workspace with \\* globs (meaning all folders)', () => {
+    // docs: https://yarnpkg.com/features/workspaces#how-to-declare-a-worktree
+    const packageJsonFileName =
+      'C:\\snyk\\yarn-workspace\\tools\\apple\\package.json';
+    const workspaceRoot = 'C:\\snyk\\yarn-workspace\\package.json';
+    expect(
+      packageJsonBelongsToWorkspace(
+        packageJsonFileName,
+        yarnWorkspacesMapWindows,
+        workspaceRoot,
+      ),
+    ).toBeTruthy();
+  });
+
+  test('correctly matches a workspace with /*/** globs', () => {
+    const packageJsonFileName =
+      'C:\\snyk\\test\\acceptance\\workspaces\\yarn-workspace\\libs\\a\\package.json';
+    const workspaceRoot =
+      'C:\\snyk\\test\\acceptance\\workspaces\\yarn-workspace\\package.json';
+    expect(
+      packageJsonBelongsToWorkspace(
+        packageJsonFileName,
+        yarnWorkspacesMapWindows,
+        workspaceRoot,
+      ),
+    ).toBeTruthy();
+  });
+
+  test('does not match a workspace outside declared globs', () => {
+    const packageJsonFileName =
+      'C:\\snyk\\test\\acceptance\\workspaces\\yarn-workspace\\packages\\a\\package.json';
+    const workspaceRoot =
+      'C:\\snyk\\test\\acceptance\\workspaces\\yarn-workspace\\package.json';
+    expect(
+      packageJsonBelongsToWorkspace(
+        packageJsonFileName,
+        yarnWorkspacesMapWindows,
+        workspaceRoot,
+      ),
+    ).toBeFalsy();
+  });
+});


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Re-enable windows tests as they have been hiding the fact that the
feature broke on Windows.

Update the file matching logic to support both Windows & Linux file names
as well as different glob types.
e.g. 'package/*' is an example given in Yarn docs


#### Where should the reviewer start?
https://github.com/snyk/snyk/compare/fix/yarn-workspaces-windows?expand=1#diff-58a7b63707ecc3959ab8c5f5ec8cfb77660fc185f22cb4c2677b5af04180bba4R165

#### How should this be manually tested?


#### Any background context you want to provide?
Disabled tests did not catch that Windows support had a bug

#### What are the relevant tickets?
https://github.com/snyk/snyk/issues/1560

#### Screenshots


#### Additional questions
