### PR TITLE
fix: fix combination of rubygems and --all-projects

### DIFF
--- a/src/lib/plugins/rubygems/index.ts
+++ b/src/lib/plugins/rubygems/index.ts
@@ -1,17 +1,19 @@
 import { inspectors, Spec } from './inspectors';
 import { MissingTargetFileError } from '../../errors/missing-targetfile-error';
 import gemfileLockToDependencies = require('./gemfile-lock-to-dependencies');
-const get = require('lodash.get');
+import * as get from 'lodash.get';
 import { MultiProjectResult } from '@snyk/cli-interface/legacy/plugin';
+import * as types from '../types';
 
 export async function inspect(
   root: string,
   targetFile: string,
+  options: types.Options = {},
 ): Promise<MultiProjectResult> {
   if (!targetFile) {
     throw MissingTargetFileError(root);
   }
-  const specs = await gatherSpecs(root, targetFile);
+  const specs = await gatherSpecs(root, targetFile, options);
 
   return {
     plugin: {
@@ -41,10 +43,14 @@ function getDependenciesFromSpecs(specs) {
   return dependencies;
 }
 
-async function gatherSpecs(root, targetFile): Promise<Spec> {
+async function gatherSpecs(
+  root: string,
+  targetFile: string,
+  options: types.Options,
+): Promise<Spec> {
   for (const inspector of inspectors) {
     if (inspector.canHandle(targetFile)) {
-      return await inspector.gatherSpecs(root, targetFile);
+      return await inspector.gatherSpecs(root, targetFile, options);
     }
   }
 

--- a/src/lib/plugins/rubygems/inspectors/gemfile.ts
+++ b/src/lib/plugins/rubygems/inspectors/gemfile.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import { tryGetSpec } from './try-get-spec';
 import { Spec } from './index';
+import * as types from '../../types';
 
 /* Supported example patterns:
  * Gemfile
@@ -18,7 +19,11 @@ export function canHandle(file: string): boolean {
   return !!file && gemfileOrLockfilePattern.test(path.basename(file));
 }
 
-export async function gatherSpecs(root: string, target: string): Promise<Spec> {
+export async function gatherSpecs(
+  root: string,
+  target: string,
+  options: types.Options,
+): Promise<Spec> {
   const { dir, name } = path.parse(target);
   const isGemfileLock = gemfileLockPattern.test(target);
   // if the target is a Gemfile we treat is as the lockfile
@@ -28,8 +33,11 @@ export async function gatherSpecs(root: string, target: string): Promise<Spec> {
   );
 
   if (gemfileLock) {
+    const basePackageName = path.basename(root);
     return {
-      packageName: path.basename(root),
+      packageName: options.allSubProjects
+        ? path.join(basePackageName, dir)
+        : basePackageName,
       targetFile: path.join(dir, name),
       files: { gemfileLock },
     };

--- a/test/acceptance/cli-test/cli-test.ruby.spec.ts
+++ b/test/acceptance/cli-test/cli-test.ruby.spec.ts
@@ -3,6 +3,7 @@ const sortBy = require('lodash.sortby');
 import { AcceptanceTests } from './cli-test.acceptance.test';
 import { getWorkspaceJSON } from '../workspace-helper';
 import { CommandResult } from '../../../src/cli/commands/types';
+import * as path from 'path';
 
 export const RubyTests: AcceptanceTests = {
   language: 'Ruby',
@@ -784,6 +785,18 @@ export const RubyTests: AcceptanceTests = {
         '--all-projects',
         'Suggest using --all-projects',
       );
+    },
+
+    '`test monorepo --all-projects`': (params, utils) => async (t) => {
+      utils.chdirWorkspaces();
+      await params.cli.test('monorepo', { allProjects: true });
+
+      const req = params.server.popRequest();
+
+      const rootNodePkgId = req.body.depGraph.graph.nodes.find(
+        (x) => x.nodeId == 'root-node',
+      ).pkgId;
+      t.equal(rootNodePkgId, `monorepo${path.sep}sub-ruby-app@`);
     },
   },
 };


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
today all rebygems projects have the same project name with --all-projects flag.
this adds the nested dir name into the project name.
