### PR TITLE
feat: allow pulling from an AWS Elastic registry url [CFG-1142]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,13 @@ jobs:
                 name: Running system tests (Jest)
                 command: npm run test:jest-system -- --ci
             - run:
+                name: Download AWS CLI
+                command: |
+                  msiexec.exe /i AWSCLIV2.msi /quiet
+                  [Environment]::SetEnvironmentVariable("Path", $env:PATH + `
+                  ";c:\Program Files\Amazon\AWSCLIV2", "Machine")
+                shell: powershell.exe
+            - run:
                 name: Running acceptance tests (Jest)
                 command: npm run test:jest-acceptance -- --ci
       - when:
@@ -317,6 +324,8 @@ jobs:
             - run:
                 name: Running system tests (Jest)
                 command: npm run test:jest-system -- --ci
+            - aws-cli/install:
+                version: 2.2.32
             - run:
                 name: Running acceptance tests (Jest)
                 command: npm run test:jest-acceptance -- --ci

--- a/src/cli/commands/test/iac-local-execution/oci-pull.ts
+++ b/src/cli/commands/test/iac-local-execution/oci-pull.ts
@@ -22,10 +22,12 @@ export function extractOCIRegistryURLComponents(
   OCIRegistryURL: string,
 ): OCIRegistryURLComponents {
   try {
-    const url = OCIRegistryURL.split('://')[1];
-    const [registryBase, accountName, repoWithTag] = url.split('/');
-    const [repoName, tag = 'latest'] = repoWithTag.split(':');
-    const repo = accountName + '/' + repoName;
+    const url = new URL(OCIRegistryURL);
+    const registryBase = url.hostname;
+    // with or without a path, there will at least be a / in the pathname
+    const repoWithTag = url.pathname.substring(1);
+
+    const [repo, tag = 'latest'] = repoWithTag.split(':');
     return { registryBase, repo, tag };
   } catch {
     throw new InvalidRemoteRegistryURLError();

--- a/test/jest/unit/iac-unit-tests/oci-pull.spec.ts
+++ b/test/jest/unit/iac-unit-tests/oci-pull.spec.ts
@@ -32,6 +32,18 @@ describe('extractOCIRegistryURLComponents', () => {
       tag: '0.5.2',
     });
   });
+
+  it('extracts components when no account provided', async () => {
+    const expected = extractOCIRegistryURLComponents(
+      'https://gcr.io/repo-test:0.5.2',
+    );
+    expect(expected).toEqual({
+      registryBase: 'gcr.io',
+      repo: 'repo-test',
+      tag: '0.5.2',
+    });
+  });
+
   it('extracts components and a latest tag, when tag is undefined', async () => {
     const expected = extractOCIRegistryURLComponents(
       'https://gcr.io/user/repo-test',


### PR DESCRIPTION
#### What does this PR do?
This PR updates the `oci-pull` functionality in the CLI so that it supports registries where the repo is directly under the registry, not under an account under that registry.

#### How should this be manually tested?
1. Run `npm run build`
2. Run the CLI with no configs: `snyk-dev iac test test/fixtures/iac/terraform/sg_open_ssh.tf`
3. Use the Elastic details in the `IaC Tests - OCI Registries Credentials` vault to set the following:
```
snyk-dev config set oci-registry-url=
snyk-dev config set oci-registry-username=
snyk-dev config set oci-registry-password=
```
4. Run the CLI with the configs: `snyk-dev iac test test/fixtures/iac/terraform/sg_open_ssh.tf`

This is already being tested by the added acceptance tests.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CFG-1142
