### PR TITLE
Feat/add iac custom rules entitlement

### DIFF
--- a/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
+++ b/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
@@ -40,7 +40,7 @@ function getFlagName(key: string) {
 }
 
 export class FlagError extends CustomError {
-  constructor(key: string, featureFlag: string) {
+  constructor(key: string, featureFlag?: string) {
     const flag = getFlagName(key);
     let msg;
     if (featureFlag) {
@@ -65,6 +65,18 @@ export class FlagValueError extends CustomError {
     this.code = IaCErrorCodes.FlagValueError;
     this.strCode = getErrorStringCode(this.code);
     this.userMessage = msg;
+  }
+}
+
+export class UnsupportedEntitlementFlagError extends CustomError {
+  constructor(key: string, entitlementName: string) {
+    const flag = getFlagName(key);
+    super(
+      `Unsupported flag: ${flag} - Missing the ${entitlementName} entitlement`,
+    );
+    this.code = IaCErrorCodes.UnsupportedEntitlementFlagError;
+    this.strCode = getErrorStringCode(this.code);
+    this.userMessage = `Flag "${flag}" is currently not supported for this org. To enable it, please contact snyk support.`;
   }
 }
 

--- a/src/cli/commands/test/iac-local-execution/oci-pull.ts
+++ b/src/cli/commands/test/iac-local-execution/oci-pull.ts
@@ -6,7 +6,7 @@ import {
   ImageManifest,
   ManifestConfig,
   OCIPullOptions,
-  OciUrl,
+  OCIRegistryURLComponents,
 } from './types';
 import { CustomError } from '../../../../lib/errors';
 import { getErrorStringCode } from './error-utils';
@@ -18,7 +18,9 @@ const debug = Debug('iac-oci-pull');
 
 export const CUSTOM_RULES_TARBALL = 'custom-bundle.tar.gz';
 
-export function extractURLComponents(OCIRegistryURL: string): OciUrl {
+export function extractOCIRegistryURLComponents(
+  OCIRegistryURL: string,
+): OCIRegistryURLComponents {
   try {
     const url = OCIRegistryURL.split('://')[1];
     const [registryBase, accountName, repoWithTag] = url.split('/');
@@ -39,7 +41,7 @@ export function extractURLComponents(OCIRegistryURL: string): OciUrl {
  * @param opt????? (optional) - object that holds the credentials and other metadata required for the registry-v2-client
  **/
 export async function pull(
-  { registryBase, repo, tag }: OciUrl,
+  { registryBase, repo, tag }: OCIRegistryURLComponents,
   opt?: OCIPullOptions,
 ): Promise<void> {
   const manifest: ImageManifest = await registryClient.getManifest(
@@ -108,5 +110,23 @@ export class InvalidRemoteRegistryURLError extends CustomError {
     this.strCode = getErrorStringCode(this.code);
     this.userMessage =
       'The Remote Registry URL is invalid, or does not include a http/https protocol. Please check it again.';
+  }
+}
+
+export class UnsupportedFeatureFlagPullError extends CustomError {
+  constructor(featureFlag: string) {
+    super('OCI Pull not supported - Missing the ${featureFlag} feature flag');
+    this.code = IaCErrorCodes.UnsupportedFeatureFlagPullError;
+    this.strCode = getErrorStringCode(this.code);
+    this.userMessage = `The custom rules feature is not supported for this org - The feature flag '${featureFlag}' is not currently enabled. It can be enabled via Snyk Preview, if you are on the Enterprise Plan.`;
+  }
+}
+
+export class UnsupportedEntitlementPullError extends CustomError {
+  constructor(entitlement: string) {
+    super(`OCI Pull not supported - Missing the ${entitlement} entitlement`);
+    this.code = IaCErrorCodes.UnsupportedEntitlementPullError;
+    this.strCode = getErrorStringCode(this.code);
+    this.userMessage = `The custom rules feature is currently not supported for this org. To enable it, please contact snyk support.`;
   }
 }

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -68,16 +68,21 @@ export type FormattedResult = {
 
 export type IacCustomPolicies = Record<string, { severity?: string }>;
 
-export interface IaCCustomRulesConfigs {
+export interface IacCustomRules {
   isEnabled?: boolean;
   ociRegistryURL?: string;
   ociRegistryTag?: string;
 }
 
+export interface IacEntitlements {
+  iacCustomRulesEntitlement?: boolean;
+}
+
 export interface IacOrgSettings {
   meta: TestMeta;
   customPolicies: IacCustomPolicies;
-  customRules?: IaCCustomRulesConfigs;
+  customRules?: IacCustomRules;
+  entitlements?: IacEntitlements;
 }
 
 export interface TestMeta {
@@ -283,6 +288,7 @@ export enum IaCErrorCodes {
   // assert-iac-options-flag
   FlagError = 1090,
   FlagValueError = 1091,
+  UnsupportedEntitlementFlagError = 1092,
 
   // oci-pull errors
   FailedToExecuteCustomRulesError = 1100,
@@ -290,6 +296,8 @@ export enum IaCErrorCodes {
   FailedToBuildOCIArtifactError = 1102,
   InvalidRemoteRegistryURLError = 1103,
   InvalidManifestSchemaVersionError = 1104,
+  UnsupportedFeatureFlagPullError = 1105,
+  UnsupportedEntitlementPullError = 1106,
 }
 
 export interface TestReturnValue {
@@ -325,7 +333,7 @@ export interface OCIPullOptions {
   imageSavePath?: string;
 }
 
-export interface OciUrl {
+export interface OCIRegistryURLComponents {
   registryBase: string;
   repo: string;
   tag: string;

--- a/src/lib/errors/unsupported-entitlement-error.ts
+++ b/src/lib/errors/unsupported-entitlement-error.ts
@@ -1,0 +1,17 @@
+import { CustomError } from './custom-error';
+
+export class UnsupportedEntitlementError extends CustomError {
+  public readonly entitlement: string;
+
+  private static ERROR_CODE = 403;
+
+  constructor(
+    entitlement: string,
+    userMessage = `This feature is currently not enabled for your org. To enable it, please contact snyk support.`,
+  ) {
+    super('Unsupported feature - Missing the ${entitlementName} entitlement');
+    this.entitlement = entitlement;
+    this.code = UnsupportedEntitlementError.ERROR_CODE;
+    this.userMessage = userMessage;
+  }
+}

--- a/src/lib/errors/unsupported-feature-flag-error.ts
+++ b/src/lib/errors/unsupported-feature-flag-error.ts
@@ -1,6 +1,7 @@
 import { CustomError } from './custom-error';
 
 export class UnsupportedFeatureFlagError extends CustomError {
+  public readonly featureFlag: string;
   private static ERROR_CODE = 403;
 
   constructor(
@@ -8,6 +9,7 @@ export class UnsupportedFeatureFlagError extends CustomError {
     userMessage = `Feature flag '${featureFlag}' is not currently enabled for your org, to enable please contact snyk support`,
   ) {
     super(userMessage);
+    this.featureFlag = featureFlag;
     this.userMessage = userMessage;
     this.code = UnsupportedFeatureFlagError.ERROR_CODE;
   }

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -357,7 +357,7 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
   });
 
   app.get(basePath + '/iac-org-settings', (req, res) => {
-    res.status(200).send({
+    const baseResponse = {
       meta: {
         isPrivate: false,
         isLicensesEnabled: false,
@@ -366,7 +366,21 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
       },
       customPolicies: {},
       customRules: {},
-    });
+      entitlements: {
+        iacCustomRulesEntitlement: true,
+      },
+    };
+
+    if (req.query.org === 'no-entitlements') {
+      return res.status(200).send({
+        ...baseResponse,
+        entitlements: {
+          iacCustomRulesEntitlement: false,
+        },
+      });
+    }
+
+    res.status(200).send(baseResponse);
   });
 
   app.get(basePath + '/authorization/:action', (req, res, next) => {

--- a/test/jest/unit/iac-unit-tests/oci-pull.spec.ts
+++ b/test/jest/unit/iac-unit-tests/oci-pull.spec.ts
@@ -1,7 +1,7 @@
 import * as OCIPull from '../../../../src/cli/commands/test/iac-local-execution/oci-pull';
 import {
   CUSTOM_RULES_TARBALL,
-  extractURLComponents,
+  extractOCIRegistryURLComponents,
   FailedToBuildOCIArtifactError,
   InvalidRemoteRegistryURLError,
 } from '../../../../src/cli/commands/test/iac-local-execution/oci-pull';
@@ -11,9 +11,9 @@ import { promises as fs } from 'fs';
 import * as fileUtilsModule from '../../../../src/cli/commands/test/iac-local-execution/file-utils';
 import * as measurableMethods from '../../../../src/cli/commands/test/iac-local-execution/measurable-methods';
 
-describe('extractURLComponents', () => {
+describe('extractOCIRegistryURLComponents', () => {
   it('extracts baseURL, repo and tag from an OCI URL', async () => {
-    const expected = extractURLComponents(
+    const expected = extractOCIRegistryURLComponents(
       'https://registry-1.docker.io/accountName/bundle-test:latest',
     );
     expect(expected).toEqual({
@@ -23,7 +23,7 @@ describe('extractURLComponents', () => {
     });
   });
   it('extracts components and a versioned tag', async () => {
-    const expected = extractURLComponents(
+    const expected = extractOCIRegistryURLComponents(
       'https://gcr.io/user/repo-test:0.5.2',
     );
     expect(expected).toEqual({
@@ -33,7 +33,9 @@ describe('extractURLComponents', () => {
     });
   });
   it('extracts components and a latest tag, when tag is undefined', async () => {
-    const expected = extractURLComponents('https://gcr.io/user/repo-test');
+    const expected = extractOCIRegistryURLComponents(
+      'https://gcr.io/user/repo-test',
+    );
     expect(expected).toEqual({
       registryBase: 'gcr.io',
       repo: 'user/repo-test',
@@ -43,7 +45,7 @@ describe('extractURLComponents', () => {
 
   it('throws an error if URL is invalid', () => {
     expect(() => {
-      extractURLComponents('url/not/valid');
+      extractOCIRegistryURLComponents('url/not/valid');
     }).toThrow(InvalidRemoteRegistryURLError);
   });
 });


### PR DESCRIPTION
### What this does
- Refactors the pull flow in the `iac test` command.
- Wraps the `--rules` flag with the `iacCustomRulesEntitlement` entitlement.
- Wraps the custom-rules bundles pulling operation with the `iacCustomRules` flag.
- Wraps the custom-rules bundles pulling operation with the `iacCustomRulesEntitlement` entitlement.

### Notes for the reviewer

<details>
  <summary><b>Background context</b></summary>

The custom-rules feature and `--rules` flag in the Snyk CLI is currently behind a feature flag called `iacCustomRules`. 

We have introduced a new entitlement called `iacCustomRulesEntitlement`, which will soon replace the deprecated feature flag and will be the only gate after GA that will be used to make sure only specific customers can use this feature.

</details>

<details>
  <summary><b>How to run locally</b></summary>

  ##### The `--rules` Flag:
1. Prepare a custom-rules bundle generated by the [Snyk custom-rules bundles generator](https://github.com/snyk/snyk-iac-rules). 
2. Make sure your org has the `iacCustomRules` and the `infrastructureAsCode` feature flags.
3. Make sure your org has the `iacCustomRulesEntitlement` entitlement.
4. In the DB, make sure to not have any preconfigured OCI registry configurations in `org.cloudConfig.customRules`.
5. In the Snyk CLI, run `snyk-dev iac test <file> --rules=<path-to-bundle>`.
6. Verify that:
    - No errors were thrown.
    - The defined custom rules generated the expected issues successfully.
7. Through the org's admin page, disable the `iacCustomRulesEntitlement` entitlement.
8. In the Snyk CLI, run `snyk-dev iac test <file> --rules=<path-to-bundle>`.
9. Verify that the flag was not available due to the disabled entitlement.

  ##### Custom-Rules Bundles Pulling:
1. Prepare a custom-rules bundle generated by the [Snyk custom-rules bundles generator](https://github.com/snyk/snyk-iac-rules). 
2. Store the generated bundle in your preferred OCI registry.
3. Export the following env variables:
    - `OCI_REGISTRY_USERNAME`: The username for the desired registry.
    - `OCI_REGISTRY_PASSWORD`: The password for the desired registry. 
4. Make sure your org has the `iacCustomRules` and the `infrastructureAsCode` feature flags.
5. Make sure your org has the `iacCustomRulesEntitlement` entitlement.
6. Make sure your user has the following org permission: `READ`, `IAC_SETTINGS_READ` `IAC_SETTINGS_EDIT`.
7. Navigate to the custom-rules configurations section in the org IaC settings page on `/org/ofekatr/manage/cloud-config`.
8. Update the OCI registry URL and tag for the desired custom-rules bundle.
9. In the Snyk CLI, run `snyk-dev iac test <file>`.
10. Verify that:
    - No errors were thrown.
    - The bundle was pulled successfully into the `.iac-data` directory.
    - The defined custom rules generated the expected issues successfully.
11. Through the org's admin page, disable the `iacCustomRulesEntitlement` entitlement.
12. In the Snyk CLI, run `snyk-dev iac test <file>`.
13. Verify that the operation was not available due to the disabled entitlement.
14. Through the org's admin page, enable the `iacCustomRulesEntitlement` entitlement.
15. Through the org's admin page, disable the `iacCustomRules` feature flag.
16. Verify that the operation was not available due to the disabled feature flag.

</details>

### More information

- [Jira ticket CFG-1086](https://snyksec.atlassian.net/browse/CFG-1086)
- [Related PR on snyk/registry](https://github.com/snyk/registry/pull/24450)