### PR TITLE
change msg  when missing = in key=value

### DIFF
--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -426,7 +426,7 @@ export function generateTags(options): Tag[] | undefined {
     const parts = keyEqualsValue.split('=');
     if (parts.length !== 2) {
       throw new ValidationError(
-        `The tag "${keyEqualsValue}" does not have an "=" separating the key and value.`,
+        `The tag "${keyEqualsValue}" does not have an "=" separating the key and value. For example: --project-tag=KEY=VALUE`,
       );
     }
     tags.push({


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR changes the error message when the user supplies --project-tags=THING : instead of getting the error:
The tag "XXX" does not have an "=" separating the key and value.
User will now get the error:
The tag "XXX" does not have an "=" separating the key and value. eg: --project-tag=KEY=VALUE

https://github.com/snyk/snyk/blob/afe15c7fad3baddb8958bcdc979894aba5bf30b8/src/cli/commands/monitor/index.ts#L429

