### PR TITLE
test: migrate cli tap tests to jest

### DIFF
--- a/src/cli/commands/fix/validate-fix-command-is-supported.ts
+++ b/src/cli/commands/fix/validate-fix-command-is-supported.ts
@@ -31,7 +31,7 @@ export async function validateFixCommandIsSupported(
   debug('Feature flag check returned: ', snykFixSupported);
 
   if (snykFixSupported.code === 401 || snykFixSupported.code === 403) {
-    throw AuthFailedError(snykFixSupported.error, snykFixSupported.code);
+    throw new AuthFailedError(snykFixSupported.error, snykFixSupported.code);
   }
 
   if (!snykFixSupported.ok) {

--- a/src/cli/commands/ignore.ts
+++ b/src/cli/commands/ignore.ts
@@ -2,28 +2,16 @@ import * as policy from 'snyk-policy';
 import chalk from 'chalk';
 import * as authorization from '../../lib/authorization';
 import * as auth from './auth/is-authed';
-import { apiTokenExists } from '../../lib/api-token';
-import { isCI } from '../../lib/is-ci';
 import { MethodResult } from './types';
 
 import * as Debug from 'debug';
 const debug = Debug('snyk');
-
-import { MisconfiguredAuthInCI } from '../../lib/errors/misconfigured-auth-in-ci-error';
 
 export default function ignore(options): Promise<MethodResult> {
   debug('snyk ignore called with options: %O', options);
 
   return auth
     .isAuthed()
-    .then((authed) => {
-      if (!authed) {
-        if (isCI()) {
-          throw MisconfiguredAuthInCI();
-        }
-      }
-      apiTokenExists();
-    })
     .then(() => {
       return authorization.actionAllowed('cliIgnore', options);
     })

--- a/src/cli/commands/protect/wizard.ts
+++ b/src/cli/commands/protect/wizard.ts
@@ -1,6 +1,5 @@
 import * as debugModule from 'debug';
 const debug = debugModule('snyk');
-
 import * as path from 'path';
 import * as inquirer from '@snyk/inquirer';
 import * as fs from 'fs';
@@ -10,7 +9,6 @@ import * as url from 'url';
 const cloneDeep = require('lodash.clonedeep');
 const get = require('lodash.get');
 import { exec } from 'child_process';
-import { apiTokenExists } from '../../../lib/api-token';
 import * as auth from '../auth/is-authed';
 import getVersion from '../version';
 import * as allPrompts from './prompts';
@@ -28,7 +26,6 @@ import npm, { getVersion as npmGetVersion } from '../../../lib/npm';
 import * as detect from '../../../lib/detect';
 import * as plugins from '../../../lib/plugins';
 import { ModuleInfo as moduleInfo } from '../../../lib/module-info';
-import { MisconfiguredAuthInCI } from '../../../lib/errors/misconfigured-auth-in-ci-error';
 import { MissingTargetFileError } from '../../../lib/errors/missing-targetfile-error';
 import * as pm from '../../../lib/package-managers';
 import { icon, color } from '../../../lib/theme';
@@ -102,13 +99,8 @@ async function processWizardFlow(options) {
   debug(message);
   const policyFile = await loadOrCreatePolicyFile(options);
 
-  const authed = await auth.isAuthed();
-  analytics.add('inline-auth', !authed);
-  if (!authed && isCI()) {
-    throw MisconfiguredAuthInCI();
-  }
+  await auth.isAuthed();
 
-  apiTokenExists();
   const cliIgnoreAuthorization = await authorization.actionAllowed(
     'cliIgnore',
     options,

--- a/src/lib/ecosystems/monitor.ts
+++ b/src/lib/ecosystems/monitor.ts
@@ -152,7 +152,7 @@ async function monitorDependencies(
         });
       } catch (error) {
         if (error.code === 401) {
-          throw AuthFailedError();
+          throw new AuthFailedError();
         }
         if (error.code >= 400 && error.code < 500) {
           throw new MonitorError(error.code, error.message);

--- a/src/lib/ecosystems/resolve-monitor-facts.ts
+++ b/src/lib/ecosystems/resolve-monitor-facts.ts
@@ -52,7 +52,7 @@ export async function resolveAndMonitorFacts(
         results.push(ecosystemMonitorResult);
       } catch (error) {
         if (error.code === 401) {
-          throw AuthFailedError();
+          throw new AuthFailedError();
         }
 
         if (error.code >= 400 && error.code < 500) {

--- a/src/lib/errors/authentication-failed-error.ts
+++ b/src/lib/errors/authentication-failed-error.ts
@@ -1,14 +1,19 @@
 import { CustomError } from './custom-error';
 import config from '../config';
 
-export function AuthFailedError(
-  errorMessage: string = 'Authentication failed. Please check the API token on ' +
-    config.ROOT,
-  errorCode = 401,
-) {
-  const error = new CustomError(errorMessage);
-  error.code = errorCode;
-  error.strCode = 'authfail';
-  error.userMessage = errorMessage;
-  return error;
+export class AuthFailedError extends CustomError {
+  private static ERROR_CODE = 401;
+  private static ERROR_STRING_CODE = 'authfail';
+  private static ERROR_MESSAGE =
+    'Authentication failed. Please check the API token on ' + config.ROOT;
+
+  constructor(
+    message = AuthFailedError.ERROR_MESSAGE,
+    code = AuthFailedError.ERROR_CODE,
+  ) {
+    super(message);
+    this.code = code;
+    this.strCode = AuthFailedError.ERROR_STRING_CODE;
+    this.userMessage = message;
+  }
 }

--- a/src/lib/errors/misconfigured-auth-in-ci-error.ts
+++ b/src/lib/errors/misconfigured-auth-in-ci-error.ts
@@ -1,13 +1,15 @@
 import { CustomError } from './custom-error';
 
-export function MisconfiguredAuthInCI() {
-  const errorMsg =
-    'Snyk is missing auth token in order to run inside CI. You must include ' +
-    'your API token as an environment value: `SNYK_TOKEN=12345678`';
+export class MisconfiguredAuthInCI extends CustomError {
+  private static ERROR_CODE = 401;
+  private static ERROR_STRING_CODE = 'noAuthInCI';
+  private static ERROR_MESSAGE =
+    '`snyk` requires an authenticated account. Provide your Snyk API token using a "SNYK_TOKEN" environment variable.';
 
-  const error = new CustomError(errorMsg);
-  error.code = 401;
-  error.strCode = 'noAuthInCI';
-  error.userMessage = errorMsg;
-  return error;
+  constructor() {
+    super(MisconfiguredAuthInCI.ERROR_MESSAGE);
+    this.code = MisconfiguredAuthInCI.ERROR_CODE;
+    this.strCode = MisconfiguredAuthInCI.ERROR_STRING_CODE;
+    this.userMessage = MisconfiguredAuthInCI.ERROR_MESSAGE;
+  }
 }

--- a/src/lib/plugins/sast/validate.ts
+++ b/src/lib/plugins/sast/validate.ts
@@ -23,7 +23,7 @@ export async function validateCodeTest(options: Options) {
     sastSettingsResponse?.code === 401 ||
     sastSettingsResponse?.code === 403
   ) {
-    throw AuthFailedError(
+    throw new AuthFailedError(
       sastSettingsResponse.error,
       sastSettingsResponse.code,
     );

--- a/src/lib/reachable-vulns.ts
+++ b/src/lib/reachable-vulns.ts
@@ -52,7 +52,7 @@ export async function validatePayload(
   );
 
   if (reachableVulnsSupportedRes.code === 401) {
-    throw AuthFailedError(
+    throw new AuthFailedError(
       reachableVulnsSupportedRes.error,
       reachableVulnsSupportedRes.code,
     );

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -491,7 +491,7 @@ function handleTestHttpErrorResponse(res, body) {
   switch (statusCode) {
     case 401:
     case 403:
-      err = AuthFailedError(userMessage, statusCode);
+      err = new AuthFailedError(userMessage, statusCode);
       err.innerError = body.stack;
       break;
     case 404:

--- a/test/acceptance/docker-token.test.ts
+++ b/test/acceptance/docker-token.test.ts
@@ -153,9 +153,9 @@ test('`snyk test` without docker flag - docker token and no api key', async (t) 
     await cli.test('foo:latest', {
       docker: false,
     });
-    t.fail('expected MissingApiTokenError');
+    t.fail('expected missing token error');
   } catch (err) {
-    t.equal(err.name, 'MissingApiTokenError', 'should throw if not docker');
+    t.equal(err.code, 401, 'should throw if not docker');
   }
 });
 

--- a/test/acceptance/workspaces/policy/.snyk
+++ b/test/acceptance/workspaces/policy/.snyk
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.22.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'npm:marked:20170907':
+    - '*':
+        reason: Default policy location test
+        expires: 2027-11-19T14:12:53.987Z
+patch: {}

--- a/test/jest/acceptance/snyk-auth/snyk-auth.spec.ts
+++ b/test/jest/acceptance/snyk-auth/snyk-auth.spec.ts
@@ -1,0 +1,59 @@
+import { fakeServer } from '../../../acceptance/fake-server';
+import { createProjectFromWorkspace } from '../../util/createProject';
+import { runSnykCLI } from '../../util/runSnykCLI';
+import { removeAuth } from '../../util/removeAuth';
+
+jest.setTimeout(1000 * 60);
+
+describe('snyk auth', () => {
+  let server: ReturnType<typeof fakeServer>;
+  let env: Record<string, string>;
+
+  beforeAll((done) => {
+    const apiPath = '/api/v1';
+    const apiPort = process.env.PORT || process.env.SNYK_PORT || '12345';
+    env = {
+      ...process.env,
+      SNYK_API: 'http://localhost:' + apiPort + apiPath,
+      SNYK_TOKEN: '123456789', // replace token from process.env
+      SNYK_DISABLE_ANALYTICS: '1',
+    };
+
+    server = fakeServer(apiPath, env.SNYK_TOKEN);
+    server.listen(apiPort, () => done());
+  });
+
+  afterEach(() => {
+    server.restore();
+  });
+
+  afterAll((done) => {
+    server.close(() => done());
+  });
+
+  it('accepts valid token', async () => {
+    const project = await createProjectFromWorkspace('fail-on/no-vulns');
+    server.setDepGraphResponse(await project.readJSON('vulns-result.json'));
+
+    const { code, stdout } = await runSnykCLI(`auth ${server.getSnykToken()}`, {
+      cwd: project.path(),
+      env: removeAuth(project, env),
+    });
+
+    expect(code).toEqual(0);
+    expect(stdout).toMatch('Your account has been authenticated.');
+  });
+
+  it('rejects invalid token', async () => {
+    const project = await createProjectFromWorkspace('fail-on/no-vulns');
+    server.setDepGraphResponse(await project.readJSON('vulns-result.json'));
+
+    const { code, stdout } = await runSnykCLI(`auth invalid-token`, {
+      cwd: project.path(),
+      env: removeAuth(project, env),
+    });
+
+    expect(code).toEqual(2);
+    expect(stdout).toMatch('Authentication failed.');
+  });
+});

--- a/test/jest/acceptance/snyk-ignore/snyk-ignore.spec.ts
+++ b/test/jest/acceptance/snyk-ignore/snyk-ignore.spec.ts
@@ -1,0 +1,109 @@
+import { load as loadPolicy } from 'snyk-policy';
+import { fakeServer } from '../../../acceptance/fake-server';
+import { createProjectFromWorkspace } from '../../util/createProject';
+import { runSnykCLI } from '../../util/runSnykCLI';
+
+jest.setTimeout(1000 * 60);
+
+describe('snyk ignore', () => {
+  let server: ReturnType<typeof fakeServer>;
+  let env: Record<string, string>;
+
+  beforeAll((done) => {
+    const apiPath = '/api/v1';
+    const apiPort = process.env.PORT || process.env.SNYK_PORT || '12345';
+    env = {
+      ...process.env,
+      SNYK_API: 'http://localhost:' + apiPort + apiPath,
+      SNYK_TOKEN: '123456789', // replace token from process.env
+      SNYK_DISABLE_ANALYTICS: '1',
+    };
+
+    server = fakeServer(apiPath, env.SNYK_TOKEN);
+    server.listen(apiPort, () => done());
+  });
+
+  afterEach(() => {
+    server.restore();
+  });
+
+  afterAll((done) => {
+    server.close(() => done());
+  });
+
+  it('creates a policy file using minimal options', async () => {
+    const project = await createProjectFromWorkspace('empty');
+    const { code } = await runSnykCLI(`ignore --id=ID`, {
+      cwd: project.path(),
+      env: env,
+    });
+
+    expect(code).toEqual(0);
+
+    const policy = await loadPolicy(project.path());
+    expect(policy).toMatchObject({
+      ignore: {
+        ID: [
+          {
+            '*': {
+              reason: 'None Given',
+              expires: expect.any(Date),
+              created: expect.any(Date),
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('creates a policy file using provided options', async () => {
+    const project = await createProjectFromWorkspace('empty');
+    const { code } = await runSnykCLI(
+      `ignore --id=ID --reason=REASON --expiry=2017-10-07 --policy-path=${project.path()}`,
+      {
+        cwd: project.path(),
+        env: env,
+      },
+    );
+
+    expect(code).toEqual(0);
+    const policy = await loadPolicy(project.path());
+    expect(policy).toMatchObject({
+      ignore: {
+        ID: [
+          {
+            '*': {
+              reason: 'REASON',
+              expires: new Date('2017-10-07'),
+              created: expect.any(Date),
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('fails on missing ID', async () => {
+    const project = await createProjectFromWorkspace('empty');
+    const { code, stdout } = await runSnykCLI(`ignore --reason=REASON`, {
+      cwd: project.path(),
+      env: env,
+    });
+
+    expect(code).toEqual(2);
+    expect(stdout).toMatch('id is a required field');
+  });
+
+  it('errors when user is not authorized to ignore', async () => {
+    const project = await createProjectFromWorkspace('empty');
+    server.unauthorizeAction('cliIgnore', 'not allowed');
+
+    const { code, stdout } = await runSnykCLI(`ignore --id=ID`, {
+      cwd: project.path(),
+      env,
+    });
+
+    expect(code).toEqual(0);
+    expect(stdout).toMatch('not allowed');
+  });
+});

--- a/test/jest/acceptance/snyk-monitor/json-output.spec.ts
+++ b/test/jest/acceptance/snyk-monitor/json-output.spec.ts
@@ -1,0 +1,64 @@
+import { fakeServer } from '../../../acceptance/fake-server';
+import { createProjectFromWorkspace } from '../../util/createProject';
+import { runSnykCLI } from '../../util/runSnykCLI';
+
+jest.setTimeout(1000 * 60);
+
+describe('snyk monitor --json', () => {
+  let server: ReturnType<typeof fakeServer>;
+  let env: Record<string, string>;
+
+  beforeAll((done) => {
+    const apiPath = '/api/v1';
+    const apiPort = process.env.PORT || process.env.SNYK_PORT || '12345';
+    env = {
+      ...process.env,
+      SNYK_API: 'http://localhost:' + apiPort + apiPath,
+      SNYK_TOKEN: '123456789', // replace token from process.env
+      SNYK_DISABLE_ANALYTICS: '1',
+    };
+
+    server = fakeServer(apiPath, env.SNYK_TOKEN);
+    server.listen(apiPort, () => done());
+  });
+
+  afterEach(() => {
+    server.restore();
+  });
+
+  afterAll((done) => {
+    server.close(() => done());
+  });
+
+  it('includes result details', async () => {
+    const project = await createProjectFromWorkspace('no-vulns');
+    const { code, stdout } = await runSnykCLI(`monitor --json`, {
+      cwd: project.path(),
+      env: env,
+    });
+
+    expect(code).toEqual(0);
+    expect(JSON.parse(stdout)).toMatchObject({
+      packageManager: 'npm',
+      manageUrl: 'http://localhost:12345/manage',
+    });
+  });
+
+  it('includes path errors', async () => {
+    const project = await createProjectFromWorkspace(
+      'no-supported-target-files',
+    );
+    const { code, stdout } = await runSnykCLI(`monitor --json`, {
+      cwd: project.path(),
+      env: env,
+    });
+
+    expect(code).toEqual(3);
+    expect(JSON.parse(stdout)).toMatchObject({
+      path: project.path(),
+      error: expect.stringContaining(
+        `Could not detect supported target files in ${project.path()}.`,
+      ),
+    });
+  });
+});

--- a/test/jest/acceptance/snyk-policy/snyk-policy.spec.ts
+++ b/test/jest/acceptance/snyk-policy/snyk-policy.spec.ts
@@ -1,0 +1,54 @@
+import { fakeServer } from '../../../acceptance/fake-server';
+import { createProjectFromWorkspace } from '../../util/createProject';
+import { runSnykCLI } from '../../util/runSnykCLI';
+
+jest.setTimeout(1000 * 60);
+
+describe('snyk policy', () => {
+  let server: ReturnType<typeof fakeServer>;
+  let env: Record<string, string>;
+
+  beforeAll((done) => {
+    const apiPath = '/api/v1';
+    const apiPort = process.env.PORT || process.env.SNYK_PORT || '12345';
+    env = {
+      ...process.env,
+      SNYK_API: 'http://localhost:' + apiPort + apiPath,
+      SNYK_TOKEN: '123456789', // replace token from process.env
+      SNYK_DISABLE_ANALYTICS: '1',
+    };
+
+    server = fakeServer(apiPath, env.SNYK_TOKEN);
+    server.listen(apiPort, () => done());
+  });
+
+  afterEach(() => {
+    server.restore();
+  });
+
+  afterAll((done) => {
+    server.close(() => done());
+  });
+
+  it('loads policy file', async () => {
+    const project = await createProjectFromWorkspace('policy');
+    const { code, stdout } = await runSnykCLI('policy', {
+      cwd: project.path(),
+      env: env,
+    });
+
+    expect(code).toEqual(0);
+    expect(stdout).toMatch('Current Snyk policy, read from .snyk file');
+  });
+
+  it('fails when policy not found', async () => {
+    const project = await createProjectFromWorkspace('empty');
+    const { code, stdout } = await runSnykCLI('policy', {
+      cwd: project.path(),
+      env: env,
+    });
+
+    expect(code).toEqual(2);
+    expect(stdout).toMatch('Could not load policy.');
+  });
+});

--- a/test/jest/acceptance/snyk-test/json-output.spec.ts
+++ b/test/jest/acceptance/snyk-test/json-output.spec.ts
@@ -1,0 +1,50 @@
+import { fakeServer } from '../../../acceptance/fake-server';
+import { createProjectFromWorkspace } from '../../util/createProject';
+import { runSnykCLI } from '../../util/runSnykCLI';
+
+jest.setTimeout(1000 * 60);
+
+describe('snyk test --json', () => {
+  let server: ReturnType<typeof fakeServer>;
+  let env: Record<string, string>;
+
+  beforeAll((done) => {
+    const apiPath = '/api/v1';
+    const apiPort = process.env.PORT || process.env.SNYK_PORT || '12345';
+    env = {
+      ...process.env,
+      SNYK_API: 'http://localhost:' + apiPort + apiPath,
+      SNYK_TOKEN: '123456789', // replace token from process.env
+      SNYK_DISABLE_ANALYTICS: '1',
+    };
+
+    server = fakeServer(apiPath, env.SNYK_TOKEN);
+    server.listen(apiPort, () => done());
+  });
+
+  afterEach(() => {
+    server.restore();
+  });
+
+  afterAll((done) => {
+    server.close(() => done());
+  });
+
+  it('includes path errors', async () => {
+    const project = await createProjectFromWorkspace(
+      'no-supported-target-files',
+    );
+    const { code, stdout } = await runSnykCLI(`test --json`, {
+      cwd: project.path(),
+      env: env,
+    });
+
+    expect(code).toEqual(3);
+    expect(JSON.parse(stdout)).toMatchObject({
+      path: project.path(),
+      error: expect.stringContaining(
+        `Could not detect supported target files in ${project.path()}.`,
+      ),
+    });
+  });
+});

--- a/test/jest/acceptance/snyk-test/no-auth.spec.ts
+++ b/test/jest/acceptance/snyk-test/no-auth.spec.ts
@@ -39,9 +39,7 @@ describe('snyk test without authentication', () => {
       env: removeAuth(project, env),
     });
 
-    expect(code).toEqual(0);
-    expect(stdout).toMatch(
-      '`snyk` requires an authenticated account. Please run `snyk auth` and try again.',
-    );
+    expect(code).toEqual(2);
+    expect(stdout).toMatch('`snyk` requires an authenticated account.');
   });
 });

--- a/test/jest/acceptance/snyk-test/no-auth.spec.ts
+++ b/test/jest/acceptance/snyk-test/no-auth.spec.ts
@@ -1,0 +1,47 @@
+import { fakeServer } from '../../../acceptance/fake-server';
+import { createProjectFromWorkspace } from '../../util/createProject';
+import { runSnykCLI } from '../../util/runSnykCLI';
+import { removeAuth } from '../../util/removeAuth';
+
+jest.setTimeout(1000 * 60);
+
+describe('snyk test without authentication', () => {
+  let server: ReturnType<typeof fakeServer>;
+  let env: Record<string, string>;
+
+  beforeAll((done) => {
+    const apiPath = '/api/v1';
+    const apiPort = process.env.PORT || process.env.SNYK_PORT || '12345';
+    env = {
+      ...process.env,
+      SNYK_API: 'http://localhost:' + apiPort + apiPath,
+      SNYK_TOKEN: '123456789',
+      SNYK_DISABLE_ANALYTICS: '1',
+    };
+
+    server = fakeServer(apiPath, env.SNYK_TOKEN);
+    server.listen(apiPort, () => done());
+  });
+
+  afterEach(() => {
+    server.restore();
+  });
+
+  afterAll((done) => {
+    server.close(() => done());
+  });
+
+  it('errors when auth token is not provided', async () => {
+    const project = await createProjectFromWorkspace('no-vulns');
+
+    const { code, stdout } = await runSnykCLI(`test`, {
+      cwd: project.path(),
+      env: removeAuth(project, env),
+    });
+
+    expect(code).toEqual(0);
+    expect(stdout).toMatch(
+      '`snyk` requires an authenticated account. Please run `snyk auth` and try again.',
+    );
+  });
+});

--- a/test/jest/util/createProject.ts
+++ b/test/jest/util/createProject.ts
@@ -2,7 +2,7 @@ import * as fse from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
 
-type TestProject = {
+export type TestProject = {
   path: (filePath?: string) => string;
   read: (filePath: string) => Promise<string>;
   readJSON: (filePath: string) => Promise<any>;

--- a/test/jest/util/removeAuth.ts
+++ b/test/jest/util/removeAuth.ts
@@ -1,0 +1,18 @@
+import omit = require('lodash.omit');
+import { TestProject } from './createProject';
+
+/**
+ * Removes authentication tokens from environment variables and persisted
+ * config stores. The latter is done by pointing the config path to a local
+ * directory within the test project rather than using the user's
+ * home directory.
+ */
+export const removeAuth = (
+  project: TestProject,
+  env: Record<string, string>,
+): Record<string, string> => {
+  return {
+    ...omit(env, ['SNYK_TOKEN']),
+    XDG_CONFIG_HOME: project.path('.config'),
+  };
+};

--- a/test/smoke/spec/snyk_auth_spec.sh
+++ b/test/smoke/spec/snyk_auth_spec.sh
@@ -5,7 +5,7 @@ Describe "Snyk CLI Authorization"
 
   It "fails when run in CI without token set"
     When run snyk auth
-    The output should include "Snyk is missing auth token in order to run inside CI"
+    The output should include "Provide your Snyk API token using a \"SNYK_TOKEN\" environment variable."
     The status should be failure
     # TODO: unusable with our current docker issues
     The stderr should equal ""

--- a/test/system/auth.test.ts
+++ b/test/system/auth.test.ts
@@ -28,7 +28,7 @@ test('setup', (t) => {
 
 test('auth shows an appropriate error message when a request times out', async (t) => {
   const failedReq = new Promise((resolve) => {
-    return resolve({ res: { statusCode: 502 } });
+    return resolve({ statusCode: 502 });
   });
   const verifyStub = sinon.stub(isAuthed, 'verifyAPI').returns(failedReq);
 
@@ -48,7 +48,7 @@ test('auth shows an appropriate error message when a request times out', async (
 test('auth shows an appropriate error message when a request fails with a user message', async (t) => {
   const userMessage = 'Oh no! The request failed';
   const failedReq = new Promise((resolve) => {
-    return resolve({ res: { statusCode: 502, body: { userMessage } } });
+    return resolve({ statusCode: 502, body: { userMessage } });
   });
   const verifyStub = sinon.stub(isAuthed, 'verifyAPI').returns(failedReq);
 

--- a/test/validate-fix-command-is-supported.spec.ts
+++ b/test/validate-fix-command-is-supported.spec.ts
@@ -32,7 +32,7 @@ describe('setDefaultTestOptions', () => {
       .mockResolvedValue({ ok: false, code: 401, error: 'Invalid auth token' });
     const options = { path: '/', showVulnPaths: 'all' as ShowVulnPaths };
     await expect(validateFixCommandIsSupported(options)).rejects.toThrowError(
-      AuthFailedError('Invalid auth token', 401),
+      new AuthFailedError('Invalid auth token', 401),
     );
   });
 


### PR DESCRIPTION
WIP

Follow up to #2343 and #2265

`system/cli.test.ts` contains a bunch of tests ranging from auth, test, monitor, policy and more. There are issues with how they setup and cleanup which causes a single test failure to fail the rest of them. Likely because they use Restify via cli-server which isn't supported in Node 16 (see #2265). So I've started migrating them to Jest and fake-server.

## Auth in Tests

A lot of tests use `snyk config` to setup/teardown authentication. These need to be migrated to env vars as `snyk config` uses a global config file causing cross-test pollution. One simple option is to make the config path configurable.

## To Do

- Split up PRs. There's a few improvements here that came about from fixing various things.