### PR TITLE
refactor: modularise dangerfile and rules

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,137 +1,43 @@
-import { danger, fail, message, warn } from 'danger';
-import * as fs from 'fs';
+import {
+  danger,
+  fail,
+  markdown,
+  message,
+  peril,
+  results,
+  schedule,
+  warn,
+} from 'danger';
 
-function validateCommitMessages() {
-  const commitizenRegex = /^(feat|fix|chore|test|docs|perf|refactor|revert)(\(.*\))?:(.+)$/;
-  const maxMessageLength = 72;
-  const ghCommits = danger.github.commits;
-  let willTriggerRelease = false;
-  for (const { commit } of ghCommits) {
-    const { message, url } = commit;
-    const firstLine = message.split('\n')[0];
+(async () => {
+  /**
+   * The 'danger' import above is a hack DangerJS uses for type-safety. When
+   * this script is run, DangerJS adds those values to the global runtime and
+   * removes the import statement. So we need to pass through those globals to
+   * each rule. This lets us test them outside the Danger runtime and avoid weird
+   * global namespace hacks.
+   */
+  const dangerJs = {
+    danger,
+    fail,
+    markdown,
+    message,
+    peril,
+    results,
+    schedule,
+    warn,
+  };
 
-    if (message.startsWith('feat') || message.startsWith('fix')) {
-      willTriggerRelease = true;
-    }
+  const modules = [
+    () => import('@snyk/danger-rules/validateCommitMessages'),
+    () => import('@snyk/danger-rules/requireGeneratingHelpFiles'),
+    () => import('@snyk/danger-rules/recommendWritingTest'),
+    () => import('@snyk/danger-rules/recommendJest'),
+    () => import('@snyk/danger-rules/recommendRunningSmokeTests'),
+    () => import('@snyk/danger-rules/recommendMigratingModuleSyntax'),
+  ];
 
-    const regexMatch = commitizenRegex.exec(firstLine);
-    if (!regexMatch) {
-      fail(
-        `Commit ["${firstLine}"](${url}) is not a valid commitizen message. See [Contributing page](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md#commit-types) with required commit message format.`,
-      );
-    }
-
-    if (firstLine.length >= maxMessageLength) {
-      warn(
-        `Your commit message ["${firstLine}"](${url}) is too long. Keep first line of your commit under ${maxMessageLength} characters.`,
-      );
-    }
+  for (const module of modules) {
+    (await module()).rule(dangerJs);
   }
-
-  if (!willTriggerRelease) {
-    message(
-      "This PR will not trigger a new version. It doesn't include any commit message with `feat` or `fix`.",
-    );
-  }
-}
-
-function recommendWritingTest() {
-  const modifiedTest =
-    danger.git.modified_files.some((f) => f.startsWith('test/')) ||
-    danger.git.created_files.some((f) => f.startsWith('test/'));
-  const modifiedSrc =
-    danger.git.modified_files.some((f) => f.startsWith('src/')) ||
-    danger.git.created_files.some((f) => f.startsWith('src/'));
-
-  if (modifiedSrc && !modifiedTest) {
-    warn(
-      "You've modified files in src/ directory, but haven't updated anything in test folder. Is there something that could be tested?",
-    );
-  }
-}
-
-function recommendJest() {
-  // `.spec.ts` is always used for Jest tests
-  // `.test.ts` is normally used for Tap tests and but there are also `.spec.ts` files which are used be Tap tests in test/acceptance.
-  // either way, we should warn about new `.test.ts` or `.spec.ts` files being created outside the `/test/jest` folder
-  const newTestFiles = danger.git.created_files.filter((f) => {
-    const inTestFolder = f.startsWith('test/');
-    const isATestFile = f.includes('.test.ts') || f.includes('.spec.ts');
-    const inJestFolder = f.startsWith('test/jest/');
-    const inFixturesFolder = f.startsWith('test/fixtures/');
-    return inTestFolder && isATestFile && !inJestFolder && !inFixturesFolder;
-  });
-
-  if (newTestFiles.length) {
-    const joinedFileList = newTestFiles.map((f) => '- `' + f + '`').join('\n');
-    const msg = `Looks like you added a new Tap test. Consider making it a Jest test instead. See files in \`test/jest/(unit|system|acceptance)\` for examples. Files found:\n${joinedFileList}`;
-    warn(msg);
-  }
-}
-
-function recommendRunningSmokeTests() {
-  const branchPrefix = 'smoke/';
-  const workflowPath = '.github/workflows/smoke-tests.yml';
-
-  const modifiedSmokeTest =
-    danger.git.modified_files.some((f) => f.startsWith('test/smoke/')) ||
-    danger.git.created_files.some((f) => f.startsWith('test/smoke/')) ||
-    danger.git.modified_files.includes(workflowPath);
-
-  const isOnSmokeTestBranch = danger.github.pr.head.ref.startsWith(
-    branchPrefix,
-  );
-
-  if (modifiedSmokeTest && !isOnSmokeTestBranch) {
-    message(
-      `You are modifying something in test/smoke directory, yet you are not on the branch starting with ${branchPrefix}. You can prefix your branch with ${branchPrefix} and Smoke tests will trigger for this PR.`,
-    );
-  }
-}
-
-function requireGeneratingHelpFiles() {
-  const modifiedHelpFiles =
-    danger.git.modified_files.some((f) =>
-      f.startsWith('help/commands-docs/'),
-    ) ||
-    danger.git.created_files.some((f) => f.startsWith('help/commands-docs/'));
-  const modifiedGeneratedHelpFiles =
-    danger.git.modified_files.some((f) => f.startsWith('help/commands-txt/')) ||
-    danger.git.created_files.some((f) => f.startsWith('help/commands-txt/'));
-
-  if (modifiedHelpFiles && !modifiedGeneratedHelpFiles) {
-    fail(
-      "You've modified help files in /help/commands-docs. You need to regenerate manpages locally by running `npm run generate-help` and commiting the changed files. See [README in /help for more details](https://github.com/snyk/snyk/blob/master/help/README.md)",
-    );
-  }
-}
-
-function recommendMigratingModuleSyntax() {
-  const filesUsingNodeJSImportExport = danger.git.modified_files
-    .filter((filePath) => {
-      if (filePath.endsWith('.js')) {
-        return false;
-      }
-      const fileContent = fs.readFileSync(filePath, 'utf8');
-      return (
-        fileContent.includes('module.exports') ||
-        fileContent.includes('= require(')
-      );
-    })
-    .map((filePath) => `- \`${filePath}\``)
-    .join('\n');
-
-  if (filesUsingNodeJSImportExport) {
-    const message =
-      "Since the CLI is unifying on a standard and improved tooling, we're starting to migrate old-style `import`s and `export`s to ES6 ones.\nA file you've modified is using either `module.exports` or `require()`. If you can, please update them to ES6 [import syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) and [export syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export).\n Files found:\n" +
-      filesUsingNodeJSImportExport;
-    warn(message);
-  }
-}
-
-validateCommitMessages();
-requireGeneratingHelpFiles();
-recommendWritingTest();
-recommendJest();
-recommendRunningSmokeTests();
-recommendMigratingModuleSyntax();
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
         "snyk": "bin/snyk"
       },
       "devDependencies": {
+        "@snyk/danger-rules": "file:packages/danger-rules",
         "@types/body-parser": "^1.19.1",
         "@types/cross-spawn": "^6.0.2",
         "@types/express": "^4.17.13",
@@ -593,7 +594,6 @@
       "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
       "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
       "deprecated": "🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.",
-      "dev": true,
       "dependencies": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -4609,7 +4609,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.2.tgz",
       "integrity": "sha512-jbsSoi5Q1pj63sC16XIUboklNw+8tL9VOnJsWycWYR78TKss5PVpIPb1TUUcMQ+bBh7cY579cVAWmf5qG+dw+Q==",
-      "dev": true,
       "dependencies": {
         "@octokit/types": "^2.0.1"
       }
@@ -4618,7 +4617,6 @@
       "version": "2.16.2",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
       "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
-      "dev": true,
       "dependencies": {
         "@types/node": ">= 8"
       }
@@ -4635,7 +4633,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.4.0.tgz",
       "integrity": "sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==",
-      "dev": true,
       "dependencies": {
         "@octokit/types": "^2.0.1",
         "deprecation": "^2.3.1"
@@ -4645,7 +4642,6 @@
       "version": "2.16.2",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
       "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
-      "dev": true,
       "dependencies": {
         "@types/node": ">= 8"
       }
@@ -4667,7 +4663,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.1.tgz",
       "integrity": "sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==",
-      "dev": true,
       "dependencies": {
         "@octokit/types": "^2.0.0",
         "deprecation": "^2.0.0",
@@ -4678,7 +4673,6 @@
       "version": "2.16.2",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
       "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
-      "dev": true,
       "dependencies": {
         "@types/node": ">= 8"
       }
@@ -4702,7 +4696,6 @@
       "version": "16.43.2",
       "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.2.tgz",
       "integrity": "sha512-ngDBevLbBTFfrHZeiS7SAMAZ6ssuVmXuya+F/7RaVvlysgGa1JKJkKWY+jV6TCJYcW0OALfJ7nTIGXcBXzycfQ==",
-      "dev": true,
       "dependencies": {
         "@octokit/auth-token": "^2.4.0",
         "@octokit/plugin-paginate-rest": "^1.1.1",
@@ -5007,6 +5000,10 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@snyk/danger-rules": {
+      "resolved": "packages/danger-rules",
+      "link": true
     },
     "node_modules/@snyk/dep-graph": {
       "version": "1.28.1",
@@ -6898,7 +6895,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -6976,7 +6972,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
       "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-      "dev": true,
       "dependencies": {
         "es6-promisify": "^5.0.0"
       },
@@ -7320,7 +7315,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.2.3.tgz",
       "integrity": "sha512-tfDb02Th6CE6pJUF2gjW5ZVjsgwlucVXOEQMvEX9JgSJMs9gAX+Nz3xRuJBKuUYjTSYORqvDBORdAQ3LU59g7Q==",
-      "dev": true,
       "dependencies": {
         "retry": "0.12.0"
       }
@@ -7328,8 +7322,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -7355,8 +7348,7 @@
     "node_modules/atob-lite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
-      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
-      "dev": true
+      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
     },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
@@ -7836,8 +7828,7 @@
     "node_modules/btoa-lite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
-      "dev": true
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
     },
     "node_modules/buffer": {
       "version": "5.7.1",
@@ -7865,8 +7856,7 @@
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
-      "dev": true
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -8643,7 +8633,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -8683,7 +8672,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -8694,8 +8682,7 @@
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/commondir": {
       "version": "1.0.1",
@@ -9145,7 +9132,6 @@
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
       "deprecated": "core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
-      "dev": true,
       "hasInstallScript": true
     },
     "node_modules/core-util-is": {
@@ -9377,7 +9363,6 @@
       "version": "10.7.1",
       "resolved": "https://registry.npmjs.org/danger/-/danger-10.7.1.tgz",
       "integrity": "sha512-lKyWrWxNxtSfLSsOqse+O9MOrxa++a0kHEBxrgCBvjF36EjNuInuvY06omUTDGdIy6VEbDQRoGeQFIBauj8sMA==",
-      "dev": true,
       "dependencies": {
         "@babel/polyfill": "^7.2.5",
         "@octokit/rest": "^16.43.1",
@@ -9432,7 +9417,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
       "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-      "dev": true,
       "dependencies": {
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
@@ -9445,7 +9429,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -9569,7 +9552,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -9772,7 +9754,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -10119,7 +10100,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -10319,14 +10299,12 @@
     "node_modules/es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "node_modules/es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
       "dependencies": {
         "es6-promise": "^4.0.3"
       }
@@ -10879,7 +10857,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -11134,7 +11111,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-      "dev": true,
       "dependencies": {
         "homedir-polyfill": "^1.0.1"
       },
@@ -11325,7 +11301,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dev": true,
       "dependencies": {
         "is-extendable": "^0.1.0"
       },
@@ -11439,8 +11414,7 @@
     "node_modules/fast-json-patch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.0.tgz",
-      "integrity": "sha512-IhpytlsVTRndz0hU5t0/MGzS/etxLlfrpG5V5M9mVbuj9TrJLWaMfsox9REM5rkuGX0T+5qjpe8XA1o0gZ42nA==",
-      "dev": true
+      "integrity": "sha512-IhpytlsVTRndz0hU5t0/MGzS/etxLlfrpG5V5M9mVbuj9TrJLWaMfsox9REM5rkuGX0T+5qjpe8XA1o0gZ42nA=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -11537,7 +11511,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
       "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11869,7 +11842,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
       "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -11973,7 +11945,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
       "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12537,7 +12508,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
       "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -12576,7 +12546,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
       "integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
-      "dev": true,
       "dependencies": {
         "extend-shallow": "^2.0.1",
         "fs-exists-sync": "^0.1.0",
@@ -12959,7 +12928,6 @@
       "resolved": "https://registry.npmjs.org/gitlab/-/gitlab-10.2.1.tgz",
       "integrity": "sha512-z+DxRF1C9uayVbocs9aJkJz+kGy14TSm1noB/rAIEBbXOkOYbjKxyuqJzt+0zeFpXFdgA0yq6DVVbvM7HIfGwg==",
       "deprecated": "The gitlab package has found a new home in the @gitbeaker organization. For the latest gitlab node library, check out @gitbeaker/node. A full list of the features can be found here: https://github.com/jdalrymple/gitbeaker#readme",
-      "dev": true,
       "dependencies": {
         "form-data": "^2.5.0",
         "humps": "^2.0.1",
@@ -13417,7 +13385,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hasurl/-/hasurl-1.0.0.tgz",
       "integrity": "sha512-43ypUd3DbwyCT01UYpA99AEZxZ4aKtRxWGBHEIbjcOsUghd9YUON0C+JF6isNjaiwC/UF5neaUudy6JS9jZPZQ==",
-      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -13426,7 +13393,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
       "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
-      "dev": true,
       "dependencies": {
         "parse-passwd": "^1.0.0"
       },
@@ -13537,7 +13503,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
       "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-      "dev": true,
       "dependencies": {
         "agent-base": "4",
         "debug": "3.1.0"
@@ -13550,7 +13515,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
       "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -13558,8 +13522,7 @@
     "node_modules/http-proxy-agent/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/http-signature": {
       "version": "1.2.0",
@@ -13603,7 +13566,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
       "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-      "dev": true,
       "dependencies": {
         "agent-base": "^4.3.0",
         "debug": "^3.1.0"
@@ -13616,7 +13578,6 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -13642,14 +13603,12 @@
     "node_modules/humps": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
-      "integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=",
-      "dev": true
+      "integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao="
     },
     "node_modules/hyperlinker": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hyperlinker/-/hyperlinker-1.0.0.tgz",
       "integrity": "sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -13801,8 +13760,7 @@
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "node_modules/init-package-json": {
       "version": "1.10.3",
@@ -14221,7 +14179,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16631,7 +16588,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
       "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -16667,7 +16623,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
       "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16692,7 +16647,6 @@
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
       "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-      "dev": true,
       "dependencies": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -16714,7 +16668,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -16787,7 +16740,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
       "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "dev": true,
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -16798,7 +16750,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
       "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "dev": true,
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
@@ -16834,7 +16785,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/ky/-/ky-0.12.0.tgz",
       "integrity": "sha512-t9b7v3V2fGwAcQnnDDQwKQGF55eWrf4pwi1RN08Fy8b/9GEwV7Ea0xQiaSW6ZbeghBHIwl8kgnla4vVo9seepQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -16843,7 +16793,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.3.0.tgz",
       "integrity": "sha512-CM4Bgb2zZZpsprcjI6DNYTaH3oGHXL2u7BU4DK+lfCuC4snkt9/WRpMYeKbBbXscvKkeqBwzzjFX2WwmKY5K/A==",
-      "dev": true,
       "dependencies": {
         "abort-controller": "^3.0.0",
         "node-fetch": "^2.6.0"
@@ -17031,8 +16980,7 @@
     "node_modules/li": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/li/-/li-1.3.0.tgz",
-      "integrity": "sha1-IsWbyu+qmo7zWc91l4TkvxBq6hs=",
-      "dev": true
+      "integrity": "sha1-IsWbyu+qmo7zWc91l4TkvxBq6hs="
     },
     "node_modules/lie": {
       "version": "3.3.0",
@@ -17237,8 +17185,7 @@
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
-      "dev": true
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
     },
     "node_modules/lodash.invert": {
       "version": "4.3.0",
@@ -17268,8 +17215,7 @@
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
-      "dev": true
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
     },
     "node_modules/lodash.ismatch": {
       "version": "4.4.0",
@@ -17320,14 +17266,12 @@
     "node_modules/lodash.mapvalues": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
-      "dev": true
+      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -17342,8 +17286,7 @@
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
-      "dev": true
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "node_modules/lodash.orderby": {
       "version": "4.6.0",
@@ -17700,7 +17643,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.0.tgz",
       "integrity": "sha512-PloI9AkRXrLQuBU1s7eYQpl+4hkL0U0h23lddMaJ3ZGUufn8pdNRxd1kCfBqL5gISCFQs78ttXS15e4/f5vcTA==",
-      "dev": true,
       "dependencies": {
         "@octokit/rest": "^16.43.1"
       }
@@ -17963,7 +17905,6 @@
       "version": "1.49.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
       "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -17972,7 +17913,6 @@
       "version": "2.1.32",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
       "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.49.0"
       },
@@ -18629,8 +18569,7 @@
     "node_modules/node-cleanup": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
-      "integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
-      "dev": true
+      "integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw="
     },
     "node_modules/node-fetch": {
       "version": "2.6.1",
@@ -19570,8 +19509,7 @@
     "node_modules/octokit-pagination-methods": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
-      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
-      "dev": true
+      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ=="
     },
     "node_modules/on-finished": {
       "version": "2.3.0",
@@ -19787,8 +19725,7 @@
     "node_modules/override-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/override-require/-/override-require-1.1.1.tgz",
-      "integrity": "sha1-auIvresfhQ/7DPTCD/e4fl62UN8=",
-      "dev": true
+      "integrity": "sha1-auIvresfhQ/7DPTCD/e4fl62UN8="
     },
     "node_modules/own-or": {
       "version": "1.0.0",
@@ -20031,14 +19968,12 @@
     "node_modules/parse-diff": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/parse-diff/-/parse-diff-0.7.1.tgz",
-      "integrity": "sha512-1j3l8IKcy4yRK2W4o9EYvJLSzpAVwz4DXqCewYyx2vEwk2gcf3DBPqc8Fj4XV3K33OYJ08A8fWwyu/ykD/HUSg==",
-      "dev": true
+      "integrity": "sha512-1j3l8IKcy4yRK2W4o9EYvJLSzpAVwz4DXqCewYyx2vEwk2gcf3DBPqc8Fj4XV3K33OYJ08A8fWwyu/ykD/HUSg=="
     },
     "node_modules/parse-git-config": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-2.0.3.tgz",
       "integrity": "sha512-Js7ueMZOVSZ3tP8C7E3KZiHv6QQl7lnJ+OkbxoaFazzSa2KyEHqApfGbU3XboUgUnq4ZuUmskUpYKTNx01fm5A==",
-      "dev": true,
       "dependencies": {
         "expand-tilde": "^2.0.2",
         "git-config-path": "^1.0.1",
@@ -20058,7 +19993,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
       "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
-      "dev": true,
       "bin": {
         "parse-github-url": "cli.js"
       },
@@ -20096,7 +20030,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20363,8 +20296,7 @@
     "node_modules/pinpoint": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pinpoint/-/pinpoint-1.1.0.tgz",
-      "integrity": "sha1-DPd1eml38b9/ajIge3CeN3OI6HQ=",
-      "dev": true
+      "integrity": "sha1-DPd1eml38b9/ajIge3CeN3OI6HQ="
     },
     "node_modules/pirates": {
       "version": "4.0.1",
@@ -20894,7 +20826,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
       "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
-      "dev": true,
       "dependencies": {
         "colors": "^1.1.2",
         "minimist": "^1.2.0"
@@ -21130,7 +21061,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -21173,7 +21103,6 @@
       "version": "6.14.1",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
       "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
-      "dev": true,
       "dependencies": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",
@@ -21552,7 +21481,6 @@
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
       "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -21585,8 +21513,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "node_modules/regex-not": {
       "version": "1.0.2",
@@ -21799,7 +21726,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21966,7 +21892,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -23922,7 +23847,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
       "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -24276,7 +24200,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
       "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -24507,7 +24430,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz",
       "integrity": "sha512-HHi5kVSefKaJkGYXbDuKbUGRVxqnWGn3J2e39CYcNJEfWciGq2zYtOhXLTlvrOZW1QU7VX67w7fMmWafHX9Pfw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^2.0.0",
         "supports-color": "^5.0.0"
@@ -24520,7 +24442,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -25902,7 +25823,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universal-url/-/universal-url-2.0.0.tgz",
       "integrity": "sha512-3DLtXdm/G1LQMCnPj+Aw7uDoleQttNHp2g5FnNQKR6cP6taNWS1b/Ehjjx4PVyvejKi3TJyu8iBraKM4q3JQPg==",
-      "dev": true,
       "dependencies": {
         "hasurl": "^1.0.0",
         "whatwg-url": "^7.0.0"
@@ -25915,7 +25835,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -25923,14 +25842,12 @@
     "node_modules/universal-url/node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
     },
     "node_modules/universal-url/node_modules/whatwg-url": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
       "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "dev": true,
       "dependencies": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",
@@ -25941,7 +25858,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
       "integrity": "sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==",
-      "dev": true,
       "dependencies": {
         "os-name": "^3.1.0"
       }
@@ -27170,6 +27086,12 @@
         "node": ">=4.2.0"
       }
     },
+    "packages/danger-rules": {
+      "version": "1.0.0",
+      "peerDependencies": {
+        "danger": "*"
+      }
+    },
     "packages/snyk-fix": {
       "name": "@snyk/fix",
       "version": "1.0.0-monorepo",
@@ -27627,7 +27549,6 @@
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
       "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-      "dev": true,
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
@@ -30893,7 +30814,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.2.tgz",
       "integrity": "sha512-jbsSoi5Q1pj63sC16XIUboklNw+8tL9VOnJsWycWYR78TKss5PVpIPb1TUUcMQ+bBh7cY579cVAWmf5qG+dw+Q==",
-      "dev": true,
       "requires": {
         "@octokit/types": "^2.0.1"
       },
@@ -30902,7 +30822,6 @@
           "version": "2.16.2",
           "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
           "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
-          "dev": true,
           "requires": {
             "@types/node": ">= 8"
           }
@@ -30919,7 +30838,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.4.0.tgz",
       "integrity": "sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==",
-      "dev": true,
       "requires": {
         "@octokit/types": "^2.0.1",
         "deprecation": "^2.3.1"
@@ -30929,7 +30847,6 @@
           "version": "2.16.2",
           "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
           "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
-          "dev": true,
           "requires": {
             "@types/node": ">= 8"
           }
@@ -30970,7 +30887,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.1.tgz",
       "integrity": "sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==",
-      "dev": true,
       "requires": {
         "@octokit/types": "^2.0.0",
         "deprecation": "^2.0.0",
@@ -30981,7 +30897,6 @@
           "version": "2.16.2",
           "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
           "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
-          "dev": true,
           "requires": {
             "@types/node": ">= 8"
           }
@@ -30992,7 +30907,6 @@
       "version": "16.43.2",
       "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.2.tgz",
       "integrity": "sha512-ngDBevLbBTFfrHZeiS7SAMAZ6ssuVmXuya+F/7RaVvlysgGa1JKJkKWY+jV6TCJYcW0OALfJ7nTIGXcBXzycfQ==",
-      "dev": true,
       "requires": {
         "@octokit/auth-token": "^2.4.0",
         "@octokit/plugin-paginate-rest": "^1.1.1",
@@ -31278,6 +31192,10 @@
         "lodash.invert": "^4.3.0",
         "lodash.isempty": "^4.4.0"
       }
+    },
+    "@snyk/danger-rules": {
+      "version": "file:packages/danger-rules",
+      "requires": {}
     },
     "@snyk/dep-graph": {
       "version": "1.28.1",
@@ -32907,7 +32825,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
       "requires": {
         "event-target-shim": "^5.0.0"
       }
@@ -32965,7 +32882,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
       "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-      "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -33244,7 +33160,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.2.3.tgz",
       "integrity": "sha512-tfDb02Th6CE6pJUF2gjW5ZVjsgwlucVXOEQMvEX9JgSJMs9gAX+Nz3xRuJBKuUYjTSYORqvDBORdAQ3LU59g7Q==",
-      "dev": true,
       "requires": {
         "retry": "0.12.0"
       }
@@ -33252,8 +33167,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -33270,8 +33184,7 @@
     "atob-lite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
-      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
-      "dev": true
+      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -33655,8 +33568,7 @@
     "btoa-lite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
-      "dev": true
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
     },
     "buffer": {
       "version": "5.7.1",
@@ -33670,8 +33582,7 @@
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
-      "dev": true
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
       "version": "1.1.2",
@@ -34283,8 +34194,7 @@
     "colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "columnify": {
       "version": "1.5.4",
@@ -34317,7 +34227,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -34325,8 +34234,7 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -34691,8 +34599,7 @@
     "core-js": {
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "dev": true
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -34883,7 +34790,6 @@
       "version": "10.7.1",
       "resolved": "https://registry.npmjs.org/danger/-/danger-10.7.1.tgz",
       "integrity": "sha512-lKyWrWxNxtSfLSsOqse+O9MOrxa++a0kHEBxrgCBvjF36EjNuInuvY06omUTDGdIy6VEbDQRoGeQFIBauj8sMA==",
-      "dev": true,
       "requires": {
         "@babel/polyfill": "^7.2.5",
         "@octokit/rest": "^16.43.1",
@@ -34927,7 +34833,6 @@
           "version": "4.0.4",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
           "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-          "dev": true,
           "requires": {
             "braces": "^3.0.1",
             "picomatch": "^2.2.3"
@@ -34937,7 +34842,6 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -35026,8 +34930,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress-response": {
       "version": "6.0.0",
@@ -35175,8 +35078,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -35458,7 +35360,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -35621,14 +35522,12 @@
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -36015,8 +35914,7 @@
     "event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "eventemitter3": {
       "version": "3.1.2",
@@ -36219,7 +36117,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-      "dev": true,
       "requires": {
         "homedir-polyfill": "^1.0.1"
       }
@@ -36383,7 +36280,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dev": true,
       "requires": {
         "is-extendable": "^0.1.0"
       }
@@ -36477,8 +36373,7 @@
     "fast-json-patch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.0.tgz",
-      "integrity": "sha512-IhpytlsVTRndz0hU5t0/MGzS/etxLlfrpG5V5M9mVbuj9TrJLWaMfsox9REM5rkuGX0T+5qjpe8XA1o0gZ42nA==",
-      "dev": true
+      "integrity": "sha512-IhpytlsVTRndz0hU5t0/MGzS/etxLlfrpG5V5M9mVbuj9TrJLWaMfsox9REM5rkuGX0T+5qjpe8XA1o0gZ42nA=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -36559,8 +36454,7 @@
     "filter-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
-      "dev": true
+      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
     },
     "finalhandler": {
       "version": "1.1.2",
@@ -36831,7 +36725,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
       "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -36921,8 +36814,7 @@
     "fs-exists-sync": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
-      "dev": true
+      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
     },
     "fs-extra": {
       "version": "9.1.0",
@@ -37381,8 +37273,7 @@
     "get-stdin": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-      "dev": true
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
     },
     "get-stream": {
       "version": "6.0.1",
@@ -37409,7 +37300,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
       "integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
-      "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "fs-exists-sync": "^0.1.0",
@@ -37716,7 +37606,6 @@
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/gitlab/-/gitlab-10.2.1.tgz",
       "integrity": "sha512-z+DxRF1C9uayVbocs9aJkJz+kGy14TSm1noB/rAIEBbXOkOYbjKxyuqJzt+0zeFpXFdgA0yq6DVVbvM7HIfGwg==",
-      "dev": true,
       "requires": {
         "form-data": "^2.5.0",
         "humps": "^2.0.1",
@@ -38069,14 +37958,12 @@
     "hasurl": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hasurl/-/hasurl-1.0.0.tgz",
-      "integrity": "sha512-43ypUd3DbwyCT01UYpA99AEZxZ4aKtRxWGBHEIbjcOsUghd9YUON0C+JF6isNjaiwC/UF5neaUudy6JS9jZPZQ==",
-      "dev": true
+      "integrity": "sha512-43ypUd3DbwyCT01UYpA99AEZxZ4aKtRxWGBHEIbjcOsUghd9YUON0C+JF6isNjaiwC/UF5neaUudy6JS9jZPZQ=="
     },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
       "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
-      "dev": true,
       "requires": {
         "parse-passwd": "^1.0.0"
       }
@@ -38182,7 +38069,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
       "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-      "dev": true,
       "requires": {
         "agent-base": "4",
         "debug": "3.1.0"
@@ -38192,7 +38078,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -38200,8 +38085,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -38236,7 +38120,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
       "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-      "dev": true,
       "requires": {
         "agent-base": "^4.3.0",
         "debug": "^3.1.0"
@@ -38246,7 +38129,6 @@
           "version": "3.2.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
           "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -38271,14 +38153,12 @@
     "humps": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
-      "integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=",
-      "dev": true
+      "integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao="
     },
     "hyperlinker": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/hyperlinker/-/hyperlinker-1.0.0.tgz",
-      "integrity": "sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==",
-      "dev": true
+      "integrity": "sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ=="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -38384,8 +38264,7 @@
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "init-package-json": {
       "version": "1.10.3",
@@ -38690,8 +38569,7 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -40470,7 +40348,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
       "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -40494,8 +40371,7 @@
     "jsonpointer": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
-      "dev": true
+      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg=="
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -40511,7 +40387,6 @@
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
       "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-      "dev": true,
       "requires": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -40528,8 +40403,7 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
@@ -40600,7 +40474,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
       "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "dev": true,
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -40611,7 +40484,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
       "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "dev": true,
       "requires": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
@@ -40640,14 +40512,12 @@
     "ky": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/ky/-/ky-0.12.0.tgz",
-      "integrity": "sha512-t9b7v3V2fGwAcQnnDDQwKQGF55eWrf4pwi1RN08Fy8b/9GEwV7Ea0xQiaSW6ZbeghBHIwl8kgnla4vVo9seepQ==",
-      "dev": true
+      "integrity": "sha512-t9b7v3V2fGwAcQnnDDQwKQGF55eWrf4pwi1RN08Fy8b/9GEwV7Ea0xQiaSW6ZbeghBHIwl8kgnla4vVo9seepQ=="
     },
     "ky-universal": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.3.0.tgz",
       "integrity": "sha512-CM4Bgb2zZZpsprcjI6DNYTaH3oGHXL2u7BU4DK+lfCuC4snkt9/WRpMYeKbBbXscvKkeqBwzzjFX2WwmKY5K/A==",
-      "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "node-fetch": "^2.6.0"
@@ -40783,8 +40653,7 @@
     "li": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/li/-/li-1.3.0.tgz",
-      "integrity": "sha1-IsWbyu+qmo7zWc91l4TkvxBq6hs=",
-      "dev": true
+      "integrity": "sha1-IsWbyu+qmo7zWc91l4TkvxBq6hs="
     },
     "lie": {
       "version": "3.3.0",
@@ -40972,8 +40841,7 @@
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
-      "dev": true
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
     },
     "lodash.invert": {
       "version": "4.3.0",
@@ -41003,8 +40871,7 @@
     "lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
-      "dev": true
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
     },
     "lodash.ismatch": {
       "version": "4.4.0",
@@ -41055,14 +40922,12 @@
     "lodash.mapvalues": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
-      "dev": true
+      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
     },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -41077,8 +40942,7 @@
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
-      "dev": true
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.orderby": {
       "version": "4.6.0",
@@ -41364,7 +41228,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.0.tgz",
       "integrity": "sha512-PloI9AkRXrLQuBU1s7eYQpl+4hkL0U0h23lddMaJ3ZGUufn8pdNRxd1kCfBqL5gISCFQs78ttXS15e4/f5vcTA==",
-      "dev": true,
       "requires": {
         "@octokit/rest": "^16.43.1"
       }
@@ -41568,14 +41431,12 @@
     "mime-db": {
       "version": "1.49.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
-      "dev": true
+      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA=="
     },
     "mime-types": {
       "version": "2.1.32",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
       "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
-      "dev": true,
       "requires": {
         "mime-db": "1.49.0"
       }
@@ -42128,8 +41989,7 @@
     "node-cleanup": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
-      "integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
-      "dev": true
+      "integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw="
     },
     "node-fetch": {
       "version": "2.6.1",
@@ -42870,8 +42730,7 @@
     "octokit-pagination-methods": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
-      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
-      "dev": true
+      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -43029,8 +42888,7 @@
     "override-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/override-require/-/override-require-1.1.1.tgz",
-      "integrity": "sha1-auIvresfhQ/7DPTCD/e4fl62UN8=",
-      "dev": true
+      "integrity": "sha1-auIvresfhQ/7DPTCD/e4fl62UN8="
     },
     "own-or": {
       "version": "1.0.0",
@@ -43220,14 +43078,12 @@
     "parse-diff": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/parse-diff/-/parse-diff-0.7.1.tgz",
-      "integrity": "sha512-1j3l8IKcy4yRK2W4o9EYvJLSzpAVwz4DXqCewYyx2vEwk2gcf3DBPqc8Fj4XV3K33OYJ08A8fWwyu/ykD/HUSg==",
-      "dev": true
+      "integrity": "sha512-1j3l8IKcy4yRK2W4o9EYvJLSzpAVwz4DXqCewYyx2vEwk2gcf3DBPqc8Fj4XV3K33OYJ08A8fWwyu/ykD/HUSg=="
     },
     "parse-git-config": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-2.0.3.tgz",
       "integrity": "sha512-Js7ueMZOVSZ3tP8C7E3KZiHv6QQl7lnJ+OkbxoaFazzSa2KyEHqApfGbU3XboUgUnq4ZuUmskUpYKTNx01fm5A==",
-      "dev": true,
       "requires": {
         "expand-tilde": "^2.0.2",
         "git-config-path": "^1.0.1",
@@ -43243,8 +43099,7 @@
     "parse-github-url": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
-      "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
-      "dev": true
+      "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw=="
     },
     "parse-json": {
       "version": "5.2.0",
@@ -43269,8 +43124,7 @@
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-      "dev": true
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
     },
     "parse-path": {
       "version": "4.0.3",
@@ -43473,8 +43327,7 @@
     "pinpoint": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pinpoint/-/pinpoint-1.1.0.tgz",
-      "integrity": "sha1-DPd1eml38b9/ajIge3CeN3OI6HQ=",
-      "dev": true
+      "integrity": "sha1-DPd1eml38b9/ajIge3CeN3OI6HQ="
     },
     "pirates": {
       "version": "4.0.1",
@@ -43858,7 +43711,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
       "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
-      "dev": true,
       "requires": {
         "colors": "^1.1.2",
         "minimist": "^1.2.0"
@@ -44060,8 +43912,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
       "version": "1.5.1",
@@ -44091,7 +43942,6 @@
       "version": "6.14.1",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
       "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
-      "dev": true,
       "requires": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",
@@ -44388,8 +44238,7 @@
     "readline-sync": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
-      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
-      "dev": true
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw=="
     },
     "rechoir": {
       "version": "0.7.1",
@@ -44413,8 +44262,7 @@
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regex-not": {
       "version": "1.0.2",
@@ -44574,8 +44422,7 @@
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "require-main-filename": {
       "version": "2.0.0",
@@ -44709,8 +44556,7 @@
     "retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-      "dev": true
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "reusify": {
       "version": "1.0.4",
@@ -45379,6 +45225,7 @@
         "@snyk/cli-interface": "2.11.0",
         "@snyk/cloud-config-parser": "^1.12.0",
         "@snyk/code-client": "^4.4.1",
+        "@snyk/danger-rules": "file:packages/danger-rules",
         "@snyk/dep-graph": "^1.27.1",
         "@snyk/docker-registry-v2-client": "2.5.1",
         "@snyk/fix": "file:packages/snyk-fix",
@@ -45831,7 +45678,6 @@
           "version": "7.12.1",
           "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
           "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-          "dev": true,
           "requires": {
             "core-js": "^2.6.5",
             "regenerator-runtime": "^0.13.4"
@@ -49097,7 +48943,6 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.2.tgz",
           "integrity": "sha512-jbsSoi5Q1pj63sC16XIUboklNw+8tL9VOnJsWycWYR78TKss5PVpIPb1TUUcMQ+bBh7cY579cVAWmf5qG+dw+Q==",
-          "dev": true,
           "requires": {
             "@octokit/types": "^2.0.1"
           },
@@ -49106,7 +48951,6 @@
               "version": "2.16.2",
               "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
               "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
-              "dev": true,
               "requires": {
                 "@types/node": ">= 8"
               }
@@ -49123,7 +48967,6 @@
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.4.0.tgz",
           "integrity": "sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==",
-          "dev": true,
           "requires": {
             "@octokit/types": "^2.0.1",
             "deprecation": "^2.3.1"
@@ -49133,7 +48976,6 @@
               "version": "2.16.2",
               "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
               "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
-              "dev": true,
               "requires": {
                 "@types/node": ">= 8"
               }
@@ -49174,7 +49016,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.1.tgz",
           "integrity": "sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==",
-          "dev": true,
           "requires": {
             "@octokit/types": "^2.0.0",
             "deprecation": "^2.0.0",
@@ -49185,7 +49026,6 @@
               "version": "2.16.2",
               "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
               "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
-              "dev": true,
               "requires": {
                 "@types/node": ">= 8"
               }
@@ -49196,7 +49036,6 @@
           "version": "16.43.2",
           "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.2.tgz",
           "integrity": "sha512-ngDBevLbBTFfrHZeiS7SAMAZ6ssuVmXuya+F/7RaVvlysgGa1JKJkKWY+jV6TCJYcW0OALfJ7nTIGXcBXzycfQ==",
-          "dev": true,
           "requires": {
             "@octokit/auth-token": "^2.4.0",
             "@octokit/plugin-paginate-rest": "^1.1.1",
@@ -49482,6 +49321,10 @@
             "lodash.invert": "^4.3.0",
             "lodash.isempty": "^4.4.0"
           }
+        },
+        "@snyk/danger-rules": {
+          "version": "file:packages/danger-rules",
+          "requires": {}
         },
         "@snyk/dep-graph": {
           "version": "1.28.1",
@@ -51111,7 +50954,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
           "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-          "dev": true,
           "requires": {
             "event-target-shim": "^5.0.0"
           }
@@ -51169,7 +51011,6 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
           "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-          "dev": true,
           "requires": {
             "es6-promisify": "^5.0.0"
           }
@@ -51448,7 +51289,6 @@
           "version": "1.2.3",
           "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.2.3.tgz",
           "integrity": "sha512-tfDb02Th6CE6pJUF2gjW5ZVjsgwlucVXOEQMvEX9JgSJMs9gAX+Nz3xRuJBKuUYjTSYORqvDBORdAQ3LU59g7Q==",
-          "dev": true,
           "requires": {
             "retry": "0.12.0"
           }
@@ -51456,8 +51296,7 @@
         "asynckit": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-          "dev": true
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "at-least-node": {
           "version": "1.0.0",
@@ -51474,8 +51313,7 @@
         "atob-lite": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
-          "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
-          "dev": true
+          "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
         },
         "aws-sign2": {
           "version": "0.7.0",
@@ -51859,8 +51697,7 @@
         "btoa-lite": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-          "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
-          "dev": true
+          "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
         },
         "buffer": {
           "version": "5.7.1",
@@ -51874,8 +51711,7 @@
         "buffer-equal-constant-time": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-          "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
-          "dev": true
+          "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
         },
         "buffer-from": {
           "version": "1.1.2",
@@ -52487,8 +52323,7 @@
         "colors": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-          "dev": true
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
         },
         "columnify": {
           "version": "1.5.4",
@@ -52521,7 +52356,6 @@
           "version": "1.0.8",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
           "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-          "dev": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -52529,8 +52363,7 @@
         "commander": {
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
         },
         "commondir": {
           "version": "1.0.1",
@@ -52895,8 +52728,7 @@
         "core-js": {
           "version": "2.6.12",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-          "dev": true
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -53087,7 +52919,6 @@
           "version": "10.7.1",
           "resolved": "https://registry.npmjs.org/danger/-/danger-10.7.1.tgz",
           "integrity": "sha512-lKyWrWxNxtSfLSsOqse+O9MOrxa++a0kHEBxrgCBvjF36EjNuInuvY06omUTDGdIy6VEbDQRoGeQFIBauj8sMA==",
-          "dev": true,
           "requires": {
             "@babel/polyfill": "^7.2.5",
             "@octokit/rest": "^16.43.1",
@@ -53131,7 +52962,6 @@
               "version": "4.0.4",
               "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
               "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-              "dev": true,
               "requires": {
                 "braces": "^3.0.1",
                 "picomatch": "^2.2.3"
@@ -53141,7 +52971,6 @@
               "version": "2.3.0",
               "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
               "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-              "dev": true,
               "requires": {
                 "p-try": "^2.0.0"
               }
@@ -53230,8 +53059,7 @@
         "decode-uri-component": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-          "dev": true
+          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
         },
         "decompress-response": {
           "version": "6.0.0",
@@ -53379,8 +53207,7 @@
         "delayed-stream": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-          "dev": true
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "delegates": {
           "version": "1.0.0",
@@ -53662,7 +53489,6 @@
           "version": "1.0.11",
           "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
           "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-          "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -53825,14 +53651,12 @@
         "es6-promise": {
           "version": "4.2.8",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-          "dev": true
+          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
         },
         "es6-promisify": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
           "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-          "dev": true,
           "requires": {
             "es6-promise": "^4.0.3"
           }
@@ -54219,8 +54043,7 @@
         "event-target-shim": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-          "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-          "dev": true
+          "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
         },
         "eventemitter3": {
           "version": "3.1.2",
@@ -54423,7 +54246,6 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-          "dev": true,
           "requires": {
             "homedir-polyfill": "^1.0.1"
           }
@@ -54587,7 +54409,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -54681,8 +54502,7 @@
         "fast-json-patch": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.0.tgz",
-          "integrity": "sha512-IhpytlsVTRndz0hU5t0/MGzS/etxLlfrpG5V5M9mVbuj9TrJLWaMfsox9REM5rkuGX0T+5qjpe8XA1o0gZ42nA==",
-          "dev": true
+          "integrity": "sha512-IhpytlsVTRndz0hU5t0/MGzS/etxLlfrpG5V5M9mVbuj9TrJLWaMfsox9REM5rkuGX0T+5qjpe8XA1o0gZ42nA=="
         },
         "fast-json-stable-stringify": {
           "version": "2.1.0",
@@ -54763,8 +54583,7 @@
         "filter-obj": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-          "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs=",
-          "dev": true
+          "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
         },
         "finalhandler": {
           "version": "1.1.2",
@@ -55035,7 +54854,6 @@
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
           "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
@@ -55125,8 +54943,7 @@
         "fs-exists-sync": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-          "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
-          "dev": true
+          "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
         },
         "fs-extra": {
           "version": "9.1.0",
@@ -55585,8 +55402,7 @@
         "get-stdin": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-          "dev": true
+          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
         },
         "get-stream": {
           "version": "6.0.1",
@@ -55613,7 +55429,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
           "integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
-          "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "fs-exists-sync": "^0.1.0",
@@ -55920,7 +55735,6 @@
           "version": "10.2.1",
           "resolved": "https://registry.npmjs.org/gitlab/-/gitlab-10.2.1.tgz",
           "integrity": "sha512-z+DxRF1C9uayVbocs9aJkJz+kGy14TSm1noB/rAIEBbXOkOYbjKxyuqJzt+0zeFpXFdgA0yq6DVVbvM7HIfGwg==",
-          "dev": true,
           "requires": {
             "form-data": "^2.5.0",
             "humps": "^2.0.1",
@@ -56273,14 +56087,12 @@
         "hasurl": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/hasurl/-/hasurl-1.0.0.tgz",
-          "integrity": "sha512-43ypUd3DbwyCT01UYpA99AEZxZ4aKtRxWGBHEIbjcOsUghd9YUON0C+JF6isNjaiwC/UF5neaUudy6JS9jZPZQ==",
-          "dev": true
+          "integrity": "sha512-43ypUd3DbwyCT01UYpA99AEZxZ4aKtRxWGBHEIbjcOsUghd9YUON0C+JF6isNjaiwC/UF5neaUudy6JS9jZPZQ=="
         },
         "homedir-polyfill": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
           "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
-          "dev": true,
           "requires": {
             "parse-passwd": "^1.0.0"
           }
@@ -56386,7 +56198,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
           "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-          "dev": true,
           "requires": {
             "agent-base": "4",
             "debug": "3.1.0"
@@ -56396,7 +56207,6 @@
               "version": "3.1.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
               "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-              "dev": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -56404,8 +56214,7 @@
             "ms": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         },
@@ -56440,7 +56249,6 @@
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
           "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-          "dev": true,
           "requires": {
             "agent-base": "^4.3.0",
             "debug": "^3.1.0"
@@ -56450,7 +56258,6 @@
               "version": "3.2.7",
               "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
               "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-              "dev": true,
               "requires": {
                 "ms": "^2.1.1"
               }
@@ -56475,14 +56282,12 @@
         "humps": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
-          "integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=",
-          "dev": true
+          "integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao="
         },
         "hyperlinker": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/hyperlinker/-/hyperlinker-1.0.0.tgz",
-          "integrity": "sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==",
-          "dev": true
+          "integrity": "sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ=="
         },
         "iconv-lite": {
           "version": "0.4.24",
@@ -56588,8 +56393,7 @@
         "ini": {
           "version": "1.3.8",
           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-          "dev": true
+          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
         },
         "init-package-json": {
           "version": "1.10.3",
@@ -56894,8 +56698,7 @@
         "is-extendable": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-          "dev": true
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
         },
         "is-extglob": {
           "version": "2.1.1",
@@ -58674,7 +58477,6 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
           "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-          "dev": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -58698,8 +58500,7 @@
         "jsonpointer": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-          "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
-          "dev": true
+          "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg=="
         },
         "JSONStream": {
           "version": "1.3.5",
@@ -58715,7 +58516,6 @@
           "version": "8.5.1",
           "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
           "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-          "dev": true,
           "requires": {
             "jws": "^3.2.2",
             "lodash.includes": "^4.3.0",
@@ -58732,8 +58532,7 @@
             "semver": {
               "version": "5.7.1",
               "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-              "dev": true
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
             }
           }
         },
@@ -58804,7 +58603,6 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
           "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-          "dev": true,
           "requires": {
             "buffer-equal-constant-time": "1.0.1",
             "ecdsa-sig-formatter": "1.0.11",
@@ -58815,7 +58613,6 @@
           "version": "3.2.2",
           "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
           "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-          "dev": true,
           "requires": {
             "jwa": "^1.4.1",
             "safe-buffer": "^5.0.1"
@@ -58844,14 +58641,12 @@
         "ky": {
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/ky/-/ky-0.12.0.tgz",
-          "integrity": "sha512-t9b7v3V2fGwAcQnnDDQwKQGF55eWrf4pwi1RN08Fy8b/9GEwV7Ea0xQiaSW6ZbeghBHIwl8kgnla4vVo9seepQ==",
-          "dev": true
+          "integrity": "sha512-t9b7v3V2fGwAcQnnDDQwKQGF55eWrf4pwi1RN08Fy8b/9GEwV7Ea0xQiaSW6ZbeghBHIwl8kgnla4vVo9seepQ=="
         },
         "ky-universal": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.3.0.tgz",
           "integrity": "sha512-CM4Bgb2zZZpsprcjI6DNYTaH3oGHXL2u7BU4DK+lfCuC4snkt9/WRpMYeKbBbXscvKkeqBwzzjFX2WwmKY5K/A==",
-          "dev": true,
           "requires": {
             "abort-controller": "^3.0.0",
             "node-fetch": "^2.6.0"
@@ -58987,8 +58782,7 @@
         "li": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/li/-/li-1.3.0.tgz",
-          "integrity": "sha1-IsWbyu+qmo7zWc91l4TkvxBq6hs=",
-          "dev": true
+          "integrity": "sha1-IsWbyu+qmo7zWc91l4TkvxBq6hs="
         },
         "lie": {
           "version": "3.3.0",
@@ -59176,8 +58970,7 @@
         "lodash.includes": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-          "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
-          "dev": true
+          "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
         },
         "lodash.invert": {
           "version": "4.3.0",
@@ -59207,8 +59000,7 @@
         "lodash.isinteger": {
           "version": "4.0.4",
           "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-          "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
-          "dev": true
+          "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
         },
         "lodash.ismatch": {
           "version": "4.4.0",
@@ -59259,14 +59051,12 @@
         "lodash.mapvalues": {
           "version": "4.6.0",
           "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-          "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
-          "dev": true
+          "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
         },
         "lodash.memoize": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-          "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-          "dev": true
+          "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
         },
         "lodash.merge": {
           "version": "4.6.2",
@@ -59281,8 +59071,7 @@
         "lodash.once": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-          "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
-          "dev": true
+          "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
         },
         "lodash.orderby": {
           "version": "4.6.0",
@@ -59568,7 +59357,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/memfs-or-file-map-to-github-branch/-/memfs-or-file-map-to-github-branch-1.2.0.tgz",
           "integrity": "sha512-PloI9AkRXrLQuBU1s7eYQpl+4hkL0U0h23lddMaJ3ZGUufn8pdNRxd1kCfBqL5gISCFQs78ttXS15e4/f5vcTA==",
-          "dev": true,
           "requires": {
             "@octokit/rest": "^16.43.1"
           }
@@ -59772,14 +59560,12 @@
         "mime-db": {
           "version": "1.49.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-          "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
-          "dev": true
+          "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA=="
         },
         "mime-types": {
           "version": "2.1.32",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
           "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
-          "dev": true,
           "requires": {
             "mime-db": "1.49.0"
           }
@@ -60332,8 +60118,7 @@
         "node-cleanup": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz",
-          "integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=",
-          "dev": true
+          "integrity": "sha1-esGavSl+Caf3KnFUXZUbUX5N3iw="
         },
         "node-fetch": {
           "version": "2.6.1",
@@ -61074,8 +60859,7 @@
         "octokit-pagination-methods": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
-          "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
-          "dev": true
+          "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ=="
         },
         "on-finished": {
           "version": "2.3.0",
@@ -61233,8 +61017,7 @@
         "override-require": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/override-require/-/override-require-1.1.1.tgz",
-          "integrity": "sha1-auIvresfhQ/7DPTCD/e4fl62UN8=",
-          "dev": true
+          "integrity": "sha1-auIvresfhQ/7DPTCD/e4fl62UN8="
         },
         "own-or": {
           "version": "1.0.0",
@@ -61424,14 +61207,12 @@
         "parse-diff": {
           "version": "0.7.1",
           "resolved": "https://registry.npmjs.org/parse-diff/-/parse-diff-0.7.1.tgz",
-          "integrity": "sha512-1j3l8IKcy4yRK2W4o9EYvJLSzpAVwz4DXqCewYyx2vEwk2gcf3DBPqc8Fj4XV3K33OYJ08A8fWwyu/ykD/HUSg==",
-          "dev": true
+          "integrity": "sha512-1j3l8IKcy4yRK2W4o9EYvJLSzpAVwz4DXqCewYyx2vEwk2gcf3DBPqc8Fj4XV3K33OYJ08A8fWwyu/ykD/HUSg=="
         },
         "parse-git-config": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-2.0.3.tgz",
           "integrity": "sha512-Js7ueMZOVSZ3tP8C7E3KZiHv6QQl7lnJ+OkbxoaFazzSa2KyEHqApfGbU3XboUgUnq4ZuUmskUpYKTNx01fm5A==",
-          "dev": true,
           "requires": {
             "expand-tilde": "^2.0.2",
             "git-config-path": "^1.0.1",
@@ -61447,8 +61228,7 @@
         "parse-github-url": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
-          "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
-          "dev": true
+          "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw=="
         },
         "parse-json": {
           "version": "5.2.0",
@@ -61473,8 +61253,7 @@
         "parse-passwd": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-          "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-          "dev": true
+          "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
         },
         "parse-path": {
           "version": "4.0.3",
@@ -61677,8 +61456,7 @@
         "pinpoint": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/pinpoint/-/pinpoint-1.1.0.tgz",
-          "integrity": "sha1-DPd1eml38b9/ajIge3CeN3OI6HQ=",
-          "dev": true
+          "integrity": "sha1-DPd1eml38b9/ajIge3CeN3OI6HQ="
         },
         "pirates": {
           "version": "4.0.1",
@@ -62062,7 +61840,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
           "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
-          "dev": true,
           "requires": {
             "colors": "^1.1.2",
             "minimist": "^1.2.0"
@@ -62264,8 +62041,7 @@
         "punycode": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-          "dev": true
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         },
         "q": {
           "version": "1.5.1",
@@ -62295,7 +62071,6 @@
           "version": "6.14.1",
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
           "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
-          "dev": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
             "filter-obj": "^1.1.0",
@@ -62592,8 +62367,7 @@
         "readline-sync": {
           "version": "1.4.10",
           "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
-          "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
-          "dev": true
+          "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw=="
         },
         "rechoir": {
           "version": "0.7.1",
@@ -62617,8 +62391,7 @@
         "regenerator-runtime": {
           "version": "0.13.9",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-          "dev": true
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
         },
         "regex-not": {
           "version": "1.0.2",
@@ -62778,8 +62551,7 @@
         "require-from-string": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-          "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-          "dev": true
+          "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
         },
         "require-main-filename": {
           "version": "2.0.0",
@@ -62913,8 +62685,7 @@
         "retry": {
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-          "dev": true
+          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
         },
         "reusify": {
           "version": "1.0.4",
@@ -64523,8 +64294,7 @@
         "split-on-first": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-          "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-          "dev": true
+          "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
         },
         "split-string": {
           "version": "3.1.0",
@@ -64826,8 +64596,7 @@
         "strict-uri-encode": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
-          "dev": true
+          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
         },
         "string_decoder": {
           "version": "1.3.0",
@@ -64992,7 +64761,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz",
           "integrity": "sha512-HHi5kVSefKaJkGYXbDuKbUGRVxqnWGn3J2e39CYcNJEfWciGq2zYtOhXLTlvrOZW1QU7VX67w7fMmWafHX9Pfw==",
-          "dev": true,
           "requires": {
             "has-flag": "^2.0.0",
             "supports-color": "^5.0.0"
@@ -65001,8 +64769,7 @@
             "has-flag": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-              "dev": true
+              "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
             }
           }
         },
@@ -66068,7 +65835,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/universal-url/-/universal-url-2.0.0.tgz",
           "integrity": "sha512-3DLtXdm/G1LQMCnPj+Aw7uDoleQttNHp2g5FnNQKR6cP6taNWS1b/Ehjjx4PVyvejKi3TJyu8iBraKM4q3JQPg==",
-          "dev": true,
           "requires": {
             "hasurl": "^1.0.0",
             "whatwg-url": "^7.0.0"
@@ -66078,7 +65844,6 @@
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
               "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-              "dev": true,
               "requires": {
                 "punycode": "^2.1.0"
               }
@@ -66086,14 +65851,12 @@
             "webidl-conversions": {
               "version": "4.0.2",
               "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-              "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-              "dev": true
+              "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
             },
             "whatwg-url": {
               "version": "7.1.0",
               "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
               "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-              "dev": true,
               "requires": {
                 "lodash.sortby": "^4.7.0",
                 "tr46": "^1.0.1",
@@ -66106,7 +65869,6 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
           "integrity": "sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==",
-          "dev": true,
           "requires": {
             "os-name": "^3.1.0"
           }
@@ -67977,8 +67739,7 @@
     "split-on-first": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-      "dev": true
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
     },
     "split-string": {
       "version": "3.1.0",
@@ -68280,8 +68041,7 @@
     "strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
-      "dev": true
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -68446,7 +68206,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz",
       "integrity": "sha512-HHi5kVSefKaJkGYXbDuKbUGRVxqnWGn3J2e39CYcNJEfWciGq2zYtOhXLTlvrOZW1QU7VX67w7fMmWafHX9Pfw==",
-      "dev": true,
       "requires": {
         "has-flag": "^2.0.0",
         "supports-color": "^5.0.0"
@@ -68455,8 +68214,7 @@
         "has-flag": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
         }
       }
     },
@@ -69522,7 +69280,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universal-url/-/universal-url-2.0.0.tgz",
       "integrity": "sha512-3DLtXdm/G1LQMCnPj+Aw7uDoleQttNHp2g5FnNQKR6cP6taNWS1b/Ehjjx4PVyvejKi3TJyu8iBraKM4q3JQPg==",
-      "dev": true,
       "requires": {
         "hasurl": "^1.0.0",
         "whatwg-url": "^7.0.0"
@@ -69532,7 +69289,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
           "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-          "dev": true,
           "requires": {
             "punycode": "^2.1.0"
           }
@@ -69540,14 +69296,12 @@
         "webidl-conversions": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-          "dev": true
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
         },
         "whatwg-url": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
           "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-          "dev": true,
           "requires": {
             "lodash.sortby": "^4.7.0",
             "tr46": "^1.0.1",
@@ -69560,7 +69314,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
       "integrity": "sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==",
-      "dev": true,
       "requires": {
         "os-name": "^3.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "wrap-ansi": "^5.1.0"
   },
   "devDependencies": {
+    "@snyk/danger-rules": "file:packages/danger-rules",
     "@types/body-parser": "^1.19.1",
     "@types/cross-spawn": "^6.0.2",
     "@types/express": "^4.17.13",

--- a/packages/danger-rules/package.json
+++ b/packages/danger-rules/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@snyk/danger-rules",
+  "version": "1.0.0",
+  "private": true,
+  "peerDependencies": {
+    "danger": "*"
+  }
+}

--- a/packages/danger-rules/recommendJest.ts
+++ b/packages/danger-rules/recommendJest.ts
@@ -1,0 +1,22 @@
+import { DangerRule } from './types';
+
+const recommendJest: DangerRule = ({ danger, warn }) => {
+  // `.spec.ts` is always used for Jest tests
+  // `.test.ts` is normally used for Tap tests and but there are also `.spec.ts` files which are used be Tap tests in test/acceptance.
+  // either way, we should warn about new `.test.ts` or `.spec.ts` files being created outside the `/test/jest` folder
+  const newTestFiles = danger.git.created_files.filter((f) => {
+    const inTestFolder = f.startsWith('test/');
+    const isATestFile = f.includes('.test.ts') || f.includes('.spec.ts');
+    const inJestFolder = f.startsWith('test/jest/');
+    const inFixturesFolder = f.startsWith('test/fixtures/');
+    return inTestFolder && isATestFile && !inJestFolder && !inFixturesFolder;
+  });
+
+  if (newTestFiles.length) {
+    const joinedFileList = newTestFiles.map((f) => '- `' + f + '`').join('\n');
+    const msg = `Looks like you added a new Tap test. Consider making it a Jest test instead. See files in \`test/jest/(unit|system|acceptance)\` for examples. Files found:\n${joinedFileList}`;
+    warn(msg);
+  }
+};
+
+export { recommendJest as rule };

--- a/packages/danger-rules/recommendMigratingModuleSyntax.ts
+++ b/packages/danger-rules/recommendMigratingModuleSyntax.ts
@@ -1,0 +1,27 @@
+import * as fs from 'fs';
+import { DangerRule } from './types';
+
+const recommendMigratingModuleSyntax: DangerRule = ({ danger, warn }) => {
+  const filesUsingNodeJSImportExport = danger.git.modified_files
+    .filter((filePath) => {
+      if (filePath.endsWith('.js')) {
+        return false;
+      }
+      const fileContent = fs.readFileSync(filePath, 'utf8');
+      return (
+        fileContent.includes('module.exports') ||
+        fileContent.includes('= require(')
+      );
+    })
+    .map((filePath) => `- \`${filePath}\``)
+    .join('\n');
+
+  if (filesUsingNodeJSImportExport) {
+    const message =
+      "Since the CLI is unifying on a standard and improved tooling, we're starting to migrate old-style `import`s and `export`s to ES6 ones.\nA file you've modified is using either `module.exports` or `require()`. If you can, please update them to ES6 [import syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) and [export syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export).\n Files found:\n" +
+      filesUsingNodeJSImportExport;
+    warn(message);
+  }
+};
+
+export { recommendMigratingModuleSyntax as rule };

--- a/packages/danger-rules/recommendRunningSmokeTests.ts
+++ b/packages/danger-rules/recommendRunningSmokeTests.ts
@@ -1,0 +1,23 @@
+import { DangerRule } from './types';
+
+const recommendRunningSmokeTests: DangerRule = ({ danger, message }) => {
+  const branchPrefix = 'smoke/';
+  const workflowPath = '.github/workflows/smoke-tests.yml';
+
+  const modifiedSmokeTest =
+    danger.git.modified_files.some((f) => f.startsWith('test/smoke/')) ||
+    danger.git.created_files.some((f) => f.startsWith('test/smoke/')) ||
+    danger.git.modified_files.includes(workflowPath);
+
+  const isOnSmokeTestBranch = danger.github.pr.head.ref.startsWith(
+    branchPrefix,
+  );
+
+  if (modifiedSmokeTest && !isOnSmokeTestBranch) {
+    message(
+      `You are modifying something in test/smoke directory, yet you are not on the branch starting with ${branchPrefix}. You can prefix your branch with ${branchPrefix} and Smoke tests will trigger for this PR.`,
+    );
+  }
+};
+
+export { recommendRunningSmokeTests as rule };

--- a/packages/danger-rules/recommendWritingTest.ts
+++ b/packages/danger-rules/recommendWritingTest.ts
@@ -1,0 +1,18 @@
+import { DangerRule } from './types';
+
+const recommendWritingTest: DangerRule = ({ danger, warn }) => {
+  const modifiedTest =
+    danger.git.modified_files.some((f) => f.startsWith('test/')) ||
+    danger.git.created_files.some((f) => f.startsWith('test/'));
+  const modifiedSrc =
+    danger.git.modified_files.some((f) => f.startsWith('src/')) ||
+    danger.git.created_files.some((f) => f.startsWith('src/'));
+
+  if (modifiedSrc && !modifiedTest) {
+    warn(
+      "You've modified files in src/ directory, but haven't updated anything in test folder. Is there something that could be tested?",
+    );
+  }
+};
+
+export { recommendWritingTest as rule };

--- a/packages/danger-rules/requireGeneratingHelpFiles.ts
+++ b/packages/danger-rules/requireGeneratingHelpFiles.ts
@@ -1,0 +1,20 @@
+import { DangerRule } from './types';
+
+const requireGeneratingHelpFiles: DangerRule = ({ danger, fail }) => {
+  const modifiedHelpFiles =
+    danger.git.modified_files.some((f) =>
+      f.startsWith('help/commands-docs/'),
+    ) ||
+    danger.git.created_files.some((f) => f.startsWith('help/commands-docs/'));
+  const modifiedGeneratedHelpFiles =
+    danger.git.modified_files.some((f) => f.startsWith('help/commands-txt/')) ||
+    danger.git.created_files.some((f) => f.startsWith('help/commands-txt/'));
+
+  if (modifiedHelpFiles && !modifiedGeneratedHelpFiles) {
+    fail(
+      "You've modified help files in /help/commands-docs. You need to regenerate manpages locally by running `npm run generate-help` and commiting the changed files. See [README in /help for more details](https://github.com/snyk/snyk/blob/master/help/README.md)",
+    );
+  }
+};
+
+export { requireGeneratingHelpFiles as rule };

--- a/packages/danger-rules/types.ts
+++ b/packages/danger-rules/types.ts
@@ -1,0 +1,4 @@
+import * as danger from 'danger';
+
+export type DangerJS = typeof danger;
+export type DangerRule = (dangerjs: DangerJS) => void;

--- a/packages/danger-rules/validateCommitMessages.ts
+++ b/packages/danger-rules/validateCommitMessages.ts
@@ -1,0 +1,42 @@
+import { DangerRule } from './types';
+
+const validateCommitMessages: DangerRule = ({
+  danger,
+  fail,
+  message,
+  warn,
+}) => {
+  const commitizenRegex = /^(feat|fix|chore|test|docs|perf|refactor|revert)(\(.*\))?:(.+)$/;
+  const maxMessageLength = 72;
+  const ghCommits = danger.github.commits;
+  let willTriggerRelease = false;
+  for (const { commit } of ghCommits) {
+    const { message, url } = commit;
+    const firstLine = message.split('\n')[0];
+
+    if (message.startsWith('feat') || message.startsWith('fix')) {
+      willTriggerRelease = true;
+    }
+
+    const regexMatch = commitizenRegex.exec(firstLine);
+    if (!regexMatch) {
+      fail(
+        `Commit ["${firstLine}"](${url}) is not a valid commitizen message. See [Contributing page](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md#commit-types) with required commit message format.`,
+      );
+    }
+
+    if (firstLine.length >= maxMessageLength) {
+      warn(
+        `Your commit message ["${firstLine}"](${url}) is too long. Keep first line of your commit under ${maxMessageLength} characters.`,
+      );
+    }
+  }
+
+  if (!willTriggerRelease) {
+    message(
+      "This PR will not trigger a new version. It doesn't include any commit message with `feat` or `fix`.",
+    );
+  }
+};
+
+export { validateCommitMessages as rule };


### PR DESCRIPTION
I'm looking into moving check-dependencies into our Dangerfile to reduce number of PR workflows and places to check for errors.

This PR makes Dangerfile modular so that it's easier to test individual rules.

It also allows us to move Danger-specific deps to their own package so that we have a clear view of where various deps are used. This isn't used yet, but check-dependencies will move `depcheck` over.

## Notes

https://spectrum.chat/danger/javascript/danger-js-actually-runs-your-imports-as-globals~0a005b56-31ec-4919-9a28-ced623949d4d