### PR TITLE
fix: add proper colour for displaying critical issues/CVEs 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "rimraf": "^2.6.3",
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.13.0",
+        "snyk-cpp-plugin": "2.14.0",
         "snyk-docker-plugin": "^4.27.1",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
@@ -22339,9 +22339,9 @@
       }
     },
     "node_modules/snyk-cpp-plugin": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.13.0.tgz",
-      "integrity": "sha512-yCTFg5YVpm67HDAYSpSv1RynQXeZd4EQoK8DSBKG00abj+eIow++zca7c6j56e4sH2GBTpMCOt9VNAjJ7gydHg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.14.0.tgz",
+      "integrity": "sha512-u/IqZYI59TyvnD39RGbvkJgtuxnEn8zrk+vQLETRw+ZaJ7e8MH/3cFPdw0hvHLZHHAi1uzCthAjm/NoCW9U+rg==",
       "dependencies": {
         "@snyk/dep-graph": "^1.19.3",
         "chalk": "^4.1.0",
@@ -44522,7 +44522,7 @@
         "sinon": "^4.0.0",
         "snyk": "file:",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.13.0",
+        "snyk-cpp-plugin": "2.14.0",
         "snyk-docker-plugin": "^4.27.1",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
@@ -62246,9 +62246,9 @@
           }
         },
         "snyk-cpp-plugin": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.13.0.tgz",
-          "integrity": "sha512-yCTFg5YVpm67HDAYSpSv1RynQXeZd4EQoK8DSBKG00abj+eIow++zca7c6j56e4sH2GBTpMCOt9VNAjJ7gydHg==",
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.14.0.tgz",
+          "integrity": "sha512-u/IqZYI59TyvnD39RGbvkJgtuxnEn8zrk+vQLETRw+ZaJ7e8MH/3cFPdw0hvHLZHHAi1uzCthAjm/NoCW9U+rg==",
           "requires": {
             "@snyk/dep-graph": "^1.19.3",
             "chalk": "^4.1.0",
@@ -65640,9 +65640,9 @@
       }
     },
     "snyk-cpp-plugin": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.13.0.tgz",
-      "integrity": "sha512-yCTFg5YVpm67HDAYSpSv1RynQXeZd4EQoK8DSBKG00abj+eIow++zca7c6j56e4sH2GBTpMCOt9VNAjJ7gydHg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.14.0.tgz",
+      "integrity": "sha512-u/IqZYI59TyvnD39RGbvkJgtuxnEn8zrk+vQLETRw+ZaJ7e8MH/3cFPdw0hvHLZHHAi1uzCthAjm/NoCW9U+rg==",
       "requires": {
         "@snyk/dep-graph": "^1.19.3",
         "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "rimraf": "^2.6.3",
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
-    "snyk-cpp-plugin": "2.13.0",
+    "snyk-cpp-plugin": "2.14.0",
     "snyk-docker-plugin": "^4.27.1",
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.17.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Bump the version of the cpp plugin from 2.13.0 to 2.14.0 (https://github.com/snyk/snyk-cpp-plugin/releases/tag/v2.14.0).

#### Any background context you want to provide?

In the version 2.14.0 of the cpp plugin we added support for displaying the critical vulnerabilities.

#### Screenshots

<img width="1229" alt="Screenshot 2021-12-02 at 11 35 10" src="https://user-images.githubusercontent.com/6909300/144617172-806ade7b-b9be-4d21-9f7d-d5812108b55e.png">

