### PR TITLE
refactor: remove references to experimental local execution flow

### DIFF
--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -45,7 +45,7 @@ export interface IacFileScanResult extends IacFileParsed {
   violatedPolicies: PolicyMetadata[];
 }
 
-// This type is the integration point with the CLI test command, please note it is still partial in the experimental version
+// This type is the integration point with the CLI test command, please note it is still partial in the local execution version
 export type FormattedResult = {
   result: {
     cloudConfigResults: Array<PolicyMetadata>;
@@ -143,7 +143,6 @@ export type IaCTestFlags = Pick<
   | 'org'
   | 'insecure'
   | 'debug'
-  | 'experimental'
   | 'detectionDepth'
   | 'severityThreshold'
   | 'json'

--- a/src/cli/commands/test/iac-test-shim.ts
+++ b/src/cli/commands/test/iac-test-shim.ts
@@ -17,9 +17,7 @@ export async function test(
   pathToScan: string,
   options: IaCTestOptions,
 ): Promise<TestReturnValue> {
-  // Ensure that all flags are correct. We do this to ensure that the
-  // caller doesn't accidentally mistype --experimental and send their
-  // configuration files to our backend by accident.
+  // Ensure that all flags are correct.
   assertIaCOptionsFlags(process.argv);
   const iacOrgSettings = await getIacOrgSettings(options.org || config.org);
   const shouldOptOutFromLocalExec = await isFeatureFlagSupportedForOrg(
@@ -27,7 +25,7 @@ export async function test(
     iacOrgSettings.meta.org,
   );
   if (shouldOptOutFromLocalExec.ok || options.legacy) {
-    // this path allows users to opt-out from the local IaC scan which is GA and continue using the remote-processing legacy flow.
+    // this path allows users to opt-out from the local IaC scan which is the default flow and continue using the remote-processing legacy flow.
     const results = await legacyTest(pathToScan, options);
     return {
       failures: options.iacDirFiles?.filter((file) => !!file.failureReason),

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -101,8 +101,6 @@ export default async function test(
     let res: (TestResult | TestResult[]) | Error;
     try {
       if (options.iac) {
-        // this path is an experimental feature feature for IaC which does issue scanning locally without sending files to our Backend servers.
-        // once ready for GA, it is aimed to deprecate our remote-processing model, so IaC file scanning in the CLI is done locally.
         const { results, failures } = await iacTest(path, testOpts);
         res = results;
         iacScanFailures = failures;

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -400,37 +400,11 @@ test('test command line "iac test --help" should display help for mode', (t) => 
   t.end();
 });
 
-test('test command line "snyk iac --experimental" should be true on options', (t) => {
+test('test command line "snyk iac --detection-depth=1" should be 1 on options', (t) => {
   const cliArgsWithFlag = [
     '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
     '/Users/dror/work/snyk/snyk-internal/cli',
     'iac',
-    '--experimental',
-  ];
-  const resultWithFlag = args(cliArgsWithFlag);
-  t.ok(
-    resultWithFlag.options['experimental'],
-    'expected options[experimental] to be true',
-  );
-  const cliArgsWithoutFlag = [
-    '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
-    '/Users/dror/work/snyk/snyk-internal/cli',
-    'iac',
-  ];
-  const resultWithoutFlag = args(cliArgsWithoutFlag);
-  t.notOk(
-    resultWithoutFlag.options['experimental'],
-    'expected options[experimental] to be false',
-  );
-  t.end();
-});
-
-test('test command line "snyk iac --experimental --detection-depth=1" should be 1 on options', (t) => {
-  const cliArgsWithFlag = [
-    '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
-    '/Users/dror/work/snyk/snyk-internal/cli',
-    'iac',
-    '--experimental',
     '--detection-depth=1',
   ];
   const resultWithFlag = args(cliArgsWithFlag);
@@ -443,7 +417,6 @@ test('test command line "snyk iac --experimental --detection-depth=1" should be 
     '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
     '/Users/dror/work/snyk/snyk-internal/cli',
     'iac',
-    '--experimental',
   ];
   const resultWithoutFlag = args(cliArgsWithoutFlag);
   t.equal(


### PR DESCRIPTION
This is a tiny cleanup.

This feature is GA for many months, so this PR removes all references to 'experimental'. 

We also do not provide the option to have an `--experimental` flag anymore when running a scan, so any tests that used to have that reference were updated too.

## IaC 
Also removed some references for the flag in Snyk Preview (not used) in Registry: https://github.com/snyk/registry/pull/25196

## Hammer & Open Source

There is only a cleanup of references in tests and comments.