### PR TITLE
[CFG-1299] add drift subcommand to the iac command

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,7 @@ help/  @snyk/hammer
 src/cli/commands/test/iac-local-execution/ @snyk/group-infrastructure-as-code
 src/cli/commands/test/iac-output.ts @snyk/group-infrastructure-as-code
 src/cli/commands/test/iac-test-shim.ts @snyk/group-infrastructure-as-code
+src/cli/commands/drift.ts @snyk/group-infrastructure-as-code
 src/cli/commands/apps @snyk/moose
 src/lib/apps @snyk/moose
 src/lib/cloud-config-projects.ts @snyk/group-infrastructure-as-code
@@ -35,6 +36,7 @@ test/smoke/spec/snyk_code_spec.sh @snyk/nebula
 test/smoke/.iac-data/ @snyk/group-infrastructure-as-code
 test/jest/unit/lib/formatters/iac-output.spec.ts @snyk/group-infrastructure-as-code
 test/jest/unit/iac/ @snyk/group-infrastructure-as-code
+test/jest/lib/iac/ @snyk/group-infrastructure-as-code
 test/jest/acceptance/iac/ @snyk/group-infrastructure-as-code
 test/jest/acceptance/snyk-apps @snyk-moose
 src/lib/errors/invalid-iac-file.ts @snyk/group-infrastructure-as-code

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "configstore": "^5.0.1",
         "debug": "^4.1.1",
         "diff": "^4.0.1",
+        "env-paths": "^2.0.0",
         "glob": "^7.1.7",
         "global-agent": "^2.1.12",
         "lodash.assign": "^4.2.0",
@@ -6825,6 +6826,14 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/endian-reader/-/endian-reader-0.3.0.tgz",
       "integrity": "sha1-hOykNrgK7Q0GOcRykTOLky7+UKA="
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/envinfo": {
       "version": "7.8.1",
@@ -25471,6 +25480,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/endian-reader/-/endian-reader-0.3.0.tgz",
       "integrity": "sha1-hOykNrgK7Q0GOcRykTOLky7+UKA="
+    },
+    "env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
     },
     "envinfo": {
       "version": "7.8.1",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "configstore": "^5.0.1",
     "debug": "^4.1.1",
     "diff": "^4.0.1",
+    "env-paths": "^2.0.0",
     "glob": "^7.1.7",
     "global-agent": "^2.1.12",
     "lodash.assign": "^4.2.0",

--- a/src/cli/commands/drift.ts
+++ b/src/cli/commands/drift.ts
@@ -1,0 +1,32 @@
+import { MethodArgs } from '../args';
+import { processCommandArgs } from './process-command-args';
+import { driftctl, parseArgs } from '../../lib/iac/drift';
+import { UnsupportedEntitlementCommandError } from './test/iac-local-execution/assert-iac-options-flag';
+import { getIacOrgSettings } from './test/iac-local-execution/measurable-methods';
+import config from '../../lib/config';
+
+const legacyError = require('../../lib/errors/legacy-errors');
+
+export default async function drift(...args: MethodArgs): Promise<any> {
+  const { options, paths } = processCommandArgs(...args);
+
+  if (options.iac != true) {
+    return legacyError('drift');
+  }
+
+  const orgPublicId = options.org ?? config.org;
+  const iacOrgSettings = await getIacOrgSettings(orgPublicId);
+
+  if (!iacOrgSettings.entitlements?.iacDrift) {
+    throw new UnsupportedEntitlementCommandError('drift', 'iacDrift');
+  }
+
+  try {
+    const args = parseArgs(paths, options);
+    const ret = await driftctl(args);
+    process.exit(ret);
+  } catch (e) {
+    const err = new Error('Error running `iac drift` ' + e);
+    return Promise.reject(err);
+  }
+}

--- a/src/cli/commands/index.js
+++ b/src/cli/commands/index.js
@@ -9,6 +9,7 @@ async function callModule(mod, args) {
 const commands = {
   auth: async (...args) => callModule(import('./auth'), args),
   config: async (...args) => callModule(import('./config'), args),
+  drift: async (...args) => callModule(import('./drift'), args),
   help: async (...args) => callModule(import('./help'), args),
   ignore: async (...args) => callModule(import('./ignore'), args),
   monitor: async (...args) => callModule(import('./monitor'), args),

--- a/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
+++ b/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
@@ -80,6 +80,17 @@ export class UnsupportedEntitlementFlagError extends CustomError {
   }
 }
 
+export class UnsupportedEntitlementCommandError extends CustomError {
+  constructor(key: string, entitlementName: string) {
+    super(
+      `Unsupported command: ${key} - Missing the ${entitlementName} entitlement`,
+    );
+    this.code = IaCErrorCodes.UnsupportedEntitlementFlagError;
+    this.strCode = getErrorStringCode(this.code);
+    this.userMessage = `Command "${key}" is currently not supported for this org. To enable it, please contact snyk support.`;
+  }
+}
+
 /**
  * Validates the command line flags passed to the snyk iac test
  * command. The current argument parsing is very permissive and

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -76,6 +76,7 @@ export interface IacCustomRules {
 
 export interface IacEntitlements {
   infrastructureAsCode?: boolean;
+  iacDrift?: boolean;
   iacCustomRulesEntitlement?: boolean;
 }
 

--- a/src/cli/modes.ts
+++ b/src/cli/modes.ts
@@ -23,7 +23,7 @@ const modes: Record<string, ModeData> = {
     },
   },
   iac: {
-    allowedCommands: ['test'],
+    allowedCommands: ['test', 'drift'],
     config: (args): [] => {
       args['iac'] = true;
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -18,6 +18,9 @@ interface Config {
   TOKEN: string;
   CODE_CLIENT_PROXY_URL: string;
   DISABLE_ANALYTICS: unknown;
+  CACHE_PATH?: string;
+  DRIFTCTL_PATH?: string;
+  DRIFTCTL_URL?: string;
 }
 
 // TODO: fix the types!

--- a/src/lib/iac/drift.ts
+++ b/src/lib/iac/drift.ts
@@ -1,0 +1,324 @@
+import * as debugLib from 'debug';
+import * as child_process from 'child_process';
+import * as os from 'os';
+import envPaths from 'env-paths';
+import * as fs from 'fs';
+import { spinner } from '../spinner';
+import { makeRequest } from '../request';
+import config from '../../lib/config';
+
+const cachePath = config.CACHE_PATH ?? envPaths('snyk').cache;
+const debug = debugLib('drift');
+
+export const driftctlVersion = 'v0.19.0';
+const driftctlChecksums = {
+  'driftctl_windows_386.exe':
+    '0336132cc0c24beaef2535e0a129d146c1a267f6296d5d6bcc7fbe0b02f0bc78',
+  driftctl_darwin_amd64:
+    '07eae8f9e537183031bb78203c1c50a0ca80e114716598946b76baadcbca26566',
+  driftctl_linux_386:
+    '4b83a5644ce72d3eabd915ffc1bba13ad1d61914984801800f598b35db2fe054',
+  driftctl_linux_amd64:
+    '4bfd536e2123667e01b6e5d54acc27733be0db5a00b7fda7f41fabcd9e910e1d',
+  driftctl_linux_arm64:
+    '50bbf8f47ec7dcb9cc09a628444b093a0305aa9b4accc84b7c366a2297390881',
+  'driftctl_windows_arm64.exe':
+    '6eee390fb97998f309ff0491b893d8727f90f45b98f42fd1aa3ebef29fd7fc5b',
+  driftctl_darwin_arm64:
+    '6f37d9f2e385ef81adea9a1f68f2c85f859608dd854416d8ecf629e626bc8b0c',
+  'driftctl_windows_arm.exe':
+    '7ce916deaad289f41c874a4ddff41e9e6195cd5f78821a5769f8e66434be5465',
+  driftctl_linux_arm:
+    'a73193472fb33744f0a344a5f3a5663bd0f4791c393a68ea1b4c219b02eda8f1',
+  'driftctl_windows_amd64.exe':
+    'be423648c164f816ea98eae9694aa7c6679d0a6c33305aceb435cd75821bc730',
+};
+
+const dctlBaseUrl = 'https://github.com/snyk/driftctl/releases/download/';
+const driftctlPath = cachePath + '/driftctl_' + driftctlVersion;
+
+interface DriftCTLOptions {
+  quiet?: true;
+  filter?: string;
+  output?: string;
+  to?: string;
+  headers?: string;
+  'tfc-token'?: string;
+  'tfc-endpoint'?: string;
+  'tf-provider-version'?: string;
+  strict?: true;
+  deep?: true;
+  driftignore?: string;
+  'tf-lockfile'?: string;
+  'config-dir'?: string;
+  from?: string; // TODO We only handle one from at a time due to snyk cli arg parsing
+}
+
+export function parseArgs(
+  commands: string[],
+  options: DriftCTLOptions,
+): string[] {
+  const args: string[] = commands;
+
+  if (options.quiet) {
+    args.push('--quiet');
+  }
+
+  if (options.filter) {
+    args.push('--filter');
+    args.push(options.filter);
+  }
+
+  if (options.output) {
+    args.push('--output');
+    args.push(options.output);
+  }
+
+  if (options.headers) {
+    args.push('--headers');
+    args.push(options.headers);
+  }
+
+  if (options['tfc-token']) {
+    args.push('--tfc-token');
+    args.push(options['tfc-token']);
+  }
+
+  if (options['tfc-endpoint']) {
+    args.push('--tfc-endpoint');
+    args.push(options['tfc-endpoint']);
+  }
+
+  if (options['tf-provider-version']) {
+    args.push('--tf-provider-version');
+    args.push(options['tf-provider-version']);
+  }
+
+  if (options.strict) {
+    args.push('--strict');
+  }
+
+  if (options.deep) {
+    args.push('--deep');
+  }
+
+  if (options.driftignore) {
+    args.push('--driftignore');
+    args.push(options.driftignore);
+  }
+
+  if (options['tf-lockfile']) {
+    args.push('--tf-lockfile');
+    args.push(options['tf-lockfile']);
+  }
+
+  let configDir = cachePath;
+  createIfNotExists(cachePath);
+  if (options['config-dir']) {
+    configDir = options['config-dir'];
+  }
+  args.push('--config-dir');
+  args.push(configDir);
+
+  if (options.from) {
+    args.push('--from');
+    args.push(options.from);
+  }
+
+  let to = 'aws+tf';
+  if (options.to) {
+    to = options.to;
+  }
+  args.push('--to');
+  args.push(to);
+
+  debug(args);
+
+  return args;
+}
+
+export async function driftctl(args: string[]): Promise<number> {
+  debug('running driftctl %s ', args.join(' '));
+
+  const path = await findOrDownload();
+
+  return await launch(path, args);
+}
+
+async function launch(path: string, args: string[]): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const child = child_process.spawn(path, args, { stdio: 'inherit' });
+
+    child.on('error', (error) => {
+      reject(error);
+    });
+
+    child.on('exit', (code) => {
+      if (code == null) {
+        //failed to find why this could happen...
+        reject(new Error('Process was terminated'));
+      } else {
+        resolve(code);
+      }
+    });
+  });
+}
+
+async function findOrDownload(): Promise<string> {
+  let dctl = await findDriftCtl();
+  if (dctl === '') {
+    try {
+      createIfNotExists(cachePath);
+      dctl = driftctlPath;
+      await download(driftctlUrl(), dctl);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  }
+  return dctl;
+}
+
+export async function findDriftCtl(): Promise<string> {
+  // lookup in custom path contained in env var DRIFTCTL_PATH
+  let dctlPath = config.DRIFTCTL_PATH;
+  if (dctlPath != null) {
+    const exists = await isExe(dctlPath);
+    if (exists) {
+      debug('Found driftctl in $DRIFTCTL_PATH: %s', dctlPath);
+      return dctlPath;
+    }
+  }
+
+  // lookup in app cache
+  dctlPath = driftctlPath;
+  const exists = await isExe(dctlPath);
+  if (exists) {
+    debug('Found driftctl in cache: %s', dctlPath);
+    return dctlPath;
+  }
+  debug('driftctl not found');
+
+  return '';
+}
+
+async function download(url, destination: string): Promise<boolean> {
+  debug('downloading driftctl into %s', destination);
+
+  const payload = {
+    method: 'GET',
+    url: url,
+    output: destination,
+    follow: 3,
+  };
+
+  await spinner('Downloading...');
+  return new Promise<boolean>((resolve, reject) => {
+    makeRequest(payload, function(err, res, body) {
+      try {
+        if (err) {
+          reject(
+            new Error('Could not download driftctl from ' + url + ': ' + err),
+          );
+          return;
+        }
+        if (res.statusCode !== 200) {
+          reject(
+            new Error(
+              'Could not download driftctl from ' + url + ': ' + res.statusCode,
+            ),
+          );
+          return;
+        }
+
+        validateChecksum(body);
+
+        fs.writeFileSync(destination, body);
+        debug('File saved: ' + destination);
+
+        fs.chmodSync(destination, 0o744);
+        resolve(true);
+      } finally {
+        spinner.clearAll();
+      }
+    });
+  });
+}
+
+function validateChecksum(body: string) {
+  // only validate if we downloaded the official driftctl binary
+  if (config.DRIFTCTL_URL || config.DRIFTCTL_PATH) {
+    return;
+  }
+
+  const crypto = require('crypto');
+  const computedHash = crypto
+    .createHash('sha256')
+    .update(body)
+    .digest('hex');
+  const givenHash = driftctlChecksums[driftctlFileName()];
+
+  if (computedHash != givenHash) {
+    throw new Error('Downloaded file has inconsistent checksum...');
+  }
+}
+
+function driftctlFileName(): string {
+  let platform = 'linux';
+  switch (os.platform()) {
+    case 'darwin':
+      platform = 'darwin';
+      break;
+    case 'win32':
+      platform = 'windows';
+      break;
+  }
+
+  let arch = 'amd64';
+  switch (os.arch()) {
+    case 'ia32':
+    case 'x32':
+      arch = '386';
+      break;
+    case 'arm':
+      arch = 'arm';
+      break;
+    case 'arm64':
+      arch = 'arm64';
+      break;
+  }
+
+  let ext = '';
+  switch (os.platform()) {
+    case 'win32':
+      ext = '.exe';
+      break;
+  }
+
+  return `driftctl_${platform}_${arch}${ext}`;
+}
+
+function driftctlUrl(): string {
+  if (config.DRIFTCTL_URL) {
+    return config.DRIFTCTL_URL;
+  }
+
+  return `${dctlBaseUrl}/${driftctlVersion}/${driftctlFileName()}`;
+}
+
+function isExe(dctlPath: string): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    fs.access(dctlPath, fs.constants.X_OK, (err) => {
+      if (err) {
+        resolve(false);
+        return;
+      }
+      resolve(true);
+    });
+  });
+}
+
+function createIfNotExists(path: string) {
+  if (!fs.existsSync(path)) {
+    fs.mkdirSync(path, { recursive: true });
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -253,6 +253,7 @@ export enum SupportedCliCommands {
   woof = 'woof',
   log4shell = 'log4shell',
   apps = 'apps',
+  drift = 'drift',
 }
 
 export interface IacFileInDirectory {

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -395,6 +395,7 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
       entitlements: {
         infrastructureAsCode: true,
         iacCustomRulesEntitlement: true,
+        iacDrift: true,
       },
     };
 
@@ -414,6 +415,16 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
         entitlements: {
           ...baseResponse.entitlements,
           iacCustomRulesEntitlement: false,
+        },
+      });
+    }
+
+    if (req.query.org === 'no-iac-drift-entitlements') {
+      return res.status(200).send({
+        ...baseResponse,
+        entitlements: {
+          ...baseResponse.entitlements,
+          iacDrift: false,
         },
       });
     }
@@ -482,6 +493,13 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
 
   app.post(basePath + '/analytics/cli', (req, res) => {
     res.status(200).send({});
+  });
+
+  app.get(basePath + '/download/driftctl', (req, res) => {
+    const fixturePath = getFixturePath('iac');
+    const path1 = path.join(fixturePath, '/drift/args-echo');
+    const body = fs.readFileSync(path1);
+    res.send(body);
   });
 
   const listen = (port: string | number, callback: () => void) => {

--- a/test/fixtures/iac/drift/args-echo
+++ b/test/fixtures/iac/drift/args-echo
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo $@
+exit 0

--- a/test/jest/acceptance/iac/dift.spec.ts
+++ b/test/jest/acceptance/iac/dift.spec.ts
@@ -1,0 +1,61 @@
+import { startMockServer } from './helpers';
+import envPaths from 'env-paths';
+import { driftctlVersion } from '../../../../src/lib/iac/drift';
+import * as fs from 'fs';
+
+const paths = envPaths('snyk');
+
+jest.setTimeout(50000);
+
+describe('iac drift scan', () => {
+  let run: (
+    cmd: string,
+    env: Record<string, string>,
+  ) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+  let teardown: () => void;
+  let apiUrl: string;
+
+  beforeAll(async () => {
+    ({ run, teardown, apiUrl } = await startMockServer());
+  });
+
+  afterAll(async () => teardown());
+
+  it('Fail without the right entitlement', async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `snyk iac drift scan --org=no-iac-drift-entitlements`,
+      {
+        SNYK_DRIFTCTL_PATH: './iac/drift/args-echo',
+      },
+    );
+
+    expect(stdout).toMatch(
+      'Command "drift" is currently not supported for this org. To enable it, please contact snyk support.',
+    );
+    expect(stderr).toMatch('');
+    expect(exitCode).toBe(2);
+  });
+
+  it('Launch driftctl from SNYK_DRIFTCTL_PATH env var when org has the entitlement', async () => {
+    const { stdout, stderr, exitCode } = await run(`snyk iac drift scan`, {
+      SNYK_DRIFTCTL_PATH: './iac/drift/args-echo',
+    });
+
+    expect(stdout).toMatch('scan --config-dir ' + paths.cache + ' --to aws+tf');
+    expect(stderr).toMatch('');
+    expect(exitCode).toBe(0);
+  });
+
+  it('Download and launch driftctl when executable is not found and org has the entitlement', async () => {
+    const cachedir = '/tmp/driftctl_download_' + Date.now();
+    const { stdout, stderr, exitCode } = await run(`snyk iac drift scan`, {
+      SNYK_DRIFTCTL_URL: apiUrl + '/download/driftctl',
+      SNYK_CACHE_PATH: cachedir,
+    });
+
+    expect(stdout).toMatch('scan --config-dir ' + cachedir + ' --to aws+tf');
+    expect(stderr).toMatch('');
+    expect(exitCode).toBe(0);
+    expect(fs.existsSync(cachedir + '/driftctl_' + driftctlVersion)).toBe(true);
+  });
+});

--- a/test/jest/acceptance/iac/helpers.ts
+++ b/test/jest/acceptance/iac/helpers.ts
@@ -37,6 +37,7 @@ export async function startMockServer() {
       cwd?: string,
     ) => run(cmd, { ...env, ...overrides }, cwd),
     teardown: async () => new Promise((resolve) => server.close(resolve)),
+    apiUrl: SNYK_API,
   };
 }
 

--- a/test/jest/unit/lib/iac/drift.spec.ts
+++ b/test/jest/unit/lib/iac/drift.spec.ts
@@ -1,0 +1,71 @@
+const mockFs = require('mock-fs');
+
+import { parseArgs } from '../../../../../src/lib/iac/drift';
+import envPaths from 'env-paths';
+
+const paths = envPaths('snyk');
+
+describe('driftctl integration', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockFs.restore();
+  });
+
+  it('default arguments are correct', () => {
+    const args = parseArgs(['scan'], {});
+    expect(args).toEqual([
+      'scan',
+      '--config-dir',
+      paths.cache,
+      '--to',
+      'aws+tf',
+    ]);
+  });
+
+  it('passing options generate correct arguments', () => {
+    const args = parseArgs(['scan'], {
+      'config-dir': 'confdir',
+      'tf-lockfile': 'tflockfile',
+      'tf-provider-version': 'tfproviderversion',
+      'tfc-endpoint': 'tfcendpoint',
+      'tfc-token': 'tfctoken',
+      deep: true,
+      driftignore: 'driftignore',
+      filter: 'filter',
+      from: 'from',
+      headers: 'headers',
+      output: 'output',
+      quiet: true,
+      strict: true,
+      to: 'to',
+    });
+    expect(args).toEqual([
+      'scan',
+      '--quiet',
+      '--filter',
+      'filter',
+      '--output',
+      'output',
+      '--headers',
+      'headers',
+      '--tfc-token',
+      'tfctoken',
+      '--tfc-endpoint',
+      'tfcendpoint',
+      '--tf-provider-version',
+      'tfproviderversion',
+      '--strict',
+      '--deep',
+      '--driftignore',
+      'driftignore',
+      '--tf-lockfile',
+      'tflockfile',
+      '--config-dir',
+      'confdir',
+      '--from',
+      'from',
+      '--to',
+      'to',
+    ]);
+  });
+});


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR is meant to add a new subcommand `snyk iac drift scan`. As a first step integrating driftctl into snyk this will only launch driftctl and mirror driftctl command, scan arguments and return code.

Current limitation are:
- snyk arg parsing does not support variadic args but driftctl support multiple --from. For now running it through snyk cli will only support one from argument.
- snyk cli help was not meant to support help for subcommand so we will need to find a way to show how the new command work.
- currently I only mirrored arguments for drifctl's scan command. If we want to support more command we should check their args.

#### Where should the reviewer start?
- Added a new command, that can be found in `src/cli/commands/drift.ts`. It will error using legacy-error if the mode is not iac.
- The command call `parseArgs` and `driftctl` from `src/lib/iac/drift.ts` where most of the code live. `driftctl` function will try to find driftctl executable and download it to a cache directory if needed.

#### How should this be manually tested?
launching `snyk iac drift scan` should show an error like:
```
error configuring Terraform AWS Provider: no valid credential sources for Terraform AWS Provider found.

Please see https://registry.terraform.io/providers/hashicorp/aws
for more information about providing credentials.

Error: NoCredentialProviders: no valid providers in chain. Deprecated.
	For verbose messaging see aws.Config.CredentialsChainVerboseErrors
```
To make it work correctly it will be useful to check [driftctl doc](https://docs.driftctl.com/)

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CFG-1299

#### Screenshots
![image](https://user-images.githubusercontent.com/4931174/151220868-aabee77c-440e-4f6d-83dd-e67131bb8bd7.png)

