### PR TITLE
[CFG-1525] add drift test subcommand

### DIFF
--- a/src/cli/commands/drift.ts
+++ b/src/cli/commands/drift.ts
@@ -1,14 +1,23 @@
 import { MethodArgs } from '../args';
 import { processCommandArgs } from './process-command-args';
-import { driftctl, parseArgs } from '../../lib/iac/drift';
+import {
+  driftctl,
+  DriftCTLOptions,
+  DriftCTLResult,
+  parseArgs,
+} from '../../lib/iac/drift';
 import { UnsupportedEntitlementCommandError } from './test/iac-local-execution/assert-iac-options-flag';
 import { getIacOrgSettings } from './test/iac-local-execution/measurable-methods';
 import config from '../../lib/config';
+import { testDrifts } from '../../lib/iac/drift-test';
+import { TestCommandResult } from './types';
 
 const legacyError = require('../../lib/errors/legacy-errors');
 
-export default async function drift(...args: MethodArgs): Promise<any> {
-  const { options, paths } = processCommandArgs(...args);
+export default async function drift(
+  ...args: MethodArgs
+): Promise<TestCommandResult | void> {
+  const { options, paths } = processCommandArgs<DriftCTLOptions>(...args);
 
   if (options.iac != true) {
     return legacyError('drift');
@@ -21,12 +30,27 @@ export default async function drift(...args: MethodArgs): Promise<any> {
     throw new UnsupportedEntitlementCommandError('drift', 'iacDrift');
   }
 
+  let result: DriftCTLResult;
   try {
-    const args = parseArgs(paths, options);
-    const ret = await driftctl(args);
-    process.exit(ret);
+    let opt = options;
+    let isTestSubCommand = false;
+    if (paths[0] === 'test') {
+      opt = { ...opt, deep: true, output: 'plan://stdout' };
+      isTestSubCommand = true;
+    }
+
+    const args = parseArgs(paths, opt);
+    result = await driftctl(args, isTestSubCommand);
   } catch (e) {
     const err = new Error('Error running `iac drift` ' + e);
     return Promise.reject(err);
   }
+
+  if (result.stderr) {
+    throw new Error(result.stderr);
+  }
+  if (result.stdout) {
+    return testDrifts(result.stdout, options, iacOrgSettings);
+  }
+  process.exit(result.returnCode);
 }

--- a/src/lib/iac/drift-test.ts
+++ b/src/lib/iac/drift-test.ts
@@ -1,0 +1,143 @@
+import * as debugLib from 'debug';
+import { EOL } from 'os';
+import chalk from 'chalk';
+import { IacFileInDirectory, Options } from '../../lib/types';
+import { LegacyVulnApiResult, TestResult } from '../../lib/snyk-test/legacy';
+import { mapIacTestResult } from '../../lib/snyk-test/iac-test-result';
+import { getIacDisplayErrorFileOutput } from '../../lib/formatters/iac-output';
+import { extractDataToSendFromResults } from '../../lib/formatters/test/format-test-results';
+import { displayResult } from '../../lib/formatters/test/display-result';
+import {
+  cleanLocalCache,
+  formatScanResults,
+  initLocalCache,
+  scanFiles,
+} from '../../cli/commands/test/iac-local-execution/measurable-methods';
+import { IacOrgSettings } from '../../cli/commands/test/iac-local-execution/types';
+import { findAndLoadPolicy } from '../policy';
+import { filterIgnoredIssues } from '../../cli/commands/test/iac-local-execution/policy';
+import { formatTestError } from '../../cli/commands/test/format-test-error';
+import { TestCommandResult } from '../../cli/commands/types';
+import { tryParsingTerraformPlan } from '../../cli/commands/test/iac-local-execution/parsers/terraform-plan-parser';
+import { DriftCTLOptions } from './drift';
+
+const debug = debugLib('drift-test');
+const SEPARATOR = '\n-------------------------------------------------------\n';
+
+export async function testDrifts(
+  content: string,
+  options: Options & DriftCTLOptions,
+  iacOrgSettings: IacOrgSettings,
+): Promise<TestCommandResult> {
+  let results = [] as any[];
+
+  let iacScanFailures: IacFileInDirectory[] | undefined;
+
+  let res: TestResult[] | Error;
+  try {
+    await initLocalCache();
+
+    const parsedPlan = tryParsingTerraformPlan(
+      {
+        filePath: '',
+        fileType: 'json',
+        fileContent: content,
+      },
+      JSON.parse(content),
+    );
+
+    const policy = await findAndLoadPolicy('', 'iac', options as any);
+
+    const scannedFiles = await scanFiles(parsedPlan);
+
+    const formattedResults = formatScanResults(
+      scannedFiles,
+      options,
+      iacOrgSettings.meta,
+    );
+
+    const { filteredIssues } = filterIgnoredIssues(policy, formattedResults);
+
+    res = (filteredIssues as unknown) as TestResult[];
+  } catch (error) {
+    res = formatTestError(error);
+  } finally {
+    cleanLocalCache();
+  }
+
+  results = Array.isArray(res) ? res : [res];
+
+  const vulnerableResults = results.filter(
+    (res) =>
+      (res.vulnerabilities && res.vulnerabilities.length) ||
+      (res.result &&
+        res.result.cloudConfigResults &&
+        res.result.cloudConfigResults.length),
+  );
+  const errorResults = results.filter((res) => res instanceof Error);
+  const notSuccess = errorResults.length > 0;
+  const foundVulnerabilities = vulnerableResults.length > 0;
+
+  const mappedResults = results.map(mapIacTestResult);
+
+  const {
+    stringifiedJsonData,
+    stringifiedSarifData,
+  } = extractDataToSendFromResults(results, mappedResults, options);
+
+  let response = results
+    .map((result, i) =>
+      displayResult(
+        results[i] as LegacyVulnApiResult,
+        options as any,
+        result.foundProjectCount,
+      ),
+    )
+    .join(`\n${SEPARATOR}`);
+
+  if (notSuccess) {
+    debug(`Failed to test ${errorResults.length} projects, errors:`);
+    errorResults.forEach((err) => {
+      const errString = err.stack ? err.stack.toString() : err.toString();
+      debug('error: %s', errString);
+    });
+  }
+
+  const summaryMessage = '';
+
+  if (iacScanFailures) {
+    for (const reason of iacScanFailures) {
+      response += chalk.bold.red(getIacDisplayErrorFileOutput(reason));
+    }
+  }
+
+  if (notSuccess) {
+    response += chalk.bold.red(summaryMessage);
+
+    const error = new Error(response) as any;
+    error.code = errorResults[0].code;
+    error.userMessage = errorResults[0].userMessage;
+    error.strCode = errorResults[0].strCode;
+    throw error;
+  }
+
+  if (foundVulnerabilities) {
+    response += chalk.bold.red(summaryMessage);
+
+    const error = new Error(response) as any;
+    error.code = vulnerableResults[0].code || 'VULNS';
+    error.userMessage = vulnerableResults[0].userMessage;
+    error.jsonStringifiedResults = stringifiedJsonData;
+    error.sarifStringifiedResults = stringifiedSarifData;
+    throw error;
+  }
+
+  response += chalk.bold.green(summaryMessage);
+  response += EOL + EOL;
+
+  return TestCommandResult.createHumanReadableTestCommandResult(
+    response,
+    stringifiedJsonData,
+    stringifiedSarifData,
+  );
+}


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Since we've [introduced a way to run driftctl through the Snyk CLI](https://github.com/snyk/snyk/pull/2634), we may now want to gather security insights out of those drifts. This PR adds a new subcommand to the existing `snyk iac drift` command, in order to perform a security analysis of drifts. It's currently possible to do `snyk iac drift scan --output plan://path/to/plan.json && snyk iac test ://path/to/plan.json`, but this method offers poor user experience and can bring confusion. Running `snyk iac drift test` is just a shorthand to perform the exact same operation.

#### Where should the reviewer start?

- Added the flags to output the JSON plan format from driftctl scan command (`src/cli/commands/drift.ts`)
- Captured stdout/stderr from driftctl function (`src/lib/iac/drift.ts`)
- Rewrote a minimal form of the IaC test command (`src/lib/iac/drift-test.ts`)

#### How should this be manually tested?

1. `./bin/snyk iac drift test --from='tfstate://path/to/terraform.tfstate'`

#### What are the relevant tickets?

- https://snyksec.atlassian.net/browse/CFG-1525

#### Screenshots

<img width="953" alt="image" src="https://user-images.githubusercontent.com/8110579/153449341-7b56a320-7098-4f2c-827a-a38d662c3778.png">
 