### PR TITLE
fix: Invalid JAR fingerprints for Maven projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.15.3",
-        "snyk-docker-plugin": "^4.33.0",
+        "snyk-docker-plugin": "^4.34.5",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
         "snyk-module": "3.1.0",
@@ -32873,9 +32873,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.33.0.tgz",
-      "integrity": "sha512-ha85npGG86Ef6ygCtNt1KtOVW+IuoIKjFOIS84ZQJ3uHDSjjlOjdMENW2sN7OQntYtWs01mp73IJW0sbKDRwaw==",
+      "version": "4.34.5",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.34.5.tgz",
+      "integrity": "sha512-s8NVOFigLbhRfMEWZNtOQAV4HUmpZ5cCEPybsL/f7fKmw3HFSYNsH0YQtESBx77fAUAN2gK/8wF/7y6C/Dgnig==",
       "requires": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/rpm-parser": "^2.0.0",
@@ -32890,7 +32890,7 @@
         "gunzip-maybe": "^1.4.2",
         "mkdirp": "^1.0.4",
         "semver": "^7.3.4",
-        "snyk-nodejs-lockfile-parser": "1.37.2",
+        "snyk-nodejs-lockfile-parser": "1.37.3",
         "tar-stream": "^2.1.0",
         "tmp": "^0.2.1",
         "tslib": "^1",
@@ -32940,9 +32940,9 @@
           }
         },
         "snyk-nodejs-lockfile-parser": {
-          "version": "1.37.2",
-          "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.2.tgz",
-          "integrity": "sha512-AOQ73l5xZWeIvK/wJY++QMLqrbuIr1VGAi5eaXdTkodpZ2kO6AlhtvM6F3KjdUOsDbT8mM96tKqNrBl1vTHE5Q==",
+          "version": "1.37.3",
+          "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.3.tgz",
+          "integrity": "sha512-kpCWluXEEOOnVh91CmwrRU9aQACLzoZ0hZDFRLshOZfDHvMiYjopw6JBq+IGXWpbzXgbQNr5Zzq5p6DcvrHFwA==",
           "requires": {
             "@snyk/dep-graph": "^1.28.0",
             "@snyk/graphlib": "2.1.9-patch.3",
@@ -32953,7 +32953,6 @@
             "lodash.clonedeep": "^4.5.0",
             "lodash.flatmap": "^4.5.0",
             "lodash.isempty": "^4.4.0",
-            "lodash.set": "^4.3.2",
             "lodash.topairs": "^4.3.0",
             "semver": "^7.3.5",
             "snyk-config": "^4.0.0-rc.2",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.15.3",
-    "snyk-docker-plugin": "^4.33.0",
+    "snyk-docker-plugin": "^4.34.5",
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.17.0",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR bumps `snyk-docker-plugin` to v4.34.5 which fixes invalid `dep-graph` in Maven
projects causing issues with calculating a package's vulnerable paths

#### Any background context you want to provide?
- https://snyk.zendesk.com/agent/tickets/17457
- https://snyksec.atlassian.net/browse/CAP-684

