### PR TITLE
feat: Do not reverse vulns order when grouping

### DIFF
--- a/src/lib/formatters/test/format-test-results.ts
+++ b/src/lib/formatters/test/format-test-results.ts
@@ -45,13 +45,11 @@ function createJsonResultOutput(jsonResult, options: Options) {
 
 function formatJsonVulnerabilityStructure(jsonResult, options: Options) {
   if (options['group-issues']) {
-    // Note: we have to reverse the array to keep the existing behavior so that the json output will stay the same.
-    // Since the entire array is reversed before grouping, we reverse it back after grouping to preserve the grouped vulns order.
-    const reversedVulnerabilities = jsonResult.vulnerabilities
-      ? jsonResult.vulnerabilities.slice().reverse()
-      : [];
     jsonResult.vulnerabilities = Object.values(
-      reversedVulnerabilities.reduce((acc, vuln): Record<string, any> => {
+      (jsonResult.vulnerabilities || []).reduce((acc, vuln): Record<
+        string,
+        any
+      > => {
         if (!acc[vuln.id]) {
           acc[vuln.id] = {
             ...vuln,
@@ -64,7 +62,7 @@ function formatJsonVulnerabilityStructure(jsonResult, options: Options) {
         }
         return acc;
       }, {}),
-    ).reverse();
+    );
   }
 
   if (jsonResult.vulnerabilities) {

--- a/test/fixtures/basic-apk/resultJsonDataGrouped.json
+++ b/test/fixtures/basic-apk/resultJsonDataGrouped.json
@@ -38,56 +38,6 @@
       "from": [
         [
           "docker-image|alpine@3.12.1",
-          "libc-dev/libc-utils@0.7.2-r3",
-          "musl/musl-utils@1.1.24-r9"
-        ],
-        [
-          "docker-image|alpine@3.12.1",
-          "musl/musl-utils@1.1.24-r9"
-        ],
-        [
-          "docker-image|alpine@3.12.1",
-          "zlib/zlib@1.2.11-r3",
-          "musl/musl@1.1.24-r9"
-        ],
-        [
-          "docker-image|alpine@3.12.1",
-          "musl/musl-utils@1.1.24-r9",
-          "musl/musl@1.1.24-r9"
-        ],
-        [
-          "docker-image|alpine@3.12.1",
-          "busybox/ssl_client@1.31.1-r19",
-          "musl/musl@1.1.24-r9"
-        ],
-        [
-          "docker-image|alpine@3.12.1",
-          "libtls-standalone/libtls-standalone@2.9.1-r1",
-          "musl/musl@1.1.24-r9"
-        ],
-        [
-          "docker-image|alpine@3.12.1",
-          "apk-tools/apk-tools@2.10.5-r1",
-          "musl/musl@1.1.24-r9"
-        ],
-        [
-          "docker-image|alpine@3.12.1",
-          "busybox/busybox@1.31.1-r19",
-          "musl/musl@1.1.24-r9"
-        ],
-        [
-          "docker-image|alpine@3.12.1",
-          "openssl/libssl1.1@1.1.1g-r0",
-          "musl/musl@1.1.24-r9"
-        ],
-        [
-          "docker-image|alpine@3.12.1",
-          "openssl/libcrypto1.1@1.1.1g-r0",
-          "musl/musl@1.1.24-r9"
-        ],
-        [
-          "docker-image|alpine@3.12.1",
-          "alpine-baselayout/alpine-baselayout@3.2.0-r7",
           "musl/musl@1.1.24-r9"
         ],
         [
@@ -97,26 +47,76 @@
         ],
         [
           "docker-image|alpine@3.12.1",
+          "alpine-baselayout/alpine-baselayout@3.2.0-r7",
           "musl/musl@1.1.24-r9"
+        ],
+        [
+          "docker-image|alpine@3.12.1",
+          "openssl/libcrypto1.1@1.1.1g-r0",
+          "musl/musl@1.1.24-r9"
+        ],
+        [
+          "docker-image|alpine@3.12.1",
+          "openssl/libssl1.1@1.1.1g-r0",
+          "musl/musl@1.1.24-r9"
+        ],
+        [
+          "docker-image|alpine@3.12.1",
+          "busybox/busybox@1.31.1-r19",
+          "musl/musl@1.1.24-r9"
+        ],
+        [
+          "docker-image|alpine@3.12.1",
+          "apk-tools/apk-tools@2.10.5-r1",
+          "musl/musl@1.1.24-r9"
+        ],
+        [
+          "docker-image|alpine@3.12.1",
+          "libtls-standalone/libtls-standalone@2.9.1-r1",
+          "musl/musl@1.1.24-r9"
+        ],
+        [
+          "docker-image|alpine@3.12.1",
+          "busybox/ssl_client@1.31.1-r19",
+          "musl/musl@1.1.24-r9"
+        ],
+        [
+          "docker-image|alpine@3.12.1",
+          "musl/musl-utils@1.1.24-r9",
+          "musl/musl@1.1.24-r9"
+        ],
+        [
+          "docker-image|alpine@3.12.1",
+          "zlib/zlib@1.2.11-r3",
+          "musl/musl@1.1.24-r9"
+        ],
+        [
+          "docker-image|alpine@3.12.1",
+          "musl/musl-utils@1.1.24-r9"
+        ],
+        [
+          "docker-image|alpine@3.12.1",
+          "libc-dev/libc-utils@0.7.2-r3",
+          "musl/musl-utils@1.1.24-r9"
         ]
       ],
       "upgradePath": [],
       "isUpgradable": false,
       "isPatchable": false,
       "name": [
+        "musl/musl",
+        "musl/musl",
+        "musl/musl",
+        "musl/musl",
+        "musl/musl",
+        "musl/musl",
+        "musl/musl",
+        "musl/musl",
+        "musl/musl",
+        "musl/musl",
+        "musl/musl",
         "musl/musl-utils",
-        "musl/musl-utils",
-        "musl/musl",
-        "musl/musl",
-        "musl/musl",
-        "musl/musl",
-        "musl/musl",
-        "musl/musl",
-        "musl/musl",
-        "musl/musl",
-        "musl/musl",
-        "musl/musl",
-        "musl/musl"
+        "musl/musl-utils"
       ],
       "version": "1.1.24-r9",
       "nearestFixedInVersion": "1.1.24-r10"

--- a/test/fixtures/container-app-vulns/resultJsonDataGrouped.json
+++ b/test/fixtures/container-app-vulns/resultJsonDataGrouped.json
@@ -68,7 +68,7 @@
         "from": [
           [
             "docker-image|cli-grouping@latest",
-            "busybox/ssl_client@1.31.1-r21"
+            "busybox/busybox@1.31.1-r21"
           ],
           [
             "docker-image|cli-grouping@latest",
@@ -77,16 +77,16 @@
           ],
           [
             "docker-image|cli-grouping@latest",
-            "busybox/busybox@1.31.1-r21"
+            "busybox/ssl_client@1.31.1-r21"
           ]
         ],
         "upgradePath": [],
         "isUpgradable": false,
         "isPatchable": false,
         "name": [
-          "busybox/ssl_client",
           "busybox/busybox",
-          "busybox/busybox"
+          "busybox/busybox",
+          "busybox/ssl_client"
         ],
         "version": "1.31.1-r21",
         "nearestFixedInVersion": "1.32.1-r4"
@@ -611,20 +611,18 @@
           [
             "cli-grouping@1.0.0",
             "express@2.5.11",
-            "connect@1.9.2",
             "mime@1.2.4"
           ],
           [
             "cli-grouping@1.0.0",
             "express@2.5.11",
+            "connect@1.9.2",
             "mime@1.2.4"
           ]
         ],
         "upgradePath": [
           false,
-          "express@2.5.11",
-          "connect@1.9.2",
-          "mime@1.4.1"
+          "express@3.0.0"
         ],
         "isUpgradable": true,
         "isPatchable": false,
@@ -747,20 +745,18 @@
           [
             "cli-grouping@1.0.0",
             "express@2.5.11",
-            "connect@1.9.2",
             "qs@0.4.2"
           ],
           [
             "cli-grouping@1.0.0",
             "express@2.5.11",
+            "connect@1.9.2",
             "qs@0.4.2"
           ]
         ],
         "upgradePath": [
           false,
-          "express@2.5.11",
-          "connect@1.9.2",
-          "qs@1.0.0"
+          "express@3.0.0"
         ],
         "isUpgradable": true,
         "isPatchable": false,
@@ -853,20 +849,18 @@
           [
             "cli-grouping@1.0.0",
             "express@2.5.11",
-            "connect@1.9.2",
             "qs@0.4.2"
           ],
           [
             "cli-grouping@1.0.0",
             "express@2.5.11",
+            "connect@1.9.2",
             "qs@0.4.2"
           ]
         ],
         "upgradePath": [
           false,
-          "express@2.5.11",
-          "connect@1.9.2",
-          "qs@1.0.0"
+          "express@3.0.0"
         ],
         "isUpgradable": true,
         "isPatchable": false,
@@ -1081,20 +1075,18 @@
           [
             "cli-grouping@1.0.0",
             "express@2.5.11",
-            "connect@1.9.2",
             "qs@0.4.2"
           ],
           [
             "cli-grouping@1.0.0",
             "express@2.5.11",
+            "connect@1.9.2",
             "qs@0.4.2"
           ]
         ],
         "upgradePath": [
           false,
-          "express@2.5.11",
-          "connect@1.9.2",
-          "qs@6.0.4"
+          "express@3.0.0"
         ],
         "isUpgradable": true,
         "isPatchable": false,

--- a/test/fixtures/npm/issue-grouping/multiProjectResultJsonDataGrouped.json
+++ b/test/fixtures/npm/issue-grouping/multiProjectResultJsonDataGrouped.json
@@ -393,20 +393,18 @@
           [
             "cli-grouping@1.0.0",
             "express@2.5.11",
-            "connect@1.9.2",
             "mime@1.2.4"
           ],
           [
             "cli-grouping@1.0.0",
             "express@2.5.11",
+            "connect@1.9.2",
             "mime@1.2.4"
           ]
         ],
         "upgradePath": [
           false,
-          "express@2.5.11",
-          "connect@1.9.2",
-          "mime@1.4.1"
+          "express@3.0.0"
         ],
         "isUpgradable": true,
         "isPatchable": false,
@@ -529,20 +527,18 @@
           [
             "cli-grouping@1.0.0",
             "express@2.5.11",
-            "connect@1.9.2",
             "qs@0.4.2"
           ],
           [
             "cli-grouping@1.0.0",
             "express@2.5.11",
+            "connect@1.9.2",
             "qs@0.4.2"
           ]
         ],
         "upgradePath": [
           false,
-          "express@2.5.11",
-          "connect@1.9.2",
-          "qs@1.0.0"
+          "express@3.0.0"
         ],
         "isUpgradable": true,
         "isPatchable": false,
@@ -635,20 +631,18 @@
           [
             "cli-grouping@1.0.0",
             "express@2.5.11",
-            "connect@1.9.2",
             "qs@0.4.2"
           ],
           [
             "cli-grouping@1.0.0",
             "express@2.5.11",
+            "connect@1.9.2",
             "qs@0.4.2"
           ]
         ],
         "upgradePath": [
           false,
-          "express@2.5.11",
-          "connect@1.9.2",
-          "qs@1.0.0"
+          "express@3.0.0"
         ],
         "isUpgradable": true,
         "isPatchable": false,
@@ -863,20 +857,18 @@
           [
             "cli-grouping@1.0.0",
             "express@2.5.11",
-            "connect@1.9.2",
             "qs@0.4.2"
           ],
           [
             "cli-grouping@1.0.0",
             "express@2.5.11",
+            "connect@1.9.2",
             "qs@0.4.2"
           ]
         ],
         "upgradePath": [
           false,
-          "express@2.5.11",
-          "connect@1.9.2",
-          "qs@6.0.4"
+          "express@3.0.0"
         ],
         "isUpgradable": true,
         "isPatchable": false,
@@ -1083,7 +1075,6 @@
             "nodemon@1.19.4",
             "update-notifier@2.5.0",
             "boxen@1.3.0",
-            "widest-line@2.0.1",
             "string-width@2.1.1",
             "strip-ansi@4.0.0",
             "ansi-regex@3.0.0"
@@ -1103,6 +1094,7 @@
             "nodemon@1.19.4",
             "update-notifier@2.5.0",
             "boxen@1.3.0",
+            "widest-line@2.0.1",
             "string-width@2.1.1",
             "strip-ansi@4.0.0",
             "ansi-regex@3.0.0"
@@ -1113,7 +1105,6 @@
           "nodemon@2.0.3",
           "update-notifier@4.0.0",
           "boxen@4.2.0",
-          "widest-line@3.1.0",
           "string-width@4.2.0",
           "strip-ansi@6.0.0",
           "ansi-regex@5.0.1"

--- a/test/fixtures/npm/issue-grouping/singleProjectResultJsonDataGrouped.json
+++ b/test/fixtures/npm/issue-grouping/singleProjectResultJsonDataGrouped.json
@@ -392,20 +392,18 @@
         [
           "cli-grouping@1.0.0",
           "express@2.5.11",
-          "connect@1.9.2",
           "mime@1.2.4"
         ],
         [
           "cli-grouping@1.0.0",
           "express@2.5.11",
+          "connect@1.9.2",
           "mime@1.2.4"
         ]
       ],
       "upgradePath": [
         false,
-        "express@2.5.11",
-        "connect@1.9.2",
-        "mime@1.4.1"
+        "express@3.0.0"
       ],
       "isUpgradable": true,
       "isPatchable": false,
@@ -528,20 +526,18 @@
         [
           "cli-grouping@1.0.0",
           "express@2.5.11",
-          "connect@1.9.2",
           "qs@0.4.2"
         ],
         [
           "cli-grouping@1.0.0",
           "express@2.5.11",
+          "connect@1.9.2",
           "qs@0.4.2"
         ]
       ],
       "upgradePath": [
         false,
-        "express@2.5.11",
-        "connect@1.9.2",
-        "qs@1.0.0"
+        "express@3.0.0"
       ],
       "isUpgradable": true,
       "isPatchable": false,
@@ -634,20 +630,18 @@
         [
           "cli-grouping@1.0.0",
           "express@2.5.11",
-          "connect@1.9.2",
           "qs@0.4.2"
         ],
         [
           "cli-grouping@1.0.0",
           "express@2.5.11",
+          "connect@1.9.2",
           "qs@0.4.2"
         ]
       ],
       "upgradePath": [
         false,
-        "express@2.5.11",
-        "connect@1.9.2",
-        "qs@1.0.0"
+        "express@3.0.0"
       ],
       "isUpgradable": true,
       "isPatchable": false,
@@ -862,20 +856,18 @@
         [
           "cli-grouping@1.0.0",
           "express@2.5.11",
-          "connect@1.9.2",
           "qs@0.4.2"
         ],
         [
           "cli-grouping@1.0.0",
           "express@2.5.11",
+          "connect@1.9.2",
           "qs@0.4.2"
         ]
       ],
       "upgradePath": [
         false,
-        "express@2.5.11",
-        "connect@1.9.2",
-        "qs@6.0.4"
+        "express@3.0.0"
       ],
       "isUpgradable": true,
       "isPatchable": false,


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR changes the order of the "from" and "name" arrays of grouped vulns (when using the `--group-issues` flag) and uses the upgrade path of the first vuln of the same ID. This is done in order to prevent having 2 reverse() calls on the vulnerabilities array. 

Until today, when grouping vulns using the --group-issues flag, the "from" and "name" arrays of the grouped vuln information were returned in the reversed order than what appeared in the non-grouped output of vulns with the same ID, because each new vulns "from" and "name" data was pushed in the beginning of the array. In addition the last vuln (of the same ID) "upgradePath" was returned.

In a recent performance improvement of the grouping function, we had to reverse the vuln array twice, in order to keep this order. In this change, we suggest to remove the vuln array 2 reverse() calls, which means that the "from" and "name" arrays of the grouped vulns of the same ID will appear in the same order as in the non-grouped results. In addition, the first vuln (of the same ID) upgrade path will be returned, instead of the last one.

Notes:
- It appears that this change makes the order of the CLI grouped vulns more similar to the order of issues in the UI. 
- `upgradePath` should also be grouped probably, but this will break the existing output format so it's not done as part of this PR.

#### How should this be manually tested?

Clone the http://github.com/snyk/npm7-goof and run `snyk test  --json --group-issues` within this repo.

#### Any background context you want to provide?

This issue was raised following a performance-related PR: https://github.com/snyk/snyk/pull/2709

The change of order has been discussed and agreed on with product (see [thread](https://snyk.slack.com/archives/CBXS33GJY/p1643899263725699))

The change of order was also discussed with architects as part of performance PR review (see [thread](https://snyk.slack.com/archives/CFTAUCYQ7/p1644239753163269))

#### Screenshots

Vuln grouping before and after the change - order of "from" and "name" arrays now the same as in the original non-grouped results, and we show the "upgradePath" of the first vuln of a specific ID rather than the last:

![image](https://user-images.githubusercontent.com/11232557/154279944-e556b5dd-4f9d-454d-81c7-8e1f199c0d82.png)
