### PR TITLE
chore: fix issues with release process of snyk-iac-parsers

### DIFF
--- a/release-scripts/hcl-to-json-parser-generator-v2/Makefile
+++ b/release-scripts/hcl-to-json-parser-generator-v2/Makefile
@@ -18,17 +18,14 @@ print-%  : ; @echo $* = $($*)
 
 .PHONY: release
 release:
-ifndef version
-$(error version is not set. Please provide a version)
-endif
 	chmod +x ./test-and-release.sh && ./test-and-release.sh $(version)
 
 $(GOBIN)/gopherjs:
-	go get github.com/gopherjs/gopherjs
+	go get github.com/gopherjs/gopherjs@v0.0.0-20220221023154-0b2280d3ff96
 
 $(PROJECT_SRC)/vendor: $(PROJECT_SRC)/go.mod $(PROJECT_SRC)/go.sum
 	cd $(PROJECT_SRC); go mod vendor
 
 $(PROJECT_OUT)/hcltojson-v2.js $(PROJECT_OUT)/hcltojson-v2.js.map: $(GOBIN)/gopherjs $(PROJECT_SRC)/hcltojson-v2.go $(PROJECT_SRC)/vendor
-	cd $(PROJECT_SRC); GOOS=linux $(GOBIN)/gopherjs build -m -o $(PROJECT_OUT)/hcltojson-v2.js $(PROJECT_SRC)/hcltojson-v2.go
+	cd $(PROJECT_SRC); GOOS=linux $(GOBIN)/gopherjs build -m -o $(PROJECT_OUT)/hcltojson-v2.js hcltojson-v2.go
 

--- a/release-scripts/hcl-to-json-parser-generator-v2/test-and-release.sh
+++ b/release-scripts/hcl-to-json-parser-generator-v2/test-and-release.sh
@@ -3,6 +3,10 @@ set -e
 
 # default version is the minimum workable version, coming from the makefile
 VERSION=$1
+if [[ -z "$VERSION" ]]; then
+    echo "version is not set. Please provide a version" 1>&2
+    exit 1
+fi
 
 function print() {
   GREEN='\033[0;32m'
@@ -35,9 +39,13 @@ if grep -q "github.com/snyk/snyk-iac-parsers ${VERSION}" "go.mod"; then
 else
   echo "Downloading new version of the parser... ${VERSION}
   "
-  go get github.com/snyk/snyk-iac-parsers@"${VERSION}" ||
-  printError "Download of version ${VERSION} of the snyk-iac-parsers failed. Please check the error above for details."
-  exit 1
+  go get github.com/snyk/snyk-iac-parsers@"${VERSION}"
+  if [ $? -eq 0 ]; then
+      echo "Downloaded version ${VERSION} of the synk-iac-parsers"
+  else
+    printError "Download of version ${VERSION} of the snyk-iac-parsers failed. Please check the error above for details."
+    exit 1
+  fi
 fi
 
 #run tests to make sure there are no breaking changes


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR fixes the release process for new versions of `snyk-iac-parsers`.

There were a couple problems:
- the `version` argument was required by `make test` unnecessarily
- the `make release version=...` script was failing randomly
#### Screenshots
![Screenshot 2022-03-07 at 14 25 40](https://user-images.githubusercontent.com/81559517/157052815-86a65aae-c4a7-4859-9aa4-14fc3e92915e.png)
![Screenshot 2022-03-07 at 14 25 46](https://user-images.githubusercontent.com/81559517/157052823-a2d44714-03ef-4be3-9f08-21006f93a084.png)
![Screenshot 2022-03-07 at 14 27 49](https://user-images.githubusercontent.com/81559517/157052999-b211ae3f-a873-4f5d-b042-5fdc146fe5df.png)
