### PR TITLE
Enable drift analytics to be sent to registry

### DIFF
--- a/src/cli/commands/describe.ts
+++ b/src/cli/commands/describe.ts
@@ -5,6 +5,7 @@ import { DCTL_EXIT_CODES, runDriftCTL } from '../../lib/iac/drift';
 import { getIacOrgSettings } from './test/iac-local-execution/org-settings/get-iac-org-settings';
 import { UnsupportedEntitlementCommandError } from './test/iac-local-execution/assert-iac-options-flag';
 import config from '../../lib/config';
+import { addIacDriftAnalytics } from './test/iac-local-execution/analytics';
 
 export default async (...args: MethodArgs): Promise<any> => {
   const { options } = processCommandArgs(...args);
@@ -30,14 +31,16 @@ export default async (...args: MethodArgs): Promise<any> => {
     if (describe.code === DCTL_EXIT_CODES.EXIT_ERROR) {
       process.exit(describe.code);
     }
-    // TODO handle drift related analytics here
-    //const driftctlAnalysis = parseDriftAnalysisResults(describe.stdout)
+
+    // Add analytics
+    addIacDriftAnalytics(describe, options);
+
     const fmtResult = await runDriftCTL({
       options: { kind: 'fmt', ...options },
       input: describe.stdout,
     });
     process.stdout.write(fmtResult.stdout);
-    process.exit(describe.code);
+    process.exitCode = describe.code;
   } catch (e) {
     const err = new Error('Error running `iac describe` ' + e);
     return Promise.reject(err);

--- a/src/cli/commands/describe.ts
+++ b/src/cli/commands/describe.ts
@@ -1,11 +1,16 @@
 import { MethodArgs } from '../args';
 import { processCommandArgs } from './process-command-args';
 import * as legacyError from '../../lib/errors/legacy-errors';
-import { DCTL_EXIT_CODES, runDriftCTL } from '../../lib/iac/drift';
+import {
+  DCTL_EXIT_CODES,
+  parseDriftAnalysisResults,
+  runDriftCTL,
+} from '../../lib/iac/drift';
 import { getIacOrgSettings } from './test/iac-local-execution/org-settings/get-iac-org-settings';
 import { UnsupportedEntitlementCommandError } from './test/iac-local-execution/assert-iac-options-flag';
 import config from '../../lib/config';
 import { addIacDriftAnalytics } from './test/iac-local-execution/analytics';
+import * as analytics from '../../lib/analytics';
 
 export default async (...args: MethodArgs): Promise<any> => {
   const { options } = processCommandArgs(...args);
@@ -28,12 +33,15 @@ export default async (...args: MethodArgs): Promise<any> => {
     const describe = await runDriftCTL({
       options: { kind: 'describe', ...options },
     });
+    analytics.add('iac-drift-exit-code', describe.code);
     if (describe.code === DCTL_EXIT_CODES.EXIT_ERROR) {
-      process.exit(describe.code);
+      process.exitCode = describe.code;
+      throw new Error();
     }
 
-    // Add analytics
-    addIacDriftAnalytics(describe, options);
+    // Parse analysis JSON and add to analytics
+    const analysis = parseDriftAnalysisResults(describe.stdout);
+    addIacDriftAnalytics(analysis, options);
 
     const fmtResult = await runDriftCTL({
       options: { kind: 'fmt', ...options },
@@ -42,7 +50,6 @@ export default async (...args: MethodArgs): Promise<any> => {
     process.stdout.write(fmtResult.stdout);
     process.exitCode = describe.code;
   } catch (e) {
-    const err = new Error('Error running `iac describe` ' + e);
-    return Promise.reject(err);
+    return Promise.reject(e);
   }
 };

--- a/src/cli/commands/test/iac-local-execution/analytics.ts
+++ b/src/cli/commands/test/iac-local-execution/analytics.ts
@@ -2,14 +2,8 @@ import { FormattedResult, PerformanceAnalyticsKey, RulesOrigin } from './types';
 import * as analytics from '../../../../lib/analytics';
 import { calculatePercentage } from './math-utils';
 import { computeCustomRulesBundleChecksum } from './file-utils';
-import {
-  DescribeOptions,
-  DriftctlExecutionResult,
-} from '../../../../lib/iac/types';
-import {
-  driftctlVersion,
-  parseDriftAnalysisResults,
-} from '../../../../lib/iac/drift';
+import { DescribeOptions, DriftAnalysis } from '../../../../lib/iac/types';
+import { driftctlVersion } from '../../../../lib/iac/drift';
 
 export function addIacAnalytics(
   formattedResults: FormattedResult[],
@@ -94,58 +88,30 @@ export const performanceAnalyticsObject: Record<
 };
 
 export function addIacDriftAnalytics(
-  describe: DriftctlExecutionResult,
+  analysis: DriftAnalysis,
   options: DescribeOptions,
 ): void {
-  const driftctlAnalysis = parseDriftAnalysisResults(describe.stdout);
+  analytics.add('is-iac-drift', true);
+  analytics.add('iac-drift-coverage', analysis.coverage);
+  analytics.add('iac-drift-total-resources', analysis.summary.total_resources);
+  analytics.add('iac-drift-total-unmanaged', analysis.summary.total_unmanaged);
+  analytics.add('iac-drift-total-managed', analysis.summary.total_managed);
+  analytics.add('iac-drift-total-missing', analysis.summary.total_missing);
+  analytics.add('iac-drift-total-changed', analysis.summary.total_changed);
+  analytics.add(
+    'iac-drift-iac-source-count',
+    analysis.summary.total_iac_source_count,
+  );
+  analytics.add('iac-drift-provider-name', analysis.provider_name);
+  analytics.add('iac-drift-provider-version', analysis.provider_version);
+  analytics.add('iac-drift-version', driftctlVersion);
+  analytics.add('iac-drift-scan-duration', analysis.scan_duration);
 
-  let scope: string;
+  let scope = 'all';
   if (options['only-managed']) {
     scope = 'managed';
   } else if (options['only-unmanaged']) {
     scope = 'unmanaged';
-  } else {
-    scope = 'all';
   }
-
-  analytics.add('is-iac-drift', true);
-  analytics.add('iac-drift-coverage', driftctlAnalysis.coverage);
-  analytics.add('iac-drift-exit-code', describe.code);
-  analytics.add(
-    'iac-drift-total-resources',
-    driftctlAnalysis.summary.total_resources,
-  );
-  analytics.add(
-    'iac-drift-total-unmanaged',
-    driftctlAnalysis.summary.total_unmanaged,
-  );
-  analytics.add(
-    'iac-drift-total-managed',
-    driftctlAnalysis.summary.total_managed,
-  );
-  analytics.add(
-    'iac-drift-total-missing',
-    driftctlAnalysis.summary.total_missing,
-  );
-  analytics.add(
-    'iac-drift-total-changed',
-    driftctlAnalysis.summary.total_changed,
-  );
-  analytics.add(
-    'iac-drift-iac-source-count',
-    driftctlAnalysis.summary.total_iac_source_count,
-  );
-  analytics.add('iac-drift-provider-name', driftctlAnalysis.provider_name);
-  analytics.add(
-    'iac-drift-provider-version',
-    driftctlAnalysis.provider_version,
-  );
-  analytics.add('iac-drift-version', driftctlVersion);
-  analytics.add('iac-drift-scan-duration', driftctlAnalysis.scan_duration);
-  analytics.add('iac-drift-binary-already-exist', describe.binaryExist);
-  analytics.add(
-    'iac-drift-binary-download-duration-seconds',
-    describe.downloadDuration,
-  );
   analytics.add('iac-drift-scan-scope', scope);
 }

--- a/src/lib/iac/types.d.ts
+++ b/src/lib/iac/types.d.ts
@@ -1,7 +1,7 @@
 export type DriftctlExecutionResult = {
   code: number;
   stdout: string;
-} & Omit<DriftFindOrDownloadResult, 'path'>;
+};
 
 interface DriftCTLOptions {
   kind: string;
@@ -109,10 +109,4 @@ export type DriftAnalysis = {
   scan_duration: number;
   provider_name: string;
   provider_version: string;
-};
-
-export type DriftFindOrDownloadResult = {
-  path: string;
-  binaryExist: boolean;
-  downloadDuration: number;
 };

--- a/src/lib/iac/types.d.ts
+++ b/src/lib/iac/types.d.ts
@@ -1,7 +1,7 @@
-interface DriftctlExecutionResult {
+export type DriftctlExecutionResult = {
   code: number;
   stdout: string;
-}
+} & Omit<DriftFindOrDownloadResult, 'path'>;
 
 interface DriftCTLOptions {
   kind: string;
@@ -109,4 +109,10 @@ export type DriftAnalysis = {
   scan_duration: number;
   provider_name: string;
   provider_version: string;
+};
+
+export type DriftFindOrDownloadResult = {
+  path: string;
+  binaryExist: boolean;
+  downloadDuration: number;
 };

--- a/test/fixtures/iac/drift/args-echo.sh
+++ b/test/fixtures/iac/drift/args-echo.sh
@@ -1,2 +1,2 @@
-#!/bin/env bash
+#!/bin/bash
 node iac/drift/args-echo.js $@

--- a/test/fixtures/iac/drift/args-echo.sh
+++ b/test/fixtures/iac/drift/args-echo.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 node iac/drift/args-echo.js $@

--- a/test/fixtures/iac/drift/download-test.sh
+++ b/test/fixtures/iac/drift/download-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo -n "download ok" >&2
 # We exit in failure here to prevent driftctl fmt to be launched
 # The goal in this test is only to test that the file has been downloaded

--- a/test/fixtures/iac/drift/download-test.sh
+++ b/test/fixtures/iac/drift/download-test.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/bin/bash
 echo -n "download ok" >&2
 # We exit in failure here to prevent driftctl fmt to be launched
 # The goal in this test is only to test that the file has been downloaded


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR enables the `snyk iac describe` to send drift analytics to registry.

I also changed the way we exit the process after running driftctl. Before we were just `process.exit` but that prevented us from using the builtin `analytics.addDataAndSend` function already written for us. Now we're just using the `process.exitCode` that changes only the exit code that will be returned without exiting the process.

#### Where should the reviewer start?

`src/cli/commands/describe.ts`

#### How should this be manually tested?

```
$ snyk iac describe
```

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/CFG-1647
https://snyksec.atlassian.net/browse/CFG-1649

#### Screenshots

<img width="721" alt="image" src="https://user-images.githubusercontent.com/8110579/157686957-425ff506-f03e-4c63-bf52-e7406bbf4372.png">
