### PR TITLE
Drop Node.js 10 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,7 +401,7 @@ workflows:
             - Build
           matrix:
             parameters:
-              node_version: ['10.24.1', '12.22.9', '14.18.2', '16.13.2']
+              node_version: ['12.22.9', '14.18.2', '16.13.2']
       - test-tap:
           name: Tap Tests
           context: nodejs-install
@@ -438,7 +438,6 @@ workflows:
           requires:
             - Lint
             - Tap Tests
-            - Jest Tests (Linux, Node v10.24.1)
             - Jest Tests (Linux, Node v12.22.9)
             - Jest Tests (Linux, Node v14.18.2)
             - Jest Tests (Linux, Node v16.13.2)

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -17,20 +17,16 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         snyk_install_method: [binary, npm, yarn]
-        node_version: [10, 12, 14, 16]
+        node_version: [12, 14, 16]
         exclude:
           # Skip yarn for Windows, as it's a bit crazy to get it working in CI environment. Unless we see evidence we need it, I'd avoid it
           - snyk_install_method: yarn
             os: windows
           # For binary, use only the Node 14
           - snyk_install_method: binary
-            node_version: 10
-          - snyk_install_method: binary
             node_version: 12
           - snyk_install_method: binary
-            node_version: 15
-          - snyk_install_method: yarn # yarn doesn't support Node v10 anymore
-            node_version: 10
+            node_version: 16
         include:
           - snyk_install_method: binary
             os: ubuntu

--- a/.github/workflows/snyk-protect-production-smoke-tests.yml
+++ b/.github/workflows/snyk-protect-production-smoke-tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        node_version: [10, 12, 14, 16]
+        node_version: [12, 14, 16]
     runs-on: ${{ matrix.os }}-latest
     steps:
       # Avoid modifying line endings in fixtures.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "snyk": "bin/snyk"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "workspaces": [
     "packages/*"

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -1,6 +1,6 @@
 import { gte } from 'semver';
 
-const MIN_RUNTIME = '10.0.0';
+const MIN_RUNTIME = '12.0.0';
 
 export const supportedRange = `>= ${MIN_RUNTIME}`;
 

--- a/test/jest/unit/runtime.spec.ts
+++ b/test/jest/unit/runtime.spec.ts
@@ -6,7 +6,7 @@ describe('verify supported nodejs runtime versions', () => {
   });
 
   it('pre-release is supported', async () => {
-    expect(runtime.isSupported('11.0.0-pre')).toBeTruthy();
+    expect(runtime.isSupported('19.0.0-pre')).toBeTruthy();
   });
 });
 

--- a/test/smoke/spec/snyk_code_spec.sh
+++ b/test/smoke/spec/snyk_code_spec.sh
@@ -5,7 +5,6 @@ Describe "Snyk Code test command"
   After snyk_logout
 
   Describe "snyk code test"
-    Skip if "skip for node 10" check_if_node10
     run_test_in_subfolder() {
       cd ../fixtures/sast/shallow_sast_webgoat || return
       snyk code test . --org=snyk-cli-smoke-test-with-snykcode
@@ -21,7 +20,6 @@ Describe "Snyk Code test command"
   End
 
   Describe "code test with SARIF output"
-    Skip if "skip for node 10" check_if_node10 
     It "outputs a valid SARIF with vulns"
       When run snyk code test ../fixtures/sast/shallow_sast_webgoat --sarif --org=snyk-cli-smoke-test-with-snykcode
       The status should be failure # issues found

--- a/test/smoke/spec/snyk_monitor_spec.sh
+++ b/test/smoke/spec/snyk_monitor_spec.sh
@@ -5,7 +5,6 @@ Describe "Snyk monitor command"
   After snyk_logout
 
   Describe "monitor npm project"
-    Skip if "skip for node 10" check_if_node10
     run_monitor_in_subfolder() {
       cd ../fixtures/basic-npm || return
       snyk monitor

--- a/test/smoke/spec/snyk_test_spec.sh
+++ b/test/smoke/spec/snyk_test_spec.sh
@@ -56,7 +56,6 @@ Describe "Snyk test command"
     End
 
     It "finds vulns in a project in the same folder"
-      Skip if "skip for node 10" check_if_node10
       When run run_test_in_subfolder
       The status should equal 1
       The output should include "https://snyk.io/vuln/npm:minimatch:20160620"
@@ -64,7 +63,6 @@ Describe "Snyk test command"
     End
 
     It "finds vulns in a project when pointing to a folder"
-      Skip if "skip for node 10" check_if_node10
       When run snyk test ../fixtures/basic-npm
       The status should be failure # issues found
       The output should include "https://snyk.io/vuln/npm:minimatch:20160620"
@@ -72,7 +70,6 @@ Describe "Snyk test command"
     End
 
     It "finds vulns in a project when pointing to a file"
-      Skip if "skip for node 10" check_if_node10
       When run snyk test --file=../fixtures/basic-npm/package.json
       The status should be failure # issues found
       The output should include "https://snyk.io/vuln/npm:minimatch:20160620"

--- a/test/smoke/spec/spec_helper.sh
+++ b/test/smoke/spec/spec_helper.sh
@@ -68,11 +68,4 @@ spec_helper_configure() {
   snyk() {
     eval "${SNYK_COMMAND:=$ORIGINAL_SNYK_EXECUTABLE}" "$@"
   }
-
-  check_if_node10() {
-    if command -v node > /dev/null 2>&1; then
-      if node --version | grep -Eq '^v10.*'; then echo 1
-      fi
-    fi
-  }
 }

--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -4,8 +4,16 @@
     "rootDir": ".",
     "pretty": true,
     "moduleResolution": "node",
-    "target": "es2018",
-    "lib": ["ES2018", "ES2019", "DOM", "DOM.Iterable"],
+    // https://github.com/tsconfig/bases#node-12-tsconfigjson
+    "target": "es2019",
+    "lib": [
+      "es2019",
+      "es2020.promise",
+      "es2020.bigint",
+      "es2020.string",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "commonjs",
     "allowJs": true,
     "sourceMap": true,

--- a/webpack.common.ts
+++ b/webpack.common.ts
@@ -3,7 +3,7 @@ const CopyPlugin = require('copy-webpack-plugin');
 
 export default {
   entry: './src/cli/index.ts',
-  target: 'node10',
+  target: 'node12',
   output: {
     clean: true,
     path: path.resolve(__dirname, 'dist/cli/'),


### PR DESCRIPTION
Snyk announced end of support for Node v10 https://updates.snyk.io/ending-snyk-cli-support-for-node-js-v10-219175