### PR TITLE
fix: Single files scans of non-tf files behind FF

### DIFF
--- a/test/jest/acceptance/iac/test-terraform-var-deref.spec.ts
+++ b/test/jest/acceptance/iac/test-terraform-var-deref.spec.ts
@@ -43,8 +43,8 @@ describe('Terraform Language Support', () => {
   });
 
   describe('with feature flag', () => {
-    // TODO: can be merged with the existing test-terraform.spec.ts when the flag is removed
-    describe('files', () => {
+    describe('single files', () => {
+      // TODO: these can be merged with the existing test-terraform.spec.ts when the flag is removed
       it('finds issues in Terraform file', async () => {
         const { stdout, exitCode } = await run(
           `snyk iac test --org=tf-lang-support iac/terraform/sg_open_ssh.tf`,
@@ -67,6 +67,88 @@ describe('Terraform Language Support', () => {
           `snyk iac test --org=tf-lang-support ./iac/terraform/empty_file.tf`,
         );
         expect(exitCode).toBe(0);
+      });
+      describe('single non-terraform files', () => {
+        it('finds issues in a Terraform plan file', async () => {
+          const { stdout, exitCode } = await run(
+            `snyk iac test --org=tf-lang-support ./iac/terraform-plan/tf-plan-create.json`,
+          );
+          expect(exitCode).toBe(1);
+
+          expect(stdout).toContain(
+            'Testing ./iac/terraform-plan/tf-plan-create.json',
+          );
+          expect(stdout).toContain('Infrastructure as code issues:');
+          expect(stdout).toContain('✗ S3 bucket versioning disabled');
+          expect(stdout).toContain(
+            'resource > aws_s3_bucket[terra_ci] > versioning > enabled',
+          );
+        });
+        it('finds issues in CloudFormation YAML file', async () => {
+          const { stdout, exitCode } = await run(
+            `snyk iac test --org=tf-lang-support ./iac/cloudformation/aurora-valid.yml`,
+          );
+          expect(exitCode).toBe(1);
+
+          expect(stdout).toContain(
+            'Testing ./iac/cloudformation/aurora-valid.yml',
+          );
+          expect(stdout).toContain('Infrastructure as code issues:');
+          expect(stdout).toContain(
+            '✗ SNS topic is not encrypted with customer managed key',
+          );
+          expect(stdout).toContain(
+            '[DocId: 0] > Resources[DatabaseAlarmTopic] > Properties > KmsMasterKeyId',
+          );
+        });
+
+        it('finds issues in CloudFormation JSON file', async () => {
+          const { stdout, exitCode } = await run(
+            `snyk iac test --org=tf-lang-support ./iac/cloudformation/fargate-valid.json`,
+          );
+          expect(exitCode).toBe(1);
+
+          expect(stdout).toContain(
+            'Testing ./iac/cloudformation/fargate-valid.json',
+          );
+          expect(stdout).toContain('Infrastructure as code issues:');
+          expect(stdout).toContain(
+            '✗ S3 restrict public bucket control is disabled',
+          );
+          expect(stdout).toContain(
+            'Resources[CodePipelineArtifactBucket] > Properties > PublicAccessBlockConfiguration > RestrictPublicBuckets',
+          );
+        });
+        it('finds issues in ARM JSON file', async () => {
+          const { stdout, exitCode } = await run(
+            `snyk iac test --org=tf-lang-support ./iac/arm/rule_test.json`,
+          );
+          expect(exitCode).toBe(1);
+
+          expect(stdout).toContain('Testing ./iac/arm/rule_test.json');
+          expect(stdout).toContain('Infrastructure as code issues:');
+          expect(stdout).toContain(
+            '✗ Azure Firewall Network Rule Collection allows public access',
+          );
+          expect(stdout).toContain(
+            'resources[1] > properties > networkRuleCollections[0] > properties > rules[0] > sourceAddresses',
+          );
+        });
+        it('finds issues in Kubernetes JSON file', async () => {
+          const { stdout, exitCode } = await run(
+            `snyk iac test --org=tf-lang-support ./iac/kubernetes/pod-privileged.yaml`,
+          );
+          expect(exitCode).toBe(1);
+
+          expect(stdout).toContain(
+            'Testing ./iac/kubernetes/pod-privileged.yaml',
+          );
+          expect(stdout).toContain('Infrastructure as code issues:');
+          expect(stdout).toContain('✗ Privileged container');
+          expect(stdout).toContain(
+            '[DocId: 0] > input > spec > containers[example] > securityContext > privileged',
+          );
+        });
       });
     });
 
@@ -97,8 +179,6 @@ describe('Terraform Language Support', () => {
           `Testing ${path.join('nested_var_deref', 'sg_open_ssh.tf')}...`,
         );
       });
-
-      //TODO: add another test that checks a folder with edge cases
 
       it('scans a mix of IaC files in nested directories', async () => {
         const { stdout, exitCode } = await run(

--- a/test/jest/unit/iac/handle-terraform-files.spec.ts
+++ b/test/jest/unit/iac/handle-terraform-files.spec.ts
@@ -2,6 +2,8 @@ const mockFs = require('mock-fs');
 import {
   getTerraformFilesInDirectoryGenerator,
   getAllDirectoriesForPath,
+  loadAndParseTerraformFiles,
+  getFilesForDirectory,
 } from '../../../../src/cli/commands/test/iac-local-execution/handle-terraform-files';
 import * as terraformFileHandler from '../../../../src/cli/commands/test/iac-local-execution/handle-terraform-files';
 import * as path from 'path';
@@ -46,11 +48,18 @@ describe('getAllDirectoriesForPath', () => {
   });
 
   describe('errors', () => {
-    it('throws an error if a single file scan and the file is not IaC', () => {
+    it('throws an error if a single file scan and the file is not IaC', async () => {
       mockFs({ [nonIacFileStub.filePath]: 'content' });
-      expect(() => {
-        getAllDirectoriesForPath(nonIacFileStub.filePath);
-      }).toThrow(NoFilesToScanError);
+
+      expect(getAllDirectoriesForPath(nonIacFileStub.filePath)).toEqual([
+        nonIacFileStub.filePath,
+      ]);
+      expect(
+        getFilesForDirectory(nonIacFileStub.filePath, nonIacFileStub.filePath),
+      ).toEqual([nonIacFileStub.filePath]);
+      await expect(
+        loadAndParseTerraformFiles(nonIacFileStub.filePath, [], []),
+      ).rejects.toThrow(NoFilesToScanError);
     });
 
     it('throws an error when an error occurs when loading files', () => {


### PR DESCRIPTION
This commit fixes the issue introduced on a previous PR where a single file scan of a non-Terraform file (.tf, .tfvars) would fail as a non-valid IaC file.

This is because we didn't ignore the error when the file has already successfully been parsed in the file take of the parsing.
We will now ignore the error and continue with the scan.

I also added regression tests that will check each one of the other supported fileTypes for a single file scan with the FF on.
They are duplicate but can be removed when we remove the FF.

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

Thread: https://snyk.slack.com/archives/C030WL9BLSW/p1646759529069249

![image](https://user-images.githubusercontent.com/6989529/157308882-1714e6ed-0aea-41c5-aa59-2f80b27eb774.png)

![image](https://user-images.githubusercontent.com/6989529/157308928-6ce4da33-c25d-4699-8258-d5ece6124a17.png)

