### PR TITLE
Revert "fix: Single files scans of non-tf files behind FF"

### DIFF
--- a/src/cli/commands/test/iac-local-execution/handle-terraform-files.ts
+++ b/src/cli/commands/test/iac-local-execution/handle-terraform-files.ts
@@ -40,14 +40,6 @@ export async function loadAndParseTerraformFiles(
       currentDirectory,
     );
     if (filePathsInDirectory.length === 0) continue; // skip directories that have 0 files but have other directories
-    if (
-      filePathsInDirectory.length === 1 &&
-      allParsedFiles.length === 0 &&
-      (!shouldBeParsed(filePathsInDirectory[0]) ||
-        isIgnoredFile(filePathsInDirectory[0]))
-    ) {
-      throw new NoFilesToScanError();
-    }
     try {
       const tfFilesToParse = await loadContentForFiles(filePathsInDirectory);
       const {
@@ -58,8 +50,7 @@ export async function loadAndParseTerraformFiles(
       allFailedFiles = allFailedFiles.concat(failedTfFiles);
     } catch (err) {
       if (allParsedFiles.length !== 0 && err instanceof NoFilesToScanError) {
-        // ignore this error since we might only have TF files in the folder and we have separated them,
-        // or if we have a single file scan of a non-TF file, and we have already parsed it
+        // ignore this error since we might only have .tf files in the folder and we have separated them
       } else {
         throw err;
       }
@@ -80,6 +71,9 @@ export function getAllDirectoriesForPath(
 ): string[] {
   // if it is a single file (it has an extension)
   if (isSingleFile(pathToScan)) {
+    if (!shouldBeParsed(pathToScan) || isIgnoredFile(pathToScan)) {
+      throw new NoFilesToScanError();
+    }
     return [path.resolve(pathToScan)]; // we return the current path if it is a single file
   }
   // if the path we scanned itself is an empty directory, finish the scan here

--- a/test/jest/acceptance/iac/test-terraform-var-deref.spec.ts
+++ b/test/jest/acceptance/iac/test-terraform-var-deref.spec.ts
@@ -44,8 +44,8 @@ describe('Terraform Language Support', () => {
   });
 
   describe('with feature flag', () => {
-    describe('single files', () => {
-      // TODO: these can be merged with the existing test-terraform.spec.ts when the flag is removed
+    // TODO: can be merged with the existing test-terraform.spec.ts when the flag is removed
+    describe('files', () => {
       it('finds issues in Terraform file', async () => {
         const { stdout, exitCode } = await run(
           `snyk iac test --org=tf-lang-support iac/terraform/var_deref/sg_open_ssh.tf`,
@@ -70,88 +70,6 @@ describe('Terraform Language Support', () => {
         );
 
         expect(exitCode).toBe(0);
-      });
-      describe('single non-terraform files', () => {
-        it('finds issues in a Terraform plan file', async () => {
-          const { stdout, exitCode } = await run(
-            `snyk iac test --org=tf-lang-support ./iac/terraform-plan/tf-plan-create.json`,
-          );
-          expect(exitCode).toBe(1);
-
-          expect(stdout).toContain(
-            'Testing ./iac/terraform-plan/tf-plan-create.json',
-          );
-          expect(stdout).toContain('Infrastructure as code issues:');
-          expect(stdout).toContain('✗ S3 bucket versioning disabled');
-          expect(stdout).toContain(
-            'resource > aws_s3_bucket[terra_ci] > versioning > enabled',
-          );
-        });
-        it('finds issues in CloudFormation YAML file', async () => {
-          const { stdout, exitCode } = await run(
-            `snyk iac test --org=tf-lang-support ./iac/cloudformation/aurora-valid.yml`,
-          );
-          expect(exitCode).toBe(1);
-
-          expect(stdout).toContain(
-            'Testing ./iac/cloudformation/aurora-valid.yml',
-          );
-          expect(stdout).toContain('Infrastructure as code issues:');
-          expect(stdout).toContain(
-            '✗ SNS topic is not encrypted with customer managed key',
-          );
-          expect(stdout).toContain(
-            '[DocId: 0] > Resources[DatabaseAlarmTopic] > Properties > KmsMasterKeyId',
-          );
-        });
-
-        it('finds issues in CloudFormation JSON file', async () => {
-          const { stdout, exitCode } = await run(
-            `snyk iac test --org=tf-lang-support ./iac/cloudformation/fargate-valid.json`,
-          );
-          expect(exitCode).toBe(1);
-
-          expect(stdout).toContain(
-            'Testing ./iac/cloudformation/fargate-valid.json',
-          );
-          expect(stdout).toContain('Infrastructure as code issues:');
-          expect(stdout).toContain(
-            '✗ S3 restrict public bucket control is disabled',
-          );
-          expect(stdout).toContain(
-            'Resources[CodePipelineArtifactBucket] > Properties > PublicAccessBlockConfiguration > RestrictPublicBuckets',
-          );
-        });
-        it('finds issues in ARM JSON file', async () => {
-          const { stdout, exitCode } = await run(
-            `snyk iac test --org=tf-lang-support ./iac/arm/rule_test.json`,
-          );
-          expect(exitCode).toBe(1);
-
-          expect(stdout).toContain('Testing ./iac/arm/rule_test.json');
-          expect(stdout).toContain('Infrastructure as code issues:');
-          expect(stdout).toContain(
-            '✗ Azure Firewall Network Rule Collection allows public access',
-          );
-          expect(stdout).toContain(
-            'resources[1] > properties > networkRuleCollections[0] > properties > rules[0] > sourceAddresses',
-          );
-        });
-        it('finds issues in Kubernetes JSON file', async () => {
-          const { stdout, exitCode } = await run(
-            `snyk iac test --org=tf-lang-support ./iac/kubernetes/pod-privileged.yaml`,
-          );
-          expect(exitCode).toBe(1);
-
-          expect(stdout).toContain(
-            'Testing ./iac/kubernetes/pod-privileged.yaml',
-          );
-          expect(stdout).toContain('Infrastructure as code issues:');
-          expect(stdout).toContain('✗ Privileged container');
-          expect(stdout).toContain(
-            '[DocId: 0] > input > spec > containers[example] > securityContext > privileged',
-          );
-        });
       });
     });
 
@@ -180,6 +98,8 @@ describe('Terraform Language Support', () => {
           )} for known issues`,
         );
       });
+
+      //TODO: add another test that checks a folder with edge cases
 
       it('scans a mix of IaC files in nested directories', async () => {
         const { stdout, exitCode } = await run(

--- a/test/jest/unit/iac/handle-terraform-files.spec.ts
+++ b/test/jest/unit/iac/handle-terraform-files.spec.ts
@@ -2,8 +2,6 @@ const mockFs = require('mock-fs');
 import {
   getTerraformFilesInDirectoryGenerator,
   getAllDirectoriesForPath,
-  loadAndParseTerraformFiles,
-  getFilesForDirectory,
 } from '../../../../src/cli/commands/test/iac-local-execution/handle-terraform-files';
 import * as terraformFileHandler from '../../../../src/cli/commands/test/iac-local-execution/handle-terraform-files';
 import * as path from 'path';
@@ -48,18 +46,11 @@ describe('getAllDirectoriesForPath', () => {
   });
 
   describe('errors', () => {
-    it('throws an error if a single file scan and the file is not IaC', async () => {
+    it('throws an error if a single file scan and the file is not IaC', () => {
       mockFs({ [nonIacFileStub.filePath]: 'content' });
-
-      expect(getAllDirectoriesForPath(nonIacFileStub.filePath)).toEqual([
-        nonIacFileStub.filePath,
-      ]);
-      expect(
-        getFilesForDirectory(nonIacFileStub.filePath, nonIacFileStub.filePath),
-      ).toEqual([nonIacFileStub.filePath]);
-      await expect(
-        loadAndParseTerraformFiles(nonIacFileStub.filePath, [], []),
-      ).rejects.toThrow(NoFilesToScanError);
+      expect(() => {
+        getAllDirectoriesForPath(nonIacFileStub.filePath);
+      }).toThrow(NoFilesToScanError);
     });
 
     it('throws an error when an error occurs when loading files', () => {


### PR DESCRIPTION
This reverts commit 473abef6c3f22e6b665c6e104340bbda9152c91d that looks to break tests in master.
All tests have passed [there](https://github.com/snyk/cli/pull/2848/checks?check_run_id=5486360429) and I can't replicate locally, so I'm reverting the commit to clear the pipeline.

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules