### PR TITLE
Add resource to google_compute_engine service

### DIFF
--- a/src/lib/iac/service-mappings.ts
+++ b/src/lib/iac/service-mappings.ts
@@ -187,6 +187,7 @@ export const services2resources = new Map<string, Array<string>>([
       'google_compute_image',
       'google_compute_instance',
       'google_compute_instance_group',
+      'google_compute_instance_group_manager',
       'google_compute_network',
       'google_compute_node_group',
       'google_compute_router',


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR is directly related to https://github.com/snyk/driftctl/pull/1379 and adds that new resource to the `google_compute_engine` service.

#### How should this be manually tested?

```
$ ./bin/snyk iac describe --service=google_compute_engine
```

#### What are the relevant tickets?

- https://snyksec.atlassian.net/browse/CFG-1395
