### PR TITLE
fix: upgrade snyk-python-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "snyk-nuget-plugin": "1.23.4",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.22.2",
-        "snyk-python-plugin": "1.22.2",
+        "snyk-python-plugin": "1.22.3",
         "snyk-resolve": "1.1.0",
         "snyk-resolve-deps": "4.7.3",
         "snyk-sbt-plugin": "2.13.0",
@@ -17146,9 +17146,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-python-plugin": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.22.2.tgz",
-      "integrity": "sha512-4qTI3CsYeurMXex519xLMY4qVuJsPhAAoY2/R9O+pcXZ8Ca4PtuNDJKx/Zie2a0JhXPc7ZFpTY5acxValAqSyw==",
+      "version": "1.22.3",
+      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.22.3.tgz",
+      "integrity": "sha512-ISwY5GZtNlUqA4R58eG6MhaDbZb3NfG9suSgU2r4OTjyLrym6l+XYZGVQNUG+5G677j7Ms20AVSPmL/5eP6ezg==",
       "dependencies": {
         "@snyk/cli-interface": "^2.11.2",
         "@snyk/dep-graph": "^1.28.1",
@@ -33410,9 +33410,9 @@
       }
     },
     "snyk-python-plugin": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.22.2.tgz",
-      "integrity": "sha512-4qTI3CsYeurMXex519xLMY4qVuJsPhAAoY2/R9O+pcXZ8Ca4PtuNDJKx/Zie2a0JhXPc7ZFpTY5acxValAqSyw==",
+      "version": "1.22.3",
+      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.22.3.tgz",
+      "integrity": "sha512-ISwY5GZtNlUqA4R58eG6MhaDbZb3NfG9suSgU2r4OTjyLrym6l+XYZGVQNUG+5G677j7Ms20AVSPmL/5eP6ezg==",
       "requires": {
         "@snyk/cli-interface": "^2.11.2",
         "@snyk/dep-graph": "^1.28.1",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "snyk-nuget-plugin": "1.23.4",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.22.2",
-    "snyk-python-plugin": "1.22.2",
+    "snyk-python-plugin": "1.22.3",
     "snyk-resolve": "1.1.0",
     "snyk-resolve-deps": "4.7.3",
     "snyk-sbt-plugin": "2.13.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Previously the plugin used "=>" whereas pep508 specifies ">=" as the ge operator.
