### PR TITLE
feat: add support for snyk policy

### DIFF
--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -123,6 +123,7 @@ export async function test(
         resultsWithCustomSeverities,
         options,
         orgPublicId,
+        policy,
       );
     }
 

--- a/src/cli/commands/test/iac-local-execution/share-results.ts
+++ b/src/cli/commands/test/iac-local-execution/share-results.ts
@@ -1,12 +1,15 @@
 import { isFeatureFlagSupportedForOrg } from '../../../../lib/feature-flags';
 import { shareResults } from '../../../../lib/iac/cli-share-results';
+import { Policy } from '../../../../lib/policy/find-and-load-policy';
 import { FeatureFlagError } from './assert-iac-options-flag';
 import { formatShareResults } from './share-results-formatter';
+import { IacFileScanResult, IaCTestFlags } from './types';
 
 export async function formatAndShareResults(
-  results,
-  options,
-  orgPublicId,
+  results: IacFileScanResult[],
+  options: IaCTestFlags,
+  orgPublicId: string,
+  policy: Policy | undefined,
 ): Promise<Record<string, string>> {
   const isCliReportEnabled = await isFeatureFlagSupportedForOrg(
     'iacCliShareResults',
@@ -18,5 +21,5 @@ export async function formatAndShareResults(
 
   const formattedResults = formatShareResults(results, options);
 
-  return await shareResults(formattedResults);
+  return await shareResults(formattedResults, policy);
 }

--- a/src/lib/iac/cli-share-results.ts
+++ b/src/lib/iac/cli-share-results.ts
@@ -4,11 +4,15 @@ import { getAuthHeader } from '../api-token';
 import { IacShareResultsFormat } from '../../cli/commands/test/iac-local-execution/types';
 import { convertIacResultToScanResult } from './envelope-formatters';
 import { AuthFailedError } from '../errors/authentication-failed-error';
+import { Policy } from '../policy/find-and-load-policy';
 
 export async function shareResults(
   results: IacShareResultsFormat[],
+  policy: Policy | undefined,
 ): Promise<Record<string, string>> {
-  const scanResults = results.map(convertIacResultToScanResult);
+  const scanResults = results.map((result) =>
+    convertIacResultToScanResult(result, policy),
+  );
 
   const { res, body } = await makeRequest({
     method: 'POST',

--- a/src/lib/iac/envelope-formatters.ts
+++ b/src/lib/iac/envelope-formatters.ts
@@ -3,9 +3,11 @@ import {
   PolicyMetadata,
 } from '../../cli/commands/test/iac-local-execution/types';
 import { ScanResult } from '../ecosystems/types';
+import { Policy } from '../policy/find-and-load-policy';
 
 export function convertIacResultToScanResult(
   iacResult: IacShareResultsFormat,
+  policy: Policy | undefined,
 ): ScanResult {
   return {
     identity: {
@@ -21,5 +23,6 @@ export function convertIacResultToScanResult(
     }),
     name: iacResult.projectName,
     target: { name: iacResult.projectName },
+    policy: policy?.toString() ?? '',
   };
 }

--- a/test/jest/unit/iac/cli-share-results.fixtures.ts
+++ b/test/jest/unit/iac/cli-share-results.fixtures.ts
@@ -35,26 +35,24 @@ const anotherPolicyStub: PolicyMetadata = {
   docId: 1,
 };
 
-export function generateScanResults(): IacShareResultsFormat[] {
-  return [
-    {
-      projectName: 'projectA',
-      targetFile: 'file.yaml',
-      filePath: '/some/path/to/file.yaml',
-      fileType: 'yaml',
-      projectType: IacProjectType.K8S,
-      violatedPolicies: [{ ...policyStub }, { ...anotherPolicyStub }],
-    },
-    {
-      projectName: 'projectB',
-      targetFile: 'file.yaml',
-      filePath: '/some/path/to/file.yaml',
-      fileType: 'yaml',
-      projectType: IacProjectType.K8S,
-      violatedPolicies: [{ ...policyStub }],
-    },
-  ];
-}
+export const scanResults: IacShareResultsFormat[] = [
+  {
+    projectName: 'projectA',
+    targetFile: 'file.yaml',
+    filePath: '/some/path/to/file.yaml',
+    fileType: 'yaml',
+    projectType: IacProjectType.K8S,
+    violatedPolicies: [{ ...policyStub }, { ...anotherPolicyStub }],
+  },
+  {
+    projectName: 'projectB',
+    targetFile: 'file.yaml',
+    filePath: '/some/path/to/file.yaml',
+    fileType: 'yaml',
+    projectType: IacProjectType.K8S,
+    violatedPolicies: [{ ...policyStub }],
+  },
+];
 
 export const expectedEnvelopeFormatterResults = [
   {
@@ -120,6 +118,7 @@ export const expectedEnvelopeFormatterResults = [
       },
     ],
     name: 'projectA',
+    policy: '',
     target: { name: 'projectA' },
   },
   {
@@ -158,6 +157,24 @@ export const expectedEnvelopeFormatterResults = [
       },
     ],
     name: 'projectB',
+    policy: '',
     target: { name: 'projectB' },
   },
 ];
+
+export const expectedEnvelopeFormatterResultsWithPolicy = expectedEnvelopeFormatterResults.map(
+  (result) => {
+    return {
+      ...result,
+      policy: `# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.22.2
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-CC-TF-4:
+    - '*':
+        reason: IGNORE ALL THE THINGS!
+patch: {}
+`,
+    };
+  },
+);

--- a/test/jest/unit/iac/fixtures/.snyk
+++ b/test/jest/unit/iac/fixtures/.snyk
@@ -1,0 +1,8 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.22.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-CC-TF-4:
+    - '*':
+        reason: IGNORE ALL THE THINGS!
+patch: {}


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds to the Iac CLI Share Results feature support for the `.snyk` policy file.


#### How should this be manually tested?
1. Run registry locally with [the following branch](https://github.com/snyk/registry/pull/26636).
2. Scan an IaC directory with a `.snyk` file inside that ignores a relevant issue using the command `snyk iac test --report`
3. Watch the issues getting ignored in the platform.


#### What are the relevant tickets?
https://snyksec.atlassian.net/jira/software/c/projects/CFG/boards/301?modal=detail&selectedIssue=CFG-1522

#### Screenshots
![image](https://user-images.githubusercontent.com/71096571/157703977-3615c53c-03d1-4039-bdfe-53e038fee824.png)