### PR TITLE
[CFG-1658] feat: iac-describe driftignore support in policy

### DIFF
--- a/help/cli-commands/iac-describe.md
+++ b/help/cli-commands/iac-describe.md
@@ -48,6 +48,14 @@ Output report as html to stdout or into a file.
 
 driftctl supports multiple providers. By default it will scan against AWS, but you can change this using `--to`.
 
+### `--ignore-policy`
+
+Ignore all set policies, the current policy in the `.snyk` file, Org level ignores, and the project policy on snyk.io.
+
+### `--policy-path=<PATH_TO_POLICY_FILE>`
+
+Manually pass a path to a `.snyk` policy file.
+
 #### Usage
 
 Environment: `DCTL_TO`

--- a/src/lib/iac/drift.ts
+++ b/src/lib/iac/drift.ts
@@ -24,6 +24,7 @@ import {
 } from './types';
 import { TimerMetricInstance } from '../metrics';
 import * as analytics from '../../lib/analytics';
+import { Policy } from '../policy/find-and-load-policy';
 
 const cachePath = config.CACHE_PATH ?? envPaths('snyk').cache;
 const debug = debugLib('drift');
@@ -195,6 +196,11 @@ const generateScanFlags = (options: DescribeOptions): string[] => {
   if (options['tf-lockfile']) {
     args.push('--tf-lockfile');
     args.push(options['tf-lockfile']);
+  }
+
+  if (options.ignore && options.ignore.length > 0) {
+    args.push('--ignore');
+    args.push(options.ignore.join(','));
   }
 
   let configDir = cachePath;
@@ -464,4 +470,12 @@ function createIfNotExists(path: string) {
   if (!fs.existsSync(path)) {
     fs.mkdirSync(path, { recursive: true });
   }
+}
+
+export function driftignoreFromPolicy(policy: Policy | undefined): string[] {
+  const excludeSection = 'iac-drift';
+  if (!policy || !policy.exclude || !(excludeSection in policy.exclude)) {
+    return [];
+  }
+  return policy.exclude[excludeSection];
 }

--- a/src/lib/iac/types.d.ts
+++ b/src/lib/iac/types.d.ts
@@ -43,6 +43,7 @@ export interface DescribeOptions extends DriftCTLOptions {
   'html-file-output'?: string;
   service?: string;
   from?: string; // snyk cli args parsing does not support variadic args so this will be coma separated values
+  ignore?: string[];
 }
 
 export type DriftResource = {

--- a/src/lib/policy/find-and-load-policy.ts
+++ b/src/lib/policy/find-and-load-policy.ts
@@ -52,4 +52,5 @@ export async function findAndLoadPolicy(
 
 export interface Policy {
   filter(vulns: any, root?: string, matchStrategy?: string): any;
+  exclude?: { [key: string]: string[] };
 }

--- a/test/jest/unit/lib/iac/fixtures/policy-empty-drift-excludes.yml
+++ b/test/jest/unit/lib/iac/fixtures/policy-empty-drift-excludes.yml
@@ -1,0 +1,5 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.22.1
+exclude:
+  iac-drift: []
+patch: {}

--- a/test/jest/unit/lib/iac/fixtures/policy-irrelevant-excludes.yml
+++ b/test/jest/unit/lib/iac/fixtures/policy-irrelevant-excludes.yml
@@ -1,0 +1,7 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.22.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+exclude:
+  foo:
+    - bar
+patch: {}

--- a/test/jest/unit/lib/iac/fixtures/policy-no-excludes.yml
+++ b/test/jest/unit/lib/iac/fixtures/policy-no-excludes.yml
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.22.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+patch: {}

--- a/test/jest/unit/lib/iac/fixtures/policy-one-drift-exclude.yml
+++ b/test/jest/unit/lib/iac/fixtures/policy-one-drift-exclude.yml
@@ -1,0 +1,7 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.22.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+exclude:
+  iac-drift:
+    - foo
+patch: {}

--- a/test/jest/unit/lib/iac/fixtures/policy-several-drift-excludes.yml
+++ b/test/jest/unit/lib/iac/fixtures/policy-several-drift-excludes.yml
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.22.1
+exclude:
+  iac-drift:
+    - '*'
+    - '!aws_iam_*'
+    - 'aws_s3_*'
+    - 'aws_s3_bucket.*'
+    - 'aws_s3_bucket.name*'
+patch: {}


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

`snyk iac describe` enumerates drift between terraform states and cloud
projects using the open-source driftctl tool. This tool can be
configured to ignore certain resources using a pseudo-glob syntax in a
".driftignore" file, as documented here:
https://docs.driftctl.com/next/usage/filtering/driftignore.

This commit adds `.snyk` policy file support for `iac describe` drift
ignores, but does not use the ignore section, instead using the
"exclude" section
(https://www.notion.so/Exclude-files-folders-1bd80d232ca34931a243509af5e2a4bd):

```
version: v1.22.1
exclude:
  iac-drift:
    - '*'
    - '!aws_s3_bucket'
```

Semantically, Snyk ignores discard discovered issues, whereas Snyk
excludes instruct Snyk to not inspect something. See
https://snyksec.atlassian.net/browse/CFG-1658?focusedCommentId=353203
for a justification on using excludes instead of ignores.

This implementation requires no changes to the policy library.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?

If this PR is approved, I'll document this in gitbook, along with the rest of the policy file docs.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/CFG-1658

#### Screenshots


#### Additional questions
