### PR TITLE
fix: non-tf single files scan successfully in new flow

### DIFF
--- a/src/cli/commands/test/iac-local-execution/handle-terraform-files.ts
+++ b/src/cli/commands/test/iac-local-execution/handle-terraform-files.ts
@@ -39,7 +39,19 @@ export async function loadAndParseTerraformFiles(
       pathToScan,
       currentDirectory,
     );
-    if (filePathsInDirectory.length === 0) continue; // skip directories that have 0 files but have other directories
+    if (
+      filePathsInDirectory.length === 0 || // skip directories that have 0 files but have other directories
+      (filePathsInDirectory.length === 1 && allParsedFiles.length === 1) // skip single files that have already been parsed
+    )
+      continue;
+    if (
+      filePathsInDirectory.length === 1 &&
+      allParsedFiles.length === 0 &&
+      (!shouldBeParsed(filePathsInDirectory[0]) ||
+        isIgnoredFile(filePathsInDirectory[0]))
+    ) {
+      throw new NoFilesToScanError();
+    }
     try {
       const tfFilesToParse = await loadContentForFiles(filePathsInDirectory);
       const {
@@ -50,7 +62,8 @@ export async function loadAndParseTerraformFiles(
       allFailedFiles = allFailedFiles.concat(failedTfFiles);
     } catch (err) {
       if (allParsedFiles.length !== 0 && err instanceof NoFilesToScanError) {
-        // ignore this error since we might only have .tf files in the folder and we have separated them
+        // ignore this error since we might only have TF files in the folder and we have separated them,
+        // or if we have a single file scan of a non-TF file, and we have already parsed it
       } else {
         throw err;
       }
@@ -69,12 +82,9 @@ export function getAllDirectoriesForPath(
   pathToScan: string,
   maxDepth?: number,
 ): string[] {
-  // if it is a single file (it has an extension)
+  // if it is a single file (it has an extension), we return the current path
   if (isSingleFile(pathToScan)) {
-    if (!shouldBeParsed(pathToScan) || isIgnoredFile(pathToScan)) {
-      throw new NoFilesToScanError();
-    }
-    return [path.resolve(pathToScan)]; // we return the current path if it is a single file
+    return [path.resolve(pathToScan)];
   }
   // if the path we scanned itself is an empty directory, finish the scan here
   if (fs.readdirSync(pathToScan).length === 0) {

--- a/test/jest/unit/iac/handle-terraform-files.spec.ts
+++ b/test/jest/unit/iac/handle-terraform-files.spec.ts
@@ -2,6 +2,8 @@ const mockFs = require('mock-fs');
 import {
   getTerraformFilesInDirectoryGenerator,
   getAllDirectoriesForPath,
+  getFilesForDirectory,
+  loadAndParseTerraformFiles,
 } from '../../../../src/cli/commands/test/iac-local-execution/handle-terraform-files';
 import * as terraformFileHandler from '../../../../src/cli/commands/test/iac-local-execution/handle-terraform-files';
 import * as path from 'path';
@@ -46,11 +48,18 @@ describe('getAllDirectoriesForPath', () => {
   });
 
   describe('errors', () => {
-    it('throws an error if a single file scan and the file is not IaC', () => {
+    it('throws an error if a single file scan and the file is not IaC', async () => {
       mockFs({ [nonIacFileStub.filePath]: 'content' });
-      expect(() => {
-        getAllDirectoriesForPath(nonIacFileStub.filePath);
-      }).toThrow(NoFilesToScanError);
+
+      expect(getAllDirectoriesForPath(nonIacFileStub.filePath)).toEqual([
+        nonIacFileStub.filePath,
+      ]);
+      expect(
+        getFilesForDirectory(nonIacFileStub.filePath, nonIacFileStub.filePath),
+      ).toEqual([nonIacFileStub.filePath]);
+      await expect(
+        loadAndParseTerraformFiles(nonIacFileStub.filePath, [], []),
+      ).rejects.toThrow(NoFilesToScanError);
     });
 
     it('throws an error when an error occurs when loading files', () => {


### PR DESCRIPTION
This commit fixes the issue where we scanned single non-tf files and they failed when using the new flow (behind FF). This is because we were throwing an (non-iac-file) error early in the flow, without checking if files have already been parsed or not.
This is a quick fix for the bug, refactoring to follow.

I also added regression tests that will check each one of the other supported fileTypes for a single file scan with the FF on.
They are duplicate but can be removed when we remove the FF.

This is an "almost" duplicate of https://github.com/snyk/cli/pull/2848#event-6212805181 which I had to revert due to failing tests on master.

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

Non-TF single file
![image](https://user-images.githubusercontent.com/6989529/157848471-d7e82a38-2031-4059-9eeb-6a8e660bd1db.png)

TF single file
![image](https://user-images.githubusercontent.com/6989529/157848583-dabea3e8-c408-495b-87bb-de33c57ec2de.png)

