### PR TITLE
chore: Measure loadAndParseTerraformFiles function

### DIFF
--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -23,6 +23,7 @@ import {
   parseFiles,
   scanFiles,
   trackUsage,
+  loadAndParseTerraformFiles,
 } from './measurable-methods';
 import { UnsupportedEntitlementError } from '../../../../lib/errors/unsupported-entitlement-error';
 import config from '../../../../lib/config';
@@ -31,7 +32,6 @@ import { isFeatureFlagSupportedForOrg } from '../../../../lib/feature-flags';
 import { initRules } from './rules';
 import { NoFilesToScanError } from './file-loader';
 import { formatAndShareResults } from './share-results';
-import { loadAndParseTerraformFiles } from './handle-terraform-files';
 
 // this method executes the local processing engine and then formats the results to adapt with the CLI output.
 // this flow is the default GA flow for IAC scanning.

--- a/src/cli/commands/test/iac-local-execution/measurable-methods.ts
+++ b/src/cli/commands/test/iac-local-execution/measurable-methods.ts
@@ -10,6 +10,7 @@ import { test } from './index';
 import { pull } from './oci-pull';
 import { performanceAnalyticsObject } from './analytics';
 import { PerformanceAnalyticsKey } from './types';
+import { loadAndParseTerraformFiles } from './handle-terraform-files';
 
 // Unwrap a promise: https://stackoverflow.com/questions/48011353/how-to-unwrap-type-of-a-promise
 type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
@@ -102,6 +103,11 @@ const measurableOciPull = asyncPerformanceAnalyticsDecorator(
   PerformanceAnalyticsKey.Total,
 );
 
+const measurableLoadAndParseTerraformFiles = asyncPerformanceAnalyticsDecorator(
+  loadAndParseTerraformFiles,
+  PerformanceAnalyticsKey.Total,
+);
+
 export {
   measurableInitLocalCache as initLocalCache,
   measurableLoadFiles as loadFiles,
@@ -114,4 +120,5 @@ export {
   measurableCleanLocalCache as cleanLocalCache,
   measurableLocalTest as localTest,
   measurableOciPull as pull,
+  measurableLoadAndParseTerraformFiles as loadAndParseTerraformFiles,
 };


### PR DESCRIPTION
Adds the loadAndParseTerraformFiles to the measurable methods file so that we can track metrics and see them in the `Total`  analytics.

Question for the reviewer:
I haven't added it to its own analytics key yet - it might need to change depending the refactoring on that function so I'm leaving it to the total for now.


- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules