### PR TITLE
feat: Add support for `--target-reference` for CLI Share Results [CFG-1521]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
+++ b/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
@@ -28,6 +28,7 @@ const keys: (keyof IaCTestFlags)[] = [
   'project-environment',
   'project-lifecycle',
   'project-business-criticality',
+  'target-reference',
   // PolicyOptions
   'ignore-policy',
   'policy-path',

--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -131,14 +131,14 @@ export async function test(
 
     let projectPublicIds: Record<string, string> = {};
     if (options.report) {
-      projectPublicIds = await formatAndShareResults(
-        resultsWithCustomSeverities,
+      projectPublicIds = await formatAndShareResults({
+        results: resultsWithCustomSeverities,
         options,
         orgPublicId,
         policy,
         tags,
         attributes,
-      );
+      });
     }
 
     const formattedResults = formatScanResults(

--- a/src/cli/commands/test/iac-local-execution/share-results.ts
+++ b/src/cli/commands/test/iac-local-execution/share-results.ts
@@ -6,14 +6,21 @@ import { FeatureFlagError } from './assert-iac-options-flag';
 import { formatShareResults } from './share-results-formatter';
 import { IacFileScanResult, IaCTestFlags } from './types';
 
-export async function formatAndShareResults(
-  results: IacFileScanResult[],
-  options: IaCTestFlags,
-  orgPublicId: string,
-  policy: Policy | undefined,
-  tags?: Tag[],
-  attributes?: ProjectAttributes,
-): Promise<Record<string, string>> {
+export async function formatAndShareResults({
+  results,
+  options,
+  orgPublicId,
+  policy,
+  tags,
+  attributes,
+}: {
+  results: IacFileScanResult[];
+  options: IaCTestFlags;
+  orgPublicId: string;
+  policy: Policy | undefined;
+  tags?: Tag[];
+  attributes?: ProjectAttributes;
+}): Promise<Record<string, string>> {
   const isCliReportEnabled = await isFeatureFlagSupportedForOrg(
     'iacCliShareResults',
     orgPublicId,
@@ -24,5 +31,11 @@ export async function formatAndShareResults(
 
   const formattedResults = formatShareResults(results, options);
 
-  return await shareResults(formattedResults, policy, tags, attributes);
+  return await shareResults({
+    results: formattedResults,
+    policy,
+    tags,
+    attributes,
+    options,
+  });
 }

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -180,6 +180,8 @@ export type IaCTestFlags = Pick<
   | 'json'
   | 'sarif'
   | 'report'
+  | 'target-reference'
+
   // PolicyOptions
   | 'ignore-policy'
   | 'policy-path'

--- a/src/lib/ecosystems/types.ts
+++ b/src/lib/ecosystems/types.ts
@@ -32,6 +32,7 @@ export interface ScanResult {
   policy?: string;
   target?: GitTarget | ContainerTarget | UnknownTarget;
   analytics?: Analytics[];
+  targetReference?: string;
 }
 
 export interface Analytics {

--- a/src/lib/iac/cli-share-results.ts
+++ b/src/lib/iac/cli-share-results.ts
@@ -50,6 +50,7 @@ export async function shareResults({
     method: 'POST',
     url: `${config.API}/iac-cli-share-results`,
     json: true,
+    qs: { org: options?.org ?? config.org },
     headers: {
       authorization: getAuthHeader(),
     },

--- a/src/lib/iac/envelope-formatters.ts
+++ b/src/lib/iac/envelope-formatters.ts
@@ -1,5 +1,6 @@
 import {
   IacShareResultsFormat,
+  IaCTestFlags,
   PolicyMetadata,
 } from '../../cli/commands/test/iac-local-execution/types';
 import { GitTarget, ScanResult } from '../ecosystems/types';
@@ -9,6 +10,7 @@ export function convertIacResultToScanResult(
   iacResult: IacShareResultsFormat,
   policy: Policy | undefined,
   gitTarget: GitTarget,
+  options?: IaCTestFlags,
 ): ScanResult {
   return {
     identity: {
@@ -28,5 +30,6 @@ export function convertIacResultToScanResult(
         ? { name: iacResult.projectName }
         : { remoteUrl: gitTarget.remoteUrl },
     policy: policy?.toString() ?? '',
+    targetReference: options?.['target-reference'],
   };
 }

--- a/test/jest/acceptance/iac/cli-share-results.spec.ts
+++ b/test/jest/acceptance/iac/cli-share-results.spec.ts
@@ -175,5 +175,42 @@ describe('CLI Share Results', () => {
         },
       });
     });
+
+    describe('with target reference', () => {
+      it('forwards the target reference to iac-cli-share-results endpoint', async () => {
+        const testTargetRef = 'test-target-ref';
+
+        const { exitCode } = await run(
+          `snyk iac test ./iac/arm/rule_test.json --report --target-reference=${testTargetRef}`,
+        );
+
+        expect(exitCode).toEqual(1);
+
+        const testRequests = server
+          .getRequests()
+          .filter((request) => request.url?.includes('/iac-cli-share-results'));
+
+        expect(testRequests[0]).toMatchObject({
+          body: {
+            contributors: expect.any(Array),
+            scanResults: [
+              {
+                identity: {
+                  type: 'armconfig',
+                  targetFile: './iac/arm/rule_test.json',
+                },
+                facts: [],
+                findings: expect.arrayContaining([]),
+                name: 'arm',
+                target: {
+                  remoteUrl: 'http://github.com/snyk/cli.git',
+                },
+                targetReference: testTargetRef,
+              },
+            ],
+          },
+        });
+      });
+    });
   });
 });

--- a/test/jest/unit/iac/cli-share-results.fixtures.ts
+++ b/test/jest/unit/iac/cli-share-results.fixtures.ts
@@ -122,6 +122,7 @@ export const expectedEnvelopeFormatterResults = [
     target: {
       remoteUrl: 'http://github.com/snyk/cli.git',
     },
+    targetReference: undefined,
   },
   {
     identity: {
@@ -163,6 +164,7 @@ export const expectedEnvelopeFormatterResults = [
     target: {
       remoteUrl: 'http://github.com/snyk/cli.git',
     },
+    targetReference: undefined,
   },
 ];
 
@@ -182,3 +184,13 @@ patch: {}
     };
   },
 );
+
+export const createEnvelopeFormatterResultsWithTargetRef = (
+  targetReference: string,
+) =>
+  expectedEnvelopeFormatterResults.map((result) => {
+    return {
+      ...result,
+      targetReference,
+    };
+  });

--- a/test/jest/unit/iac/cli-share-results.spec.ts
+++ b/test/jest/unit/iac/cli-share-results.spec.ts
@@ -2,6 +2,7 @@ import { shareResults } from '../../../../src/lib/iac/cli-share-results';
 import {
   expectedEnvelopeFormatterResults,
   expectedEnvelopeFormatterResultsWithPolicy,
+  createEnvelopeFormatterResultsWithTargetRef,
   scanResults,
 } from './cli-share-results.fixtures';
 import * as request from '../../../../src/lib/request';
@@ -59,6 +60,58 @@ describe('CLI Share Results', () => {
       secondCallResult,
     ] = envelopeFormattersSpy.mock.results;
 
+    expect(firstCallResult.value).toEqual(
+      expectedEnvelopeFormatterResultsWithPolicy[0],
+    );
+    expect(secondCallResult.value).toEqual(
+      expectedEnvelopeFormatterResultsWithPolicy[1],
+    );
+  });
+
+  describe('when given a target reference', () => {
+    it("should include it in the Envelope's ScanResult interface", async () => {
+      const testTargetRef = 'test-target-ref';
+      const expectedEnvelopeFormatterResults = createEnvelopeFormatterResultsWithTargetRef(
+        testTargetRef,
+      );
+
+      await shareResults(scanResults, undefined, {
+        'target-reference': testTargetRef,
+      });
+
+      expect(envelopeFormattersSpy.mock.calls.length).toBe(2);
+
+      const [firstCall, secondCall] = envelopeFormattersSpy.mock.calls;
+      expect(firstCall[0]).toEqual(scanResults[0]);
+      expect(secondCall[0]).toEqual(scanResults[1]);
+
+      const [
+        firstCallResult,
+        secondCallResult,
+      ] = envelopeFormattersSpy.mock.results;
+      expect(firstCallResult.value).toEqual(
+        expectedEnvelopeFormatterResults[0],
+      );
+
+      expect(secondCallResult.value).toEqual(
+        expectedEnvelopeFormatterResults[1],
+      );
+    });
+  });
+
+  it("converts the results to Envelope's ScanResult interface - with .snyk policies", async () => {
+    await shareResults(scanResults, snykPolicy);
+
+    expect(envelopeFormattersSpy.mock.calls.length).toBe(2);
+
+    const [firstCall, secondCall] = envelopeFormattersSpy.mock.calls;
+    expect(firstCall[0]).toEqual(scanResults[0]);
+    expect(secondCall[0]).toEqual(scanResults[1]);
+
+    const [
+      firstCallResult,
+      secondCallResult,
+    ] = envelopeFormattersSpy.mock.results;
     expect(firstCallResult.value).toEqual(
       expectedEnvelopeFormatterResultsWithPolicy[0],
     );

--- a/test/jest/unit/iac/cli-share-results.spec.ts
+++ b/test/jest/unit/iac/cli-share-results.spec.ts
@@ -5,19 +5,25 @@ import {
   createEnvelopeFormatterResultsWithTargetRef,
   scanResults,
 } from './cli-share-results.fixtures';
-import * as request from '../../../../src/lib/request';
+import * as request from '../../../../src/lib/request/request';
 import * as envelopeFormatters from '../../../../src/lib/iac/envelope-formatters';
 import { Policy } from '../../../../src/lib/policy/find-and-load-policy';
 import * as snykPolicyLib from 'snyk-policy';
 
 describe('CLI Share Results', () => {
   let snykPolicy: Policy;
-  let requestSpy, envelopeFormattersSpy;
+  let requestSpy: jest.SpiedFunction<typeof request.makeRequest>;
+  let envelopeFormattersSpy: jest.SpiedFunction<typeof envelopeFormatters.convertIacResultToScanResult>;
 
   beforeAll(async () => {
     snykPolicy = await snykPolicyLib.load('test/jest/unit/iac/fixtures');
-    requestSpy = await jest.spyOn(request, 'makeRequest');
-    envelopeFormattersSpy = await jest.spyOn(
+  });
+
+  beforeEach(() => {
+    requestSpy = jest
+      .spyOn(request, 'makeRequest')
+      .mockImplementation(async () => ({ res: {} as any, body: {} }));
+    envelopeFormattersSpy = jest.spyOn(
       envelopeFormatters,
       'convertIacResultToScanResult',
     );
@@ -29,7 +35,7 @@ describe('CLI Share Results', () => {
   });
 
   it("converts the results to Envelope's ScanResult interface - without .snyk policies", async () => {
-    await shareResults(scanResults, undefined);
+    await shareResults({ results: scanResults, policy: undefined });
 
     expect(envelopeFormattersSpy.mock.calls.length).toBe(2);
 
@@ -47,7 +53,7 @@ describe('CLI Share Results', () => {
   });
 
   it("converts the results to Envelope's ScanResult interface - with .snyk policies", async () => {
-    await shareResults(scanResults, snykPolicy);
+    await shareResults({ results: scanResults, policy: snykPolicy });
 
     expect(envelopeFormattersSpy.mock.calls.length).toBe(2);
 
@@ -75,8 +81,12 @@ describe('CLI Share Results', () => {
         testTargetRef,
       );
 
-      await shareResults(scanResults, undefined, {
-        'target-reference': testTargetRef,
+      await shareResults({
+        results: scanResults,
+        policy: undefined,
+        options: {
+          'target-reference': testTargetRef,
+        },
       });
 
       expect(envelopeFormattersSpy.mock.calls.length).toBe(2);
@@ -99,8 +109,8 @@ describe('CLI Share Results', () => {
     });
   });
 
-  it("converts the results to Envelope's ScanResult interface - with .snyk policies", async () => {
-    await shareResults(scanResults, snykPolicy);
+  it("converts the results to Envelope's ScanResult interface - with .snyk policies (2)", async () => {
+    await shareResults({ results: scanResults, policy: snykPolicy });
 
     expect(envelopeFormattersSpy.mock.calls.length).toBe(2);
 
@@ -121,7 +131,7 @@ describe('CLI Share Results', () => {
   });
 
   it('forwards value to iac-cli-share-results endpoint', async () => {
-    await shareResults(scanResults, undefined);
+    await shareResults({ results: scanResults, policy: undefined });
 
     expect(requestSpy.mock.calls.length).toBe(1);
 
@@ -129,6 +139,27 @@ describe('CLI Share Results', () => {
       method: 'POST',
       url: expect.stringContaining('/iac-cli-share-results'),
       json: true,
+      headers: expect.objectContaining({
+        authorization: expect.stringContaining('token'),
+      }),
+    });
+  });
+
+  it('respects the org flag provided', async () => {
+    await shareResults({
+      results: scanResults,
+      policy: undefined,
+      options: {
+        org: 'my-custom-org',
+      },
+    });
+
+    expect(requestSpy.mock.calls.length).toBe(1);
+
+    expect(requestSpy.mock.calls[0][0]).toMatchObject({
+      method: 'POST',
+      url: expect.stringContaining('/iac-cli-share-results'),
+      qs: expect.objectContaining({ org: 'my-custom-org' }),
       headers: expect.objectContaining({
         authorization: expect.stringContaining('token'),
       }),


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

### What does this PR do?

- Adds support for the `--target-reference` flag for the CLI Share Results feature for Snyk IaC

### Where should the reviewer start?

- `src/cli/commands/test/iac-local-execution/index.ts` - Branching into all CLI Share Results related steps.

### How should this be manually tested?

1. Enable the FF named `iacCliShareResults`
2. In the Snyk CLI, test any IaC file/directory with the following commands:
```
snyk-dev iac test {path_to_the_file} --report --target-reference={target_reference}
```
3. The API call to Registry for publishing this project should include a top-level property, named `targetReference`, which includes the provided value to the `--target-reference` flag.

### Any background context you want to provide?

- The `--target-reference` flag provides a reference that differentiates this project, for example, a branch name, or version.
    Projects having the same reference can be grouped based on that reference. Only supported for
    Snyk Open Source. For more information see Separating projects by branch or version.

### Notes for the Reviewer

- For this ticket, the [`ScanResult` model](https://www.notion.so/snyk/The-payload-interface-f713ed7d071a461ca9d1ae3b19505f9c#59372aea0a6a4c56a4e90fa3fe1f24f4) was updated to include a new top-level optional property for the target reference. It was approved in the discussion conducted in [this thread](https://snyk.slack.com/archives/C01342FUD53/p1647173307120089) in [#project-envelope](https://snyk.slack.com/archives/C01342FUD53).
- There are no Help docs updates for the `snyk iac test` command in this PR, based on a discussion with the CLI Share Results feature lead, @YairZ101, who asserted that since this feature has yet to reach beta release, user docs will be added at a later stage closer to the release.

### What are the relevant tickets?

- [CFG-1521](https://snyksec.atlassian.net/browse/CFG-1521)

### Additional information
- [CLI Share Results feature page](https://www.notion.so/snyk/Share-test-results-from-IaC-CLI-6e8287fcc7534a4f8d628d1f8f4187ba)
- [Thread](https://snyk.slack.com/archives/C01342FUD53/p1647173307120089) in [#project-envelope](https://snyk.slack.com/archives/C01342FUD53) about the changes in the `ScanResult` model.
- [Relevant PR in snyk/registry](https://github.com/snyk/registry/pull/26664)