### PR TITLE
feat: Send git contributors to /iac-share-results

### DIFF
--- a/packages/snyk-fix/src/types.ts
+++ b/packages/snyk-fix/src/types.ts
@@ -6,8 +6,8 @@ import { CustomError } from './lib/errors/custom-error';
  * what should be scanned for issues
  */
 export interface GitTarget {
-  remoteUrl: string;
-  branch: string;
+  remoteUrl?: string;
+  branch?: string;
 }
 export interface ContainerTarget {
   image: string;

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -13,9 +13,8 @@ import {
   IacFileInDirectory,
   Options,
   TestOptions,
-  PolicyOptions, Contributor,
+  PolicyOptions,
 } from '../../../../lib/types';
-import {GitTarget} from "../../../../lib/ecosystems/types";
 
 export interface IacFileData extends IacFileInDirectory {
   fileContent: string;
@@ -66,11 +65,6 @@ export interface IacShareResultsFormat {
   fileType: IacFileTypes;
   projectType: IacProjectType;
   violatedPolicies: PolicyMetadata[];
-}
-
-export interface GitInfo{
-  gitTarget: GitTarget;
-  contributors: Contributor[];
 }
 
 // This type is the integration point with the CLI test command, please note it is still partial in the experimental version

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -13,8 +13,9 @@ import {
   IacFileInDirectory,
   Options,
   TestOptions,
-  PolicyOptions,
+  PolicyOptions, Contributor,
 } from '../../../../lib/types';
+import {GitTarget} from "../../../../lib/ecosystems/types";
 
 export interface IacFileData extends IacFileInDirectory {
   fileContent: string;
@@ -65,6 +66,11 @@ export interface IacShareResultsFormat {
   fileType: IacFileTypes;
   projectType: IacProjectType;
   violatedPolicies: PolicyMetadata[];
+}
+
+export interface GitInfo{
+  gitTarget: GitTarget;
+  contributors: Contributor[];
 }
 
 // This type is the integration point with the CLI test command, please note it is still partial in the experimental version

--- a/src/lib/ecosystems/types.ts
+++ b/src/lib/ecosystems/types.ts
@@ -12,8 +12,8 @@ export interface PluginResponse {
 }
 
 export interface GitTarget {
-  remoteUrl: string;
-  branch: string;
+  remoteUrl?: string;
+  branch?: string;
 }
 
 export interface ContainerTarget {

--- a/src/lib/iac/cli-share-results.ts
+++ b/src/lib/iac/cli-share-results.ts
@@ -5,14 +5,31 @@ import { IacShareResultsFormat } from '../../cli/commands/test/iac-local-executi
 import { convertIacResultToScanResult } from './envelope-formatters';
 import { AuthFailedError } from '../errors/authentication-failed-error';
 import { Policy } from '../policy/find-and-load-policy';
+import { getInfo } from '../project-metadata/target-builders/git';
+import { GitTarget } from '../ecosystems/types';
+import {Contributor} from "../types";
+import * as analytics from "../analytics";
+import {getContributors} from "../monitor/dev-count-analysis";
+import * as debug from "debug";
 
 export async function shareResults(
   results: IacShareResultsFormat[],
   policy: Policy | undefined,
 ): Promise<Record<string, string>> {
-  const scanResults = results.map((result) =>
-    convertIacResultToScanResult(result, policy),
-  );
+  const gitTarget = (await getInfo(false)) as GitTarget;
+  let contributors: Contributor[] = [];
+  if (gitTarget.remoteUrl) {
+    if (analytics.allowAnalytics()) {
+      try {
+        contributors = await getContributors();
+      } catch (err) {
+        debug('error getting repo contributors', err);
+      }
+    }
+  }
+  const scanResults = results.map((result) => {
+    convertIacResultToScanResult(result, policy, {gitTarget, contributors});
+  });
 
   const { res, body } = await makeRequest({
     method: 'POST',

--- a/src/lib/iac/envelope-formatters.ts
+++ b/src/lib/iac/envelope-formatters.ts
@@ -1,19 +1,22 @@
 import {
+  GitInfo,
   IacShareResultsFormat,
   PolicyMetadata,
 } from '../../cli/commands/test/iac-local-execution/types';
-import { ScanResult } from '../ecosystems/types';
+import { GitTarget, ScanResult } from '../ecosystems/types';
 import { Policy } from '../policy/find-and-load-policy';
 
 export function convertIacResultToScanResult(
-  iacResult: IacShareResultsFormat,
-  policy: Policy | undefined,
+    iacResult: IacShareResultsFormat,
+    policy: Policy | undefined,
+    gitInfo: GitInfo,
 ): ScanResult {
   return {
     identity: {
       type: iacResult.projectType,
       targetFile: iacResult.targetFile,
     },
+    // TODO: should the contributors be under facts or under a new property?
     facts: [],
     findings: iacResult.violatedPolicies.map((policy: PolicyMetadata) => {
       return {
@@ -22,7 +25,10 @@ export function convertIacResultToScanResult(
       };
     }),
     name: iacResult.projectName,
-    target: { name: iacResult.projectName },
+    target:
+      Object.keys(gitInfo.gitTarget).length === 0
+        ? { name: iacResult.projectName }
+        : { ...gitInfo.gitTarget, branch: 'master' },
     policy: policy?.toString() ?? '',
   };
 }

--- a/src/lib/iac/envelope-formatters.ts
+++ b/src/lib/iac/envelope-formatters.ts
@@ -1,5 +1,4 @@
 import {
-  GitInfo,
   IacShareResultsFormat,
   PolicyMetadata,
 } from '../../cli/commands/test/iac-local-execution/types';
@@ -7,16 +6,15 @@ import { GitTarget, ScanResult } from '../ecosystems/types';
 import { Policy } from '../policy/find-and-load-policy';
 
 export function convertIacResultToScanResult(
-    iacResult: IacShareResultsFormat,
-    policy: Policy | undefined,
-    gitInfo: GitInfo,
+  iacResult: IacShareResultsFormat,
+  policy: Policy | undefined,
+  gitTarget: GitTarget,
 ): ScanResult {
   return {
     identity: {
       type: iacResult.projectType,
       targetFile: iacResult.targetFile,
     },
-    // TODO: should the contributors be under facts or under a new property?
     facts: [],
     findings: iacResult.violatedPolicies.map((policy: PolicyMetadata) => {
       return {
@@ -26,9 +24,9 @@ export function convertIacResultToScanResult(
     }),
     name: iacResult.projectName,
     target:
-      Object.keys(gitInfo.gitTarget).length === 0
+      Object.keys(gitTarget).length === 0
         ? { name: iacResult.projectName }
-        : { ...gitInfo.gitTarget, branch: 'master' },
+        : { ...gitTarget, branch: 'master' },
     policy: policy?.toString() ?? '',
   };
 }

--- a/test/jest/acceptance/iac/cli-share-results.spec.ts
+++ b/test/jest/acceptance/iac/cli-share-results.spec.ts
@@ -68,23 +68,27 @@ describe('CLI Share Results', () => {
         .filter((request) => request.url?.includes('/iac-cli-share-results'));
 
       expect(testRequests.length).toEqual(1);
-
-      expect(testRequests[0]).toMatchObject({
-        body: [
-          {
-            identity: {
-              type: 'armconfig',
-              targetFile: './iac/arm/rule_test.json',
-            },
-            facts: [],
-            findings: expect.arrayContaining([]),
-            name: 'arm',
-            target: {
+      expect(testRequests[0].body).toEqual(
+        expect.objectContaining({
+          contributors: expect.any(Array),
+          scanResults: [
+            {
+              identity: {
+                type: 'armconfig',
+                targetFile: './iac/arm/rule_test.json',
+              },
+              facts: [],
+              findings: expect.any(Array),
+              policy: '',
               name: 'arm',
+              target: {
+                branch: 'master',
+                remoteUrl: 'http://github.com/snyk/cli.git',
+              },
             },
-          },
-        ],
-      });
+          ],
+        }),
+      );
     });
   });
 });

--- a/test/jest/unit/iac/cli-share-results.fixtures.ts
+++ b/test/jest/unit/iac/cli-share-results.fixtures.ts
@@ -119,7 +119,10 @@ export const expectedEnvelopeFormatterResults = [
     ],
     name: 'projectA',
     policy: '',
-    target: { name: 'projectA' },
+    target: {
+      remoteUrl: 'http://github.com/snyk/cli.git',
+      branch: 'master',
+    },
   },
   {
     identity: {
@@ -158,7 +161,10 @@ export const expectedEnvelopeFormatterResults = [
     ],
     name: 'projectB',
     policy: '',
-    target: { name: 'projectB' },
+    target: {
+      remoteUrl: 'http://github.com/snyk/cli.git',
+      branch: 'master',
+    },
   },
 ];
 


### PR DESCRIPTION
#### What does this PR do?

This PR consists of two commits:

1. The first commit utilises the `getInfo()` from the gitBuilder to get the remote url and branch and add it back to the iac-cli-share-results endpoint. We override the branch with `master` as in this feature, we do not care about branches.
2. The second commit utilises the existing 'getContributors()' function to count the developers of the repo we scan.
It returns the emails and the lastCommitDate for each one of the commits in the last 90 days.
We then send this as part of the body to '/iac-share-cli-results'.

So, the payload we send now for the body is:
```
{
   scanResults: [ ],
   contributors: { }
}
```
an example curl:
```
curl --location --request POST 'http://127.0.0.1:8000/api/v1/iac-cli-share-results' \
--header 'Authorization: token a-token-here' \
--header 'Content-Type: application/json' \
--data-raw '{
    "scanResults": [],
    "contributors": {}
}'
```

[CFG-1518]

Co-authored-by: Yair Zohar <yair.zohar@snyk.com>

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules


#### Where should the reviewer start?
Commit by commit should give you the clean changes overview.

## For external reviewers: We are adding a `?` operator into the GitTarget type - to comply with the rest of the interfaces.
Edit: The target can be `{}` an empty object as shown here https://github.com/snyk/cli/blob/master/src/lib/project-metadata/target-builders/git.ts#L8-L55 and that's the main reason we wanted to update the interface

#### How should this be manually tested?
- Run `npm run build` on this branch
- Run registry locally (`npm run build && npm run dev`), on this branch: https://github.com/snyk/registry/pull/26726
- Run ` node ./dist/cli iac test test/fixtures/iac/ --report`

See the logs in registry with the new body received.

#### Any background context you want to provide?
Contributing developers is about getting the unique count of contributors per repo. More context: https://snyksec.atlassian.net/browse/CFG-1506

#### What are the relevant tickets?
[CFG-1518]

#### Screenshots

[CFG-1518]: https://snyksec.atlassian.net/browse/CFG-1518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CFG-1518]: https://snyksec.atlassian.net/browse/CFG-1518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ