### PR TITLE
Should add is-iac-drift on error exit code too

### DIFF
--- a/src/cli/commands/describe.ts
+++ b/src/cli/commands/describe.ts
@@ -33,6 +33,7 @@ export default async (...args: MethodArgs): Promise<any> => {
     const describe = await runDriftCTL({
       options: { kind: 'describe', ...options },
     });
+    analytics.add('is-iac-drift', true);
     analytics.add('iac-drift-exit-code', describe.code);
     if (describe.code === DCTL_EXIT_CODES.EXIT_ERROR) {
       process.exitCode = describe.code;

--- a/src/cli/commands/test/iac-local-execution/analytics.ts
+++ b/src/cli/commands/test/iac-local-execution/analytics.ts
@@ -91,7 +91,6 @@ export function addIacDriftAnalytics(
   analysis: DriftAnalysis,
   options: DescribeOptions,
 ): void {
-  analytics.add('is-iac-drift', true);
   analytics.add('iac-drift-coverage', analysis.coverage);
   analytics.add('iac-drift-total-resources', analysis.summary.total_resources);
   analytics.add('iac-drift-total-unmanaged', analysis.summary.total_unmanaged);

--- a/test/jest/unit/lib/iac/drift.spec.ts
+++ b/test/jest/unit/lib/iac/drift.spec.ts
@@ -253,8 +253,7 @@ describe('drift analytics', () => {
     const analysis = parseDriftAnalysisResults(driftAnalysisFile.toString());
     addIacDriftAnalytics(analysis, options);
 
-    expect(addAnalyticsSpy).toHaveBeenCalledTimes(13);
-    expect(addAnalyticsSpy).toHaveBeenCalledWith('is-iac-drift', true);
+    expect(addAnalyticsSpy).toHaveBeenCalledTimes(12);
     expect(addAnalyticsSpy).toHaveBeenCalledWith('iac-drift-coverage', 33);
     expect(addAnalyticsSpy).toHaveBeenCalledWith(
       'iac-drift-total-resources',


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
It should add the `is-iac-drift` analytics metadata when `driftctl scan` command exit with an error.

#### How should this be manually tested?
`snyk iac describe`

#### Screenshots
<img width="711" alt="Screenshot 2022-03-15 at 17 33 12" src="https://user-images.githubusercontent.com/8110579/158426917-f4ad162f-8a37-4c28-a08a-0ea20aaef650.png">
