### PR TITLE
`snyk iac describe` show help by default and has to be called with right flags

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,6 +46,8 @@ test/jest/acceptance/iac/ @snyk/group-infrastructure-as-code
 test/jest/acceptance/snyk-apps @snyk/moose
 src/lib/errors/invalid-iac-file.ts @snyk/group-infrastructure-as-code
 src/lib/errors/unsupported-options-iac-error.ts @snyk/group-infrastructure-as-code
+src/lib/errors/describe-required-argument-error.ts @snyk/group-infrastructure-as-code
+src/lib/errors/describe-exclusive-argument-error.ts @snyk/group-infrastructure-as-code
 src/lib/errors/no-supported-sast-files-found.ts @snyk/nebula
 help/commands-docs/iac-examples.md @snyk/group-infrastructure-as-code
 help/commands-docs/iac.md @snyk/group-infrastructure-as-code

--- a/src/cli/commands/describe.ts
+++ b/src/cli/commands/describe.ts
@@ -13,6 +13,8 @@ import config from '../../lib/config';
 import { addIacDriftAnalytics } from './test/iac-local-execution/analytics';
 import * as analytics from '../../lib/analytics';
 import { findAndLoadPolicy } from '../../lib/policy';
+import { DescribeRequiredArgumentError } from '../../lib/errors/describe-required-argument-error';
+import help from './help';
 
 export default async (...args: MethodArgs): Promise<any> => {
   const { options } = processCommandArgs(...args);
@@ -56,6 +58,11 @@ export default async (...args: MethodArgs): Promise<any> => {
     process.stdout.write(fmtResult.stdout);
     process.exitCode = describe.code;
   } catch (e) {
+    if (e instanceof DescribeRequiredArgumentError) {
+      // when missing a required arg we will display help to explain
+      const helpMsg = await help('iac', 'describe');
+      console.log(helpMsg);
+    }
     return Promise.reject(e);
   }
 };

--- a/src/lib/errors/describe-exclusive-argument-error.ts
+++ b/src/lib/errors/describe-exclusive-argument-error.ts
@@ -1,0 +1,11 @@
+import { CustomError } from './custom-error';
+import { DescribeExclusiveArgs } from '../iac/drift';
+
+export class DescribeExclusiveArgumentError extends CustomError {
+  constructor() {
+    super(
+      'Please use only one of these arguments: ' +
+        DescribeExclusiveArgs.join(', '),
+    );
+  }
+}

--- a/src/lib/errors/describe-required-argument-error.ts
+++ b/src/lib/errors/describe-required-argument-error.ts
@@ -1,0 +1,11 @@
+import { CustomError } from './custom-error';
+import { DescribeRequiredArgs } from '../iac/drift';
+
+export class DescribeRequiredArgumentError extends CustomError {
+  constructor() {
+    super(
+      'Describe command require one of these arguments: ' +
+        DescribeRequiredArgs.join(', '),
+    );
+  }
+}

--- a/src/lib/iac/types.d.ts
+++ b/src/lib/iac/types.d.ts
@@ -33,7 +33,9 @@ export interface DescribeOptions extends DriftCTLOptions {
   strict?: true;
   deep?: true;
   'only-managed'?: true;
+  drift?: true;
   'only-unmanaged'?: true;
+  all?: true;
   driftignore?: string;
   'tf-lockfile'?: string;
   'config-dir'?: string;

--- a/test/jest/acceptance/iac/describe.spec.ts
+++ b/test/jest/acceptance/iac/describe.spec.ts
@@ -46,7 +46,7 @@ describe('iac describe', () => {
 
   it('describe fail without the right entitlement', async () => {
     const { stdout, stderr, exitCode } = await run(
-      `snyk iac describe --org=no-iac-drift-entitlements`,
+      `snyk iac describe --all --org=no-iac-drift-entitlements`,
       {
         SNYK_DRIFTCTL_PATH: './iac/drift/args-echo',
       },
@@ -64,7 +64,7 @@ describe('iac describe', () => {
   }
 
   it('Test when driftctl scan exit in error', async () => {
-    const { stdout, stderr, exitCode } = await run(`snyk iac describe`, {
+    const { stdout, stderr, exitCode } = await run(`snyk iac describe  --all`, {
       SNYK_FIXTURE_OUTPUT_PATH: outputFile,
       DCTL_EXIT_CODE: '2',
       SNYK_DRIFTCTL_PATH: path.join(
@@ -80,7 +80,7 @@ describe('iac describe', () => {
   });
 
   it('Launch driftctl from SNYK_DRIFTCTL_PATH env var when org has the entitlement', async () => {
-    const { stdout, stderr, exitCode } = await run(`snyk iac describe`, {
+    const { stdout, stderr, exitCode } = await run(`snyk iac describe  --all`, {
       SNYK_FIXTURE_OUTPUT_PATH: outputFile,
       SNYK_DRIFTCTL_PATH: path.join(
         getFixturePath('iac'),
@@ -114,7 +114,7 @@ describe('iac describe', () => {
 
   it('Download and launch driftctl when executable is not found and org has the entitlement', async () => {
     const cachedir = path.join(os.tmpdir(), 'driftctl_download_' + Date.now());
-    const { stderr, exitCode } = await run(`snyk iac describe`, {
+    const { stderr, exitCode } = await run(`snyk iac describe --all`, {
       SNYK_DRIFTCTL_URL: apiUrl + '/download/driftctl',
       SNYK_CACHE_PATH: cachedir,
     });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
`snyk iac describe` show help by default and has to be called with right flags:
--all, --only-managed or --only-managed

#### Where should the reviewer start?
Added a way to validate flags (both exclusive and required). It calls help command to get the help markdown rendered before throwing ab error that ask to add the right flag.

#### How should this be manually tested?
`snyk iac describe --all --only-unmanaged` should throw an error asking to only use one of the flags
`snyk iac describe` should throw an error asking to add one of the required flags