### PR TITLE
[CFG-1725] fix: redact sensitive flag values from analytics

### DIFF
--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -7,6 +7,11 @@ import { makeRequest } from '../request';
 import { config as userConfig } from '../user-config';
 import { getStandardData } from './getStandardData';
 
+// Add flags whose values should be redacted in analytics here.
+// TODO make this less error-prone by baking the concept of sensitivity into the
+// flag-parsing code, but this is a start.
+const sensitiveFlags = ['tfc-token'];
+
 const debug = createDebug('snyk');
 const metadata = {};
 // analytics module is required at the beginning of the CLI run cycle
@@ -27,6 +32,14 @@ export function addDataAndSend(
   if (Array.isArray(data.args)) {
     // this is an overhang from the cli/args.js and we don't want it
     delete (data.args.slice(-1).pop() || {})._;
+
+    data.args.forEach((argObj) => {
+      Object.keys(argObj).forEach((field) => {
+        if (sensitiveFlags.includes(field)) {
+          argObj[field] = 'REDACTED';
+        }
+      });
+    });
   }
 
   if (Object.keys(metadata).length) {

--- a/test/jest/unit/lib/analytics/index.spec.ts
+++ b/test/jest/unit/lib/analytics/index.spec.ts
@@ -26,6 +26,25 @@ describe('analytics module', () => {
     );
   });
 
+  it('removes sensitive flags', async () => {
+    const requestSpy = jest.spyOn(request, 'makeRequest');
+    requestSpy.mockResolvedValue();
+
+    await analytics.addDataAndSend({
+      args: argsFrom({
+        'tfc-endpoint': "I don't care who sees this",
+        'tfc-token': 'itsasecret',
+      }),
+    });
+
+    expect(requestSpy.mock.calls[0][0].body.data).toHaveProperty('args', [
+      {
+        'tfc-endpoint': "I don't care who sees this",
+        'tfc-token': 'REDACTED',
+      },
+    ]);
+  });
+
   it('ignores analytics request failures', async () => {
     const requestSpy = jest.spyOn(request, 'makeRequest');
     requestSpy.mockRejectedValue(new Error('this should be ignored'));


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Flag values that contain secrets should not be posted to our analytics
endpoint.

Users of this code who introduce new sensitive flags would have to know
it exists and add their flag there, but this is a starting point that
doesn't involve overhauling our flag parsing.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?

`snyk iac describe`, a new command that wraps `driftctl scan`, allows terraform cloud tokens to be specified on the command line.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/CFG-1725


#### Screenshots


#### Additional questions
