### PR TITLE
Allow to lookup for driftctl binary in `/bin` too

### DIFF
--- a/src/lib/iac/drift.ts
+++ b/src/lib/iac/drift.ts
@@ -29,14 +29,15 @@ import { Policy } from '../policy/find-and-load-policy';
 const cachePath = config.CACHE_PATH ?? envPaths('snyk').cache;
 const debug = debugLib('drift');
 
-export const driftctlVersion = 'v0.23.0';
-
 export const DCTL_EXIT_CODES = {
   EXIT_IN_SYNC: 0,
   EXIT_NOT_IN_SYNC: 1,
   EXIT_ERROR: 2,
 };
 
+// ⚠ Keep in mind to also update driftctl version used to generate docker images
+// You can edit base image used for snyk final image here https://github.com/snyk/snyk-images/blob/master/alpine
+export const driftctlVersion = 'v0.23.0';
 const driftctlChecksums = {
   'driftctl_windows_386.exe':
     'e5befbafe2291674a4d6c8522411a44fea3549057fb46d331402d49b180202fe',
@@ -346,8 +347,19 @@ async function findDriftCtl(): Promise<string> {
     debug('Found driftctl in cache: %s', dctlPath);
     return dctlPath;
   }
-  debug('driftctl not found');
 
+  // lookup in /bin
+  // when used in a docker context the default binary path should be used
+  {
+    dctlPath = '/bin/driftctl';
+    const exists = await isExe(dctlPath);
+    if (exists) {
+      debug('Found driftctl in %s', dctlPath);
+      return dctlPath;
+    }
+  }
+
+  debug('driftctl not found');
   return '';
 }
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

That PR allow us to lookup for a driftctl binary in `/bin`.
This enable us to use `snyk/driftctl` as base image for our docker run.
You can see more context here : https://github.com/snyk/snyk-images/pull/26

#### Where should the reviewer start?

Probably by reading the [README.md](https://github.com/snyk/snyk-images) of `snyk/snyk-images`

#### How should this be manually tested?

```$
$ touch /bin/driftctl && chmod +x /bin/driftctl
# Be sure that you do not have any cached version
$ rm /home/elie.charra/.cache/snyk-nodejs/driftctl_*
# Be sure that you do not have any overriden binary path
$ env | grep DRIFTCTL_PATH
# Then you can run it with debug to see that we fallback to /bin/driftctl
```

There is currently no way to easily E2E test that since we should be able to have a released version with that PR to test it in docker.

#### Any background context you want to provide?

https://github.com/snyk/snyk-images/pull/26

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/CFG-1621

#### Screenshots

![image](https://user-images.githubusercontent.com/6154987/158653666-b2dc0e3b-55b8-44b2-84b8-d1da5eac1a94.png)


#### Additional questions
