### PR TITLE
feature: add excluded paths to ignore command

### DIFF
--- a/src/cli/commands/ignore.ts
+++ b/src/cli/commands/ignore.ts
@@ -34,74 +34,100 @@ export default function ignore(options): Promise<MethodResult> {
         return;
       }
 
-      if (!options.id) {
-        throw Error('idRequired');
-      }
-      options.expiry = new Date(options.expiry);
-      if (options.expiry.getTime() !== options.expiry.getTime()) {
-        debug('No/invalid expiry given, using the default 30 days');
-        options.expiry = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
-      }
-      if (!options.reason) {
-        options.reason = 'None Given';
+      const isFilePathProvided = !!options['file-path'];
+
+      if (isFilePathProvided) {
+        return excludeFilePathPattern(options);
       }
 
-      const isPathProvided = !!options.path;
-      if (!isPathProvided) {
-        options.path = '*';
-      }
-
-      debug(
-        `changing policy: ignore "%s", for %s, reason: "%s", until: %o`,
-        options.id,
-        isPathProvided ? 'all paths' : `path: '${options.path}'`,
-        options.reason,
-        options.expiry,
-      );
-      return policy
-        .load(options['policy-path'])
-        .catch((error) => {
-          if (error.code === 'ENOENT') {
-            // file does not exist - create it
-            return policy.create();
-          }
-          throw Error('policyFile');
-        })
-        .then(async function ignoreIssue(pol) {
-          let ignoreRulePathDataIdx = -1;
-          const ignoreParams = {
-            reason: options.reason,
-            expires: options.expiry,
-            created: new Date(),
-          };
-
-          const ignoreRules: IgnoreRules = pol.ignore;
-
-          const issueIgnorePaths = ignoreRules[options.id] ?? [];
-
-          // Checking if the an ignore rule for this issue exists for the provided path.
-          ignoreRulePathDataIdx = issueIgnorePaths.findIndex(
-            (ignoreMetadata) => !!ignoreMetadata[options.path],
-          );
-
-          // If an ignore rule for this path doesn't exist, create one.
-          if (ignoreRulePathDataIdx === -1) {
-            issueIgnorePaths.push({
-              [options.path]: ignoreParams,
-            });
-          }
-          // Otherwise, update the existing rule's metadata.
-          else {
-            issueIgnorePaths[ignoreRulePathDataIdx][
-              options.path
-            ] = ignoreParams;
-          }
-
-          ignoreRules[options.id] = issueIgnorePaths;
-
-          pol.ignore = ignoreRules;
-
-          return await policy.save(pol, options['policy-path']);
-        });
+      return ignoreIssue(options);
     });
+}
+
+export function ignoreIssue(options): Promise<MethodResult> {
+  if (!options.id) {
+    throw Error('idRequired');
+  }
+
+  options.expiry = new Date(options.expiry);
+  if (options.expiry.getTime() !== options.expiry.getTime()) {
+    debug('No/invalid expiry given, using the default 30 days');
+    options.expiry = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+  }
+
+  if (!options.reason) {
+    options.reason = 'None Given';
+  }
+
+  const isPathProvided = !!options.path;
+  if (!isPathProvided) {
+    options.path = '*';
+  }
+
+  debug(
+    `changing policy: ignore "%s", for %s, reason: "%s", until: %o`,
+    options.id,
+    isPathProvided ? 'all paths' : `path: '${options.path}'`,
+    options.reason,
+    options.expiry,
+  );
+
+  return load(options['policy-path']).then(async (pol) => {
+    let ignoreRulePathDataIdx = -1;
+    const ignoreParams = {
+      reason: options.reason,
+      expires: options.expiry,
+      created: new Date(),
+    };
+
+    const ignoreRules: IgnoreRules = pol.ignore;
+
+    const issueIgnorePaths = ignoreRules[options.id] ?? [];
+
+    // Checking if the ignore-rule for this issue exists for the provided path.
+    ignoreRulePathDataIdx = issueIgnorePaths.findIndex(
+      (ignoreMetadata) => !!ignoreMetadata[options.path],
+    );
+
+    // If an ignore-rule for this path doesn't exist, create one.
+    if (ignoreRulePathDataIdx === -1) {
+      issueIgnorePaths.push({
+        [options.path]: ignoreParams,
+      });
+    }
+    // Otherwise, update the existing rule's metadata.
+    else {
+      issueIgnorePaths[ignoreRulePathDataIdx][options.path] = ignoreParams;
+    }
+
+    ignoreRules[options.id] = issueIgnorePaths;
+
+    pol.ignore = ignoreRules;
+
+    return await policy.save(pol, options['policy-path']);
+  });
+}
+
+export async function excludeFilePathPattern(options): Promise<MethodResult> {
+  const pattern = options['file-path'];
+  const group = options['file-path-group'] || 'global';
+  const policyPath = options['policy-path'];
+
+  debug(`changing policy: ignore "%s" added to "%s"`, pattern, policyPath);
+
+  const pol = await load(policyPath);
+  pol.addExclude(pattern, group);
+
+  return policy.save(pol, policyPath);
+}
+
+async function load(path: string) {
+  return policy.load(path).catch((error) => {
+    if (error.code === 'ENOENT') {
+      // file does not exist - create it
+      return policy.create();
+    }
+
+    throw Error('policyFile');
+  });
 }


### PR DESCRIPTION
feat: add excluded paths to ignore command

Adds support to alter excluded files in the policy file:

- Extract ignoreVuln from ignore-function, and route CLI command to
  the correct implementation
- Add excludeFilePathPattern to be called by the ignore-implementation.

Background:

  The policy file supports two different groups of file:
  - "code", for files being ignored by Snyk Code
  - "global", for files being ignored by all products supporting the
    exclude field, for instance `snyk test --unmanaged`.

Usage:

  > snyk ignore --file-path='./deps/**.cpp'  # Defaults to the global group
  > snyk ignore --file-path='./deps/**.go' --file-path-group='code'
  > snyk ignore --file-path='./**/vendor/*.java' --file-path-group='global'