### PR TITLE
fix: TF Vars bug when scanning multi-file Kubernetes resource

### DIFF
--- a/test/jest/acceptance/iac/test-terraform-var-deref.spec.ts
+++ b/test/jest/acceptance/iac/test-terraform-var-deref.spec.ts
@@ -41,6 +41,14 @@ describe('Terraform Language Support', () => {
         )} for known issues`,
       );
     });
+
+    it('returns error if empty Terraform file', async () => {
+      const { exitCode } = await run(
+        `snyk iac test ./iac/terraform/empty_file.tf`,
+      );
+
+      expect(exitCode).toBe(3);
+    });
   });
 
   describe('with feature flag', () => {
@@ -64,12 +72,12 @@ describe('Terraform Language Support', () => {
         );
       });
 
-      it('finds no issues in empty Terraform file', async () => {
+      it('returns error empty Terraform file', async () => {
         const { exitCode } = await run(
           `snyk iac test --org=tf-lang-support ./iac/terraform/empty_file.tf`,
         );
 
-        expect(exitCode).toBe(0);
+        expect(exitCode).toBe(3);
       });
     });
     describe('single non-terraform files', () => {
@@ -138,7 +146,7 @@ describe('Terraform Language Support', () => {
           'resources[1] > properties > networkRuleCollections[0] > properties > rules[0] > sourceAddresses',
         );
       });
-      it('finds issues in Kubernetes JSON file', async () => {
+      it('finds issues in Kubernetes YAML file', async () => {
         const { stdout, exitCode } = await run(
           `snyk iac test --org=tf-lang-support ./iac/kubernetes/pod-privileged.yaml`,
         );
@@ -146,6 +154,22 @@ describe('Terraform Language Support', () => {
 
         expect(stdout).toContain(
           'Testing ./iac/kubernetes/pod-privileged.yaml',
+        );
+        expect(stdout).toContain('Infrastructure as code issues:');
+        expect(stdout).toContain('✗ Privileged container');
+        expect(stdout).toContain(
+          '[DocId: 0] > input > spec > containers[example] > securityContext > privileged',
+        );
+      });
+
+      it('finds issues in Kubernetes YAML multi file', async () => {
+        const { stdout, exitCode } = await run(
+          `snyk iac test --org=tf-lang-support ./iac/kubernetes/pod-privileged-multi.yaml`,
+        );
+        expect(exitCode).toBe(1);
+
+        expect(stdout).toContain(
+          'Testing ./iac/kubernetes/pod-privileged-multi.yaml',
         );
         expect(stdout).toContain('Infrastructure as code issues:');
         expect(stdout).toContain('✗ Privileged container');

--- a/test/jest/unit/iac/handle-terraform-files.spec.ts
+++ b/test/jest/unit/iac/handle-terraform-files.spec.ts
@@ -56,9 +56,9 @@ describe('getAllDirectoriesForPath', () => {
       ]);
       expect(
         getFilesForDirectory(nonIacFileStub.filePath, nonIacFileStub.filePath),
-      ).toEqual([nonIacFileStub.filePath]);
+      ).toEqual([]);
       await expect(
-        loadAndParseTerraformFiles(nonIacFileStub.filePath, [], []),
+        loadAndParseTerraformFiles(nonIacFileStub.filePath),
       ).rejects.toThrow(NoFilesToScanError);
     });
 
@@ -132,15 +132,6 @@ describe('getAllDirectoriesForPath', () => {
       });
 
       describe('with 1 directory', () => {
-        it('throws an error as there are no files at that level', () => {
-          mockFs({
-            'empty-dir': {},
-          });
-          expect(() => {
-            getAllDirectoriesForPath('empty-dir');
-          }).toThrow(NoFilesToScanError);
-        });
-
         describe('with 2 directories', () => {
           it('returns the files at level 2', () => {
             const directoryFilePaths = getAllDirectoriesForPath(

--- a/test/jest/unit/iac/index.spec.ts
+++ b/test/jest/unit/iac/index.spec.ts
@@ -5,14 +5,11 @@ jest.mock('../../../../src/lib/feature-flags', () => ({
   isFeatureFlagSupportedForOrg: isFeatureFlagSupportedForOrgStub,
 }));
 const parseFilesStub = jest.fn();
-const loadAndParseFilesStub = jest.fn();
-const parseTerraformFilesStub = jest.fn();
 jest.mock(
   '../../../../src/cli/commands/test/iac-local-execution/file-parser',
   () => {
     return {
       parseFiles: parseFilesStub,
-      parseTerraformFiles: parseTerraformFilesStub,
     };
   },
 );
@@ -90,19 +87,19 @@ describe('test()', () => {
           parsedFiles: [],
           failedFiles: [],
         }));
-        parseTerraformFilesStub.mockImplementation(() => ({
-          parsedFiles,
-          failedFiles,
-        }));
+        loadAndParseTerraformFilesStub.mockResolvedValue({
+          parsedFiles: parsedFiles,
+          failedFiles: failedFiles,
+        });
       } else {
         parseFilesStub.mockImplementation(() => ({
           parsedFiles,
           failedFiles,
         }));
-        parseTerraformFilesStub.mockImplementation(() => ({
+        loadAndParseTerraformFilesStub.mockResolvedValue({
           parsedFiles: [],
           failedFiles: [],
-        }));
+        });
       }
     });
 
@@ -143,10 +140,6 @@ describe('test()', () => {
 
       it('attempts to pull the custom-rules bundle using the provided configurations', async () => {
         const opts: IaCTestFlags = {};
-        loadAndParseTerraformFilesStub.mockResolvedValue({
-          allParsedFiles: parsedFiles,
-          allFailedFiles: failedFiles,
-        });
 
         await test('./iac/terraform/sg_open_ssh.tf', opts);
 
@@ -181,12 +174,6 @@ describe('test()', () => {
 
       it('returns the unparsable files excluding content', async () => {
         const opts: IaCTestFlags = {};
-        loadAndParseFilesStub.mockReturnValue(() => {
-          return {
-            allParsedFiles: parsedFiles,
-            allFailedFiles: failedFiles,
-          };
-        });
 
         const { failures } = await test('./storage/', opts);
 


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This PR fixes a bug in the CLI when `iacTerraformVarSupport` is enabled (by default for free users) and multi-file Kubernetes resources are scanned. 

#### How should this be manually tested?
1. `npm run build`
2. `mkdir empty`
3. `snyk-dev iac test empty` - still generates an empty error
4. `snyk-dev iac test ./test/fixtures/iac/terraform/empty_file.tf` - now generates an empty error, because that's what the old CLI does too and it makes sense to tell the customer if their TF file was empty
5. `snyk-dev iac test ./test/fixtures/iac/kubernetes/pod-privileged.yaml` - still generates vulnerabilities
6. `snyk-dev iac test ./test/fixtures/iac/kubernetes/pod-privileged-multi.yaml` - now generates vulnerabilities instead of an empty error, thus fixing the problem
7. `snyk-dev iac test ./test/fixtures/iac/` - still works for mixed folders, with non-TF and TF files

#### Any background context you want to provide?
A fix was delivered in https://github.com/snyk/cli/pull/3022, but we agreed it was a temporary solution for the bug and pending a refactoring. This fix checked if a single file was provided and generated a parsed output in a previous step (for non-TF files). If so, then we wouldn't throw an error if the TF parsing generated no results. However, this solution didn't catch the edge case where a multi file Kubernetes resource was provided, in which case there was more than one parsed output returned for non-TF files.

#### What are the relevant tickets?
https://snyk.slack.com/archives/C02JMMTLUF9/p1647607380819509

#### Screenshots
This is covered by the tests but just proof it actually works:
3. 
![Screenshot 2022-03-18 at 14 36 55](https://user-images.githubusercontent.com/81559517/159023303-7ecf5fcf-c1d0-4d5d-9ccd-79ace2ce1a12.png)
.4
![Screenshot 2022-03-18 at 14 37 43](https://user-images.githubusercontent.com/81559517/159023321-f9496a24-31fa-4292-821f-835e1cfbcf1a.png)
5.
![Screenshot 2022-03-18 at 14 37 04](https://user-images.githubusercontent.com/81559517/159023306-2a0e4c50-2a49-49d3-bb94-aa4bd58e9d95.png)
6.
![Screenshot 2022-03-18 at 14 37 14](https://user-images.githubusercontent.com/81559517/159023317-d4508c85-c20d-41be-81d9-94b98c4a171e.png)
7.
![Screenshot 2022-03-18 at 14 39 20](https://user-images.githubusercontent.com/81559517/159023646-36b1ee85-4e4b-47b3-8dc4-67329046e76d.png)


