### PR TITLE
fix: don't send drift excludes to analytics

### DIFF
--- a/src/cli/commands/describe.ts
+++ b/src/cli/commands/describe.ts
@@ -34,11 +34,12 @@ export default async (...args: MethodArgs): Promise<any> => {
   }
 
   const policy = await findAndLoadPolicy(process.cwd(), 'iac', options);
-  options.ignore = driftignoreFromPolicy(policy);
+  const driftIgnore = driftignoreFromPolicy(policy);
 
   try {
     const describe = await runDriftCTL({
       options: { kind: 'describe', ...options },
+      driftIgnore: driftIgnore,
     });
     analytics.add('is-iac-drift', true);
     analytics.add('iac-drift-exit-code', describe.code);

--- a/src/lib/iac/drift.ts
+++ b/src/lib/iac/drift.ts
@@ -113,9 +113,12 @@ const validateDescribeArgs = (options: DescribeOptions): void => {
   }
 };
 
-export const generateArgs = (options: DriftCTLOptions): string[] => {
+export const generateArgs = (
+  options: DriftCTLOptions,
+  driftIgnore?: string[],
+): string[] => {
   if (options.kind === 'describe') {
-    return generateScanFlags(options as DescribeOptions);
+    return generateScanFlags(options as DescribeOptions, driftIgnore);
   }
 
   if (options.kind === 'gen-driftignore') {
@@ -185,7 +188,10 @@ const generateFmtFlags = (options: FmtOptions): string[] => {
   return args;
 };
 
-const generateScanFlags = (options: DescribeOptions): string[] => {
+const generateScanFlags = (
+  options: DescribeOptions,
+  driftIgnore?: string[],
+): string[] => {
   const args: string[] = ['scan', ...driftctlDefaultOptions];
 
   if (options.quiet) {
@@ -246,9 +252,9 @@ const generateScanFlags = (options: DescribeOptions): string[] => {
     args.push(options['tf-lockfile']);
   }
 
-  if (options.ignore && options.ignore.length > 0) {
+  if (driftIgnore && driftIgnore.length > 0) {
     args.push('--ignore');
-    args.push(options.ignore.join(','));
+    args.push(driftIgnore.join(','));
   }
 
   let configDir = cachePath;
@@ -306,16 +312,18 @@ export const parseDriftAnalysisResults = (input: string): DriftAnalysis => {
 
 export const runDriftCTL = async ({
   options,
+  driftIgnore,
   input,
   stdio,
 }: {
   options: DriftCTLOptions;
+  driftIgnore?: string[];
   input?: string;
   stdio?: StdioOptions;
 }): Promise<DriftctlExecutionResult> => {
   const path = await findOrDownload();
   await validateArgs(options);
-  const args = await generateArgs(options);
+  const args = await generateArgs(options, driftIgnore);
 
   if (!stdio) {
     stdio = ['pipe', 'pipe', 'inherit'];

--- a/test/jest/unit/lib/iac/drift.spec.ts
+++ b/test/jest/unit/lib/iac/drift.spec.ts
@@ -35,7 +35,7 @@ describe('driftctl integration', () => {
   });
 
   it('describe: default arguments are correct', () => {
-    const args = generateArgs({ kind: 'describe' });
+    const args = generateArgs({ kind: 'describe' }, []);
     expect(args).toEqual([
       'scan',
       '--no-version-check',
@@ -54,25 +54,27 @@ describe('driftctl integration', () => {
   });
 
   it('describe: passing options generate correct arguments', () => {
-    const args = generateArgs({
-      kind: 'describe',
-      'config-dir': 'confdir',
-      'tf-lockfile': 'tflockfile',
-      'tf-provider-version': 'tfproviderversion',
-      'tfc-endpoint': 'tfcendpoint',
-      'tfc-token': 'tfctoken',
-      deep: true,
-      driftignore: 'driftignore',
-      filter: 'filter',
-      from: 'from',
-      'fetch-tfstate-headers': 'headers',
-      quiet: true,
-      strict: true,
-      to: 'to',
-      'only-managed': true,
-      'only-unmanaged': true,
-      ignore: ['*', '!aws_s3_bucket'],
-    } as DescribeOptions);
+    const args = generateArgs(
+      {
+        kind: 'describe',
+        'config-dir': 'confdir',
+        'tf-lockfile': 'tflockfile',
+        'tf-provider-version': 'tfproviderversion',
+        'tfc-endpoint': 'tfcendpoint',
+        'tfc-token': 'tfctoken',
+        deep: true,
+        driftignore: 'driftignore',
+        filter: 'filter',
+        from: 'from',
+        'fetch-tfstate-headers': 'headers',
+        quiet: true,
+        strict: true,
+        to: 'to',
+        'only-managed': true,
+        'only-unmanaged': true,
+      } as DescribeOptions,
+      ['*', '!aws_s3_bucket'],
+    );
     expect(args).toEqual([
       'scan',
       '--no-version-check',


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Before this commit, by modifying the args object, the entire content of
the `exclude/iac-drift` part of the policy file was being included in
the `args` analytics column:
https://console.cloud.google.com/bigquery?project=snyk-main&d=snyk&p=snyk-main&t=cli_tracking_data&page=table&ws=!1m5!1m4!4m3!1ssnyk-main!2ssnyk!3scli_tracking_data!1m5!1m4!1m3!1ssnyk-main!2sbquxjob_673b5721_17fabce8705!3sUS

For huge policy files, this risks hitting bigquery's 10MiB limit for
columns and failing to send analytics: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
