### PR TITLE
feat: ignore issue support for c/c++ flows

### DIFF
--- a/src/lib/ecosystems/policy.ts
+++ b/src/lib/ecosystems/policy.ts
@@ -3,7 +3,8 @@ import * as path from 'path';
 import { SupportedPackageManagers } from '../package-managers';
 import { findAndLoadPolicy } from '../policy';
 import { Options, PolicyOptions } from '../types';
-import { ScanResult } from './types';
+import { Issue, IssuesData, ScanResult } from './types';
+import { Policy } from '../policy/find-and-load-policy';
 
 export async function findAndLoadPolicyForScanResult(
   scanResult: ScanResult,
@@ -30,4 +31,38 @@ export async function findAndLoadPolicyForScanResult(
     targetFileDir,
   )) as object | undefined; // TODO: findAndLoadPolicy() does not return a string!
   return policy;
+}
+
+export function filterIgnoredIssues(
+  issues: Issue[],
+  issuesData: IssuesData,
+  policy?: Policy,
+): [Issue[], IssuesData] {
+  if (!policy?.ignore) {
+    return [issues, issuesData];
+  }
+
+  const filteredIssuesData: IssuesData = { ...issuesData };
+  const filteredIssues: Issue[] = issues.filter((issue) => {
+    const ignoredIssue = policy.ignore[issue.issueId];
+    if (!ignoredIssue) {
+      return true;
+    }
+
+    const allResourcesRule = ignoredIssue.find((element) => '*' in element);
+    if (!allResourcesRule) {
+      return true;
+    }
+
+    const expiredIgnoreRule =
+      new Date(allResourcesRule['*'].expires) < new Date();
+    if (!expiredIgnoreRule) {
+      delete filteredIssuesData[issue.issueId];
+      return false;
+    }
+
+    return true;
+  });
+
+  return [filteredIssues, filteredIssuesData];
 }

--- a/src/lib/ecosystems/test.ts
+++ b/src/lib/ecosystems/test.ts
@@ -1,7 +1,7 @@
 import config from '../config';
 import { isCI } from '../is-ci';
 import { makeRequest } from '../request/promise';
-import { Options } from '../types';
+import { Options, PolicyOptions } from '../types';
 import { TestCommandResult } from '../../cli/commands/types';
 import { spinner } from '../../lib/spinner';
 import { Ecosystem, ScanResult, TestResult } from './types';
@@ -15,7 +15,7 @@ import { isUnmanagedEcosystem } from './common';
 export async function testEcosystem(
   ecosystem: Ecosystem,
   paths: string[],
-  options: Options,
+  options: Options & PolicyOptions,
 ): Promise<TestCommandResult> {
   const plugin = getPlugin(ecosystem);
   // TODO: this is an intermediate step before consolidating ecosystem plugins
@@ -69,7 +69,7 @@ export async function testEcosystem(
 export async function selectAndExecuteTestStrategy(
   ecosystem: Ecosystem,
   scanResultsByPath: { [dir: string]: ScanResult[] },
-  options: Options,
+  options: Options & PolicyOptions,
 ): Promise<[TestResult[], string[]]> {
   return isUnmanagedEcosystem(ecosystem)
     ? await resolveAndTestFacts(ecosystem, scanResultsByPath, options)

--- a/src/lib/policy/find-and-load-policy.ts
+++ b/src/lib/policy/find-and-load-policy.ts
@@ -11,7 +11,7 @@ const debug = debugModule('snyk');
 
 export async function findAndLoadPolicy(
   root: string,
-  scanType: SupportedPackageManagers | 'docker' | 'iac',
+  scanType: SupportedPackageManagers | 'docker' | 'iac' | 'cpp',
   options: PolicyOptions,
   pkg?: PackageExpanded,
   scannedProjectFolder?: string,
@@ -53,4 +53,5 @@ export async function findAndLoadPolicy(
 export interface Policy {
   filter(vulns: any, root?: string, matchStrategy?: string): any;
   exclude?: { [key: string]: string[] };
+  ignore?: any;
 }

--- a/src/lib/polling/common.ts
+++ b/src/lib/polling/common.ts
@@ -24,10 +24,12 @@ export function extractResolutionMetaFromScanResult({
   name,
   target,
   identity,
+  policy,
 }: ScanResult): ResolutionMeta {
   return {
     name,
     target,
     identity,
+    policy,
   };
 }

--- a/src/lib/polling/types.ts
+++ b/src/lib/polling/types.ts
@@ -50,4 +50,5 @@ export interface ResolutionMeta {
     type: string;
   };
   target?: GitTarget | ContainerTarget | UnknownTarget;
+  policy?: string;
 }

--- a/test/jest/unit/lib/ecosystems/policy.spec.ts
+++ b/test/jest/unit/lib/ecosystems/policy.spec.ts
@@ -1,0 +1,270 @@
+import { Issue, IssuesData } from '../../../../../src/lib/ecosystems/types';
+import { Policy } from '../../../../../src/lib/policy/find-and-load-policy';
+import { SEVERITY } from '@snyk/fix/dist/types';
+import { filterIgnoredIssues } from '../../../../../src/lib/ecosystems/policy';
+
+describe('filterIgnoredIssues fn', () => {
+  it('should filter the not-expired ignored issues', () => {
+    const issues: Issue[] = [
+      {
+        pkgName: 'https://foo.bar|test1',
+        pkgVersion: '1.0.0',
+        issueId: 'SNYK-TEST-1',
+        fixInfo: {
+          isPatchable: false,
+          upgradePaths: [],
+        },
+      },
+      {
+        pkgName: 'https://foo.bar|test2',
+        pkgVersion: '2.0.0',
+        issueId: 'SNYK-TEST-2',
+        fixInfo: {
+          isPatchable: false,
+          upgradePaths: [],
+        },
+      },
+    ];
+    const issuesData: IssuesData = {
+      'SNYK-TEST-1': {
+        title: 'Arbitrary Code Execution',
+        severity: SEVERITY.LOW,
+        id: 'SNYK-TEST-1',
+      },
+      'SNYK-TEST-2': {
+        title: 'Arbitrary Code Execution',
+        severity: SEVERITY.MEDIUM,
+        id: 'SNYK-TEST-2',
+      },
+    };
+    const policy = {
+      ignore: {
+        'SNYK-TEST-1': [
+          {
+            '*': {
+              reason: 'None Given',
+              expires: new Date(new Date().getTime() + 60 * 60000),
+              created: new Date(),
+            },
+          },
+        ],
+      },
+    };
+
+    const [filteredIssues, filteredIssuesData] = filterIgnoredIssues(
+      issues,
+      issuesData,
+      policy as Policy,
+    );
+
+    expect(filteredIssues).toEqual([
+      {
+        pkgName: 'https://foo.bar|test2',
+        pkgVersion: '2.0.0',
+        issueId: 'SNYK-TEST-2',
+        fixInfo: {
+          isPatchable: false,
+          upgradePaths: [],
+        },
+      },
+    ]);
+    expect(filteredIssuesData).toEqual({
+      'SNYK-TEST-2': {
+        title: 'Arbitrary Code Execution',
+        severity: SEVERITY.MEDIUM,
+        id: 'SNYK-TEST-2',
+      },
+    });
+  });
+
+  it('should not filter the expired ignored issues', () => {
+    const issues: Issue[] = [
+      {
+        pkgName: 'https://foo.bar|test1',
+        pkgVersion: '1.0.0',
+        issueId: 'SNYK-TEST-1',
+        fixInfo: {
+          isPatchable: false,
+          upgradePaths: [],
+        },
+      },
+      {
+        pkgName: 'https://foo.bar|test2',
+        pkgVersion: '2.0.0',
+        issueId: 'SNYK-TEST-2',
+        fixInfo: {
+          isPatchable: false,
+          upgradePaths: [],
+        },
+      },
+    ];
+    const issuesData: IssuesData = {
+      'SNYK-TEST-1': {
+        title: 'Arbitrary Code Execution',
+        severity: SEVERITY.LOW,
+        id: 'SNYK-TEST-1',
+      },
+      'SNYK-TEST-2': {
+        title: 'Arbitrary Code Execution',
+        severity: SEVERITY.MEDIUM,
+        id: 'SNYK-TEST-2',
+      },
+    };
+    const policy = {
+      ignore: {
+        'SNYK-TEST-1': [
+          {
+            '*': {
+              reason: 'None Given',
+              expires: new Date(new Date().getTime() - 60 * 60000),
+              created: new Date(),
+            },
+          },
+        ],
+      },
+    };
+
+    const [filteredIssues, filteredIssuesData] = filterIgnoredIssues(
+      issues,
+      issuesData,
+      policy as Policy,
+    );
+
+    expect(filteredIssues).toEqual(issues);
+    expect(filteredIssuesData).toEqual(issuesData);
+  });
+
+  it('should handle empty issue array', () => {
+    const issues: Issue[] = [];
+    const issuesData: IssuesData = {
+      'SNYK-TEST-1': {
+        title: 'Arbitrary Code Execution',
+        severity: SEVERITY.LOW,
+        id: 'SNYK-TEST-1',
+      },
+    };
+    const policy = {
+      ignore: {
+        'SNYK-TEST-1': [
+          {
+            '*': {
+              reason: 'None Given',
+              expires: new Date(),
+              created: new Date(),
+            },
+          },
+        ],
+      },
+    };
+
+    const [filteredIssues, filteredIssuesData] = filterIgnoredIssues(
+      issues,
+      issuesData,
+      policy as Policy,
+    );
+
+    expect(filteredIssues).toEqual([]);
+    expect(filteredIssuesData).toEqual(issuesData);
+  });
+
+  it('should handle empty issues data object', () => {
+    const issues: Issue[] = [
+      {
+        pkgName: 'https://foo.bar|test1',
+        pkgVersion: '1.0.0',
+        issueId: 'SNYK-TEST-1',
+        fixInfo: {
+          isPatchable: false,
+          upgradePaths: [],
+        },
+      },
+    ];
+    const issuesData: IssuesData = {};
+    const policy = {
+      ignore: {
+        'SNYK-TEST-1': [
+          {
+            '*': {
+              reason: 'None Given',
+              expires: new Date(),
+              created: new Date(),
+            },
+          },
+        ],
+      },
+    };
+
+    const [filteredIssues, filteredIssuesData] = filterIgnoredIssues(
+      issues,
+      issuesData,
+      policy as Policy,
+    );
+
+    expect(filteredIssues).toEqual([]);
+    expect(filteredIssuesData).toEqual({});
+  });
+
+  it('should handle undefined policy file', () => {
+    const issues: Issue[] = [
+      {
+        pkgName: 'https://foo.bar|test1',
+        pkgVersion: '1.0.0',
+        issueId: 'SNYK-TEST-1',
+        fixInfo: {
+          isPatchable: false,
+          upgradePaths: [],
+        },
+      },
+    ];
+    const issuesData: IssuesData = {
+      'SNYK-TEST-1': {
+        title: 'Arbitrary Code Execution',
+        severity: SEVERITY.LOW,
+        id: 'SNYK-TEST-1',
+      },
+    };
+    const policy = undefined;
+
+    const [filteredIssues, filteredIssuesData] = filterIgnoredIssues(
+      issues,
+      issuesData,
+      policy,
+    );
+
+    expect(filteredIssues).toEqual(issues);
+    expect(filteredIssuesData).toEqual(issuesData);
+  });
+
+  it('should handle empty policy file', () => {
+    const issues: Issue[] = [
+      {
+        pkgName: 'https://foo.bar|test1',
+        pkgVersion: '1.0.0',
+        issueId: 'SNYK-TEST-1',
+        fixInfo: {
+          isPatchable: false,
+          upgradePaths: [],
+        },
+      },
+    ];
+    const issuesData: IssuesData = {
+      'SNYK-TEST-1': {
+        title: 'Arbitrary Code Execution',
+        severity: SEVERITY.LOW,
+        id: 'SNYK-TEST-1',
+      },
+    };
+    const policy = {
+      ignore: {},
+    };
+
+    const [filteredIssues, filteredIssuesData] = filterIgnoredIssues(
+      issues,
+      issuesData,
+      policy as Policy,
+    );
+
+    expect(filteredIssues).toEqual(issues);
+    expect(filteredIssuesData).toEqual(issuesData);
+  });
+});

--- a/test/jest/unit/lib/ecosystems/resolve-test-facts.spec.ts
+++ b/test/jest/unit/lib/ecosystems/resolve-test-facts.spec.ts
@@ -87,14 +87,14 @@ describe('resolve and test facts', () => {
 
     expect(extractAndApplyPluginAnalyticsSpy).toHaveBeenCalledTimes(1);
     expect(addAnalyticsSpy).toHaveBeenCalledWith('asyncRequestToken', token);
-    expect(addAnalyticsSpy).toHaveBeenLastCalledWith(
+    expect(addAnalyticsSpy).toHaveBeenCalledWith(
       'fileSignaturesAnalyticsContext',
       {
         totalFileSignatures: 3,
         totalSecondsElapsedToGenerateFileSignatures: 0,
       },
     );
-    expect(addAnalyticsSpy).toHaveBeenCalledTimes(2);
+    expect(addAnalyticsSpy).toHaveBeenCalledTimes(4);
     expect(testResults).toEqual([
       {
         issuesData: {},


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- add support for ignoring the issues when a `.snyk`-like policy is defined in the scanned project (for the unmanaged c/c++ flows)
- add tests 