### PR TITLE
chore: support sub folders in help command

### DIFF
--- a/.github/workflows/sync-cli-help-to-user-docs.yml
+++ b/.github/workflows/sync-cli-help-to-user-docs.yml
@@ -20,7 +20,7 @@ jobs:
           gh repo clone snyk/user-docs docs -- --depth=1 --quiet
           git -C ./cli checkout -b docs/automatic-gitbook-update
 
-          cp ./docs/docs/snyk-cli/commands/*.md ./cli/help/cli-commands/
+          cp -R ./docs/docs/snyk-cli/commands/ ./cli/help/cli-commands/
 
           if [[ $(git -C ./cli status --porcelain) ]]; then
             echo "Documentation changes detected"

--- a/src/cli/commands/help/index.ts
+++ b/src/cli/commands/help/index.ts
@@ -7,14 +7,32 @@ export function findHelpFile(
   helpArgs: string[],
   helpFolderPath = '../../help/cli-commands', // this is a relative path from the webpack dist directory,
 ): string {
+  let helpArgsSubFolders = helpArgs.slice();
+  let subFolder = '';
   while (helpArgs.length > 0) {
     // cleanse the filename to only contain letters
     // aka: /\W/g but figured this was easier to read
     const file = `${helpArgs.join('-').replace(/[^a-z0-9-]/gi, '')}.md`;
     const testHelpAbsolutePath = path.resolve(__dirname, helpFolderPath, file);
+
+    const fileInSubFolders = `${helpArgsSubFolders
+      .join('-')
+      .replace(/[^a-z0-9-]/gi, '')}.md`;
+    const testHelpAbsolutePathInSubFolders = path.resolve(
+      __dirname,
+      helpFolderPath,
+      subFolder,
+      fileInSubFolders,
+    );
+
     if (fs.existsSync(testHelpAbsolutePath)) {
       return testHelpAbsolutePath;
+    } else if (fs.existsSync(testHelpAbsolutePathInSubFolders)) {
+      return testHelpAbsolutePathInSubFolders;
     }
+
+    subFolder = subFolder + helpArgsSubFolders[0] + '/';
+    helpArgsSubFolders = helpArgsSubFolders.slice(1);
     helpArgs = helpArgs.slice(0, -1);
   }
   return path.resolve(__dirname, helpFolderPath, `README.md`); // Default help file


### PR DESCRIPTION
Support sub folders when running the help command.
Also solves issues like [this one](https://snyk.slack.com/archives/C0127HWU0E7/p1647938153732809)