### PR TITLE
Feat: Create IaC report command [CFG-1730]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,7 @@ src/cli/commands/test/iac-local-execution/ @snyk/group-infrastructure-as-code
 src/cli/commands/test/iac-output.ts @snyk/group-infrastructure-as-code
 src/cli/commands/test/iac-test-shim.ts @snyk/group-infrastructure-as-code
 src/cli/commands/describe.ts @snyk/group-infrastructure-as-code
+src/cli/commands/report/ @snyk/group-infrastructure-as-code
 src/cli/commands/gen-driftignore.ts @snyk/group-infrastructure-as-code
 src/cli/commands/apps @snyk/moose
 src/lib/apps @snyk/moose

--- a/src/cli/commands/index.js
+++ b/src/cli/commands/index.js
@@ -19,6 +19,7 @@ const commands = {
   policy: async (...args) => callModule(import('./policy'), args),
   protect: async (...args) => callModule(import('./protect'), args),
   test: async (...args) => callModule(import('./test'), args),
+  report: async (...args) => callModule(import('./report'), args),
   version: async (...args) => callModule(import('./version'), args),
   wizard: async (...args) => callModule(import('./protect/wizard'), args),
   woof: async (...args) => callModule(import('./woof'), args),

--- a/src/cli/commands/report/errors/unsupported-report-command.ts
+++ b/src/cli/commands/report/errors/unsupported-report-command.ts
@@ -1,0 +1,13 @@
+import { CustomError } from '../../../../lib/errors';
+import { getErrorStringCode } from '../../test/iac-local-execution/error-utils';
+import { IaCErrorCodes } from '../../test/iac-local-execution/types';
+
+export class UnsupportedReportCommandError extends CustomError {
+  constructor(message?: string) {
+    super(message || 'Command "report" is only supported for IaC');
+    this.code = IaCErrorCodes.UnsupportedReportCommandError;
+    this.strCode = getErrorStringCode(this.code);
+    this.userMessage =
+      '"report" is not a supported command. Did you mean to use "iac report"?';
+  }
+}

--- a/src/cli/commands/report/index.ts
+++ b/src/cli/commands/report/index.ts
@@ -1,0 +1,35 @@
+import { MethodArgs } from '../../args';
+import { IaCTestFlags } from '../test/iac-local-execution/types';
+import { TestCommandResult } from '../types';
+import test from '../test';
+import { hasFeatureFlag } from '../../../lib/feature-flags';
+import { Options } from '../../../lib/types';
+import { UnsupportedFeatureFlagError } from '../../../lib/errors';
+import { processCommandArgs } from '../process-command-args';
+import { UnsupportedReportCommandError } from './errors/unsupported-report-command';
+
+export default async function report(
+  ...args: MethodArgs
+): Promise<TestCommandResult> {
+  const { paths, options } = processCommandArgs(...args);
+
+  if (options.iac != true) {
+    throw new UnsupportedReportCommandError();
+  }
+
+  await assertReportSupported(options);
+
+  options.report = true;
+
+  return await test(...paths, options);
+}
+
+async function assertReportSupported(options: IaCTestFlags) {
+  const isReportSupported = await hasFeatureFlag(
+    'iacCliShareResults',
+    options as Options,
+  );
+  if (!isReportSupported) {
+    throw new UnsupportedFeatureFlagError('iacCliShareResults');
+  }
+}

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -344,6 +344,9 @@ export enum IaCErrorCodes {
 
   // drift errors
   InvalidServiceError = 1110,
+
+  // report errors
+  UnsupportedReportCommandError = 1120,
 }
 
 export interface TestReturnValue {

--- a/src/cli/modes.ts
+++ b/src/cli/modes.ts
@@ -23,7 +23,7 @@ const modes: Record<string, ModeData> = {
     },
   },
   iac: {
-    allowedCommands: ['test', 'gen-driftignore', 'describe'],
+    allowedCommands: ['test', 'gen-driftignore', 'describe', 'report'],
     config: (args): [] => {
       args['iac'] = true;
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -258,6 +258,7 @@ export enum SupportedCliCommands {
   drift = 'drift',
   describe = 'describe',
   'gen-driftignore' = 'gen-driftignore',
+  report = 'report',
 }
 
 export interface IacFileInDirectory {

--- a/test/jest/acceptance/iac/report.spec.ts
+++ b/test/jest/acceptance/iac/report.spec.ts
@@ -1,0 +1,134 @@
+import { startMockServer } from './helpers';
+import { FakeServer } from '../../../acceptance/fake-server';
+
+jest.setTimeout(50_000);
+
+describe('iac report', () => {
+  let server: FakeServer;
+  let run: (
+    cmd: string,
+  ) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+  let teardown: () => void;
+  let API_HOST: string;
+
+  beforeAll(async () => {
+    ({ server, run, teardown } = await startMockServer());
+    API_HOST = `http://localhost:${server.getPort()}`;
+  });
+
+  afterEach(() => {
+    server.restore();
+  });
+
+  afterAll(async () => teardown());
+
+  it('should return exit code 1', async () => {
+    // Act
+    const { exitCode } = await run(`snyk iac report ./iac/arm/rule_test.json`);
+
+    // Assert
+    expect(exitCode).toEqual(1);
+  });
+
+  it('should include test results in the output', async () => {
+    const { stdout } = await run(`snyk iac report ./iac/arm/rule_test.json`);
+
+    expect(stdout).toContain('Infrastructure as code issues:');
+  });
+
+  it('should include a link to the projects page in the output', async () => {
+    const { stdout } = await run(`snyk iac report ./iac/arm/rule_test.json`);
+
+    expect(stdout).toContain(
+      `Your test results are available at: ${API_HOST}/org/test-org/projects under the name arm`,
+    );
+  });
+
+  it('should forward the scan results to the /iac-cli-share-results endpoint', async () => {
+    // Act
+    await run(`snyk iac report ./iac/arm/rule_test.json`);
+
+    // Assert
+    const testRequests = server
+      .getRequests()
+      .filter((request) => request.url?.includes('/iac-cli-share-results'));
+
+    expect(testRequests.length).toEqual(1);
+    expect(testRequests[0].body).toEqual(
+      expect.objectContaining({
+        contributors: expect.any(Array),
+        scanResults: [
+          {
+            identity: {
+              type: 'armconfig',
+              targetFile: './iac/arm/rule_test.json',
+            },
+            facts: [],
+            findings: expect.any(Array),
+            policy: '',
+            name: 'arm',
+            target: {
+              remoteUrl: 'http://github.com/snyk/cli.git',
+            },
+          },
+        ],
+      }),
+    );
+  });
+
+  describe("when called without the 'iacCliShareResults' feature flag", () => {
+    it('should return an error status code', async () => {
+      // Arrange
+      server.setFeatureFlag('iacCliShareResults', false);
+
+      // Act
+      const { exitCode } = await run(
+        `snyk iac report ./iac/arm/rule_test.json`,
+      );
+
+      // Assert
+      expect(exitCode).toBe(2);
+    });
+
+    it('should print an appropriate error message', async () => {
+      // Arrange
+      server.setFeatureFlag('iacCliShareResults', false);
+
+      // Act
+      const { stdout } = await run(`snyk iac report ./iac/arm/rule_test.json`);
+
+      // Assert
+      expect(stdout).toMatch(
+        "Feature flag 'iacCliShareResults' is not currently enabled for your org, to enable please contact snyk support",
+      );
+    });
+  });
+
+  describe("when called without a preceding 'iac'", () => {
+    it('should return an error status code', async () => {
+      // Act
+      const { exitCode } = await run(`snyk report ./iac/arm/rule_test.json`);
+
+      // Assert
+      expect(exitCode).toBe(2);
+    });
+
+    it('should print an appropriate error message', async () => {
+      // Act
+      const { stdout } = await run(`snyk report ./iac/arm/rule_test.json`);
+
+      // Assert
+      expect(stdout).toContain(
+        '"report" is not a supported command. Did you mean to use "iac report"?',
+      );
+    });
+
+    it('should return an empty stderr', async () => {
+      // Act
+      const { stderr } = await run(`snyk report ./iac/arm/rule_test.json`);
+
+      // Assert
+      expect(stderr).toEqual('');
+    });
+  });
+});

--- a/test/jest/unit/iac/report.spec.ts
+++ b/test/jest/unit/iac/report.spec.ts
@@ -1,0 +1,215 @@
+import * as featureFlags from '../../../../src/lib/feature-flags';
+import * as runTest from '../../../../src/cli/commands/test';
+import report from '../../../../src/cli/commands/report';
+import { ArgsOptions } from '../../../../src/cli/args';
+import { UnsupportedFeatureFlagError } from '../../../../src/lib/errors';
+import { TestCommandResult } from '../../../../src/cli/commands/types';
+import { UnsupportedReportCommandError } from '../../../../src/cli/commands/report/errors/unsupported-report-command';
+
+describe('report', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("should call the 'test' function", async () => {
+    // Arrange
+    const iacTestOptions: any = { iac: true };
+    const fakePath = './fake-path';
+
+    const runTestOutput = TestCommandResult.createHumanReadableTestCommandResult(
+      'fake-output',
+      'fake-json-output',
+      'fake-sarif-output',
+    );
+
+    jest
+      .spyOn(featureFlags, 'hasFeatureFlag')
+      .mockImplementation(async () => true);
+
+    const runTestSpy = jest
+      .spyOn(runTest, 'default')
+      .mockImplementation(async () => runTestOutput);
+
+    // Act
+    await report(fakePath, iacTestOptions);
+
+    // Assert
+    expect(runTestSpy).toBeCalledTimes(1);
+    expect(runTestSpy).toHaveBeenCalledWith(
+      fakePath,
+      expect.objectContaining(iacTestOptions),
+    );
+  });
+
+  it('should add the report option', async () => {
+    // Arrange
+    const iacTestOptions: any = { iac: true };
+    const fakePath = './fake-path';
+
+    const runTestOutput = TestCommandResult.createHumanReadableTestCommandResult(
+      'fake-output',
+      'fake-json-output',
+      'fake-sarif-output',
+    );
+
+    jest
+      .spyOn(featureFlags, 'hasFeatureFlag')
+      .mockImplementation(async () => true);
+
+    const runTestSpy = jest
+      .spyOn(runTest, 'default')
+      .mockImplementation(async () => runTestOutput);
+
+    // Act
+    await report(fakePath, iacTestOptions);
+
+    // Assert
+    expect(runTestSpy).toBeCalledTimes(1);
+
+    const testCallArgs = runTestSpy.mock.calls[0];
+    expect(testCallArgs[testCallArgs.length - 1]).toStrictEqual({
+      ...iacTestOptions,
+      report: true,
+    });
+  });
+
+  it("should return the 'test' function's output", async () => {
+    // Arrange
+    const iacTestOptions: any = { iac: true };
+    const fakePath = './fake-path';
+
+    const runTestOutput = TestCommandResult.createHumanReadableTestCommandResult(
+      'fake-output',
+      'fake-json-output',
+      'fake-sarif-output',
+    );
+
+    jest
+      .spyOn(featureFlags, 'hasFeatureFlag')
+      .mockImplementation(async () => true);
+
+    jest
+      .spyOn(runTest, 'default')
+      .mockImplementation(async () => runTestOutput);
+
+    // Act
+    const result = await report(fakePath, iacTestOptions);
+
+    // Assert
+    expect(result).toStrictEqual(runTestOutput);
+  });
+
+  describe("when the org does not have the 'iacCliShareResults' feature flag", () => {
+    it('should throw an appropriate error', async () => {
+      // Arrange
+      const iacTestOptions: any = { iac: true };
+      const fakePath = './fake-path';
+
+      const runTestOutput = TestCommandResult.createHumanReadableTestCommandResult(
+        'fake-output',
+        'fake-json-output',
+        'fake-sarif-output',
+      );
+
+      jest
+        .spyOn(featureFlags, 'hasFeatureFlag')
+        .mockImplementation(
+          async (featureFlag) => featureFlag !== 'iacCliShareResults',
+        );
+
+      jest
+        .spyOn(runTest, 'default')
+        .mockImplementation(async () => runTestOutput);
+
+      // Act + Assert
+      await expect(report(fakePath, iacTestOptions)).rejects.toThrow(
+        UnsupportedFeatureFlagError,
+      );
+    });
+
+    it("should not call the 'test' function", async () => {
+      // Arrange
+      const iacTestOptions = {} as ArgsOptions;
+      const fakePath = './fake-path';
+
+      const runTestOutput: any = TestCommandResult.createHumanReadableTestCommandResult(
+        'fake-output',
+        'fake-json-output',
+        'fake-sarif-output',
+      );
+
+      jest
+        .spyOn(featureFlags, 'hasFeatureFlag')
+        .mockImplementation(
+          async (featureFlag) => featureFlag !== 'iacCliShareResults',
+        );
+
+      const runTestSpy = jest
+        .spyOn(runTest, 'default')
+        .mockImplementation(async () => runTestOutput);
+
+      // Act
+      await expect(report(fakePath, iacTestOptions)).rejects.toThrow();
+
+      // Assert
+      expect(runTestSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when options do not include 'iac'", () => {
+    it('should throw an appropriate error', async () => {
+      // Arrange
+      const iacTestOptions = {} as ArgsOptions;
+      const fakePath = './fake-path';
+
+      const runTestOutput = TestCommandResult.createHumanReadableTestCommandResult(
+        'fake-output',
+        'fake-json-output',
+        'fake-sarif-output',
+      );
+
+      jest
+        .spyOn(featureFlags, 'hasFeatureFlag')
+        .mockImplementation(
+          async (featureFlag) => featureFlag !== 'iacCliShareResults',
+        );
+
+      jest
+        .spyOn(runTest, 'default')
+        .mockImplementation(async () => runTestOutput);
+
+      // Act + Assert
+      await expect(report(fakePath, iacTestOptions)).rejects.toThrow(
+        UnsupportedReportCommandError,
+      );
+    });
+
+    it("should not call the 'test' function", async () => {
+      // Arrange
+      const iacTestOptions = {} as ArgsOptions;
+      const fakePath = './fake-path';
+
+      const runTestOutput: any = TestCommandResult.createHumanReadableTestCommandResult(
+        'fake-output',
+        'fake-json-output',
+        'fake-sarif-output',
+      );
+
+      jest
+        .spyOn(featureFlags, 'hasFeatureFlag')
+        .mockImplementation(
+          async (featureFlag) => featureFlag !== 'iacCliShareResults',
+        );
+
+      const runTestSpy = jest
+        .spyOn(runTest, 'default')
+        .mockImplementation(async () => runTestOutput);
+
+      // Act
+      await expect(report(fakePath, iacTestOptions)).rejects.toThrow();
+
+      // Assert
+      expect(runTestSpy).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Introduces a new command in the Snyk CLI -  `snyk iac report`, which servers as an alias to an existing command: `snyk iac test --report`

#### Where should the reviewer start?

- `src/cli/commands/report.ts`

#### How should this be manually tested?

##### With the `iacCliShareResults` feature flag

1. Ensure your org *does not have* the `iacCliShareResults` feature flag.
2. In the Snyk CLI, run:
    ```
    snyk iac report <path-to-iac-file-or-directory>
    ```
3. in the Snyk CLI, run:
    ```
    snyk iac test <path-to-iac-file-or-directory> --report
    ```
4. Ensure the `report` command has the same output as the previously existing `test --report` command.

##### With the `iacCliShareResults` feature flag

1. Ensure your org *has* the `iacCliShareResults` feature flag.
2. In the Snyk CLI, run:
    ```
    snyk iac report <path-to-iac-file-or-directory>
    ```
4. Ensure that an error appears for the missing feature flag.

#### Any background context you want to provide?

We’d like to explore various approaches for introducing the new functionality for sending scan results over from the Snyk CLI to the Snyk Platform for persistence.

In the current implementation, this feature is exclusively available via a flag for IaC's test command, `snyk iac test --report`.
For the open-beta, we’d like to also make it available via a new command, `snyk iac report`.

Both should behave similarly, as they both run a test and send the results back to the Snyk platform. 
The goal is to examine this during the Open-Beta phase and to get feedback from customers on:
1. Which of the alternatives is preferable.
2. if the naming of `report` aligns with their expectation.
3. if the user experience of this new functionality aligns with their expectations.

The decision to move forward also with the `report` command after various considerations was made [here](https://snyk.slack.com/archives/C02UUBNJH4J/p1647865267389789?thread_ts=1647427407.011679&cid=C02UUBNJH4J).

#### What are the relevant tickets?

- [CFG-1730](https://snyksec.atlassian.net/browse/CFG-1730)
