### PR TITLE
feat: support metadata for excluded paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "snyk-nodejs-lockfile-parser": "1.38.0",
         "snyk-nuget-plugin": "1.23.4",
         "snyk-php-plugin": "1.9.2",
-        "snyk-policy": "^1.24.0",
+        "snyk-policy": "^1.25.0",
         "snyk-python-plugin": "1.23.1",
         "snyk-resolve-deps": "4.7.3",
         "snyk-sbt-plugin": "2.14.0",
@@ -16896,9 +16896,9 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/snyk-policy": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-1.24.0.tgz",
-      "integrity": "sha512-IKevv5lyGCXlzgqFsu4qVJ7zxud/NzsDF+ng15wbDPjdObTuLQQSgK3xosPlNgipRHFG9TY6uZFj3fVsj1fmPA==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-1.25.0.tgz",
+      "integrity": "sha512-naAoqjlspwioBDlrSk5/pPGlSX2dMG42XDhoUdU/41NPS57jsifpENgiT83HEJDbTRGHOPTmQ1B4lvRupb70hQ==",
       "dependencies": {
         "debug": "^4.1.1",
         "email-validator": "^2.0.4",
@@ -32999,9 +32999,9 @@
       }
     },
     "snyk-policy": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-1.24.0.tgz",
-      "integrity": "sha512-IKevv5lyGCXlzgqFsu4qVJ7zxud/NzsDF+ng15wbDPjdObTuLQQSgK3xosPlNgipRHFG9TY6uZFj3fVsj1fmPA==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-1.25.0.tgz",
+      "integrity": "sha512-naAoqjlspwioBDlrSk5/pPGlSX2dMG42XDhoUdU/41NPS57jsifpENgiT83HEJDbTRGHOPTmQ1B4lvRupb70hQ==",
       "requires": {
         "debug": "^4.1.1",
         "email-validator": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "snyk-nodejs-lockfile-parser": "1.38.0",
     "snyk-nuget-plugin": "1.23.4",
     "snyk-php-plugin": "1.9.2",
-    "snyk-policy": "^1.24.0",
+    "snyk-policy": "^1.25.0",
     "snyk-python-plugin": "1.23.1",
     "snyk-resolve-deps": "4.7.3",
     "snyk-sbt-plugin": "2.14.0",

--- a/src/cli/commands/ignore.ts
+++ b/src/cli/commands/ignore.ts
@@ -113,10 +113,20 @@ export async function excludeFilePathPattern(options): Promise<MethodResult> {
   const group = options['file-path-group'] || 'global';
   const policyPath = options['policy-path'];
 
+  const excludeOptions = {};
+
+  if (options.reason !== undefined) {
+    excludeOptions['reason'] = options.reason;
+  }
+
+  if (options.expiry !== undefined) {
+    excludeOptions['expires'] = new Date(options.expiry);
+  }
+
   debug(`changing policy: ignore "%s" added to "%s"`, pattern, policyPath);
 
   const pol = await load(policyPath);
-  pol.addExclude(pattern, group);
+  pol.addExclude(pattern, group, excludeOptions);
 
   return policy.save(pol, policyPath);
 }

--- a/test/acceptance/workspaces/npm-package-policy/.snyk
+++ b/test/acceptance/workspaces/npm-package-policy/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.24.0
+version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   'npm:marked:20170907':

--- a/test/acceptance/workspaces/npm-package-policy/custom-location/.snyk
+++ b/test/acceptance/workspaces/npm-package-policy/custom-location/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.24.0
+version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   'npm:marked:20170907':

--- a/test/acceptance/workspaces/npm-with-dep-missing-policy/.snyk
+++ b/test/acceptance/workspaces/npm-with-dep-missing-policy/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.24.0
+version: v1.25.0
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 patch:

--- a/test/jest/unit/iac/cli-share-results.fixtures.ts
+++ b/test/jest/unit/iac/cli-share-results.fixtures.ts
@@ -173,7 +173,7 @@ export const expectedEnvelopeFormatterResultsWithPolicy = expectedEnvelopeFormat
     return {
       ...result,
       policy: `# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.24.0
+version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-CC-TF-4:


### PR DESCRIPTION
# feat: support metadata for excluded paths

Adds support for meta-data during write and update of excluded files.
Meta data supported:

- creation
- expiry
- reason

## Background

  Some excluded files, should only be excluded during a certain
  time. After that date, we will scan and check for vuln. in
  those files again.

## Usage

  > snyk ignore --file-path='./**/vendors/**.ts' --expiry=2092-10-10 --reason='files has been patched'