### PR TITLE
fix: remove target.branch

### DIFF
--- a/src/lib/iac/envelope-formatters.ts
+++ b/src/lib/iac/envelope-formatters.ts
@@ -26,7 +26,7 @@ export function convertIacResultToScanResult(
     target:
       Object.keys(gitTarget).length === 0
         ? { name: iacResult.projectName }
-        : { ...gitTarget, branch: 'master' },
+        : { remoteUrl: gitTarget.remoteUrl },
     policy: policy?.toString() ?? '',
   };
 }

--- a/test/jest/acceptance/iac/cli-share-results.spec.ts
+++ b/test/jest/acceptance/iac/cli-share-results.spec.ts
@@ -82,7 +82,6 @@ describe('CLI Share Results', () => {
               policy: '',
               name: 'arm',
               target: {
-                branch: 'master',
                 remoteUrl: 'http://github.com/snyk/cli.git',
               },
             },

--- a/test/jest/unit/iac/cli-share-results.fixtures.ts
+++ b/test/jest/unit/iac/cli-share-results.fixtures.ts
@@ -121,7 +121,6 @@ export const expectedEnvelopeFormatterResults = [
     policy: '',
     target: {
       remoteUrl: 'http://github.com/snyk/cli.git',
-      branch: 'master',
     },
   },
   {
@@ -163,7 +162,6 @@ export const expectedEnvelopeFormatterResults = [
     policy: '',
     target: {
       remoteUrl: 'http://github.com/snyk/cli.git',
-      branch: 'master',
     },
   },
 ];

--- a/test/jest/unit/iac/cli-share-results.spec.ts
+++ b/test/jest/unit/iac/cli-share-results.spec.ts
@@ -40,6 +40,7 @@ describe('CLI Share Results', () => {
       firstCallResult,
       secondCallResult,
     ] = envelopeFormattersSpy.mock.results;
+
     expect(firstCallResult.value).toEqual(expectedEnvelopeFormatterResults[0]);
     expect(secondCallResult.value).toEqual(expectedEnvelopeFormatterResults[1]);
   });
@@ -57,6 +58,7 @@ describe('CLI Share Results', () => {
       firstCallResult,
       secondCallResult,
     ] = envelopeFormattersSpy.mock.results;
+
     expect(firstCallResult.value).toEqual(
       expectedEnvelopeFormatterResultsWithPolicy[0],
     );


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Currently, when running a scan from a directory that is a part of a git repo we will save inside the `target` filed the repo remote URL and branch.
We are using the remote URL to get information for the contributing developers but we currently don't have any use for the branch.
In addition to that, a side affect of sending the branch inside the `target` is that it gets auto-assigned as the `target-reference` which is not the desired outcome.
Due to all the reasons I mentioned above we've decided to remove the branch from the `target`.

#### How should this be manually tested?
1. Enable the `iacCliShareResults` FF.
2. Use the command `snyk iac test --report` to test your IaC files.
3. Check that the projects have been created successfully in the platform WITHOUT target-reference.
