### PR TITLE
feat: display policy's exclude entries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "snyk-nodejs-lockfile-parser": "1.38.0",
         "snyk-nuget-plugin": "1.23.4",
         "snyk-php-plugin": "1.9.2",
-        "snyk-policy": "^1.22.2",
+        "snyk-policy": "^1.24.0",
         "snyk-python-plugin": "1.22.3",
         "snyk-resolve": "1.1.0",
         "snyk-resolve-deps": "4.7.3",
@@ -17092,9 +17092,9 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/snyk-policy": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-1.22.2.tgz",
-      "integrity": "sha512-jfyehPfeRW7wD98i0HblaUv7EkyQBaeR4JQsG+pPR0bLhuA+VdBJkByZRgaZaG2Gatt+MeoSOa93BsYRZA5bjg==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-1.24.0.tgz",
+      "integrity": "sha512-IKevv5lyGCXlzgqFsu4qVJ7zxud/NzsDF+ng15wbDPjdObTuLQQSgK3xosPlNgipRHFG9TY6uZFj3fVsj1fmPA==",
       "dependencies": {
         "debug": "^4.1.1",
         "email-validator": "^2.0.4",
@@ -33359,9 +33359,9 @@
       }
     },
     "snyk-policy": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-1.22.2.tgz",
-      "integrity": "sha512-jfyehPfeRW7wD98i0HblaUv7EkyQBaeR4JQsG+pPR0bLhuA+VdBJkByZRgaZaG2Gatt+MeoSOa93BsYRZA5bjg==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-1.24.0.tgz",
+      "integrity": "sha512-IKevv5lyGCXlzgqFsu4qVJ7zxud/NzsDF+ng15wbDPjdObTuLQQSgK3xosPlNgipRHFG9TY6uZFj3fVsj1fmPA==",
       "requires": {
         "debug": "^4.1.1",
         "email-validator": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "snyk-nodejs-lockfile-parser": "1.38.0",
     "snyk-nuget-plugin": "1.23.4",
     "snyk-php-plugin": "1.9.2",
-    "snyk-policy": "^1.22.2",
+    "snyk-policy": "^1.24.0",
     "snyk-python-plugin": "1.22.3",
     "snyk-resolve": "1.1.0",
     "snyk-resolve-deps": "4.7.3",

--- a/src/lib/display-policy.ts
+++ b/src/lib/display-policy.ts
@@ -4,6 +4,8 @@ import config from './config';
 
 export async function display(policy) {
   const p = demunge(policy, config.ROOT);
+  const delimiter = '\n\n------------------------\n';
+
   let res =
     chalk.bold(
       'Current Snyk policy, read from ' + policy.__filename + ' file',
@@ -13,9 +15,15 @@ export async function display(policy) {
 
   res += p.patch.map(displayRule('Patch vulnerability')).join('\n');
   if (p.patch.length && p.ignore.length) {
-    res += '\n\n------------------------\n';
+    res += delimiter;
   }
+
   res += p.ignore.map(displayRule('Ignore')).join('\n');
+  if (p.ignore.length && p.exclude.length) {
+    res += delimiter;
+  }
+
+  res += p.exclude.map(displayRule('Exclude')).join('\n');
 
   return Promise.resolve(res);
 }
@@ -23,9 +31,16 @@ export async function display(policy) {
 function displayRule(title) {
   return (rule, i) => {
     i += 1;
+
+    const formattedTitle =
+      title === 'Exclude'
+        ? chalk.bold(`\n#${i} ${title}`) +
+          ` the following ${chalk.bold(rule.id)} items/paths:\n`
+        : chalk.bold(`\n#${i} ${title} ${rule.url}`) +
+          ' in the following paths:\n';
+
     return (
-      chalk.bold('\n#' + i + ' ' + title + ' ' + rule.url) +
-      ' in the following paths:\n' +
+      formattedTitle +
       rule.paths
         .map((p) => {
           return (

--- a/test/acceptance/workspaces/npm-package-policy/.snyk
+++ b/test/acceptance/workspaces/npm-package-policy/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.22.2
+version: v1.24.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   'npm:marked:20170907':

--- a/test/acceptance/workspaces/npm-package-policy/custom-location/.snyk
+++ b/test/acceptance/workspaces/npm-package-policy/custom-location/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.22.2
+version: v1.24.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   'npm:marked:20170907':

--- a/test/acceptance/workspaces/npm-with-dep-missing-policy/.snyk
+++ b/test/acceptance/workspaces/npm-with-dep-missing-policy/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.22.2
+version: v1.24.0
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 patch:

--- a/test/fixtures/npm/with-vulnnerable-lodash-and-snyk-file/.snyk
+++ b/test/fixtures/npm/with-vulnnerable-lodash-and-snyk-file/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.22.2
+version: v1.24.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-JS-LODASH-590103:

--- a/test/fixtures/project-with-patchable-dep-fixture-and-snyk-patched/.snyk
+++ b/test/fixtures/project-with-patchable-dep-fixture-and-snyk-patched/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.22.2
+version: v1.24.0
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 patch:

--- a/test/fixtures/protect-lodash-skip/.snyk
+++ b/test/fixtures/protect-lodash-skip/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.22.2
+version: v1.24.0
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 

--- a/test/fixtures/protect-semver/.snyk
+++ b/test/fixtures/protect-semver/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.22.2
+version: v1.24.0
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 patch:

--- a/test/fixtures/snyk-config-no-version/.snyk
+++ b/test/fixtures/snyk-config-no-version/.snyk
@@ -41,3 +41,22 @@ patch:
   'npm:uglify-js:20151024':
     - 'handlebars@4.0.3 > uglify-js@2.4.24':
         patched: '2015-11-20T16:37:39.554Z'
+exclude:
+  global:
+    - some/excluded/file/file-to-exclude.cpp:
+        reason: False positive
+        expires: 2022-04-17T12:57:47.569Z
+        created: 2022-03-18T12:57:47.576Z
+    - some/excluded/folder:
+        reason: None Given
+        expires: 2022-04-17T12:57:47.569Z
+        created: 2022-03-18T12:57:47.576Z
+  code:
+    - some/path
+    - some/file
+  iac-drift:
+    - '*'
+    - '!aws_iam_*'
+    - 'aws_s3_*'
+    - 'aws_s3_bucket.*'
+    - 'aws_s3_bucket.name*'

--- a/test/fixtures/snyk-config-no-version/expected
+++ b/test/fixtures/snyk-config-no-version/expected
@@ -42,3 +42,25 @@ Expires: Sun, 20 Dec 2015 16:37:39 GMT
 tap@0.7.1 > runforcover@0.0.2 > bunker@0.1.2 > burrito@0.2.12 > uglify-js@1.1.1
 Reason: Stuff
 Expires: Sun, 20 Dec 2015 16:37:39 GMT
+
+------------------------
+
+#1 Exclude the following global items/paths:
+some/excluded/file/file-to-exclude.cpp
+Reason: False positive
+Expires: Sun, 17 Apr 2022 12:57:47 GMT
+
+some/excluded/folder
+Reason: None Given
+Expires: Sun, 17 Apr 2022 12:57:47 GMT
+
+#2 Exclude the following code items/paths:
+some/path
+some/file
+
+#3 Exclude the following iac-drift items/paths:
+*
+!aws_iam_*
+aws_s3_*
+aws_s3_bucket.*
+aws_s3_bucket.name*

--- a/test/jest/unit/iac/cli-share-results.fixtures.ts
+++ b/test/jest/unit/iac/cli-share-results.fixtures.ts
@@ -173,7 +173,7 @@ export const expectedEnvelopeFormatterResultsWithPolicy = expectedEnvelopeFormat
     return {
       ...result,
       policy: `# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.22.2
+version: v1.24.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-CC-TF-4:


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- include the 'exclude' rules on the demunge implementation
- exclude might contain 2 categories/ids: `global` and `code`
- the entries for `exclude.global/code` might be simple paths (strings) or objects (including metadata like reason, creation/expiration dates).

The changes on the policy library were done here: https://github.com/snyk/policy/pull/70

#### Screenshots

<img width="1054" alt="Screenshot 2022-03-24 at 18 21 55" src="https://user-images.githubusercontent.com/6909300/159962982-3347a63f-8576-48e7-84b8-107cbf458ece.png">

