### PR TITLE
fix: Honor the --org flag when running snyk iac test --report

### DIFF
--- a/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
+++ b/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
@@ -22,6 +22,7 @@ const keys: (keyof IaCTestFlags)[] = [
   'quiet',
   'scan',
   'report',
+  'target-reference',
 
   // PolicyOptions
   'ignore-policy',

--- a/src/cli/commands/test/iac-local-execution/share-results.ts
+++ b/src/cli/commands/test/iac-local-execution/share-results.ts
@@ -21,5 +21,5 @@ export async function formatAndShareResults(
 
   const formattedResults = formatShareResults(results, options);
 
-  return await shareResults(formattedResults, policy);
+  return await shareResults(formattedResults, policy, options);
 }

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -180,6 +180,7 @@ export type IaCTestFlags = Pick<
   | 'json'
   | 'sarif'
   | 'report'
+  | 'target-reference'
 
   // PolicyOptions
   | 'ignore-policy'

--- a/src/lib/ecosystems/types.ts
+++ b/src/lib/ecosystems/types.ts
@@ -32,6 +32,7 @@ export interface ScanResult {
   policy?: string;
   target?: GitTarget | ContainerTarget | UnknownTarget;
   analytics?: Analytics[];
+  targetReference?: string;
 }
 
 export interface Analytics {

--- a/src/lib/iac/cli-share-results.ts
+++ b/src/lib/iac/cli-share-results.ts
@@ -1,9 +1,11 @@
 import config from '../config';
 import { makeRequest } from '../request';
 import { getAuthHeader } from '../api-token';
-import { IacShareResultsFormat } from '../../cli/commands/test/iac-local-execution/types';
+import {
+  IacShareResultsFormat,
+  IaCTestFlags,
+} from '../../cli/commands/test/iac-local-execution/types';
 import { convertIacResultToScanResult } from './envelope-formatters';
-import { AuthFailedError } from '../errors/authentication-failed-error';
 import { Policy } from '../policy/find-and-load-policy';
 import { getInfo } from '../project-metadata/target-builders/git';
 import { GitTarget } from '../ecosystems/types';
@@ -11,15 +13,18 @@ import { Contributor } from '../types';
 import * as analytics from '../analytics';
 import { getContributors } from '../monitor/dev-count-analysis';
 import * as Debug from 'debug';
+import { AuthFailedError, ValidationError } from '../errors';
+
 const debug = Debug('iac-cli-share-results');
 
 export async function shareResults(
   results: IacShareResultsFormat[],
   policy: Policy | undefined,
+  options?: IaCTestFlags,
 ): Promise<Record<string, string>> {
   const gitTarget = (await getInfo(false)) as GitTarget;
   const scanResults = results.map((result) =>
-    convertIacResultToScanResult(result, policy, gitTarget),
+    convertIacResultToScanResult(result, policy, gitTarget, options),
   );
 
   let contributors: Contributor[] = [];
@@ -47,6 +52,12 @@ export async function shareResults(
 
   if (res.statusCode === 401) {
     throw AuthFailedError();
+  }
+
+  if (res.statusCode === 422) {
+    throw new ValidationError(
+      res.body.error ?? 'An error occurred, please contact Snyk support',
+    );
   }
 
   return body;

--- a/src/lib/iac/cli-share-results.ts
+++ b/src/lib/iac/cli-share-results.ts
@@ -41,6 +41,7 @@ export async function shareResults(
     method: 'POST',
     url: `${config.API}/iac-cli-share-results`,
     json: true,
+    qs: { org: options?.org ?? config.org },
     headers: {
       authorization: getAuthHeader(),
     },

--- a/src/lib/iac/envelope-formatters.ts
+++ b/src/lib/iac/envelope-formatters.ts
@@ -1,5 +1,6 @@
 import {
   IacShareResultsFormat,
+  IaCTestFlags,
   PolicyMetadata,
 } from '../../cli/commands/test/iac-local-execution/types';
 import { GitTarget, ScanResult } from '../ecosystems/types';
@@ -9,6 +10,7 @@ export function convertIacResultToScanResult(
   iacResult: IacShareResultsFormat,
   policy: Policy | undefined,
   gitTarget: GitTarget,
+  options?: IaCTestFlags,
 ): ScanResult {
   return {
     identity: {
@@ -28,5 +30,6 @@ export function convertIacResultToScanResult(
         ? { name: iacResult.projectName }
         : { ...gitTarget, branch: 'master' },
     policy: policy?.toString() ?? '',
+    targetReference: options?.['target-reference'],
   };
 }

--- a/test/jest/acceptance/iac/cli-share-results.spec.ts
+++ b/test/jest/acceptance/iac/cli-share-results.spec.ts
@@ -90,5 +90,43 @@ describe('CLI Share Results', () => {
         }),
       );
     });
+
+    describe('with target reference', () => {
+      it('forwards the target reference to iac-cli-share-results endpoint', async () => {
+        const testTargetRef = 'test-target-ref';
+
+        const { exitCode } = await run(
+          `snyk iac test ./iac/arm/rule_test.json --report --target-reference=${testTargetRef}`,
+        );
+
+        expect(exitCode).toEqual(1);
+
+        const testRequests = server
+          .getRequests()
+          .filter((request) => request.url?.includes('/iac-cli-share-results'));
+
+        expect(testRequests[0]).toMatchObject({
+          body: {
+            contributors: expect.any(Array),
+            scanResults: [
+              {
+                identity: {
+                  type: 'armconfig',
+                  targetFile: './iac/arm/rule_test.json',
+                },
+                facts: [],
+                findings: expect.arrayContaining([]),
+                name: 'arm',
+                target: {
+                  branch: 'master',
+                  remoteUrl: 'http://github.com/snyk/cli.git',
+                },
+                targetReference: testTargetRef,
+              },
+            ],
+          },
+        });
+      });
+    });
   });
 });

--- a/test/jest/unit/iac/cli-share-results.fixtures.ts
+++ b/test/jest/unit/iac/cli-share-results.fixtures.ts
@@ -123,6 +123,7 @@ export const expectedEnvelopeFormatterResults = [
       remoteUrl: 'http://github.com/snyk/cli.git',
       branch: 'master',
     },
+    targetReference: undefined,
   },
   {
     identity: {
@@ -165,6 +166,7 @@ export const expectedEnvelopeFormatterResults = [
       remoteUrl: 'http://github.com/snyk/cli.git',
       branch: 'master',
     },
+    targetReference: undefined,
   },
 ];
 
@@ -184,3 +186,13 @@ patch: {}
     };
   },
 );
+
+export const createEnvelopeFormatterResultsWithTargetRef = (
+  targetReference: string,
+) =>
+  expectedEnvelopeFormatterResults.map((result) => {
+    return {
+      ...result,
+      targetReference,
+    };
+  });

--- a/test/jest/unit/iac/cli-share-results.spec.ts
+++ b/test/jest/unit/iac/cli-share-results.spec.ts
@@ -2,6 +2,7 @@ import { shareResults } from '../../../../src/lib/iac/cli-share-results';
 import {
   expectedEnvelopeFormatterResults,
   expectedEnvelopeFormatterResultsWithPolicy,
+  createEnvelopeFormatterResultsWithTargetRef,
   scanResults,
 } from './cli-share-results.fixtures';
 import * as request from '../../../../src/lib/request';
@@ -42,6 +43,58 @@ describe('CLI Share Results', () => {
     ] = envelopeFormattersSpy.mock.results;
     expect(firstCallResult.value).toEqual(expectedEnvelopeFormatterResults[0]);
     expect(secondCallResult.value).toEqual(expectedEnvelopeFormatterResults[1]);
+  });
+
+  it("converts the results to Envelope's ScanResult interface - with .snyk policies", async () => {
+    await shareResults(scanResults, snykPolicy);
+
+    expect(envelopeFormattersSpy.mock.calls.length).toBe(2);
+
+    const [firstCall, secondCall] = envelopeFormattersSpy.mock.calls;
+    expect(firstCall[0]).toEqual(scanResults[0]);
+    expect(secondCall[0]).toEqual(scanResults[1]);
+
+    const [
+      firstCallResult,
+      secondCallResult,
+    ] = envelopeFormattersSpy.mock.results;
+    expect(firstCallResult.value).toEqual(
+      expectedEnvelopeFormatterResultsWithPolicy[0],
+    );
+    expect(secondCallResult.value).toEqual(
+      expectedEnvelopeFormatterResultsWithPolicy[1],
+    );
+  });
+
+  describe('when given a target reference', () => {
+    it("should include it in the Envelope's ScanResult interface", async () => {
+      const testTargetRef = 'test-target-ref';
+      const expectedEnvelopeFormatterResults = createEnvelopeFormatterResultsWithTargetRef(
+        testTargetRef,
+      );
+
+      await shareResults(scanResults, undefined, {
+        'target-reference': testTargetRef,
+      });
+
+      expect(envelopeFormattersSpy.mock.calls.length).toBe(2);
+
+      const [firstCall, secondCall] = envelopeFormattersSpy.mock.calls;
+      expect(firstCall[0]).toEqual(scanResults[0]);
+      expect(secondCall[0]).toEqual(scanResults[1]);
+
+      const [
+        firstCallResult,
+        secondCallResult,
+      ] = envelopeFormattersSpy.mock.results;
+      expect(firstCallResult.value).toEqual(
+        expectedEnvelopeFormatterResults[0],
+      );
+
+      expect(secondCallResult.value).toEqual(
+        expectedEnvelopeFormatterResults[1],
+      );
+    });
   });
 
   it("converts the results to Envelope's ScanResult interface - with .snyk policies", async () => {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Adds support for the `--org` flag to the `snyk iac test --report` command. Previous to this change the `--report` flag will always send the share results to the same default org. Now it will respect the value.

#### Where should the reviewer start?

Start in src/lib/iac/cli-share-results.ts this passes the `{ org: "<org>" }` value in the query string which is picked up by registry. I've also updated the tests. The mocks were not working before, they were set once in a beforeEach block and then reset after the first test. We also were still making network calls to the backend so the new `mockImplementation()` call also stubs that out.

#### How should this be manually tested?

    % snyk-dev iac test --report --org=<non-default-org> test/fixtures/iac/kubernetes

#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
