### PR TITLE
fix: support comments in python manifest in requirements line

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "snyk-nuget-plugin": "1.23.4",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.24.0",
-        "snyk-python-plugin": "1.22.3",
+        "snyk-python-plugin": "1.23.1",
         "snyk-resolve": "1.1.0",
         "snyk-resolve-deps": "4.7.3",
         "snyk-sbt-plugin": "2.13.0",
@@ -17138,9 +17138,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-python-plugin": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.22.3.tgz",
-      "integrity": "sha512-ISwY5GZtNlUqA4R58eG6MhaDbZb3NfG9suSgU2r4OTjyLrym6l+XYZGVQNUG+5G677j7Ms20AVSPmL/5eP6ezg==",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.23.1.tgz",
+      "integrity": "sha512-eX6HRJFIrNErlFUWwmaK9xl+NzKmkNXBk2VvF/HzyIY1jPwr75xsfwIOqEQDFwGR14IHNg+g/y4k4cMLTbZhJw==",
       "dependencies": {
         "@snyk/cli-interface": "^2.11.2",
         "@snyk/dep-graph": "^1.28.1",
@@ -33398,9 +33398,9 @@
       }
     },
     "snyk-python-plugin": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.22.3.tgz",
-      "integrity": "sha512-ISwY5GZtNlUqA4R58eG6MhaDbZb3NfG9suSgU2r4OTjyLrym6l+XYZGVQNUG+5G677j7Ms20AVSPmL/5eP6ezg==",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.23.1.tgz",
+      "integrity": "sha512-eX6HRJFIrNErlFUWwmaK9xl+NzKmkNXBk2VvF/HzyIY1jPwr75xsfwIOqEQDFwGR14IHNg+g/y4k4cMLTbZhJw==",
       "requires": {
         "@snyk/cli-interface": "^2.11.2",
         "@snyk/dep-graph": "^1.28.1",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "snyk-nuget-plugin": "1.23.4",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.24.0",
-    "snyk-python-plugin": "1.22.3",
+    "snyk-python-plugin": "1.23.1",
     "snyk-resolve": "1.1.0",
     "snyk-resolve-deps": "4.7.3",
     "snyk-sbt-plugin": "2.13.0",


### PR DESCRIPTION
#### What does this PR do?

today we fail in the case of '-r requirements # comment' line in the requirements.txt manifest file.
this upgrade fixes it (and ignore the comments)

