### PR TITLE
chore: Rename references to v3 api to rest api

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -1,6 +1,6 @@
 {
   "API": "https://snyk.io/api/v1",
-  "API_V3_URL": "https://api.snyk.io/v3",
+  "API_REST_URL": "https://api.snyk.io/rest",
   "devDeps": false,
   "PRUNE_DEPS_THRESHOLD": 40000,
   "MAX_PATH_COUNT": 1500000,

--- a/src/cli/commands/apps/create-app.ts
+++ b/src/cli/commands/apps/create-app.ts
@@ -3,12 +3,12 @@ import {
   EAppsURL,
   getAppsURL,
   handleCreateAppRes,
-  handleV3Error,
+  handleRestError,
   ICreateAppRequest,
   ICreateAppResponse,
   SNYK_APP_DEBUG,
 } from '../../../lib/apps';
-import { makeRequestV3 } from '../../../lib/request/promise';
+import { makeRequestRest } from '../../../lib/request/promise';
 import { spinner } from '../../../lib/spinner';
 
 const debug = Debug(SNYK_APP_DEBUG);
@@ -46,12 +46,12 @@ export async function createApp(
 
   try {
     await spinner('Creating your Snyk App');
-    const response = await makeRequestV3<ICreateAppResponse>(payload);
+    const response = await makeRequestRest<ICreateAppResponse>(payload);
     debug(response);
     spinner.clearAll();
     return handleCreateAppRes(response);
   } catch (error) {
     spinner.clearAll();
-    handleV3Error(error);
+    handleRestError(error);
   }
 }

--- a/src/lib/apps/index.ts
+++ b/src/lib/apps/index.ts
@@ -1,6 +1,6 @@
 export * from './constants';
 export * from './prompts';
 export * from './types';
-export * from './v3-utils';
+export * from './rest-utils';
 export * from './utils';
 export * from './input-validator';

--- a/src/lib/apps/rest-utils.ts
+++ b/src/lib/apps/rest-utils.ts
@@ -6,7 +6,7 @@ import {
   EAppsURL,
   ICreateAppResponse,
   IGetAppsURLOpts,
-  IV3ErrorResponse,
+  IRestErrorResponse,
   SNYK_APP_DEBUG,
 } from '.';
 import chalk from 'chalk';
@@ -20,10 +20,10 @@ export function getAppsURL(
   selection: EAppsURL,
   opts: IGetAppsURLOpts = {},
 ): string {
-  // Get the V3 URL from user config
+  // Get the rest URL from user config
   // Environment variable takes precendence over config
-  const baseURL = config.API_V3_URL;
-  debug(`API v3 base URL => ${baseURL}`);
+  const baseURL = config.API_REST_URL;
+  debug(`API rest base URL => ${baseURL}`);
 
   switch (selection) {
     case EAppsURL.CREATE_APP:
@@ -33,11 +33,11 @@ export function getAppsURL(
   }
 }
 
-export function handleV3Error(error: any): void {
+export function handleRestError(error: any): void {
   if (error.code) {
     if (error.code === 400) {
       // Bad request
-      const responseJSON: IV3ErrorResponse = error.body;
+      const responseJSON: IRestErrorResponse = error.body;
       const errString = errorsToDisplayString(responseJSON);
       throw new Error(errString);
     } else if (error.code === 401) {
@@ -48,7 +48,7 @@ export function handleV3Error(error: any): void {
         'Forbidden! the authentication token does not have access to the resource.',
       );
     } else if (error.code === 404) {
-      const responseJSON: IV3ErrorResponse = error.body;
+      const responseJSON: IRestErrorResponse = error.body;
       const errString = errorsToDisplayString(responseJSON);
       throw new Error(errString);
     } else if (error.code === 500) {
@@ -62,11 +62,11 @@ export function handleV3Error(error: any): void {
 }
 
 /**
- * @param errRes V3Error response
+ * @param errRes RestError response
  * @returns {String} Iterates over error and
  * converts them into a readible string
  */
-function errorsToDisplayString(errRes: IV3ErrorResponse): string {
+function errorsToDisplayString(errRes: IRestErrorResponse): string {
   const resString = `Uh oh! an error occurred while trying to create the Snyk App.
 Please run the command with '--debug' or '-d' to get more information`;
   if (!errRes.errors) return resString;
@@ -88,7 +88,7 @@ Please run the command with '--debug' or '-d' to get more information`;
     const source = sourceString || '-';
 
     return `Uh oh! an error occured while trying to create the Snyk App.
-  
+
 Error Description:\t${e.detail}
 Request Status:\t${e.status}
 Source:\t${source}

--- a/src/lib/apps/types.ts
+++ b/src/lib/apps/types.ts
@@ -26,7 +26,7 @@ export interface ICreateAppResponse {
   };
 }
 
-export interface IV3ErrorResponse {
+export interface IRestErrorResponse {
   jsonapi: IJSONApi;
   errors: [
     {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -10,6 +10,8 @@ interface Config {
   API: string;
   api: string;
   API_REST_URL: string;
+  // deprecated, use API_REST_URL instead
+  API_V3_URL?: string;
   disableSuggestions: string;
   org: string;
   ROOT: string;
@@ -66,6 +68,11 @@ if (!config.timeout) {
 if (!config.ROOT) {
   const apiUrl = url.parse(config.API);
   config.ROOT = apiUrl.protocol + '//' + apiUrl.host;
+}
+
+// maintain backwards compatibility with older name
+if (config.API_V3_URL) {
+  config.API_REST_URL = config.API_V3_URL;
 }
 
 export default config;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -9,7 +9,7 @@ interface Config {
   MAX_PATH_COUNT: number;
   API: string;
   api: string;
-  API_V3_URL: string;
+  API_REST_URL: string;
   disableSuggestions: string;
   org: string;
   ROOT: string;

--- a/src/lib/request/promise.ts
+++ b/src/lib/request/promise.ts
@@ -19,12 +19,12 @@ export async function makeRequest<T>(payload: any): Promise<T> {
 }
 
 /**
- * All v3 request will essentially be the same and are JSON by default
+ * All rest request will essentially be the same and are JSON by default
  * Thus if no headers provided default headers are used
  * @param {any} payload for the request
  * @returns
  */
-export async function makeRequestV3<T>(payload: any): Promise<T> {
+export async function makeRequestRest<T>(payload: any): Promise<T> {
   return new Promise((resolve, reject) => {
     payload.headers = payload.headers ?? {
       'Content-Type': 'application/vnd.api+json',

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -87,7 +87,7 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
 
   const app = express();
   app.use(bodyParser.json({ limit: '50mb' }));
-  // Content-Type for v3 API endpoints is 'application/vnd.api+json'
+  // Content-Type for rest API endpoints is 'application/vnd.api+json'
   app.use(express.json({ type: 'application/vnd.api+json', strict: false }));
   app.use((req, res, next) => {
     requests.push(req);

--- a/test/jest/acceptance/config.spec.ts
+++ b/test/jest/acceptance/config.spec.ts
@@ -1,0 +1,92 @@
+import { fakeServer } from '../../acceptance/fake-server';
+import { runSnykCLI } from '../util/runSnykCLI';
+
+describe('config', () => {
+  let server: ReturnType<typeof fakeServer>;
+  const port = process.env.PORT || process.env.SNYK_PORT || '12345';
+  const baseURL = '/realbase';
+  const orgId = '4e0828f9-d92a-4f54-b005-6b9d8150b75f';
+  const testData = {
+    appName: 'Test',
+    redirectURIs: 'https://example.com,https://example1.com',
+    scopes: 'org.read',
+    orgId,
+  };
+
+  beforeAll(() => {
+    server = fakeServer(baseURL, '123456789');
+    return new Promise((resolve) => server.listen(port, resolve));
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    server.restore();
+  });
+
+  afterAll(() => new Promise(server.close));
+
+  it('loads API_REST_URL from config key if set', async () => {
+    const env = {
+      ...process.env,
+      SNYK_API_REST_URL: 'http://localhost:' + port + baseURL,
+    };
+
+    const {
+      code,
+    } = await runSnykCLI(
+      `apps create --org=${testData.orgId} --name=${testData.appName} --redirect-uris=${testData.redirectURIs} --scopes=${testData.scopes} --experimental`,
+      { env },
+    );
+
+    expect(code).toBe(0);
+  });
+
+  it('fails with incorrect base url for sanity check', async () => {
+    const env = {
+      ...process.env,
+      SNYK_API_REST_URL: 'http://localhost:' + port + '/wrongbase',
+    };
+
+    const {
+      code,
+    } = await runSnykCLI(
+      `apps create --org=${testData.orgId} --name=${testData.appName} --redirect-uris=${testData.redirectURIs} --scopes=${testData.scopes} --experimental`,
+      { env },
+    );
+
+    expect(code).not.toBe(0);
+  });
+
+  it('loads API_REST_URL from API_V3_URL if set', async () => {
+    const env = {
+      ...process.env,
+      SNYK_API_V3_URL: 'http://localhost:' + port + baseURL,
+    };
+
+    const {
+      code,
+    } = await runSnykCLI(
+      `apps create --org=${testData.orgId} --name=${testData.appName} --redirect-uris=${testData.redirectURIs} --scopes=${testData.scopes} --experimental`,
+      { env },
+    );
+
+    expect(code).toBe(0);
+  });
+
+  it('prefers API_V3_URL over API_REST_URL when both are set', async () => {
+    const env = {
+      ...process.env,
+      SNYK_API_REST_URL: 'http://localhost:' + port + '/wrongbase',
+      SNYK_API_V3_URL: 'http://localhost:' + port + baseURL,
+    };
+
+    const {
+      code,
+    } = await runSnykCLI(
+      `apps create --org=${testData.orgId} --name=${testData.appName} --redirect-uris=${testData.redirectURIs} --scopes=${testData.scopes} --experimental`,
+      { env },
+    );
+
+    expect(code).toBe(0);
+  });
+});

--- a/test/jest/acceptance/snyk-apps/create-app.spec.ts
+++ b/test/jest/acceptance/snyk-apps/create-app.spec.ts
@@ -12,11 +12,11 @@ describe('snyk-apps: create app', () => {
 
   beforeAll((done) => {
     const port = process.env.PORT || process.env.SNYK_PORT || '12345';
-    const baseApi = '/v3';
+    const baseApi = '/rest';
     env = {
       ...process.env,
       SNYK_API: 'http://localhost:' + port + baseApi,
-      SNYK_API_V3_URL: 'http://localhost:' + port + baseApi,
+      SNYK_API_REST_URL: 'http://localhost:' + port + baseApi,
       SNYK_HOST: 'http://localhost:' + port,
       SNYK_TOKEN: '123456789',
       SNYK_DISABLE_ANALYTICS: '1',


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

The new Snyk rest api was originally released as the v3 api, however
since it contains its own versioning scheme it made no sense to have
another version in each endpoint. Therefore it was renamed to the more
generic "rest api" and the url moved from "/v3" to "/rest". The old url
will continue to work for a while during the transition phase but will
eventually go away.

This patch updates all references from the old v3 naming to the new rest
branding.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
