### PR TITLE
fix: point to the correct projects collection in the platform

### DIFF
--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -130,15 +130,17 @@ export async function test(
     );
 
     let projectPublicIds: Record<string, string> = {};
+    let gitRemoteUrl: string | undefined;
+
     if (options.report) {
-      projectPublicIds = await formatAndShareResults({
+      ({ projectPublicIds, gitRemoteUrl } = await formatAndShareResults({
         results: resultsWithCustomSeverities,
         options,
         orgPublicId,
         policy,
         tags,
         attributes,
-      });
+      }));
     }
 
     const formattedResults = formatScanResults(
@@ -146,6 +148,7 @@ export async function test(
       options,
       iacOrgSettings.meta,
       projectPublicIds,
+      gitRemoteUrl,
     );
 
     const { filteredIssues, ignoreCount } = filterIgnoredIssues(

--- a/src/cli/commands/test/iac-local-execution/results-formatter.ts
+++ b/src/cli/commands/test/iac-local-execution/results-formatter.ts
@@ -26,6 +26,7 @@ export function formatScanResults(
   options: IaCTestFlags,
   meta: TestMeta,
   projectPublicIds: Record<string, string>,
+  gitRemoteUrl?: string,
 ): FormattedResult[] {
   try {
     const groupedByFile = scanResults.reduce((memo, scanResult) => {
@@ -35,6 +36,7 @@ export function formatScanResults(
           ...res.result.cloudConfigResults,
         );
       } else {
+        res.meta.gitRemoteUrl = gitRemoteUrl;
         res.meta.projectId = projectPublicIds[res.targetFile];
         memo[scanResult.filePath] = res;
       }

--- a/src/cli/commands/test/iac-local-execution/share-results.ts
+++ b/src/cli/commands/test/iac-local-execution/share-results.ts
@@ -4,7 +4,7 @@ import { Policy } from '../../../../lib/policy/find-and-load-policy';
 import { ProjectAttributes, Tag } from '../../../../lib/types';
 import { FeatureFlagError } from './assert-iac-options-flag';
 import { formatShareResults } from './share-results-formatter';
-import { IacFileScanResult, IaCTestFlags } from './types';
+import { IacFileScanResult, IaCTestFlags, ShareResultsOutput } from './types';
 
 export async function formatAndShareResults({
   results,
@@ -20,7 +20,7 @@ export async function formatAndShareResults({
   policy: Policy | undefined;
   tags?: Tag[];
   attributes?: ProjectAttributes;
-}): Promise<Record<string, string>> {
+}): Promise<ShareResultsOutput> {
   const isCliReportEnabled = await isFeatureFlagSupportedForOrg(
     'iacCliShareResults',
     orgPublicId,

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -122,6 +122,7 @@ export interface TestMeta {
   ignoreSettings?: IgnoreSettings | null;
   projectId?: string;
   policy?: string;
+  gitRemoteUrl?: string;
 }
 
 export interface OpaWasmInstance {
@@ -399,4 +400,9 @@ export enum PerformanceAnalyticsKey {
   UsageTracking = 'usage-tracking-ms',
   CacheCleanup = 'cache-cleanup-ms',
   Total = 'total-iac-ms',
+}
+
+export interface ShareResultsOutput {
+  projectPublicIds: { [targetFile: string]: string };
+  gitRemoteUrl?: string;
 }

--- a/src/lib/formatters/iac-output.ts
+++ b/src/lib/formatters/iac-output.ts
@@ -15,11 +15,12 @@ import { printPath } from './remediation-based-format-issues';
 import { titleCaseText } from './legacy-format-issue';
 import * as sarif from 'sarif';
 import { colorTextBySeverity } from '../../lib/snyk-test/common';
-import { IacFileInDirectory } from '../../lib/types';
+import { IacFileInDirectory, IacOutputMeta } from '../../lib/types';
 import { isLocalFolder } from '../../lib/detect';
 import { getSeverityValue } from './get-severity-value';
 import { getIssueLevel } from './sarif-output';
 import { getVersion } from '../version';
+import config from '../config';
 const debug = Debug('iac-output');
 
 function formatIacIssue(
@@ -316,4 +317,16 @@ function getPathRelativeToRepoRoot(
 ) {
   const fullPath = pathLib.resolve(basePath, filePath).replace(/\\/g, '/');
   return fullPath.replace(repoRoot, '');
+}
+
+export function shareResultsOutput(iacOutputMeta: IacOutputMeta): string {
+  let projectName: string = iacOutputMeta.projectName;
+  if (iacOutputMeta?.gitRemoteUrl) {
+    // from "http://github.com/snyk/cli.git" to "snyk/cli"
+    projectName = iacOutputMeta.gitRemoteUrl.replace(
+      /^https?:\/\/github.com\/(.*)\.git$/,
+      '$1',
+    );
+  }
+  return `Your test results are available at: ${config.ROOT}/org/${iacOutputMeta.orgName}/projects under the name ${projectName}`;
 }

--- a/src/lib/iac/cli-share-results.ts
+++ b/src/lib/iac/cli-share-results.ts
@@ -4,6 +4,7 @@ import { getAuthHeader } from '../api-token';
 import {
   IacShareResultsFormat,
   IaCTestFlags,
+  ShareResultsOutput,
 } from '../../cli/commands/test/iac-local-execution/types';
 import { convertIacResultToScanResult } from './envelope-formatters';
 import { Policy } from '../policy/find-and-load-policy';
@@ -30,7 +31,7 @@ export async function shareResults({
   tags?: Tag[];
   attributes?: ProjectAttributes;
   options?: IaCTestFlags;
-}): Promise<Record<string, string>> {
+}): Promise<ShareResultsOutput> {
   const gitTarget = (await getInfo(false)) as GitTarget;
   const scanResults = results.map((result) =>
     convertIacResultToScanResult(result, policy, gitTarget, options),
@@ -72,5 +73,5 @@ export async function shareResults({
     );
   }
 
-  return body;
+  return { projectPublicIds: body, gitRemoteUrl: gitTarget?.remoteUrl };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -266,3 +266,9 @@ export interface IacFileInDirectory {
   projectType?: IacProjectTypes;
   failureReason?: string;
 }
+
+export interface IacOutputMeta {
+  projectName: string;
+  orgName: string;
+  gitRemoteUrl?: string;
+}

--- a/test/jest/acceptance/iac/cli-share-results.spec.ts
+++ b/test/jest/acceptance/iac/cli-share-results.spec.ts
@@ -52,7 +52,7 @@ describe('CLI Share Results', () => {
       expect(exitCode).toBe(1);
 
       expect(stdout).toContain(
-        `Your test results are available at: http://localhost:${server.getPort()}/org/test-org/projects under the name arm`,
+        `Your test results are available at: http://localhost:${server.getPort()}/org/test-org/projects under the name snyk/cli`,
       );
     });
 

--- a/test/jest/unit/lib/formatters/iac-output.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output.spec.ts
@@ -1,4 +1,7 @@
-import { createSarifOutputForIac } from '../../../../../src/lib/formatters/iac-output';
+import {
+  createSarifOutputForIac,
+  shareResultsOutput,
+} from '../../../../../src/lib/formatters/iac-output';
 import {
   IacTestResponse,
   AnnotatedIacIssue,
@@ -104,5 +107,25 @@ describe('createSarifOutputForIac', () => {
       uriBaseId: 'PROJECTROOT',
     });
     expect(location?.physicalLocation?.region).not.toBeDefined();
+  });
+});
+
+describe('shareResultsOutput', () => {
+  it('returns the correct output when gitRemoteUrl is specified', () => {
+    const output = shareResultsOutput({
+      projectName: 'test-project',
+      orgName: 'test-org',
+      gitRemoteUrl: 'http://github.com/test/repo.git',
+    });
+
+    expect(output).toContain('under the name test/repo');
+  });
+  it('returns the correct output when gitRemoteUrl is not specified', () => {
+    const output = shareResultsOutput({
+      projectName: 'test-project',
+      orgName: 'test-org',
+    });
+
+    expect(output).toContain('under the name test-project');
   });
 });


### PR DESCRIPTION
When a user runs a scan inside a git repo we pointed to the wrong projects collection, in this PR we fix this issue.

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
When invoking `snyk iac test --report` the command shows a message to the user telling him that the projects are available at his projects page under a dropdown menu with a certain name.
In cases where the user ran the scan inside a directory which is part of a git repo the dropdown menu name is incorrect.
This PR fixes this issue.


#### How should this be manually tested?
1. Run a test using the command `snyk iac test --report` inside of a directory which is part of git repo
2. The output should include the line: "Your test results are available at: http://localhost:8000/org/{org_name}/projects under the name {repo_name}"
3. Run a test using the command `snyk iac test --report` inside of a directory which is NOT part of git repo
4. The output should include the line: "Your test results are available at: http://localhost:8000/org/{org_name}/projects under the name {project_name}"


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CFG-1740

#### Screenshots
BEFORE
* part of a repo
![image](https://user-images.githubusercontent.com/71096571/160285785-090f827e-24d8-4ef5-83eb-1dbdcfb3a581.png)
* not part of a repo
![image](https://user-images.githubusercontent.com/71096571/160285816-a2f51f43-cd11-4276-9ffe-d7ad463aa4e5.png)


AFTER
* part of a repo
![image](https://user-images.githubusercontent.com/71096571/160285772-d617660a-2580-4db0-a48b-d922cfd55556.png)
* not part of a repo
![image](https://user-images.githubusercontent.com/71096571/160285824-69f9cf38-1fc7-4f59-8175-6c4088e9acd7.png)
