### PR TITLE
chore: Added warning when custom rules with the `report` command [CFG-1737]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/rules.ts
+++ b/src/cli/commands/test/iac-local-execution/rules.ts
@@ -46,9 +46,14 @@ export async function initRules(
     (isOCIRegistryURLProvided || customRulesPath) &&
     !(options.sarif || options.json)
   ) {
-    console.log(
-      chalk.hex('#ff9b00')('Using custom rules to generate misconfigurations.'),
-    );
+    let userMessage = 'Using custom rules to generate misconfigurations.';
+
+    if (options.report) {
+      userMessage +=
+        "\nPlease note that your custom rules will not be sent to the Snyk platform, and will not be available on the project's page.";
+    }
+
+    console.log(chalk.hex('#ff9b00')(userMessage));
   }
 
   if (isOCIRegistryURLProvided && customRulesPath) {


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Adds a warning user message when custom rules are provided for the:
    - `snyk iac report` command.
    - `snyk iac test --report` command.

#### Where should the reviewer start?

`src/cli/commands/test/iac-local-execution/rules.ts`

#### How should this be manually tested?

1. Prepare a bundle of custom rules, using the instructions found [here](https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules).
2. If your custom rules bundle is local:
    2.1. Run the following in the Snyk CLI:
    ```
    snyk-dev iac report <path-to-iac-file-or-dir> --rules=<path-to-custom-rules-bundle>
    ```
    2.2. Ensure the following message was displayed at the top of the output:
    ```
    Using custom rules to generate misconfigurations.
    Please note that your custom rules will not be sent to the Snyk platform, and will not be available on the project's page.
    ```
    2.3. Run the following in the Snyk CLI:
    ```
    snyk-dev iac test <path-to-iac-file-or-dir> --report --rules=<path-to-custom-rules-bundle>
    ```
    2.4. Ensure the following message was displayed at the top of the output:
    ```
    Using custom rules to generate misconfigurations.
    Please note that your custom rules will not be sent to the Snyk platform, and will not be available on the project's page.
    ```
3. If your custom rules bundle is remote:
    3.1. Run the following in the Snyk CLI:
    ```
    snyk-dev iac report <path-to-iac-file-or-dir>
    ```
    3.2. Ensure the following message was displayed at the top of the output:
    ```
    Using custom rules to generate misconfigurations.
    Please note that your custom rules will not be sent to the Snyk platform, and will not be available on the project's page.
    ```
    3.3. Run the following in the Snyk CLI:
    ```
    snyk-dev iac test <path-to-iac-file-or-dir> --report
    ```
    3.4. Ensure the following message was displayed at the top of the output:
    ```
    Using custom rules to generate misconfigurations.
    Please note that your custom rules will not be sent to the Snyk platform, and will not be available on the project's page.
    ```

#### Any background context you want to provide?

Today, the CLI Share Results feature does not support custom rules.
We would like to give a small warning to our users that will notify them that their custom rules will not be uploaded to the Snyk platform.

#### What are the relevant tickets?

- [CFG-1737](https://snyksec.atlassian.net/browse/CFG-1737)

#### Screenshots

- For `snyk iac report`:
    ![image](https://user-images.githubusercontent.com/46415136/160409556-2be0f210-f7b5-40e0-84ec-a52dbd4fe01a.png)
- For `snyk iac test --report`:
    ![image](https://user-images.githubusercontent.com/46415136/160409798-1a3bc910-28d1-4d07-a187-074bd16eaefa.png)
