### PR TITLE
feat: improve share results error handling

### DIFF
--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -348,6 +348,9 @@ export enum IaCErrorCodes {
 
   // report errors
   UnsupportedReportCommandError = 1120,
+
+  // share results errors
+  FailedToShareResults = 1130,
 }
 
 export interface TestReturnValue {

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -501,6 +501,10 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
     res.status(200).send({});
   });
 
+  app.post(basePath + '/iac-cli-share-results', (req, res) => {
+    res.status(200).send({});
+  });
+
   app.post(basePath + '/analytics/cli', (req, res) => {
     res.status(200).send({});
   });

--- a/test/jest/unit/iac/cli-share-results.fixtures.ts
+++ b/test/jest/unit/iac/cli-share-results.fixtures.ts
@@ -168,6 +168,7 @@ export const expectedEnvelopeFormatterResults = [
   },
 ];
 
+// if the test that is using this expected output fails for version, look at the package.json policy package version and update it accordingly
 export const expectedEnvelopeFormatterResultsWithPolicy = expectedEnvelopeFormatterResults.map(
   (result) => {
     return {

--- a/test/jest/unit/iac/cli-share-results.spec.ts
+++ b/test/jest/unit/iac/cli-share-results.spec.ts
@@ -22,7 +22,10 @@ describe('CLI Share Results', () => {
   beforeEach(() => {
     requestSpy = jest
       .spyOn(request, 'makeRequest')
-      .mockImplementation(async () => ({ res: {} as any, body: {} }));
+      .mockImplementation(async () => ({
+        res: { statusCode: 200 } as any,
+        body: {},
+      }));
     envelopeFormattersSpy = jest.spyOn(
       envelopeFormatters,
       'convertIacResultToScanResult',


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This PR improves how we handle errors we receive from the IaC Share Results endpoint by doing a small refactoring.