### PR TITLE
feat: use sbt plugin with improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "snyk-python-plugin": "1.22.3",
         "snyk-resolve": "1.1.0",
         "snyk-resolve-deps": "4.7.3",
-        "snyk-sbt-plugin": "2.13.0",
+        "snyk-sbt-plugin": "2.14.0",
         "snyk-try-require": "^2.0.2",
         "strip-ansi": "^5.2.0",
         "tar": "^6.1.2",
@@ -17238,9 +17238,9 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "node_modules/snyk-sbt-plugin": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.13.0.tgz",
-      "integrity": "sha512-pluHrBQb7grxKD/N/pWRFvkJ+vC6w3pm0X6X3oBRWP7J4LxsJlEQ/CsgvC6z48OT8nQyKeHcbjlKydHw4lD5Mw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.14.0.tgz",
+      "integrity": "sha512-pXA/AR/1dDCKhDz15oD89LO3dQ2/rjCwnVO9Yi6lDVcjo4xcWSRw+GQrg0/h3H5WPI2xRtnRC8yXC+Ov0VdQHw==",
       "dependencies": {
         "debug": "^4.1.1",
         "semver": "^6.1.2",
@@ -33487,9 +33487,9 @@
       }
     },
     "snyk-sbt-plugin": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.13.0.tgz",
-      "integrity": "sha512-pluHrBQb7grxKD/N/pWRFvkJ+vC6w3pm0X6X3oBRWP7J4LxsJlEQ/CsgvC6z48OT8nQyKeHcbjlKydHw4lD5Mw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.14.0.tgz",
+      "integrity": "sha512-pXA/AR/1dDCKhDz15oD89LO3dQ2/rjCwnVO9Yi6lDVcjo4xcWSRw+GQrg0/h3H5WPI2xRtnRC8yXC+Ov0VdQHw==",
       "requires": {
         "debug": "^4.1.1",
         "semver": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "snyk-python-plugin": "1.22.3",
     "snyk-resolve": "1.1.0",
     "snyk-resolve-deps": "4.7.3",
-    "snyk-sbt-plugin": "2.13.0",
+    "snyk-sbt-plugin": "2.14.0",
     "snyk-try-require": "^2.0.2",
     "strip-ansi": "^5.2.0",
     "tar": "^6.1.2",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This patch picks up v2.14.0 if the SBT plugin which includes the following improvements:

- ignore the `scalafix` plugin which breaks the plugin; and
- add a heuristic for multi-project setups with a shared `project/`
  folder.

#### Where should the reviewer start?

https://github.com/snyk/snyk-sbt-plugin/pull/106

#### How should this be manually tested?

Install the plugin locally and run on a scala SBT project.