### PR TITLE
fix: Enforce test limits when creating IaC projects

### DIFF
--- a/test/jest/acceptance/iac/cli-share-results.spec.ts
+++ b/test/jest/acceptance/iac/cli-share-results.spec.ts
@@ -176,6 +176,17 @@ describe('CLI Share Results', () => {
       });
     });
 
+    it('should print an error message if test usage is exceeded', async () => {
+      server.setNextStatusCode(429);
+
+      const { stdout, exitCode } = await run(
+        'snyk iac test ./iac/arm/rule_test.json --report --project-business-criticality=high',
+      );
+
+      expect(exitCode).toEqual(2);
+      expect(stdout).toMatch(/test limit reached/i);
+    });
+
     describe('with target reference', () => {
       it('forwards the target reference to iac-cli-share-results endpoint', async () => {
         const testTargetRef = 'test-target-ref';


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR intercepts 429 responses from the API when creating IaC projects via `snyk iac test --report`. If the API returns such a response, meaning that the user exceeded his test quotas, the CLI prints an error message on the console.

#### Screenshots

When the user exceeded its limit for IaC projects, the CLI outputs looks like this:

```
$ snyk iac test --report

Testing /Users/frm/src/test...

Test limit reached! You have exceeded your infrastructure as code test allocation for this billing period.
```

#### More information

- [PR on the Registry](https://github.com/snyk/registry/pull/26868)