### PR TITLE
fix: Increase delay between inputs on some acceptance tests

### DIFF
--- a/test/jest/acceptance/snyk-apps/create-app.spec.ts
+++ b/test/jest/acceptance/snyk-apps/create-app.spec.ts
@@ -115,7 +115,7 @@ describe('snyk-apps: create app', () => {
       } = await runSnykCLIWithUserInputs(
         'apps create --interactive --experimental',
         [testData.appName, ENTER, testData.redirectURIs, ENTER, ENTER],
-        { env },
+        { env, delay: 200 },
       );
       // Assert
       expect(stdout).toContain("Your Snyk App's permission scopes");
@@ -158,7 +158,7 @@ describe('snyk-apps: create app', () => {
           testData.orgId,
           ENTER,
         ],
-        { env },
+        { env, delay: 200 },
       );
       // Assert
       expect(code).toBe(0);

--- a/test/jest/util/runCommand.ts
+++ b/test/jest/util/runCommand.ts
@@ -7,7 +7,9 @@ type RunCommandResult = {
   stderr: string;
 };
 
-type RunCommandOptions = SpawnOptionsWithoutStdio;
+interface RunCommandOptions extends SpawnOptionsWithoutStdio {
+  delay?: number;
+}
 
 const runCommand = (
   command: string,
@@ -47,7 +49,7 @@ function runCommandsWithUserInputs(
   inputs: string[] = [],
   options?: RunCommandOptions,
 ): Promise<any> {
-  const timeout = 100;
+  const timeout = options?.delay ?? 100;
   const childProcess = spawn(command, args, options);
 
   // Creates a loop to feed user inputs to the child process


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Our prompt library inquirer only receives data from stdin after it has
been initialised. Therefore we can lose some buffered data if we send it
too fast, this is particularly noticeable if there are multiple inquirer
prompts in a row. There is no known way to check if the child process
that is under test is ready to receive input as node will swallow
anything given to stdin if it has nowhere to send it.

This hopefully will decrease the probability that these test fail by
increasing the delay between sending data to the child process.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
