### PR TITLE
fix: code-client update to v4.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@open-policy-agent/opa-wasm": "^1.6.0",
         "@snyk/cli-interface": "2.11.0",
         "@snyk/cloud-config-parser": "^1.13.1",
-        "@snyk/code-client": "^4.8.0",
+        "@snyk/code-client": "^4.9.0",
         "@snyk/dep-graph": "^1.27.1",
         "@snyk/docker-registry-v2-client": "^2.6.1",
         "@snyk/fix": "file:packages/snyk-fix",
@@ -1949,9 +1949,9 @@
       }
     },
     "node_modules/@snyk/code-client": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.8.0.tgz",
-      "integrity": "sha512-xKjzmcOLU8ZiDrMDxgbIuYdXJbKkmKUeWW8dKtgwfB0lPnU3olI3uuYGTDbzKyTC2JoiR4qokPuVBO5s64sWgw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.9.0.tgz",
+      "integrity": "sha512-t+U4b/VPG8v3s8r4V5SYxTh67ztBhfD0dHI2ReP/ePXQtiKzR1ptySNrObc96jW7cbGrG7B1IsQgDqM4sC/M9g==",
       "dependencies": {
         "@deepcode/dcignore": "^1.0.4",
         "@snyk/fast-glob": "^3.2.6-patch",
@@ -21475,9 +21475,9 @@
       }
     },
     "@snyk/code-client": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.8.0.tgz",
-      "integrity": "sha512-xKjzmcOLU8ZiDrMDxgbIuYdXJbKkmKUeWW8dKtgwfB0lPnU3olI3uuYGTDbzKyTC2JoiR4qokPuVBO5s64sWgw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.9.0.tgz",
+      "integrity": "sha512-t+U4b/VPG8v3s8r4V5SYxTh67ztBhfD0dHI2ReP/ePXQtiKzR1ptySNrObc96jW7cbGrG7B1IsQgDqM4sC/M9g==",
       "requires": {
         "@deepcode/dcignore": "^1.0.4",
         "@snyk/fast-glob": "^3.2.6-patch",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@open-policy-agent/opa-wasm": "^1.6.0",
     "@snyk/cli-interface": "2.11.0",
     "@snyk/cloud-config-parser": "^1.13.1",
-    "@snyk/code-client": "^4.8.0",
+    "@snyk/code-client": "^4.9.0",
     "@snyk/dep-graph": "^1.27.1",
     "@snyk/docker-registry-v2-client": "^2.6.1",
     "@snyk/fix": "file:packages/snyk-fix",


### PR DESCRIPTION
#### What does this PR do?
Update CLI to use code-client version 4.9.0