### PR TITLE
chore: Wrap new CLI output with `iacCliOutput` feature flag

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,7 +29,7 @@ src/lib/plugins @snyk/snyk-open-source
 src/lib/plugins/sast/ @snyk/nebula
 test/fixtures/sast/ @snyk/nebula
 test/jest/unit/snyk-code/ @snyk/nebula
-src/lib/formatters/iac-output.ts @snyk/group-infrastructure-as-code
+src/lib/formatters/iac-output/ @snyk/group-infrastructure-as-code
 src/lib/iac/ @snyk/group-infrastructure-as-code
 src/lib/snyk-test/iac-test-result.ts @snyk/group-infrastructure-as-code
 src/lib/snyk-test/payload-schema.ts @snyk/group-infrastructure-as-code
@@ -44,7 +44,7 @@ test/smoke/spec/iac/ @snyk/group-infrastructure-as-code
 test/smoke/spec/snyk_code_spec.sh @snyk/nebula
 test/smoke/spec/snyk_basic_spec.sh @snyk/hammer
 test/smoke/.iac-data/ @snyk/group-infrastructure-as-code
-test/jest/unit/lib/formatters/iac-output.spec.ts @snyk/group-infrastructure-as-code
+test/jest/unit/lib/formatters/iac-output/ @snyk/group-infrastructure-as-code
 test/jest/unit/lib/formatters/test/format-test-results.spec.ts @snyk/hammer @snyk/snyk-open-source @snyk/magma
 test/jest/unit/iac/ @snyk/group-infrastructure-as-code
 test/jest/unit/lib/iac/ @snyk/group-infrastructure-as-code

--- a/src/lib/formatters/iac-output/index.ts
+++ b/src/lib/formatters/iac-output/index.ts
@@ -1,0 +1,31 @@
+import * as v1 from './v1';
+import * as v2 from './v2';
+import { IacTestResponse } from '../../snyk-test/iac-test-result';
+import { IacFileInDirectory } from '../../types';
+
+export function getIacDisplayedOutput(
+  iacTest: IacTestResponse,
+  testedInfoText: string,
+  meta: string,
+  prefix: string,
+  isNewIacOutputSupported?: boolean,
+): string {
+  return isNewIacOutputSupported
+    ? v2.getIacDisplayedOutput(iacTest, testedInfoText, meta, prefix)
+    : v1.getIacDisplayedOutput(iacTest, testedInfoText, meta, prefix);
+}
+
+export function getIacDisplayErrorFileOutput(
+  iacFileResult: IacFileInDirectory,
+  isNewIacOutputSupported?: boolean,
+): string {
+  return isNewIacOutputSupported
+    ? v2.getIacDisplayErrorFileOutput(iacFileResult)
+    : v1.getIacDisplayErrorFileOutput(iacFileResult);
+}
+
+export {
+  capitalizePackageManager,
+  createSarifOutputForIac,
+  shareResultsOutput,
+} from './v1';

--- a/src/lib/formatters/iac-output/v1/index.ts
+++ b/src/lib/formatters/iac-output/v1/index.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { icon } from '../theme';
+import { icon } from '../../../theme';
 import * as Debug from 'debug';
 import * as pathLib from 'path';
 import { pathToFileURL } from 'url';
@@ -10,17 +10,17 @@ import { execSync } from 'child_process';
 import {
   IacTestResponse,
   AnnotatedIacIssue,
-} from '../../lib/snyk-test/iac-test-result';
-import { printPath } from './remediation-based-format-issues';
-import { titleCaseText } from './legacy-format-issue';
+} from '../../../../lib/snyk-test/iac-test-result';
+import { printPath } from '../../remediation-based-format-issues';
+import { titleCaseText } from '../../legacy-format-issue';
 import * as sarif from 'sarif';
-import { colorTextBySeverity } from '../../lib/snyk-test/common';
-import { IacFileInDirectory, IacOutputMeta } from '../../lib/types';
-import { isLocalFolder } from '../../lib/detect';
-import { getSeverityValue } from './get-severity-value';
-import { getIssueLevel } from './sarif-output';
-import { getVersion } from '../version';
-import config from '../config';
+import { colorTextBySeverity } from '../../../../lib/snyk-test/common';
+import { IacFileInDirectory, IacOutputMeta } from '../../../../lib/types';
+import { isLocalFolder } from '../../../../lib/detect';
+import { getSeverityValue } from '../../get-severity-value';
+import { getIssueLevel } from '../../sarif-output';
+import { getVersion } from '../../../version';
+import config from '../../../config';
 const debug = Debug('iac-output');
 
 function formatIacIssue(

--- a/src/lib/formatters/iac-output/v2/index.ts
+++ b/src/lib/formatters/iac-output/v2/index.ts
@@ -1,0 +1,98 @@
+import chalk from 'chalk';
+import { icon } from '../../../theme';
+import * as Debug from 'debug';
+import * as pathLib from 'path';
+
+import {
+  IacTestResponse,
+  AnnotatedIacIssue,
+} from '../../../../lib/snyk-test/iac-test-result';
+import { printPath } from '../../remediation-based-format-issues';
+import { titleCaseText } from '../../legacy-format-issue';
+import { colorTextBySeverity } from '../../../../lib/snyk-test/common';
+import { IacFileInDirectory } from '../../../../lib/types';
+
+import { getSeverityValue } from '../../get-severity-value';
+
+const debug = Debug('iac-output');
+
+function formatIacIssue(
+  issue: AnnotatedIacIssue,
+  isNew: boolean,
+  path: string[],
+): string {
+  const newBadge = isNew ? ' (new)' : '';
+  const name = issue.subType ? ` in ${chalk.bold(issue.subType)}` : '';
+
+  let introducedBy = '';
+  if (path) {
+    // In this mode, we show only one path by default, for compactness
+    const pathStr = printPath(path, 0);
+    introducedBy = `\n    introduced by ${pathStr}`;
+  }
+
+  return (
+    colorTextBySeverity(
+      issue.severity,
+      `  ${icon.ISSUE} ${chalk.bold(issue.title)}${newBadge} [${titleCaseText(
+        issue.severity,
+      )} Severity]`,
+    ) +
+    ` [${issue.id}]` +
+    name +
+    introducedBy +
+    '\n'
+  );
+}
+
+export function getIacDisplayedOutput(
+  iacTest: IacTestResponse,
+  testedInfoText: string,
+  meta: string,
+  prefix: string,
+): string {
+  const issuesTextArray = [
+    chalk.bold.white('\nInfrastructure as code issues:'),
+  ];
+
+  const NotNew = false;
+
+  const issues: AnnotatedIacIssue[] = iacTest.result.cloudConfigResults;
+  debug(`iac display output - ${issues.length} issues`);
+
+  issues
+    .sort((a, b) => getSeverityValue(b.severity) - getSeverityValue(a.severity))
+    .forEach((issue) => {
+      issuesTextArray.push(
+        formatIacIssue(issue, NotNew, issue.cloudConfigPath),
+      );
+    });
+
+  const issuesInfoOutput: string[] = [];
+  debug(`Iac display output - ${issuesTextArray.length} issues text`);
+  if (issuesTextArray.length > 0) {
+    issuesInfoOutput.push(issuesTextArray.join('\n'));
+  }
+
+  let body = issuesInfoOutput.join('\n\n') + '\n\n' + meta;
+
+  const vulnCountText = `found ${issues.length} issues`;
+  const summary = testedInfoText + ', ' + chalk.red.bold(vulnCountText);
+
+  body = body + '\n\n' + summary;
+
+  return prefix + body;
+}
+
+export function getIacDisplayErrorFileOutput(
+  iacFileResult: IacFileInDirectory,
+): string {
+  const fileName = pathLib.basename(iacFileResult.filePath);
+  return `
+
+-------------------------------------------------------
+
+Testing ${fileName}...
+
+${iacFileResult.failureReason}`;
+}

--- a/src/lib/formatters/test/display-result.ts
+++ b/src/lib/formatters/test/display-result.ts
@@ -26,9 +26,13 @@ import {
 } from '../../../lib/formatters/test/format-test-results';
 import { showMultiScanTip } from '../show-multi-scan-tip';
 
+interface DisplayResultOptions extends Options, TestOptions {
+  isNewIacOutputSupported?: boolean;
+}
+
 export function displayResult(
   res: TestResult,
-  options: Options & TestOptions,
+  options: DisplayResultOptions,
   foundProjectCount?: number,
 ) {
   const meta = formatTestMeta(res, options);
@@ -116,6 +120,7 @@ export function displayResult(
       testedInfoText,
       meta,
       prefix,
+      options.isNewIacOutputSupported,
     );
   }
 

--- a/test/jest/unit/lib/formatters/iac-output/index.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/index.spec.ts
@@ -1,0 +1,134 @@
+import * as iacOutputV1 from '../../../../../../src/lib/formatters/iac-output/v1';
+import * as iacOutputV2 from '../../../../../../src/lib/formatters/iac-output/v2';
+import {
+  getIacDisplayErrorFileOutput,
+  getIacDisplayedOutput,
+} from '../../../../../../src/lib/formatters/iac-output';
+import { IacTestResponse } from '../../../../../../src/lib/snyk-test/iac-test-result';
+import { IacFileInDirectory } from '../../../../../../src/lib/types';
+
+describe('IaC Output Formatter', () => {
+  const IAC_CLI_OUTPUT_FF = 'iacCliOutput';
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('getIacDisplayedOutput', () => {
+    it('should use the implementation from v1 with the provided arguments', () => {
+      // Arrange
+      const getIacDisplayedOutputV1Spy = jest
+        .spyOn(iacOutputV1, 'getIacDisplayedOutput')
+        .mockImplementationOnce(jest.fn());
+
+      const getIacDisplayedOutputV2Spy = jest
+        .spyOn(iacOutputV2, 'getIacDisplayedOutput')
+        .mockImplementationOnce(jest.fn());
+
+      const args: Parameters<typeof getIacDisplayedOutput> = [
+        {} as IacTestResponse,
+        'test-tested-info-text',
+        'test-meta',
+        'test-prefix',
+      ];
+
+      // Act
+      const result = getIacDisplayedOutput(...args);
+
+      // Assert
+      expect(result).toBeUndefined();
+      expect(getIacDisplayedOutputV1Spy).toHaveBeenCalledTimes(1);
+      expect(getIacDisplayedOutputV2Spy).not.toHaveBeenCalled();
+      expect([...getIacDisplayedOutputV1Spy.mock.calls[0]]).toStrictEqual(args);
+    });
+
+    describe(`when the org has the ${IAC_CLI_OUTPUT_FF} feature flag`, () => {
+      it('should use the implementation from v2 with the provided arguments', () => {
+        // Arrange
+        const getIacDisplayedOutputV1Spy = jest
+          .spyOn(iacOutputV1, 'getIacDisplayedOutput')
+          .mockImplementationOnce(jest.fn());
+
+        const getIacDisplayedOutputV2Spy = jest
+          .spyOn(iacOutputV2, 'getIacDisplayedOutput')
+          .mockImplementationOnce(jest.fn());
+
+        const args: Parameters<typeof getIacDisplayedOutput> = [
+          {} as IacTestResponse,
+          'test-tested-info-text',
+          'test-meta',
+          'test-prefix',
+          true,
+        ];
+
+        // Act
+        const result = getIacDisplayedOutput(...args);
+
+        // Assert
+        expect(result).toBeUndefined();
+        expect(getIacDisplayedOutputV1Spy).not.toHaveBeenCalled();
+        expect(getIacDisplayedOutputV2Spy).toHaveBeenCalledTimes(1);
+        expect([...getIacDisplayedOutputV2Spy.mock.calls[0]]).toStrictEqual(
+          args.slice(0, args.length - 1),
+        );
+      });
+    });
+  });
+
+  describe('getIacDisplayErrorFileOutput', () => {
+    it('should use the implementation from v1 with the provided arguments', () => {
+      // Arrange
+      const getIacDisplayErrorFileOutputV1Spy = jest
+        .spyOn(iacOutputV1, 'getIacDisplayErrorFileOutput')
+        .mockImplementationOnce(jest.fn());
+
+      const getIacDisplayErrorFileOutputV2Spy = jest
+        .spyOn(iacOutputV2, 'getIacDisplayErrorFileOutput')
+        .mockImplementationOnce(jest.fn());
+
+      const args: Parameters<typeof getIacDisplayErrorFileOutput> = [
+        {} as IacFileInDirectory,
+      ];
+
+      // Act
+      const result = getIacDisplayErrorFileOutput(...args);
+
+      // Assert
+      expect(result).toBeUndefined();
+      expect(getIacDisplayErrorFileOutputV1Spy).toHaveBeenCalledTimes(1);
+      expect(getIacDisplayErrorFileOutputV2Spy).not.toHaveBeenCalled();
+      expect([
+        ...getIacDisplayErrorFileOutputV1Spy.mock.calls[0],
+      ]).toStrictEqual(args);
+    });
+
+    describe(`when the org has the ${IAC_CLI_OUTPUT_FF} feature flag`, () => {
+      it('should use the implementation from v2 with the provided arguments', () => {
+        // Arrange
+        const getIacDisplayErrorFileOutputV1Spy = jest
+          .spyOn(iacOutputV1, 'getIacDisplayErrorFileOutput')
+          .mockImplementationOnce(jest.fn());
+
+        const getIacDisplayErrorFileOutputV2Spy = jest
+          .spyOn(iacOutputV2, 'getIacDisplayErrorFileOutput')
+          .mockImplementationOnce(jest.fn());
+
+        const args: Parameters<typeof getIacDisplayErrorFileOutput> = [
+          {} as IacFileInDirectory,
+          true,
+        ];
+
+        // Act
+        const result = getIacDisplayErrorFileOutput(...args);
+
+        // Assert
+        expect(result).toBeUndefined();
+        expect(getIacDisplayErrorFileOutputV1Spy).not.toHaveBeenCalled();
+        expect(getIacDisplayErrorFileOutputV2Spy).toHaveBeenCalledTimes(1);
+        expect([
+          ...getIacDisplayErrorFileOutputV2Spy.mock.calls[0],
+        ]).toStrictEqual(args.slice(0, args.length - 1));
+      });
+    });
+  });
+});

--- a/test/jest/unit/lib/formatters/iac-output/v1/index.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v1/index.spec.ts
@@ -1,12 +1,12 @@
 import {
   createSarifOutputForIac,
   shareResultsOutput,
-} from '../../../../../src/lib/formatters/iac-output';
+} from '../../../../../../../src/lib/formatters/iac-output';
 import {
   IacTestResponse,
   AnnotatedIacIssue,
-} from '../../../../../src/lib/snyk-test/iac-test-result';
-import { SEVERITY } from '../../../../../src/lib/snyk-test/legacy';
+} from '../../../../../../../src/lib/snyk-test/iac-test-result';
+import { SEVERITY } from '../../../../../../../src/lib/snyk-test/legacy';
 
 describe('createSarifOutputForIac', () => {
   function createResponseIssue(


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

### What does this PR do?

- Adds versioning for the IaC output formatting logic.
- Creates a new version, labeled as `v2`, which is currently identical to the original logic, labeled as `v1`.
- Wraps the `v2` version with the newly created `iacCliOutput` feature flag.

### Where should the reviewer start?

   ```
   src/lib/formatters/iac-output/index.ts
   ```

### How should this be manually tested?

At the moment there's no output difference between the 2 versions.
To test it, you can utilize tools like logs or the debugger, to ensure the correct flows are used for each case.

- Without the `iacCliOutput` feature flag, we expect to use the original output formatters, which can be found in:
   ```
   src/lib/formatters/iac-output/v1/index.ts
   ```
- With the `iacCliOutput` feature flag, we expect to use the new output formatters, which can be found in:
   ```
   src/lib/formatters/iac-output/v2/index.ts
   ```

### Any background context you want to provide?
In a recent ticket ([CFG-1565](https://snyksec.atlassian.net/browse/CFG-1565)), we've introduced a new feature flag, named `iacCliOutput`, in order to wrap the implementation for the new CLI test output for Snyk IaC. 
To do so, a new separate flow for formatting the output needs to be created.
As a first step, this new flow will include the duplicated original logic for formatting IaC test results.
**The new flow will only be accessible to users with the `iacCliOutput` feature flag.**



### What are the relevant tickets?

- [CFG-1573](https://snyksec.atlassian.net/browse/CFG-1573)

### Additional information

- Feature page: [New CLI Output](https://www.notion.so/New-CLI-Output-e6ad525e5ab244769af8be5b14d740f7)
- Slack channel: [#feat-iac-cli-output](https://snyk.slack.com/archives/C030UA3U1RB)