### PR TITLE
feat: remove `--json-file-output` for `snykl iac describe`

### DIFF
--- a/src/lib/iac/drift.ts
+++ b/src/lib/iac/drift.ts
@@ -135,11 +135,6 @@ const generateFmtFlags = (options: FmtOptions): string[] => {
     args.push('json://stdout');
   }
 
-  if (options['json-file-output']) {
-    args.push('--output');
-    args.push('json://' + options['json-file-output']);
-  }
-
   if (options.html) {
     args.push('--output');
     args.push('html://stdout');

--- a/src/lib/iac/types.d.ts
+++ b/src/lib/iac/types.d.ts
@@ -9,7 +9,6 @@ interface DriftCTLOptions {
 
 export interface FmtOptions extends DriftCTLOptions {
   json: boolean;
-  'json-file-output': string;
   html: boolean;
   'html-file-output': string;
 }
@@ -38,7 +37,6 @@ export interface DescribeOptions extends DriftCTLOptions {
   'tf-lockfile'?: string;
   'config-dir'?: string;
   json?: boolean;
-  'json-file-output'?: string;
   html?: boolean;
   'html-file-output'?: string;
   service?: string;


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR remove useless `--json-file-output` flag.
We also added a test for covering the usage of the `html-file-output`, it may look unrelevant to have make those two change in the same PR but it's related to the same bug, see the Jira ticket.

#### Where should the reviewer start?

`src/lib/iac/drift.ts`

#### How should this be manually tested?

```shell
$ snyk iac describe --all --json-file-output="test.json"
The following option combination is not currently supported: describe + json-file-output
```

#### Any background context you want to provide?

We have decided to remove that flag in flavor of a documenting a redirect

`snyk iac describe --all --json > test.json`

BTW The flag is not working because of a global flag validation related to SARIF.
We have decide not to spend time digging into that, remove the flag and document a redirect

#### What are the relevant tickets?

- https://snyksec.atlassian.net/browse/CFG-1741
- [Gitbook PR](https://app.gitbook.com/o/-M4tdxG8qotLgGZnLpFR/s/-MdwVZ6HOZriajCf5nXH/~/diff/~/changes/55TLMKqXPfIII2o0KAq9/snyk-cli/commands/iac-describe)

