### PR TITLE
chore(ci): map github release to correct commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
   # https://circleci.com/developer/orbs/orb/circleci/aws-cli
   aws-cli: circleci/aws-cli@2.0.3
   # https://circleci.com/developer/orbs/orb/circleci/github-cli
-  gh: circleci/github-cli@1.0.4
+  gh: circleci/github-cli@2.1.0
 
 parameters:
   node_version:
@@ -24,7 +24,7 @@ parameters:
   gh_version:
     type: string
     # https://github.com/cli/cli/releases
-    default: '1.9.2'
+    default: '2.7.0'
 
 executors:
   linux:

--- a/release-scripts/upload-artifacts.sh
+++ b/release-scripts/upload-artifacts.sh
@@ -24,6 +24,7 @@ VERSION_TAG="v$(cat binary-releases/version)"
 
 # Upload files to the GitHub release
 gh release create "${VERSION_TAG}" "${StaticFiles[@]}" \
+  --target "${CIRCLE_SHA1}" \
   --title "${VERSION_TAG}" \
   --notes-file binary-releases/RELEASE_NOTES.md
 


### PR DESCRIPTION
GitHub CLI by default maps a release to the last commit on the main branch. This is wrong when a release is from an older commit.

I've also updated GitHub CLI and the CircleCI orb to make sure it supports `--target`.

Docs: https://cli.github.com/manual/gh_release_create

You can see this issue here:

1. 8ac4a96 released. https://app.circleci.com/pipelines/github/snyk/cli/11302/workflows/4235d32e-b93c-47d0-a492-875c17a6760c 
2. 8538d31 was tagged with v1.892.0
3. cb8eaee released. https://app.circleci.com/pipelines/github/snyk/cli/11308/workflows/449de045-db6a-4067-9192-9699e52b23f3 
4. d49b534 was tagged with v1.893.0
