### PR TITLE
Dev Count: count merge commits as well

### DIFF
--- a/src/lib/monitor/dev-count-analysis.ts
+++ b/src/lib/monitor/dev-count-analysis.ts
@@ -144,7 +144,7 @@ export async function runGitLog(
   fnShellout: (cmd: string, workingDirectory: string) => Promise<string>,
 ): Promise<string> {
   try {
-    const gitLogCommand = `git --no-pager log --no-merges --pretty=tformat:"%H${SERIOUS_DELIMITER}%an${SERIOUS_DELIMITER}%ae${SERIOUS_DELIMITER}%aI" --after="${timestampEpochSecondsStartOfPeriod}" --until="${timestampEpochSecondsEndOfPeriod}" --max-count=${MAX_COMMITS_IN_GIT_LOG}`;
+    const gitLogCommand = `git --no-pager log --pretty=tformat:"%H${SERIOUS_DELIMITER}%an${SERIOUS_DELIMITER}%ae${SERIOUS_DELIMITER}%aI" --after="${timestampEpochSecondsStartOfPeriod}" --until="${timestampEpochSecondsEndOfPeriod}" --max-count=${MAX_COMMITS_IN_GIT_LOG}`;
     const gitLogStdout: string = await fnShellout(gitLogCommand, repoPath);
     return gitLogStdout;
   } catch {


### PR DESCRIPTION
Snyk won't be ignoring merge commits from the dev counts. This behavior is aligned with the SCM import flow