### PR TITLE
feat: Add an initial user message to the test output

### DIFF
--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -105,6 +105,19 @@ export default async function test(
   let iacScanFailures: IacFileInDirectory[] | undefined;
   let iacOutputMeta: IacOutputMeta | undefined;
 
+  const isNewIacOutputSupported = options.iac
+    ? await hasFeatureFlag('iacCliOutput', options)
+    : false;
+
+  if (shouldPrintIacInitialMessage(options, isNewIacOutputSupported)) {
+    console.log(
+      EOL +
+        chalk.white.bold(
+          'Snyk testing Infrastructure as Code configuration issues...',
+        ),
+    );
+  }
+
   // Promise waterfall to test all other paths sequentially
   for (const path of paths) {
     // Create a copy of the options so a specific test can
@@ -228,10 +241,6 @@ export default async function test(
     err.sarifStringifiedResults = stringifiedSarifData;
     throw err;
   }
-
-  const isNewIacOutputSupported = options.iac
-    ? await hasFeatureFlag('iacCliOutput', options)
-    : false;
 
   let response = results
     .map((result, i) => {
@@ -363,4 +372,8 @@ function shouldFail(vulnerableResults: any[], failOn: FailOn) {
   }
   // should fail by default when there are vulnerable results
   return vulnerableResults.length > 0;
+}
+
+function shouldPrintIacInitialMessage(options, iacCliOutputFeatureFlag) {
+  return !options.json && !options.sarif && iacCliOutputFeatureFlag;
 }

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -9,6 +9,7 @@ const featureFlagDefaults = (): Map<string, boolean> => {
   return new Map([
     ['cliFailFast', false],
     ['iacTerraformVarSupport', false],
+    ['iacCliOutput', false],
   ]);
 };
 

--- a/test/jest/acceptance/iac/new-test-output.spec.ts
+++ b/test/jest/acceptance/iac/new-test-output.spec.ts
@@ -1,0 +1,55 @@
+import { FakeServer } from '../../../acceptance/fake-server';
+import { startMockServer } from './helpers';
+
+describe('New IaC Test Output', () => {
+  const initialMessage =
+    'Snyk testing Infrastructure as Code configuration issues...';
+
+  let server: FakeServer;
+  let run;
+  let teardown;
+
+  beforeAll(async () => {
+    ({ server, run, teardown } = await startMockServer());
+  });
+
+  afterAll(async () => {
+    await teardown();
+  });
+
+  describe('with feature flag enabled', () => {
+    beforeEach(() => {
+      server.setFeatureFlag('iacCliOutput', true);
+    });
+
+    afterEach(() => {
+      server.restore();
+    });
+
+    it('should show an initial message', async () => {
+      const { stdout } = await run('snyk iac test  ./iac/arm/rule_test.json');
+      expect(stdout).toContain(initialMessage);
+    });
+
+    it('should not show an initial message for JSON output', async () => {
+      const { stdout } = await run(
+        'snyk iac test --json  ./iac/arm/rule_test.json',
+      );
+      expect(stdout).not.toContain(initialMessage);
+    });
+
+    it('should not show an initial message for SARIF output', async () => {
+      const { stdout } = await run(
+        'snyk iac test --sarif  ./iac/arm/rule_test.json',
+      );
+      expect(stdout).not.toContain(initialMessage);
+    });
+  });
+
+  describe('with feature flag disabled', () => {
+    it('should not show an initial message', async () => {
+      const { stdout } = await run('snyk iac test  ./iac/arm/rule_test.json');
+      expect(stdout).not.toContain(initialMessage);
+    });
+  });
+});


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

If the feature flag `"iacCliOutput"` is enabled and the `test` command is invoked in `iac` mode, the CLI shows an initial message to the user.

#### Where should the reviewer start?

The only change has been performed in the top-level test command (`src/cli/commands/test/index.ts`) because the initial message should be printed only once, independently on the number of tested paths.

#### How should this be manually tested?

Enable the feature flag on the Registry, and execute a `snyk iac test` command.

#### Screenshots

![image](https://user-images.githubusercontent.com/404227/161699791-f74a2cbc-525b-4b18-a456-bd093c26cc9b.png)

#### What are the relevant tickets?

[CFG-1578](https://snyksec.atlassian.net/browse/CFG-1578)
