### PR TITLE
test: document variadic path scans for IaC

### DIFF
--- a/test/jest/acceptance/iac/test-directory.spec.ts
+++ b/test/jest/acceptance/iac/test-directory.spec.ts
@@ -98,6 +98,38 @@ describe('Directory scan', () => {
     expect(stdout).not.toContain('two.tf');
   });
 
+  describe('Variadic - multiple path scans', () => {
+    it('outputs both results and failures combined when scanning two paths', async () => {
+      const { stdout, exitCode } = await run(
+        `snyk iac test ./iac/terraform ./iac/cloudformation`,
+      );
+      //directory scan shows relative path to cwd  in output
+      expect(stdout).toContain('Testing sg_open_ssh.tf');
+      //TODO: currently the failures show only for the second path->cloudformation so this will fail:
+      // expect(stdout).toContain('Testing sg_open_ssh_invalid_hcl2.tf');
+      // expect(stdout).toContain('Failed to parse Terraform file');
+      expect(stdout).toContain('Testing aurora-valid.yml');
+      expect(stdout).toContain('Testing invalid-cfn.yml');
+      expect(stdout).toContain('Failed to parse YAML file');
+      expect(exitCode).toBe(1);
+    });
+
+    //TODO: this test fails until we fix the bug:
+    // if one of the two paths fail due to not finding valid IaC files,
+    // then it will override the valid results of the first scan
+    it.skip('outputs both results and failures for first path when the last path is empty or non-existent', async () => {
+      const { stdout, exitCode } = await run(
+        `snyk iac test ./iac/arm non-existing-dir`,
+      );
+      //directory scan shows relative path to cwd  in output
+      expect(stdout).toContain('Testing rule_test.json.');
+      expect(stdout).toContain('Testing invalid_rule_test.json.');
+      expect(stdout).toContain('Failed to parse JSON file');
+      expect(stdout).toContain('Failed to parse Terraform file');
+      expect(exitCode).toBe(1);
+    });
+  });
+
   describe('Exit codes', () => {
     describe('Issues found', () => {
       it('returns 1 even if some files failed to parse', async () => {


### PR DESCRIPTION
I added the tests prematurely before fixing the bug associated with it, that's why I have skipped one of them.
It's a bit silly, but my goal was more to have this documented in case the bug does not get prioritised soon enough. [CFG-1477]

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules


[CFG-1477]: https://snyksec.atlassian.net/browse/CFG-1477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ