### PR TITLE
chore: change ownership of test file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,6 +47,7 @@ test/smoke/.iac-data/ @snyk/group-infrastructure-as-code
 test/jest/unit/lib/formatters/iac-output/ @snyk/group-infrastructure-as-code
 test/jest/unit/lib/formatters/test/format-test-results.spec.ts @snyk/hammer @snyk/snyk-open-source @snyk/magma
 test/jest/unit/iac/ @snyk/group-infrastructure-as-code
+test/jest/unit/makeDirectoryIterator.spec.ts @snyk/group-infrastructure-as-code
 test/jest/unit/lib/iac/ @snyk/group-infrastructure-as-code
 test/jest/acceptance/iac/ @snyk/group-infrastructure-as-code
 test/jest/acceptance/snyk-apps @snyk/moose


### PR DESCRIPTION
The test in question is for `src/lib/iac/makeDirectoryIterator.ts` so it was also added in the wrong place. I would move it to the right place here but actually we will remove it in https://github.com/snyk/cli/pull/3041 anyway.
