### PR TITLE
feat: produce flat dep-graph scanning unmanaged

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
         "snyk-module": "3.1.0",
-        "snyk-mvn-plugin": "2.26.4",
+        "snyk-mvn-plugin": "2.27.0",
         "snyk-nodejs-lockfile-parser": "1.38.0",
         "snyk-nuget-plugin": "1.23.4",
         "snyk-php-plugin": "1.9.2",
@@ -16684,9 +16684,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-mvn-plugin": {
-      "version": "2.26.4",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.26.4.tgz",
-      "integrity": "sha512-fKh5tA0Plu1hZejbxMGVxmqn5eiZLk31Wy/pEbPca58/8JypzqLcN2KCxnP0SZPIuy3LRiR6stJEXycGqpi/0Q==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.27.0.tgz",
+      "integrity": "sha512-oAJQA0fUQeSylB01TX4R2lCsy9gn0pGkI8GQ6wumldK5kIDe6cWscmc7IDAgf9hC3pPDtp6NUrI+JNyB5IMVWQ==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.0",
         "@snyk/dep-graph": "^1.23.1",
@@ -16694,19 +16694,7 @@
         "debug": "^4.1.1",
         "glob": "^7.1.6",
         "needle": "^2.5.0",
-        "tmp": "^0.1.0",
         "tslib": "1.11.1"
-      }
-    },
-    "node_modules/snyk-mvn-plugin/node_modules/tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-      "dependencies": {
-        "rimraf": "^2.6.3"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/snyk-mvn-plugin/node_modules/tslib": {
@@ -32810,9 +32798,9 @@
       }
     },
     "snyk-mvn-plugin": {
-      "version": "2.26.4",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.26.4.tgz",
-      "integrity": "sha512-fKh5tA0Plu1hZejbxMGVxmqn5eiZLk31Wy/pEbPca58/8JypzqLcN2KCxnP0SZPIuy3LRiR6stJEXycGqpi/0Q==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.27.0.tgz",
+      "integrity": "sha512-oAJQA0fUQeSylB01TX4R2lCsy9gn0pGkI8GQ6wumldK5kIDe6cWscmc7IDAgf9hC3pPDtp6NUrI+JNyB5IMVWQ==",
       "requires": {
         "@snyk/cli-interface": "2.11.0",
         "@snyk/dep-graph": "^1.23.1",
@@ -32820,18 +32808,9 @@
         "debug": "^4.1.1",
         "glob": "^7.1.6",
         "needle": "^2.5.0",
-        "tmp": "^0.1.0",
         "tslib": "1.11.1"
       },
       "dependencies": {
-        "tmp": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-          "requires": {
-            "rimraf": "^2.6.3"
-          }
-        },
         "tslib": {
           "version": "1.11.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.17.0",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "2.26.4",
+    "snyk-mvn-plugin": "2.27.0",
     "snyk-nodejs-lockfile-parser": "1.38.0",
     "snyk-nuget-plugin": "1.23.4",
     "snyk-php-plugin": "1.9.2",


### PR DESCRIPTION


- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
See https://github.com/snyk/snyk-mvn-plugin/pull/115

Produce a flat dependency graph when scanning unmanaged Java archives.
We no longer resolver transitive lines. Each archive is a top level dependency with no transitives.
This should fix problems reported when transitive lines were interfering with one another.

