### PR TITLE
chore : change-error-msg-lce

### DIFF
--- a/src/lib/plugins/sast/analysis.ts
+++ b/src/lib/plugins/sast/analysis.ts
@@ -195,7 +195,7 @@ function isLocalCodeEngine(sastSettings: SastSettings): boolean {
 function validateLocalCodeEngineUrl(localCodeEngineUrl: string): void {
   if (localCodeEngineUrl.length === 0) {
     throw new MissingConfigurationError(
-      'Snyk Code Local Engine. Refer to our docs to learn more: https://docs.snyk.io/products/snyk-code/deployment-options/snyk-code-local-engine/cli-and-ide',
+      'Snyk Code Local Engine. Refer to our docs on https://docs.snyk.io/products/snyk-code/deployment-options/snyk-code-local-engine/cli-and-ide to learn more',
     );
   }
 }

--- a/test/jest/unit/snyk-code/snyk-code-test.spec.ts
+++ b/test/jest/unit/snyk-code/snyk-code-test.spec.ts
@@ -794,7 +794,7 @@ describe('Test snyk code', () => {
         'test-id',
       ),
     ).rejects.toThrowError(
-      'Missing configuration for Snyk Code Local Engine. Refer to our docs to learn more: https://docs.snyk.io/products/snyk-code/deployment-options/snyk-code-local-engine/cli-and-ide',
+      'Missing configuration for Snyk Code Local Engine. Refer to our docs on https://docs.snyk.io/products/snyk-code/deployment-options/snyk-code-local-engine/cli-and-ide to learn more',
     );
   });
 });


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

To make url of docs in the error msg separated from default dot at the end of the error message. 
for more details please look at the jira item below .  

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/NEBULA-453

