### PR TITLE
feat: Implemented IaC test summary formatter [CFG-1571]

### DIFF
--- a/src/lib/formatters/iac-output/index.ts
+++ b/src/lib/formatters/iac-output/index.ts
@@ -3,6 +3,8 @@ import * as v2 from './v2';
 import { IacTestResponse } from '../../snyk-test/iac-test-result';
 import { IacFileInDirectory } from '../../types';
 
+export { formatIacTestSummary } from './v2';
+
 export function getIacDisplayedOutput(
   iacTest: IacTestResponse,
   testedInfoText: string,

--- a/src/lib/formatters/iac-output/v2/color-utils.ts
+++ b/src/lib/formatters/iac-output/v2/color-utils.ts
@@ -1,0 +1,13 @@
+import chalk, { Chalk, ColorSupport } from 'chalk';
+import { SEVERITY } from '../../../snyk-test/common';
+
+export const severityColor: {
+  [severity in SEVERITY]: Chalk & {
+    supportsColor: ColorSupport;
+  };
+} = {
+  critical: chalk.hex('#AB191A'),
+  high: chalk.hex('#CE501A'),
+  medium: chalk.hex('#D68000'),
+  low: chalk.hex('#88879E'),
+};

--- a/src/lib/formatters/iac-output/v2/index.ts
+++ b/src/lib/formatters/iac-output/v2/index.ts
@@ -14,6 +14,8 @@ import { IacFileInDirectory } from '../../../../lib/types';
 
 import { getSeverityValue } from '../../get-severity-value';
 
+export { formatIacTestSummary } from './test-summary';
+
 const debug = Debug('iac-output');
 
 function formatIacIssue(

--- a/src/lib/formatters/iac-output/v2/test-summary.ts
+++ b/src/lib/formatters/iac-output/v2/test-summary.ts
@@ -1,0 +1,97 @@
+import chalk from 'chalk';
+import { EOL } from 'os';
+import { rightPadWithSpaces } from '../../../right-pad';
+import { SEVERITY } from '../../../snyk-test/common';
+import { color, icon } from '../../../theme';
+import { IacOutputMeta } from '../../../types';
+import { severityColor } from './color-utils';
+import { IacTestData } from './types';
+
+const PAD_LENGTH = 19; // chars to align
+const INDENT = '  ';
+
+export function formatIacTestSummary(
+  testData: IacTestData,
+  outputMeta: IacOutputMeta,
+): string {
+  const title = chalk.bold.white('Test Summary');
+  const summarySections: string[] = [title];
+
+  summarySections.push(formatTestMetaSection(outputMeta));
+
+  summarySections.push(formatCountsSection(testData));
+
+  return summarySections.join(EOL.repeat(2));
+}
+
+function formatTestMetaSection(iacMeta: IacOutputMeta): string {
+  const metaSectionProperties: [string, string][] = [];
+
+  if (iacMeta.orgName) {
+    metaSectionProperties.push(['Organization', iacMeta.orgName]);
+  }
+
+  const metaSection = metaSectionProperties
+    .map(([key, value]) =>
+      rightPadWithSpaces(`${INDENT}${key}: ${value}`, PAD_LENGTH),
+    )
+    .join(EOL);
+
+  return metaSection;
+}
+
+function formatCountsSection(testData: IacTestData): string {
+  const filesWithIssues = testData.results.filter(
+    (result) => result.result.cloudConfigResults.length,
+  ).length;
+  const filesWithoutIssues = testData.results.length - filesWithIssues;
+
+  const countsSectionProperties: string[] = [];
+
+  countsSectionProperties.push(
+    `${chalk.bold(
+      color.status.success(icon.VALID),
+    )} Files without issues: ${chalk.bold.white(`${filesWithoutIssues}`)}`,
+  );
+
+  countsSectionProperties.push(
+    `${chalk.bold(
+      color.status.error(icon.ISSUE),
+    )} Files with issues: ${chalk.bold.white(`${filesWithIssues}`)}`,
+  );
+
+  countsSectionProperties.push(
+    `${INDENT}Ignored issues: ${chalk.bold.white(`${testData.ignoreCount}`)}`,
+  );
+
+  let totalIssuesCount = 0;
+
+  const issueCountsBySeverities: { [key in SEVERITY | 'none']: number } = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    none: 0,
+  };
+
+  testData.results.forEach((iacTestResponse) => {
+    totalIssuesCount += iacTestResponse.result.cloudConfigResults.length;
+    iacTestResponse.result.cloudConfigResults.forEach((iacIssue) => {
+      issueCountsBySeverities[iacIssue.severity]++;
+    });
+  });
+
+  countsSectionProperties.push(
+    `${INDENT}Total issues: ${chalk.bold.white(
+      `${totalIssuesCount}`,
+    )} [ ${severityColor.critical(
+      `${issueCountsBySeverities.critical} critical`,
+    )}, ${severityColor.high(
+      `${issueCountsBySeverities.high} high`,
+    )}, ${severityColor.medium(
+      `${issueCountsBySeverities.medium} medium`,
+    )}, ${severityColor.low(`${issueCountsBySeverities.low} low`)} ]`,
+  );
+
+  return countsSectionProperties.join(EOL);
+}

--- a/src/lib/formatters/iac-output/v2/types.ts
+++ b/src/lib/formatters/iac-output/v2/types.ts
@@ -1,0 +1,6 @@
+import { IacTestResponse } from '../../../snyk-test/iac-test-result';
+
+export interface IacTestData {
+  ignoreCount: number;
+  results: IacTestResponse[];
+}

--- a/test/jest/unit/lib/formatters/iac-output/test-summary.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/test-summary.spec.ts
@@ -1,0 +1,95 @@
+import * as fs from 'fs';
+import * as pathLib from 'path';
+import chalk from 'chalk';
+
+import { formatIacTestSummary } from '../../../../../../src/lib/formatters/iac-output';
+import { severityColor } from '../../../../../../src/lib/formatters/iac-output/v2/color-utils';
+import { IacTestResponse } from '../../../../../../src/lib/snyk-test/iac-test-result';
+
+describe('formatIacTestSummary', () => {
+  let resultFixtures: IacTestResponse[];
+
+  beforeAll(async () => {
+    resultFixtures = JSON.parse(
+      fs.readFileSync(
+        pathLib.join(
+          __dirname,
+          '..',
+          '..',
+          '..',
+          'iac/fixtures/formatted-results.json',
+        ),
+        'utf8',
+      ),
+    );
+  });
+
+  it("should include the 'Test Summary' title", () => {
+    // Arrange
+    const orgName = 'test-org-name';
+    const projectName = 'test-project-name';
+    const ignoreCount = 3;
+
+    // Act
+    const result = formatIacTestSummary(
+      { ignoreCount, results: resultFixtures as any },
+      { orgName, projectName },
+    );
+
+    // Assert
+    expect(result).toContain(
+      `${chalk.bold.white('Test Summary')}
+
+  Organization: ${orgName}
+
+${chalk.bold.green('✔')} Files without issues: ${chalk.bold.white('0')}
+${chalk.bold.red('✗')} Files with issues: ${chalk.bold.white('3')}
+  Ignored issues: ${chalk.bold.white(`${ignoreCount}`)}
+  Total issues: ${chalk.bold.white('22')} [ ${severityColor.critical(
+        '0 critical',
+      )}, ${severityColor.high('5 high')}, ${severityColor.medium(
+        '4 medium',
+      )}, ${severityColor.low('13 low')} ]`,
+    );
+  });
+  it('should include the test meta properties section with the correct values', () => {
+    // Arrange
+    const orgName = 'test-org-name';
+    const projectName = 'test-project-name';
+    const ignoreCount = 3;
+
+    // Act
+    const result = formatIacTestSummary(
+      { ignoreCount, results: resultFixtures as any },
+      { orgName, projectName },
+    );
+
+    // Assert
+    expect(result).toContain(`${chalk.bold.white('Test Summary')}`);
+  });
+
+  it('should include the counts section with the correct values', () => {
+    // Arrange
+    const orgName = 'test-org-name';
+    const projectName = 'test-project-name';
+    const ignoreCount = 3;
+
+    // Act
+    const result = formatIacTestSummary(
+      { ignoreCount, results: resultFixtures as any },
+      { orgName, projectName },
+    );
+
+    // Assert
+    expect(result).toContain(
+      `${chalk.bold.green('✔')} Files without issues: ${chalk.bold.white('0')}
+${chalk.bold.red('✗')} Files with issues: ${chalk.bold.white('3')}
+  Ignored issues: ${chalk.bold.white(`${ignoreCount}`)}
+  Total issues: ${chalk.bold.white('22')} [ ${severityColor.critical(
+        '0 critical',
+      )}, ${severityColor.high('5 high')}, ${severityColor.medium(
+        '4 medium',
+      )}, ${severityColor.low('13 low')} ]`,
+    );
+  });
+});


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

### What does this PR do?

- Adds the implementation for the formatter of the new summary section in the new CLI output for test flow of IaC in the Snyk CLI.

### Notes for the reviewer

- This formatter was **not applied** to the test flow in this PR, but rather in a future separate PR.
- This formatter is applied to the test flow in this PR: #3102 
- Following the discussion on [this Slack thread](https://snyk.slack.com/archives/C030UA3U1RB/p1649151568166039), the project name and project path were not added to the test summary as part of this ticket, but need to be added at a later point in time.

### Where should the reviewer start?

- `src/lib/formatters/iac-output/v2/test-summary.ts`

### How should this be manually tested?

- Since this PR adds the formatting logic but does not apply it in the test flow, the output of the IaC test will not be altered yet. That being said, the formatter can be still be executed and examined independently, by calling the `formatIacTestSummary`.
- The `formatIacTestSummary` function has tests that exemplify the expected output for the test summary. 
These tests can be found in:

    ``` 
    test/jest/unit/lib/formatters/iac-output/test-summary.spec.ts
    ```

### Any background context you want to provide?

As part of the MVP for the new CLI output, we’d like to replace the current per-project summaries in the current IaC test output with a single aggregated summary at the end of the test output. 
This can be viewed in the following design, taken from [the MVP definition](https://miro.com/app/board/uXjVOOpVGxU=/?moveToWidget=3458764518430874390&cot=14): 

![image](https://user-images.githubusercontent.com/46415136/162007885-4fc89eaf-bd58-46fe-aae9-12fdc0a3ba75.png)

### What are the relevant tickets?

- [CFG-1571](https://snyksec.atlassian.net/browse/CFG-1571)

### Additional information

### Additional information

- [Slack thread](https://snyk.slack.com/archives/C030UA3U1RB/p1649151568166039)
- A succeeding PR for applying the formatter in the test flow: #3102 