### PR TITLE
feat: restructure the issues list layout

### DIFF
--- a/src/cli/commands/test/iac/index.ts
+++ b/src/cli/commands/test/iac/index.ts
@@ -57,7 +57,10 @@ import {
 import { isIacShareResultsOptions } from './local-execution/assert-iac-options-flag';
 import { assertIaCOptionsFlags } from './local-execution/assert-iac-options-flag';
 import { hasFeatureFlag } from '../../../../lib/feature-flags';
-import { formatIacTestSummary } from '../../../../lib/formatters/iac-output';
+import {
+  formatIacTestSummary,
+  getIacDisplayedIssues,
+} from '../../../../lib/formatters/iac-output';
 
 const debug = Debug('snyk-test');
 const SEPARATOR = '\n-------------------------------------------------------\n';
@@ -241,18 +244,23 @@ export default async function(...args: MethodArgs): Promise<TestCommandResult> {
     throw err;
   }
 
-  let response = results
-    .map((result, i) => {
-      return displayResult(
-        results[i] as LegacyVulnApiResult,
-        {
-          ...resultOptions[i],
-          isNewIacOutputSupported,
-        },
-        result.foundProjectCount,
-      );
-    })
-    .join(`\n${SEPARATOR}`);
+  let response = '';
+
+  if (isNewIacOutputSupported && !notSuccess) {
+    response += getIacDisplayedIssues(results, iacOutputMeta!);
+  } else {
+    response += results
+      .map((result, i) => {
+        return displayResult(
+          results[i] as LegacyVulnApiResult,
+          {
+            ...resultOptions[i],
+          },
+          result.foundProjectCount,
+        );
+      })
+      .join(`\n${SEPARATOR}`);
+  }
 
   if (notSuccess) {
     debug(`Failed to test ${errorResults.length} projects, errors:`);

--- a/src/lib/formatters/iac-output/index.ts
+++ b/src/lib/formatters/iac-output/index.ts
@@ -1,21 +1,6 @@
 import * as v1 from './v1';
 import * as v2 from './v2';
-import { IacTestResponse } from '../../snyk-test/iac-test-result';
 import { IacFileInDirectory } from '../../types';
-
-export { formatIacTestSummary } from './v2';
-
-export function getIacDisplayedOutput(
-  iacTest: IacTestResponse,
-  testedInfoText: string,
-  meta: string,
-  prefix: string,
-  isNewIacOutputSupported?: boolean,
-): string {
-  return isNewIacOutputSupported
-    ? v2.getIacDisplayedOutput(iacTest, prefix)
-    : v1.getIacDisplayedOutput(iacTest, testedInfoText, meta, prefix);
-}
 
 export function getIacDisplayErrorFileOutput(
   iacFileResult: IacFileInDirectory,
@@ -30,4 +15,7 @@ export {
   capitalizePackageManager,
   createSarifOutputForIac,
   shareResultsOutput,
+  getIacDisplayedOutput,
 } from './v1';
+
+export { formatIacTestSummary, getIacDisplayedIssues } from './v2';

--- a/src/lib/formatters/iac-output/v2/formatters.ts
+++ b/src/lib/formatters/iac-output/v2/formatters.ts
@@ -1,0 +1,28 @@
+import { FormattedResult } from '../../../../cli/commands/test/iac/local-execution/types';
+import { IacOutputMeta } from '../../../types';
+import { IacTestOutput } from './types';
+
+export function formatScanResultsNewOutput(
+  oldFormattedResults: FormattedResult[],
+  outputMeta: IacOutputMeta,
+): IacTestOutput {
+  const newFormattedResults: IacTestOutput = {
+    results: {},
+    metadata: outputMeta,
+  };
+
+  oldFormattedResults.forEach((oldFormattedResult) => {
+    oldFormattedResult.result.cloudConfigResults.forEach((policyMetadata) => {
+      if (!newFormattedResults.results[policyMetadata.severity]) {
+        newFormattedResults.results[policyMetadata.severity] = [];
+      }
+      newFormattedResults.results[policyMetadata.severity].push({
+        policyMetadata,
+        targetFile: oldFormattedResult.targetFile,
+        targetFilePath: oldFormattedResult.targetFilePath,
+      });
+    });
+  });
+
+  return newFormattedResults;
+}

--- a/src/lib/formatters/iac-output/v2/index.ts
+++ b/src/lib/formatters/iac-output/v2/index.ts
@@ -1,82 +1,9 @@
-import chalk from 'chalk';
-import { icon } from '../../../theme';
-import * as Debug from 'debug';
 import * as pathLib from 'path';
 
-import {
-  IacTestResponse,
-  AnnotatedIacIssue,
-} from '../../../../lib/snyk-test/iac-test-result';
-import { printPath } from '../../remediation-based-format-issues';
-import { titleCaseText } from '../../legacy-format-issue';
-import { colorTextBySeverity } from '../../../../lib/snyk-test/common';
 import { IacFileInDirectory } from '../../../../lib/types';
-import { getSeverityValue } from '../../get-severity-value';
 
+export { getIacDisplayedIssues } from './issues-list';
 export { formatIacTestSummary } from './test-summary';
-
-const debug = Debug('iac-output');
-
-function formatIacIssue(
-  issue: AnnotatedIacIssue,
-  isNew: boolean,
-  path: string[],
-): string {
-  const newBadge = isNew ? ' (new)' : '';
-  const name = issue.subType ? ` in ${chalk.bold(issue.subType)}` : '';
-
-  let introducedBy = '';
-  if (path) {
-    // In this mode, we show only one path by default, for compactness
-    const pathStr = printPath(path, 0);
-    introducedBy = `\n    introduced by ${pathStr}`;
-  }
-
-  return (
-    colorTextBySeverity(
-      issue.severity,
-      `  ${icon.ISSUE} ${chalk.bold(issue.title)}${newBadge} [${titleCaseText(
-        issue.severity,
-      )} Severity]`,
-    ) +
-    ` [${issue.id}]` +
-    name +
-    introducedBy +
-    '\n'
-  );
-}
-
-export function getIacDisplayedOutput(
-  iacTest: IacTestResponse,
-  prefix: string,
-): string {
-  const issuesTextArray = [
-    chalk.bold.white('\nInfrastructure as code issues:'),
-  ];
-
-  const NotNew = false;
-
-  const issues: AnnotatedIacIssue[] = iacTest.result.cloudConfigResults;
-  debug(`iac display output - ${issues.length} issues`);
-
-  issues
-    .sort((a, b) => getSeverityValue(b.severity) - getSeverityValue(a.severity))
-    .forEach((issue) => {
-      issuesTextArray.push(
-        formatIacIssue(issue, NotNew, issue.cloudConfigPath),
-      );
-    });
-
-  const issuesInfoOutput: string[] = [];
-  debug(`Iac display output - ${issuesTextArray.length} issues text`);
-  if (issuesTextArray.length > 0) {
-    issuesInfoOutput.push(issuesTextArray.join('\n'));
-  }
-
-  const body = issuesInfoOutput.join('\n\n');
-
-  return prefix + body;
-}
 
 export function getIacDisplayErrorFileOutput(
   iacFileResult: IacFileInDirectory,

--- a/src/lib/formatters/iac-output/v2/issues-list.ts
+++ b/src/lib/formatters/iac-output/v2/issues-list.ts
@@ -1,0 +1,51 @@
+import chalk from 'chalk';
+import { EOL } from 'os';
+import capitalize = require('lodash/capitalize');
+import debug = require('debug');
+
+import { FormattedResult } from '../../../../cli/commands/test/iac/local-execution/types';
+import { IacOutputMeta } from '../../../types';
+import { severityColor } from './color-utils';
+import { formatScanResultsNewOutput } from './formatters';
+import { FormattedIssue } from './types';
+
+export function getIacDisplayedIssues(
+  results: FormattedResult[],
+  outputMeta: IacOutputMeta,
+): string {
+  const formattedResults = formatScanResultsNewOutput(results, outputMeta);
+
+  let output = EOL + chalk.bold.white('Issues') + EOL;
+
+  ['low', 'medium', 'high', 'critical'].forEach((severity) => {
+    if (formattedResults.results[severity]) {
+      const issues = formattedResults.results[severity];
+      output +=
+        EOL +
+        severityColor[severity](
+          chalk.bold(
+            `${capitalize(severity)} Severity Issues: ${issues.length}`,
+          ),
+        ) +
+        EOL.repeat(2);
+      output += getIssuesOutput(issues);
+
+      debug(
+        `iac display output - ${severity} severity ${issues.length} issues`,
+      );
+    }
+  });
+
+  return output;
+}
+
+// CFG-1574 will continue the work on this function
+function getIssuesOutput(issues: FormattedIssue[]) {
+  let output = '';
+
+  issues.forEach((issue) => {
+    output += chalk.white(`${issue.policyMetadata.title}`) + EOL;
+  });
+
+  return output;
+}

--- a/src/lib/formatters/iac-output/v2/types.ts
+++ b/src/lib/formatters/iac-output/v2/types.ts
@@ -1,6 +1,25 @@
 import { IacTestResponse } from '../../../snyk-test/iac-test-result';
+import { PolicyMetadata } from '../../../../cli/commands/test/iac/local-execution/types';
+import { SEVERITY } from '../../../snyk-test/common';
+import { IacOutputMeta } from '../../../types';
 
 export interface IacTestData {
   ignoreCount: number;
   results: IacTestResponse[];
 }
+
+export type FormattedIssue = {
+  policyMetadata: PolicyMetadata;
+  // Decide which one of them to keep
+  targetFile: string;
+  targetFilePath: string;
+};
+
+type FormattedResultsBySeverity = {
+  [severity in keyof SEVERITY]?: FormattedIssue[];
+};
+
+export type IacTestOutput = {
+  results: FormattedResultsBySeverity;
+  metadata: IacOutputMeta;
+};

--- a/src/lib/formatters/test/display-result.ts
+++ b/src/lib/formatters/test/display-result.ts
@@ -26,13 +26,9 @@ import {
 } from '../../../lib/formatters/test/format-test-results';
 import { showMultiScanTip } from '../show-multi-scan-tip';
 
-interface DisplayResultOptions extends Options, TestOptions {
-  isNewIacOutputSupported?: boolean;
-}
-
 export function displayResult(
   res: TestResult,
-  options: DisplayResultOptions,
+  options: Options & TestOptions,
   foundProjectCount?: number,
 ) {
   const meta = formatTestMeta(res, options);
@@ -120,7 +116,6 @@ export function displayResult(
       testedInfoText,
       meta,
       prefix,
-      options.isNewIacOutputSupported,
     );
   }
 

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -337,6 +337,13 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
       return;
     }
 
+    if (org === 'tf-lang-support' && flag === 'iacTerraformVarSupport') {
+      res.send({
+        ok: true,
+      });
+      return;
+    }
+
     if (featureFlags.has(flag)) {
       const ffEnabled = featureFlags.get(flag);
       if (ffEnabled) {

--- a/test/jest/acceptance/iac/iac-output.spec.ts
+++ b/test/jest/acceptance/iac/iac-output.spec.ts
@@ -39,6 +39,14 @@ describe('iac test output', () => {
       );
     });
 
+    it('should show a subtitle for medium severity issues', async () => {
+      const { stdout } = await run('snyk iac test  ./iac/arm/rule_test.json');
+
+      expect(stdout).toContain(
+        'Issues' + EOL.repeat(2) + 'Medium Severity Issues: 1',
+      );
+    });
+
     it('should not show an initial message for JSON output', async () => {
       const { stdout } = await run(
         'snyk iac test --json  ./iac/arm/rule_test.json',
@@ -174,6 +182,14 @@ If the issue persists contact support@snyk.io`,
     it('should not show an initial message', async () => {
       const { stdout } = await run('snyk iac test  ./iac/arm/rule_test.json');
       expect(stdout).not.toContain(initialMessage);
+    });
+
+    it('should not show a subtitle for medium severity issues', async () => {
+      const { stdout } = await run('snyk iac test  ./iac/arm/rule_test.json');
+
+      expect(stdout).not.toContain(
+        'Issues' + EOL.repeat(2) + 'Medium Severity Issues: 1',
+      );
     });
 
     it('should not display the test summary section', async () => {

--- a/test/jest/unit/iac/process-results/fixtures/new-output-formatted-results.json
+++ b/test/jest/unit/iac/process-results/fixtures/new-output-formatted-results.json
@@ -1,0 +1,846 @@
+{
+    "results":{
+      "low":[
+        {
+          "policyMetadata":{
+            "severity":"low",
+            "resolve":"Set `disable_api_termination` attribute  with value `true`",
+            "id":"SNYK-CC-AWS-426",
+            "impact":"Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+            "msg":"resource.aws_instance[denied].disable_api_termination",
+            "remediation":{
+              "cloudformation":"Set `DisableApiTermination` attribute with value `true`",
+              "terraform":"Set `disable_api_termination` attribute  with value `true`"
+            },
+            "subType":"EC2",
+            "issue":"To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+            "publicId":"SNYK-CC-AWS-426",
+            "title":"EC2 API termination protection is not enabled",
+            "references":[
+              "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+            ],
+            "name":"EC2 API termination protection is not enabled",
+            "cloudConfigPath":[
+              "resource",
+              "aws_instance[denied]",
+              "disable_api_termination"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+              "impact":"Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+              "resolve":"Set `disable_api_termination` attribute  with value `true`"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-AWS-426"
+          },
+          "targetFile":"aws_ec2_metadata_secrets.tf",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/aws_ec2_metadata_secrets.tf"
+        },
+        {
+          "policyMetadata":{
+            "severity":"low",
+            "resolve":"Set `disable_api_termination` attribute  with value `true`",
+            "id":"SNYK-CC-AWS-426",
+            "impact":"Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+            "msg":"resource.aws_instance[denied_3].disable_api_termination",
+            "remediation":{
+              "cloudformation":"Set `DisableApiTermination` attribute with value `true`",
+              "terraform":"Set `disable_api_termination` attribute  with value `true`"
+            },
+            "subType":"EC2",
+            "issue":"To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+            "publicId":"SNYK-CC-AWS-426",
+            "title":"EC2 API termination protection is not enabled",
+            "references":[
+              "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+            ],
+            "name":"EC2 API termination protection is not enabled",
+            "cloudConfigPath":[
+              "resource",
+              "aws_instance[denied_3]",
+              "disable_api_termination"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+              "impact":"Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+              "resolve":"Set `disable_api_termination` attribute  with value `true`"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-AWS-426"
+          },
+          "targetFile":"aws_ec2_metadata_secrets.tf",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/aws_ec2_metadata_secrets.tf"
+        },
+        {
+          "policyMetadata":{
+            "severity":"low",
+            "resolve":"Set `disable_api_termination` attribute  with value `true`",
+            "id":"SNYK-CC-AWS-426",
+            "impact":"Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+            "msg":"resource.aws_instance[allowed_3].disable_api_termination",
+            "remediation":{
+              "cloudformation":"Set `DisableApiTermination` attribute with value `true`",
+              "terraform":"Set `disable_api_termination` attribute  with value `true`"
+            },
+            "subType":"EC2",
+            "issue":"To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+            "publicId":"SNYK-CC-AWS-426",
+            "title":"EC2 API termination protection is not enabled",
+            "references":[
+              "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+            ],
+            "name":"EC2 API termination protection is not enabled",
+            "cloudConfigPath":[
+              "resource",
+              "aws_instance[allowed_3]",
+              "disable_api_termination"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+              "impact":"Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+              "resolve":"Set `disable_api_termination` attribute  with value `true`"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-AWS-426"
+          },
+          "targetFile":"aws_ec2_metadata_secrets.tf",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/aws_ec2_metadata_secrets.tf"
+        },
+        {
+          "policyMetadata":{
+            "severity":"low",
+            "resolve":"Set `disable_api_termination` attribute  with value `true`",
+            "id":"SNYK-CC-AWS-426",
+            "impact":"Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+            "msg":"resource.aws_instance[allowed].disable_api_termination",
+            "remediation":{
+              "cloudformation":"Set `DisableApiTermination` attribute with value `true`",
+              "terraform":"Set `disable_api_termination` attribute  with value `true`"
+            },
+            "subType":"EC2",
+            "issue":"To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+            "publicId":"SNYK-CC-AWS-426",
+            "title":"EC2 API termination protection is not enabled",
+            "references":[
+              "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+            ],
+            "name":"EC2 API termination protection is not enabled",
+            "cloudConfigPath":[
+              "resource",
+              "aws_instance[allowed]",
+              "disable_api_termination"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+              "impact":"Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+              "resolve":"Set `disable_api_termination` attribute  with value `true`"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-AWS-426"
+          },
+          "targetFile":"aws_ec2_metadata_secrets.tf",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/aws_ec2_metadata_secrets.tf"
+        },
+        {
+          "policyMetadata":{
+            "severity":"low",
+            "resolve":"Set `disable_api_termination` attribute  with value `true`",
+            "id":"SNYK-CC-AWS-426",
+            "impact":"Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+            "msg":"resource.aws_instance[denied_2].disable_api_termination",
+            "remediation":{
+              "cloudformation":"Set `DisableApiTermination` attribute with value `true`",
+              "terraform":"Set `disable_api_termination` attribute  with value `true`"
+            },
+            "subType":"EC2",
+            "issue":"To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+            "publicId":"SNYK-CC-AWS-426",
+            "title":"EC2 API termination protection is not enabled",
+            "references":[
+              "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+            ],
+            "name":"EC2 API termination protection is not enabled",
+            "cloudConfigPath":[
+              "resource",
+              "aws_instance[denied_2]",
+              "disable_api_termination"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+              "impact":"Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+              "resolve":"Set `disable_api_termination` attribute  with value `true`"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-AWS-426"
+          },
+          "targetFile":"aws_ec2_metadata_secrets.tf",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/aws_ec2_metadata_secrets.tf"
+        },
+        {
+          "policyMetadata":{
+            "severity":"low",
+            "resolve":"Set `disable_api_termination` attribute  with value `true`",
+            "id":"SNYK-CC-AWS-426",
+            "impact":"Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+            "msg":"resource.aws_instance[allowed_2].disable_api_termination",
+            "remediation":{
+              "cloudformation":"Set `DisableApiTermination` attribute with value `true`",
+              "terraform":"Set `disable_api_termination` attribute  with value `true`"
+            },
+            "subType":"EC2",
+            "issue":"To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+            "publicId":"SNYK-CC-AWS-426",
+            "title":"EC2 API termination protection is not enabled",
+            "references":[
+              "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+            ],
+            "name":"EC2 API termination protection is not enabled",
+            "cloudConfigPath":[
+              "resource",
+              "aws_instance[allowed_2]",
+              "disable_api_termination"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+              "impact":"Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+              "resolve":"Set `disable_api_termination` attribute  with value `true`"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-AWS-426"
+          },
+          "targetFile":"aws_ec2_metadata_secrets.tf",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/aws_ec2_metadata_secrets.tf"
+        },
+        {
+          "policyMetadata":{
+            "severity":"low",
+            "resolve":"Set `DisableApiTermination` attribute with value `true`",
+            "id":"SNYK-CC-AWS-426",
+            "impact":"Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+            "msg":"Resources[BastionHost].Properties.DisableApiTermination",
+            "remediation":{
+              "cloudformation":"Set `DisableApiTermination` attribute with value `true`",
+              "terraform":"Set `disable_api_termination` attribute  with value `true`"
+            },
+            "subType":"EC2",
+            "issue":"To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+            "publicId":"SNYK-CC-AWS-426",
+            "title":"EC2 API termination protection is not enabled",
+            "references":[
+              "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+            ],
+            "name":"EC2 API termination protection is not enabled",
+            "cloudConfigPath":[
+              "[DocId: 0]",
+              "Resources[BastionHost]",
+              "Properties",
+              "DisableApiTermination"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+              "impact":"Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+              "resolve":"Set `DisableApiTermination` attribute with value `true`"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-AWS-426"
+          },
+          "targetFile":"bastion.yml",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/bastion.yml"
+        },
+        {
+          "policyMetadata":{
+            "severity":"low",
+            "resolve":"Set `Properties.KmsKeyId` attribute with customer managed key id",
+            "id":"SNYK-CC-AWS-415",
+            "impact":"Scope of use of the key cannot be controlled via KMS/IAM policies",
+            "msg":"Resources[BastionSecureLogGroup].Properties.KmsKeyId",
+            "remediation":{
+              "cloudformation":"Set `Properties.KmsKeyId` attribute with customer managed key id",
+              "terraform":"Set `kms_key_id` attribute with customer managed key id"
+            },
+            "subType":"CloudWatch",
+            "issue":"Log group is not encrypted with customer managed key",
+            "publicId":"SNYK-CC-AWS-415",
+            "title":"CloudWatch log group not encrypted with managed key",
+            "references":[
+              "https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html",
+              "https://docs.aws.amazon.com/whitepapers/latest/kms-best-practices/aws-managed-and-customer-managed-cmks.html"
+            ],
+            "name":"CloudWatch log group not encrypted with managed key",
+            "cloudConfigPath":[
+              "[DocId: 0]",
+              "Resources[BastionSecureLogGroup]",
+              "Properties",
+              "KmsKeyId"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"Log group is not encrypted with customer managed key",
+              "impact":"Scope of use of the key cannot be controlled via KMS/IAM policies",
+              "resolve":"Set `Properties.KmsKeyId` attribute with customer managed key id"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-AWS-415"
+          },
+          "targetFile":"bastion.yml",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/bastion.yml"
+        },
+        {
+          "policyMetadata":{
+            "severity":"low",
+            "description":"",
+            "resolve":"Set `imagePullPolicy` attribute to `Always`",
+            "id":"SNYK-CC-K8S-42",
+            "impact":"The container may run with outdated or unauthorized image",
+            "msg":"spec.template.spec.containers[web].imagePullPolicy",
+            "subType":"Deployment",
+            "issue":"The image policy does not prevent image reuse",
+            "publicId":"SNYK-CC-K8S-42",
+            "title":"Container could be running with outdated image",
+            "references":[
+              "5.27 Ensure that Docker commands always make use of the latest version of their image",
+              "https://kubernetes.io/docs/concepts/containers/images/",
+              "https://kubernetes.io/docs/concepts/configuration/overview/#container-images"
+            ],
+            "name":"Container could be running with outdated image",
+            "cloudConfigPath":[
+              "[DocId: 0]",
+              "spec",
+              "template",
+              "spec",
+              "containers[web]",
+              "imagePullPolicy"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"The image policy does not prevent image reuse",
+              "impact":"The container may run with outdated or unauthorized image",
+              "resolve":"Set `imagePullPolicy` attribute to `Always`"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-K8S-42"
+          },
+          "targetFile":"k8s.yaml",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/k8s.yaml"
+        },
+        {
+          "policyMetadata":{
+            "severity":"low",
+            "description":"",
+            "resolve":"Set `securityContext.readOnlyRootFilesystem` to `true`",
+            "id":"SNYK-CC-K8S-8",
+            "impact":"Compromised process could abuse writable root filesystem to elevate privileges",
+            "msg":"input.spec.template.spec.containers[web].securityContext.readOnlyRootFilesystem",
+            "subType":"Deployment",
+            "issue":"`readOnlyRootFilesystem` attribute is not set to `true`",
+            "publicId":"SNYK-CC-K8S-8",
+            "title":"Container is running with writable root filesystem",
+            "references":[
+              "CIS Docker Benchmark 1.2.0 - Ensure that the container's root filesystem is mounted as read only",
+              "https://kubernetes.io/docs/concepts/policy/pod-security-policy/#volumes-and-file-systems",
+              "https://kubernetes.io/blog/2016/08/security-best-practices-kubernetes-deployment/"
+            ],
+            "name":"Container is running with writable root filesystem",
+            "cloudConfigPath":[
+              "[DocId: 0]",
+              "input",
+              "spec",
+              "template",
+              "spec",
+              "containers[web]",
+              "securityContext",
+              "readOnlyRootFilesystem"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"`readOnlyRootFilesystem` attribute is not set to `true`",
+              "impact":"Compromised process could abuse writable root filesystem to elevate privileges",
+              "resolve":"Set `securityContext.readOnlyRootFilesystem` to `true`"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-K8S-8"
+          },
+          "targetFile":"k8s.yaml",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/k8s.yaml"
+        },
+        {
+          "policyMetadata":{
+            "severity":"low",
+            "description":"",
+            "resolve":"Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`",
+            "id":"SNYK-CC-K8S-32",
+            "impact":"AppArmor will not enforce mandatory access control, which can increase the attack vectors.",
+            "msg":"metadata.annotations['container.apparmor.security.beta.kubernetes.io/web']",
+            "subType":"Deployment",
+            "issue":"The AppArmor profile is not set correctly",
+            "publicId":"SNYK-CC-K8S-32",
+            "title":"Container is running without AppArmor profile",
+            "references":[
+              "CIS Docker Benchmark 1.2.0 - 5.1 Ensure that, if applicable, an AppArmor Profile is enabled",
+              "https://kubernetes.io/docs/tutorials/clusters/apparmor/",
+              "https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor"
+            ],
+            "name":"Container is running without AppArmor profile",
+            "cloudConfigPath":[
+              "[DocId: 0]",
+              "metadata",
+              "annotations['container.apparmor.security.beta.kubernetes.io/web']"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"The AppArmor profile is not set correctly",
+              "impact":"AppArmor will not enforce mandatory access control, which can increase the attack vectors.",
+              "resolve":"Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-K8S-32"
+          },
+          "targetFile":"k8s.yaml",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/k8s.yaml"
+        },
+        {
+          "policyMetadata":{
+            "severity":"low",
+            "description":"",
+            "resolve":"Set `resources.limits.memory` value",
+            "id":"SNYK-CC-K8S-4",
+            "impact":"Containers without memory limits are more likely to be terminated when the node runs out of memory",
+            "msg":"input.spec.template.spec.containers[web].resources.limits.memory",
+            "subType":"Deployment",
+            "issue":"Memory limit is not defined",
+            "publicId":"SNYK-CC-K8S-4",
+            "title":"Container is running without memory limit",
+            "references":[
+              "CIS Docker Benchmark 1.2.0 - 5.10 Ensure that the memory usage for containers is limited",
+              "https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource/",
+              "https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/"
+            ],
+            "name":"Container is running without memory limit",
+            "cloudConfigPath":[
+              "[DocId: 0]",
+              "input",
+              "spec",
+              "template",
+              "spec",
+              "containers[web]",
+              "resources",
+              "limits",
+              "memory"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"Memory limit is not defined",
+              "impact":"Containers without memory limits are more likely to be terminated when the node runs out of memory",
+              "resolve":"Set `resources.limits.memory` value"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-K8S-4"
+          },
+          "targetFile":"k8s.yaml",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/k8s.yaml"
+        },
+        {
+          "policyMetadata":{
+            "severity":"low",
+            "description":"",
+            "resolve":"Add `resources.limits.cpu` field with required CPU limit value",
+            "id":"SNYK-CC-K8S-5",
+            "impact":"Containers without limits can exceed the capacity of the node, and affect availability/performance of the host and other containers.",
+            "msg":"input.spec.template.spec.containers[web].resources.limits.cpu",
+            "subType":"Deployment",
+            "issue":"CPU limit is not defined",
+            "publicId":"SNYK-CC-K8S-5",
+            "title":"Container is running without cpu limit",
+            "references":[
+              "CIS Docker Benchmark 1.2.0 - 5.11 Ensure that CPU priority is set appropriately on containers",
+              "https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/",
+              "https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+              "https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace/"
+            ],
+            "name":"Container is running without cpu limit",
+            "cloudConfigPath":[
+              "[DocId: 0]",
+              "input",
+              "spec",
+              "template",
+              "spec",
+              "containers[web]",
+              "resources",
+              "limits",
+              "cpu"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"CPU limit is not defined",
+              "impact":"Containers without limits can exceed the capacity of the node, and affect availability/performance of the host and other containers.",
+              "resolve":"Add `resources.limits.cpu` field with required CPU limit value"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-K8S-5"
+          },
+          "targetFile":"k8s.yaml",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/k8s.yaml"
+        }
+      ],
+      "high":[
+        {
+          "policyMetadata":{
+            "severity":"high",
+            "resolve":"Remove secret value from `user_data` attribute",
+            "id":"SNYK-CC-TF-123",
+            "impact":"Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+            "msg":"resource.aws_instance[denied_2].user_data_base64[aws_access_key_id]",
+            "remediation":{
+              "cloudformation":"Remove secret value from `Properties.UserData` attribute",
+              "terraform":"Remove secret value from `user_data` attribute"
+            },
+            "subType":"EC2",
+            "issue":"Secret keys have been hardcoded in user_data script",
+            "publicId":"SNYK-CC-TF-123",
+            "title":"Hard coded secrets in EC2 metadata",
+            "references":[
+              "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html"
+            ],
+            "name":"Hard coded secrets in EC2 metadata",
+            "cloudConfigPath":[
+              "resource",
+              "aws_instance[denied_2]",
+              "user_data_base64[aws_access_key_id]"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"Secret keys have been hardcoded in user_data script",
+              "impact":"Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+              "resolve":"Remove secret value from `user_data` attribute"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-TF-123"
+          },
+          "targetFile":"aws_ec2_metadata_secrets.tf",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/aws_ec2_metadata_secrets.tf"
+        },
+        {
+          "policyMetadata":{
+            "severity":"high",
+            "resolve":"Remove secret value from `user_data` attribute",
+            "id":"SNYK-CC-TF-123",
+            "impact":"Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+            "msg":"resource.aws_instance[denied_3].user_data[aws_secret_access_key]",
+            "remediation":{
+              "cloudformation":"Remove secret value from `Properties.UserData` attribute",
+              "terraform":"Remove secret value from `user_data` attribute"
+            },
+            "subType":"EC2",
+            "issue":"Secret keys have been hardcoded in user_data script",
+            "publicId":"SNYK-CC-TF-123",
+            "title":"Hard coded secrets in EC2 metadata",
+            "references":[
+              "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html"
+            ],
+            "name":"Hard coded secrets in EC2 metadata",
+            "cloudConfigPath":[
+              "resource",
+              "aws_instance[denied_3]",
+              "user_data[aws_secret_access_key]"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"Secret keys have been hardcoded in user_data script",
+              "impact":"Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+              "resolve":"Remove secret value from `user_data` attribute"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-TF-123"
+          },
+          "targetFile":"aws_ec2_metadata_secrets.tf",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/aws_ec2_metadata_secrets.tf"
+        },
+        {
+          "policyMetadata":{
+            "severity":"high",
+            "resolve":"Remove secret value from `user_data` attribute",
+            "id":"SNYK-CC-TF-123",
+            "impact":"Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+            "msg":"resource.aws_instance[denied].user_data[aws_access_key_id]",
+            "remediation":{
+              "cloudformation":"Remove secret value from `Properties.UserData` attribute",
+              "terraform":"Remove secret value from `user_data` attribute"
+            },
+            "subType":"EC2",
+            "issue":"Secret keys have been hardcoded in user_data script",
+            "publicId":"SNYK-CC-TF-123",
+            "title":"Hard coded secrets in EC2 metadata",
+            "references":[
+              "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html"
+            ],
+            "name":"Hard coded secrets in EC2 metadata",
+            "cloudConfigPath":[
+              "resource",
+              "aws_instance[denied]",
+              "user_data[aws_access_key_id]"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"Secret keys have been hardcoded in user_data script",
+              "impact":"Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+              "resolve":"Remove secret value from `user_data` attribute"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-TF-123"
+          },
+          "targetFile":"aws_ec2_metadata_secrets.tf",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/aws_ec2_metadata_secrets.tf"
+        },
+        {
+          "policyMetadata":{
+            "severity":"high",
+            "resolve":"Remove secret value from `user_data` attribute",
+            "id":"SNYK-CC-TF-123",
+            "impact":"Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+            "msg":"resource.aws_instance[denied_2].user_data_base64[aws_secret_access_key]",
+            "remediation":{
+              "cloudformation":"Remove secret value from `Properties.UserData` attribute",
+              "terraform":"Remove secret value from `user_data` attribute"
+            },
+            "subType":"EC2",
+            "issue":"Secret keys have been hardcoded in user_data script",
+            "publicId":"SNYK-CC-TF-123",
+            "title":"Hard coded secrets in EC2 metadata",
+            "references":[
+              "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html"
+            ],
+            "name":"Hard coded secrets in EC2 metadata",
+            "cloudConfigPath":[
+              "resource",
+              "aws_instance[denied_2]",
+              "user_data_base64[aws_secret_access_key]"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"Secret keys have been hardcoded in user_data script",
+              "impact":"Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+              "resolve":"Remove secret value from `user_data` attribute"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-TF-123"
+          },
+          "targetFile":"aws_ec2_metadata_secrets.tf",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/aws_ec2_metadata_secrets.tf"
+        },
+        {
+          "policyMetadata":{
+            "severity":"high",
+            "description":"",
+            "resolve":"Remove `securityContext.privileged` attribute, or set value to `false`",
+            "id":"SNYK-CC-K8S-1",
+            "impact":"Compromised container could potentially modify the underlying host’s kernel by loading unauthorized modules (i.e. drivers).",
+            "msg":"input.spec.template.spec.containers[web].securityContext.privileged",
+            "subType":"Deployment",
+            "issue":"Container is running in privileged mode",
+            "publicId":"SNYK-CC-K8S-1",
+            "title":"Container is running in privileged mode",
+            "references":[
+              "CIS Kubernetes Benchmark 1.6.0 - 5.2.1 Minimize the admission of privileged containers",
+              "https://kubernetes.io/docs/concepts/policy/pod-security-policy/#privileged",
+              "https://kubernetes.io/blog/2016/08/security-best-practices-kubernetes-deployment/"
+            ],
+            "name":"Container is running in privileged mode",
+            "cloudConfigPath":[
+              "[DocId: 0]",
+              "input",
+              "spec",
+              "template",
+              "spec",
+              "containers[web]",
+              "securityContext",
+              "privileged"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"Container is running in privileged mode",
+              "impact":"Compromised container could potentially modify the underlying host’s kernel by loading unauthorized modules (i.e. drivers).",
+              "resolve":"Remove `securityContext.privileged` attribute, or set value to `false`"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-K8S-1"
+          },
+          "targetFile":"k8s.yaml",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/k8s.yaml"
+        }
+      ],
+      "medium":[
+        {
+          "policyMetadata":{
+            "severity":"medium",
+            "resolve":"Set `BlockDeviceMappings.Encrypted` attribute of root device to `true`",
+            "id":"SNYK-CC-TF-53",
+            "impact":"That should someone gain unauthorized access to the data they would be able to read the contents.",
+            "msg":"Resources.BastionHost.Properties.BlockDeviceMappings",
+            "remediation":{
+              "cloudformation":"Set `BlockDeviceMappings.Encrypted` attribute of root device to `true`",
+              "terraform":"Set `root_block_device.encrypted` attribute to `true`"
+            },
+            "subType":"EC2",
+            "issue":"The root block device for ec2 instance is not encrypted",
+            "publicId":"SNYK-CC-TF-53",
+            "title":"Non-Encrypted root block device",
+            "references":[
+              "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/RootDeviceStorage.html",
+              "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html",
+              "https://aws.amazon.com/premiumsupport/knowledge-center/cloudformation-root-volume-property/",
+              "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html"
+            ],
+            "name":"Non-Encrypted root block device",
+            "cloudConfigPath":[
+              "[DocId: 0]",
+              "Resources",
+              "BastionHost",
+              "Properties",
+              "BlockDeviceMappings"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"The root block device for ec2 instance is not encrypted",
+              "impact":"That should someone gain unauthorized access to the data they would be able to read the contents.",
+              "resolve":"Set `BlockDeviceMappings.Encrypted` attribute of root device to `true`"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-TF-53"
+          },
+          "targetFile":"bastion.yml",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/bastion.yml"
+        },
+        {
+          "policyMetadata":{
+            "severity":"medium",
+            "description":"",
+            "resolve":"Set `securityContext.runAsNonRoot` to `true`",
+            "id":"SNYK-CC-K8S-10",
+            "impact":"Container could be running with full administrative privileges",
+            "msg":"input.spec.template.spec.containers[web].securityContext.runAsNonRoot",
+            "subType":"Deployment",
+            "issue":"Container is running without root user control",
+            "publicId":"SNYK-CC-K8S-10",
+            "title":"Container is running without root user control",
+            "references":[
+              "CIS Docker Benchmark 1.2.0 - 5.5 Ensure sensitive host system directories are not mounted on containers",
+              "https://kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups",
+              "https://kubernetes.io/blog/2016/08/security-best-practices-kubernetes-deployment/"
+            ],
+            "name":"Container is running without root user control",
+            "cloudConfigPath":[
+              "[DocId: 0]",
+              "input",
+              "spec",
+              "template",
+              "spec",
+              "containers[web]",
+              "securityContext",
+              "runAsNonRoot"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"Container is running without root user control",
+              "impact":"Container could be running with full administrative privileges",
+              "resolve":"Set `securityContext.runAsNonRoot` to `true`"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-K8S-10"
+          },
+          "targetFile":"k8s.yaml",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/k8s.yaml"
+        },
+        {
+          "policyMetadata":{
+            "severity":"medium",
+            "description":"",
+            "resolve":"Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`",
+            "id":"SNYK-CC-K8S-6",
+            "impact":"Containers are running with potentially unnecessary privileges",
+            "msg":"input.spec.template.spec.containers[web].securityContext.capabilities.drop",
+            "subType":"Deployment",
+            "issue":"All default capabilities are not explicitly dropped",
+            "publicId":"SNYK-CC-K8S-6",
+            "title":"Container does not drop all default capabilities",
+            "references":[
+              "https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+              "https://linux-audit.com/linux-capabilities-hardening-linux-binaries-by-removing-setuid/"
+            ],
+            "name":"Container does not drop all default capabilities",
+            "cloudConfigPath":[
+              "[DocId: 0]",
+              "input",
+              "spec",
+              "template",
+              "spec",
+              "containers[web]",
+              "securityContext",
+              "capabilities",
+              "drop"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"All default capabilities are not explicitly dropped",
+              "impact":"Containers are running with potentially unnecessary privileges",
+              "resolve":"Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-K8S-6"
+          },
+          "targetFile":"k8s.yaml",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/k8s.yaml"
+        },
+        {
+          "policyMetadata":{
+            "severity":"medium",
+            "description":"",
+            "resolve":"Set `securityContext.allowPrivilegeEscalation` to `false`",
+            "id":"SNYK-CC-K8S-9",
+            "impact":"Processes could elevate current privileges via known vectors, for example SUID binaries",
+            "msg":"input.spec.template.spec.containers[web].securityContext.allowPrivilegeEscalation",
+            "subType":"Deployment",
+            "issue":"`allowPrivilegeEscalation` attribute is not set to `false`",
+            "publicId":"SNYK-CC-K8S-9",
+            "title":"Container is running without privilege escalation control",
+            "references":[
+              "CIS Docker Benchmark 1.2.0 - 5.25 Ensure that the container is restricted from acquiring additional privileges",
+              "https://kubernetes.io/docs/concepts/policy/pod-security-policy/#privilege-escalation",
+              "https://www.kernel.org/doc/html/latest/userspace-api/no_new_privs.html"
+            ],
+            "name":"Container is running without privilege escalation control",
+            "cloudConfigPath":[
+              "[DocId: 0]",
+              "input",
+              "spec",
+              "template",
+              "spec",
+              "containers[web]",
+              "securityContext",
+              "allowPrivilegeEscalation"
+            ],
+            "isIgnored":false,
+            "iacDescription":{
+              "issue":"`allowPrivilegeEscalation` attribute is not set to `false`",
+              "impact":"Processes could elevate current privileges via known vectors, for example SUID binaries",
+              "resolve":"Set `securityContext.allowPrivilegeEscalation` to `false`"
+            },
+            "lineNumber":-1,
+            "documentation":"https://snyk.io/security-rules/SNYK-CC-K8S-9"
+          },
+          "targetFile":"k8s.yaml",
+          "targetFilePath":"/Users/craig/workspace/github.com/snyk/snyk/testdata/policies/k8s.yaml"
+        }
+      ]
+    },
+    "metadata":{
+      "orgName":"Shmulik.Kipod",
+      "projectName":"project-name"
+    }
+  }

--- a/test/jest/unit/lib/formatters/iac-output/index.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/index.spec.ts
@@ -1,10 +1,6 @@
 import * as iacOutputV1 from '../../../../../../src/lib/formatters/iac-output/v1';
 import * as iacOutputV2 from '../../../../../../src/lib/formatters/iac-output/v2';
-import {
-  getIacDisplayErrorFileOutput,
-  getIacDisplayedOutput,
-} from '../../../../../../src/lib/formatters/iac-output';
-import { IacTestResponse } from '../../../../../../src/lib/snyk-test/iac-test-result';
+import { getIacDisplayErrorFileOutput } from '../../../../../../src/lib/formatters/iac-output';
 import { IacFileInDirectory } from '../../../../../../src/lib/types';
 
 describe('IaC Output Formatter', () => {
@@ -12,74 +8,6 @@ describe('IaC Output Formatter', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
-  });
-
-  describe('getIacDisplayedOutput', () => {
-    it('should use the implementation from v1 with the provided arguments', () => {
-      // Arrange
-      const getIacDisplayedOutputV1Spy = jest
-        .spyOn(iacOutputV1, 'getIacDisplayedOutput')
-        .mockImplementationOnce(jest.fn());
-
-      const getIacDisplayedOutputV2Spy = jest
-        .spyOn(iacOutputV2, 'getIacDisplayedOutput')
-        .mockImplementationOnce(jest.fn());
-
-      const args: Parameters<typeof getIacDisplayedOutput> = [
-        {} as IacTestResponse,
-        'test-tested-info-text',
-        'test-meta',
-        'test-prefix',
-      ];
-
-      // Act
-      const result = getIacDisplayedOutput(...args);
-
-      // Assert
-      expect(result).toBeUndefined();
-      expect(getIacDisplayedOutputV1Spy).toHaveBeenCalledTimes(1);
-      expect(getIacDisplayedOutputV2Spy).not.toHaveBeenCalled();
-      expect([...getIacDisplayedOutputV1Spy.mock.calls[0]]).toStrictEqual(args);
-    });
-
-    describe(`when the org has the ${IAC_CLI_OUTPUT_FF} feature flag`, () => {
-      it('should use the implementation from v2 with the provided arguments', () => {
-        // Arrange
-        const getIacDisplayedOutputV1Spy = jest
-          .spyOn(iacOutputV1, 'getIacDisplayedOutput')
-          .mockImplementationOnce(jest.fn());
-
-        const getIacDisplayedOutputV2Spy = jest
-          .spyOn(iacOutputV2, 'getIacDisplayedOutput')
-          .mockImplementationOnce(jest.fn());
-
-        const testIacTestResponse = {} as IacTestResponse;
-        const testTestedInfoTest = 'test-tested-info-text';
-        const testMeta = 'test-meta';
-        const testPrefix = 'test-prefix';
-        const testIsNewIacOutputSupported = true;
-
-        const args: Parameters<typeof getIacDisplayedOutput> = [
-          testIacTestResponse,
-          testTestedInfoTest,
-          testMeta,
-          testPrefix,
-          testIsNewIacOutputSupported,
-        ];
-
-        // Act
-        const result = getIacDisplayedOutput(...args);
-
-        // Assert
-        expect(result).toBeUndefined();
-        expect(getIacDisplayedOutputV1Spy).not.toHaveBeenCalled();
-        expect(getIacDisplayedOutputV2Spy).toHaveBeenCalledTimes(1);
-        expect([...getIacDisplayedOutputV2Spy.mock.calls[0]]).toStrictEqual([
-          testIacTestResponse,
-          testPrefix,
-        ]);
-      });
-    });
   });
 
   describe('getIacDisplayErrorFileOutput', () => {

--- a/test/jest/unit/lib/formatters/iac-output/issues-list.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/issues-list.spec.ts
@@ -1,0 +1,54 @@
+import * as fs from 'fs';
+import * as pathLib from 'path';
+import chalk from 'chalk';
+
+import { getIacDisplayedIssues } from '../../../../../../src/lib/formatters/iac-output';
+import { severityColor } from '../../../../../../src/lib/formatters/iac-output/v2/color-utils';
+import { IacOutputMeta } from '../../../../../../src/lib/types';
+import { FormattedResult } from '../../../../../../src/cli/commands/test/iac/local-execution/types';
+
+describe('getIacDisplayedIssues', () => {
+  let resultFixtures: FormattedResult[];
+  const outputMeta: IacOutputMeta = {
+    orgName: 'Shmulik.Kipod',
+    projectName: 'project-name',
+  };
+
+  beforeAll(async () => {
+    resultFixtures = JSON.parse(
+      fs.readFileSync(
+        pathLib.join(
+          __dirname,
+          '..',
+          '..',
+          '..',
+          'iac',
+          'process-results',
+          'fixtures',
+          'formatted-results.json',
+        ),
+        'utf8',
+      ),
+    );
+  });
+
+  it("should include the 'Issues' title", () => {
+    const result = getIacDisplayedIssues(resultFixtures, outputMeta);
+
+    expect(result).toContain(chalk.bold.white('Issues'));
+  });
+
+  it('should include a subtitle for each severity with the correct amount of issues', () => {
+    const result = getIacDisplayedIssues(resultFixtures, outputMeta);
+
+    expect(result).toContain(
+      severityColor.low(chalk.bold(`Low Severity Issues: 13`)),
+    );
+    expect(result).toContain(
+      severityColor.medium(chalk.bold(`Medium Severity Issues: 4`)),
+    );
+    expect(result).toContain(
+      severityColor.high(chalk.bold(`High Severity Issues: 5`)),
+    );
+  });
+});

--- a/test/jest/unit/lib/formatters/iac-output/v2/formatters.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/formatters.spec.ts
@@ -1,0 +1,51 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import { formatScanResultsNewOutput } from '../../../../../../../src/lib/formatters/iac-output/v2/formatters';
+import { FormattedResult } from '../../../../../../../src/cli/commands/test/iac/local-execution/types';
+import { IacOutputMeta } from '../../../../../../../src/lib/types';
+import { IacTestOutput } from '../../../../../../../src/lib/formatters/iac-output/v2/types';
+
+describe('IaC Output Mapper', () => {
+  const fixtureContent = fs.readFileSync(
+    path.join(
+      __dirname,
+      '..',
+      '..',
+      '..',
+      '..',
+      'iac',
+      'process-results',
+      'fixtures',
+      'formatted-results.json',
+    ),
+    'utf-8',
+  );
+  const fixture: FormattedResult[] = JSON.parse(fixtureContent);
+
+  const formattedFixtureContent = fs.readFileSync(
+    path.join(
+      __dirname,
+      '..',
+      '..',
+      '..',
+      '..',
+      'iac',
+      'process-results',
+      'fixtures',
+      'new-output-formatted-results.json',
+    ),
+    'utf-8',
+  );
+  const formattedFixture: IacTestOutput = JSON.parse(formattedFixtureContent);
+
+  const outputMeta: IacOutputMeta = {
+    orgName: 'Shmulik.Kipod',
+    projectName: 'project-name',
+  };
+
+  it('checks that the new output formatter groups issues by severity', () => {
+    expect(formatScanResultsNewOutput(fixture, outputMeta)).toEqual(
+      formattedFixture,
+    );
+  });
+});


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
We’d like to restructure the layout of the issues list.
The changes include:
1. Shortening the current title, “Infrastructure as code issues:”, to “Issues“ (without colon)
2. Instead of having a list of issues per file, we would like to have a list of issues per severity level.
These sections should be sorted from highest severity to lowest.
Each section should have a title with the number of the issues detected with the corresponding severity. Example: “Medium Severity Issues: 2”.
The titles should be colorized based on the severity they represent. The color mapping can be found in [this design](https://miro.com/app/board/uXjVOOpVGxU=/?moveToWidget=3458764518430874390&cot=14).

#### How should this be manually tested?
Test an IaC configuration files without the FF and check that the output didn't change.
Turn on the FF, test the IaC files once again and check that the new output gets printed.

#### What are the relevant tickets?
https://snyksec.atlassian.net/jira/software/c/projects/CFG/boards/301?modal=detail&selectedIssue=CFG-1577

#### Screenshots
![image](https://user-images.githubusercontent.com/71096571/162607971-be85a0ff-4881-4b5a-9fcd-c5a7d14066c6.png)