### PR TITLE
chore(ci): prevent older commits from releasing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -397,6 +397,13 @@ jobs:
               exit 1
             fi
       - run:
+          name: Ensure not already released
+          command: |
+            if git describe --contains --tags; then
+              echo "This commit has already been released."
+              exit 1
+            fi
+      - run:
           name: Publishing npm packages
           command: |
             npm publish ./binary-releases/snyk-fix.tgz


### PR DESCRIPTION
When a merge is released, it's still possible to re-run older commits and release them. This prevents that by checking if the commit already has a git tag ahead of it.