### PR TITLE
test: use TEST_SNYK_COMMAND in run variants

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -445,6 +445,7 @@ workflows:
             branches:
               only:
                 - /^chore\/.+$/
+                - /^test\/.+$/
                 - /test-all/
                 - master
       - test-windows:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,11 +176,11 @@ git checkout -b docs/contributing
 
 You can use these patterns in your branch name to enable additional checks.
 
-| Pattern                 | Examples                                         | Description                                                                                                  |
-| ----------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| `chore/*`, `*test-all*` | `chore/build-change`, `feat/my-feature+test-all` | Build and test all artifacts. Same as a [release pipeline](#creating-a-release) without the release step.    |
-| `smoke/*`               | `smoke/test-change`                              | Run [smoke tests](https://github.com/snyk/cli/actions/workflows/smoke-tests.yml) against the latest release. |
-| default                 | `fix/a-bug`                                      | Build and test your changes.                                                                                 |
+| Pattern                           | Examples                                                             | Description                                                                                                  |
+| --------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `chore/*`, `test/*`, `*test-all*` | `chore/build-change`, `test/test-change`, `feat/my-feature+test-all` | Build and test all artifacts. Same as a [release pipeline](#creating-a-release) without the release step.    |
+| `smoke/*`                         | `smoke/test-change`                                                  | Run [smoke tests](https://github.com/snyk/cli/actions/workflows/smoke-tests.yml) against the latest release. |
+| default                           | `fix/a-bug`                                                          | Build and test your changes.                                                                                 |
 
 For more information, see: [Pull request checks](#pull-request-checks).
 

--- a/test/jest/util/runSnykCLI.ts
+++ b/test/jest/util/runSnykCLI.ts
@@ -6,28 +6,26 @@ import {
   RunCommandOptions,
 } from './runCommand';
 
-const cwd = process.cwd();
+const CLI_BIN_SCRIPT = path.resolve(__dirname, '../../../bin/snyk');
 
 const runSnykCLI = async (
   argsString: string,
   options?: RunCommandOptions,
 ): Promise<RunCommandResult> => {
-  const cliPath = path.resolve(cwd, './bin/snyk');
-  const args = argsString.split(' ').filter((v) => !!v);
-
-  if (process.env.TEST_SNYK_COMMAND) {
-    return await runCommand(process.env.TEST_SNYK_COMMAND, args, options);
-  }
-
-  return await runCommand('node', [cliPath, ...args], options);
+  return runSnykCLIWithArray(
+    argsString.split(' ').filter((v) => !!v),
+    options,
+  );
 };
 
 const runSnykCLIWithArray = async (
   args: string[],
   options?: RunCommandOptions,
 ): Promise<RunCommandResult> => {
-  const cliPath = path.resolve(cwd, './bin/snyk');
-  return await runCommand('node', [cliPath, ...args], options);
+  if (process.env.TEST_SNYK_COMMAND) {
+    return await runCommand(process.env.TEST_SNYK_COMMAND, args, options);
+  }
+  return await runCommand('node', [CLI_BIN_SCRIPT, ...args], options);
 };
 
 const runSnykCLIWithUserInputs = async (
@@ -35,11 +33,18 @@ const runSnykCLIWithUserInputs = async (
   inputs: string[],
   options?: RunCommandOptions,
 ): Promise<any> => {
-  const cliPath = path.resolve(cwd, './bin/snyk');
   const args = argsString.split(' ').filter((v) => !!v);
+  if (process.env.TEST_SNYK_COMMAND) {
+    return await runCommandsWithUserInputs(
+      process.env.TEST_SNYK_COMMAND,
+      args,
+      inputs,
+      options,
+    );
+  }
   return await runCommandsWithUserInputs(
     'node',
-    [cliPath, ...args],
+    [CLI_BIN_SCRIPT, ...args],
     inputs,
     options,
   );


### PR DESCRIPTION
Some variants of runSnykCLI did not include the check to see if `TEST_SNYK_COMMAND` was passed in so they we still testing against the NodeJS script.