### PR TITLE
chore: sign commits made by help sync action

### DIFF
--- a/.github/workflows/sync-cli-help-to-user-docs.yml
+++ b/.github/workflows/sync-cli-help-to-user-docs.yml
@@ -28,7 +28,7 @@ jobs:
             npx prettier --write ./help/cli-commands
             git --no-pager diff --name-only
             git add .
-            git commit -m "docs: synchronizing help from snyk/user-docs"
+            git commit -S -m "docs: synchronizing help from snyk/user-docs"
             git push --force --set-upstream origin docs/automatic-gitbook-update
             if [[ ! $(gh pr view docs/automatic-gitbook-update 2>&1 | grep -q "no open pull requests";) ]]; then
               echo "Creating PR"


### PR DESCRIPTION
master branch requires signed commits now.

This probably won't work: https://github.com/actions/runner/issues/667

Needs manual setup of GPG keys in the action and the keys need to be imported to the account matching the email address used for commits.