### PR TITLE
fix: support --project-name for unmanaged projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "rimraf": "^2.6.3",
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.19.1",
+        "snyk-cpp-plugin": "^2.19.2",
         "snyk-docker-plugin": "^4.34.5",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
@@ -16157,9 +16157,9 @@
       }
     },
     "node_modules/snyk-cpp-plugin": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.19.1.tgz",
-      "integrity": "sha512-03h7wFFzp6WD7mqlxpA5dK3n+3xZxblVhvbrasIFYaQ+CmnuI68VRS2r4LUbRbWR/2GbL8QqoeQJzSZvf2q91A==",
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.19.2.tgz",
+      "integrity": "sha512-oX3jBQnSb/dDOCHurMD6Z6uqDaKORQiuB7aVYnDULKjvz7P2Xk7HX+At74J9yuqtmER5s/FNdAtqBI6kZy6C3w==",
       "dependencies": {
         "@snyk/dep-graph": "^1.19.3",
         "@types/minimatch": "^3.0.5",
@@ -32346,9 +32346,9 @@
       }
     },
     "snyk-cpp-plugin": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.19.1.tgz",
-      "integrity": "sha512-03h7wFFzp6WD7mqlxpA5dK3n+3xZxblVhvbrasIFYaQ+CmnuI68VRS2r4LUbRbWR/2GbL8QqoeQJzSZvf2q91A==",
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.19.2.tgz",
+      "integrity": "sha512-oX3jBQnSb/dDOCHurMD6Z6uqDaKORQiuB7aVYnDULKjvz7P2Xk7HX+At74J9yuqtmER5s/FNdAtqBI6kZy6C3w==",
       "requires": {
         "@snyk/dep-graph": "^1.19.3",
         "@types/minimatch": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "rimraf": "^2.6.3",
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
-    "snyk-cpp-plugin": "2.19.1",
+    "snyk-cpp-plugin": "^2.19.2",
     "snyk-docker-plugin": "^4.34.5",
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.17.0",


### PR DESCRIPTION
Use CPP-plugin v2.19.2 to support --unmanaged combined with --project-name.

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules