### PR TITLE
feat: Add '--var-file' flag to iac test for loading external variable definition files [CFG-1663]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
+++ b/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
@@ -29,6 +29,7 @@ const keys: (keyof IaCTestFlags)[] = [
   'project-lifecycle',
   'project-business-criticality',
   'target-reference',
+  'var-file',
   // PolicyOptions
   'ignore-policy',
   'policy-path',

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -185,6 +185,7 @@ export type IaCTestFlags = Pick<
   | 'sarif'
   | 'report'
   | 'target-reference'
+  | 'var-file'
 
   // PolicyOptions
   | 'ignore-policy'

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -15,6 +15,7 @@ import {
   TestOptions,
   PolicyOptions,
 } from '../../../../lib/types';
+import { InvalidVarFilePath } from './index';
 
 export interface IacFileData extends IacFileInDirectory {
   fileContent: string;
@@ -299,6 +300,7 @@ export enum IaCErrorCodes {
   FailedToExtractCustomRulesError = 1003,
   InvalidCustomRules = 1004,
   InvalidCustomRulesPath = 1005,
+  InvalidVarFilePath = 1006,
 
   // file-loader errors
   NoFilesToScanError = 1010,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -88,6 +88,7 @@ export interface Options {
   'no-markdown'?: boolean;
   'max-depth'?: number;
   report?: boolean;
+  'var-file'?: string;
 }
 
 // TODO(kyegupov): catch accessing ['undefined-properties'] via noImplicitAny


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Adds a `--var-file` flag to iac test for loading external Terraform variable definition files.

#### Where should the reviewer start?

Follow the commits one by one.

#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?
[CFG-1663]

#### Screenshots

[CFG-1663]: https://snyksec.atlassian.net/browse/CFG-1663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ