### PR TITLE
feat: Add '--var-file' flag to iac test for loading external TF variable definition files [CFG-1663]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
+++ b/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
@@ -29,6 +29,7 @@ const keys: (keyof IaCTestFlags)[] = [
   'project-lifecycle',
   'project-business-criticality',
   'target-reference',
+  'var-file',
   // PolicyOptions
   'ignore-policy',
   'policy-path',

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -185,6 +185,7 @@ export type IaCTestFlags = Pick<
   | 'sarif'
   | 'report'
   | 'target-reference'
+  | 'var-file'
 
   // PolicyOptions
   | 'ignore-policy'

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -299,6 +299,7 @@ export enum IaCErrorCodes {
   FailedToExtractCustomRulesError = 1003,
   InvalidCustomRules = 1004,
   InvalidCustomRulesPath = 1005,
+  InvalidVarFilePath = 1006,
 
   // file-loader errors
   NoFilesToScanError = 1010,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -88,6 +88,7 @@ export interface Options {
   'no-markdown'?: boolean;
   'max-depth'?: number;
   report?: boolean;
+  'var-file'?: string;
 }
 
 // TODO(kyegupov): catch accessing ['undefined-properties'] via noImplicitAny

--- a/test/fixtures/iac/terraform/var_deref/nested_var_deref/sg_open_ssh.tf
+++ b/test/fixtures/iac/terraform/var_deref/nested_var_deref/sg_open_ssh.tf
@@ -6,3 +6,16 @@ resource "aws_security_group_rule" "egress" {
   cidr_blocks       = [var.remote_user_addr]
   security_group_id = aws_security_group.allow.id
 }
+
+resource "aws_security_group" "allow_ssh_external_var_file" {
+  name        = "allow_ssh"
+  description = "Allow SSH inbound from anywhere"
+  vpc_id      = "${aws_vpc.main.id}"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.remote_user_addr_external_var_file
+  }
+}

--- a/test/fixtures/iac/terraform/vars.tf
+++ b/test/fixtures/iac/terraform/vars.tf
@@ -1,0 +1,4 @@
+variable "remote_user_addr_external_var_file" {
+  type = list(string)
+  default = ["0.0.0.0/0"]
+}

--- a/test/jest/acceptance/iac/test-directory.spec.ts
+++ b/test/jest/acceptance/iac/test-directory.spec.ts
@@ -18,8 +18,6 @@ describe('Directory scan', () => {
 
   it('scans all files in a directory with Kubernetes files', async () => {
     const { stdout, exitCode } = await run(`snyk iac test ./iac/kubernetes/`);
-    expect(exitCode).toBe(1);
-
     expect(stdout).toContain('Testing pod-privileged.yaml'); //directory scan shows relative path to cwd in output
     expect(stdout).toContain('Testing pod-privileged-multi.yaml');
     expect(stdout).toContain('Testing pod-valid.json');
@@ -28,11 +26,11 @@ describe('Directory scan', () => {
     expect(stdout).toContain(
       'Tested 3 projects, 3 contained issues. Failed to test 1 project.',
     );
+    expect(exitCode).toBe(1);
   });
 
   it('scans all files in a directory with a mix of IaC files', async () => {
     const { stdout, exitCode } = await run(`snyk iac test ./iac/`);
-    expect(exitCode).toBe(1);
     //directory scan shows relative path to cwd  in output
     // here we assert just on the filename to avoid the different slashes (/) for Unix/Windows on the CI runner
     expect(stdout).toContain('pod-privileged.yaml');
@@ -47,8 +45,9 @@ describe('Directory scan', () => {
     expect(stdout).toContain('Failed to parse YAML file');
     expect(stdout).toContain('Failed to parse JSON file');
     expect(stdout).toContain(
-      '22 projects, 15 contained issues. Failed to test 8 projects.',
+      '23 projects, 15 contained issues. Failed to test 8 projects.',
     );
+    expect(exitCode).toBe(1);
   });
 
   it('filters out issues when using severity threshold', async () => {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Adds a `--var-file` flag to iac test for loading external Terraform variable definition files. See commit messages below for details.

#### Where should the reviewer start?

Follow the commits in order: 

1. chore: add 'var-file' flag option to iac test command

This commit adds the 'var-file' flag as an available command under 'iac test'. CFG-1663

2. chore: Throw errors if 'var-file' flag is misused.

This commit adds checks around the 'var-file' flag usage: - If the user does not have the 'iacTerraformVarSupport' feature flag, we will throw an error. - If the user provides a non-existent path, we will throw an error. CFG-1663


3. feat: Load TF variable definitions files via --var-file

This commit adds the ability to load an external file by using 'var-file' flag:
- The user can point to a single filepath, relative to the 'pathToScan'
- The filepath will be checked for existence, and any vars will be de-referenced into the context of the 'pathToScan' directory only.

#### How should this be manually tested?
assign yourself the `iacTerraformVarSupport` flag.

1. Run: `snyk-dev iac test test/fixtures/iac/terraform/var_deref/nested_var_deref` and check the issues.
2. Run `snyk-dev iac test test/fixtures/iac/terraform/var_deref/nested_var_deref --var-file=test/fixtures/iac/terraform/vars.tf` and check that the `sg_open_ssh.tf` has one issue more that is found due to the `allow_ssh_external_var_file` var.

"Bad case" scenarios:
1. un-assign yourself the `iacTerraformVarSupport` flag and try to run scan (2) from above
2. assign yourself the `iacTerraformVarSupport` flag and point to a non-existing path or directory and see the relevant error
3. point to an invalid hcl (or other format) file and see the "failed to parse error" for that file.

I also ran checks with other flags, such as detection-depth, sarif, json.

#### What are the relevant tickets?

[CFG-1663]

#### Screenshots
Without the flag:

![image](https://user-images.githubusercontent.com/6989529/162481560-0e093255-8118-40fd-b800-de53d898965f.png)


With the use of the flag (and finding an issue extra for the `test/fixtures/iac/terraform/var_deref/nested_var_deref/sg_open_ssh.tf`, when sharing the variable context of the external definitions file):

![image](https://user-images.githubusercontent.com/6989529/162481658-e75ba14e-ce1e-45a9-bf60-0552cb50c067.png)


[CFG-1663]: https://snyksec.atlassian.net/browse/CFG-1663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ