### PR TITLE
Updated logos with light/dark-mode support in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 <p align="center">
-  <img src="https://snyk.io/style/asset/logo/snyk-print.svg" />
+  <a href="https://snyk.io/#gh-light-mode-only">
+    <img src="https://snyk.io/style/asset/logo/snyk-print.svg" />
+  </a>
+  <a href="https://snyk.io/#gh-dark-mode-only">
+    <img src="https://user-images.githubusercontent.com/1393946/161861176-d30157b8-afcf-4119-88de-bec5b16e48b6.svg" />
+  </a>
 </p>
 
 # Snyk CLI

--- a/packages/snyk-protect/README.md
+++ b/packages/snyk-protect/README.md
@@ -3,7 +3,14 @@
 [![npm](https://img.shields.io/npm/v/@snyk/protect)](https://www.npmjs.com/package/@snyk/protect)
 [![Known Vulnerabilities](https://snyk.io/test/github/snyk/snyk/badge.svg)](https://snyk.io/test/github/snyk/snyk)
 
-![Snyk](https://snyk.io/style/asset/logo/snyk-print.svg)
+<p align="center">
+  <a href="https://snyk.io/#gh-light-mode-only">
+    <img src="https://snyk.io/style/asset/logo/snyk-print.svg" />
+  </a>
+  <a href="https://snyk.io/#gh-dark-mode-only">
+    <img src="https://user-images.githubusercontent.com/1393946/161861176-d30157b8-afcf-4119-88de-bec5b16e48b6.svg" />
+  </a>
+</p>
 
 Patch vulnerable code in your project's dependencies. This package is officially maintained by [Snyk](https://snyk.io).
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

External contributor, but contacting support for this change felt unnecessary.

#### What does this PR do?

I've noticed that the Snyk logo doesn't look good when using a darkmode theme (see screenshots below). End of last year, GitHub added support for theme specific image. This allows you to render a different image based on the current GitHub theme. Please visit the [GitHub Blog announcement](https://github.blog/changelog/2021-11-24-specify-theme-context-for-images-in-markdown/) to learn more about this feature. 


#### Where should the reviewer start?
\-

#### How should this be manually tested?
- Toggle your GitHub or system theme.

#### Any background context you want to provide?
\-

#### What are the relevant tickets?

> You can specify the theme an image is displayed to by appending #gh-dark-mode-only or #gh-light-mode-only to the end of an image URL, in Markdown.
>
> We distinguish between light and dark color modes, so there are two options available. You can use these options to display images optimized for dark or light backgrounds. This is particularly helpful for transparent PNG images.

Source [GitHub docs](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to)

#### Screenshots

**Before**
<img width="540" alt="Readme before" src="https://user-images.githubusercontent.com/1393946/162518149-a795579a-c636-4f80-82e2-1dcd3086470f.png">

**After**
<img width="542" alt="Readme after" src="https://user-images.githubusercontent.com/1393946/162518206-e0537186-a6cc-4be9-97d0-5d4501f8ad69.png">



#### Additional questions

There is one caveat. The package listing on npmjs.com does not support this trick, meaning it will render the image twice see mock below. This might be a tradeoff you are willing to make, given that most eyes are on the repository rather than the npmjs.com listing. 

<img width="706" alt="npm listing" src="https://user-images.githubusercontent.com/1393946/162518243-2bc62f62-e9e5-4755-ade5-e27451baaab3.png">
