### PR TITLE
feat: remove-deeproxy-url-configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,12 +39,14 @@ test/smoke/spec/iac/ @snyk/group-infrastructure-as-code
 test/smoke/spec/snyk_code_spec.sh @snyk/zenith
 test/smoke/spec/snyk_basic_spec.sh @snyk/hammer
 test/smoke/.iac-data/ @snyk/group-infrastructure-as-code
+test/jest/unit/lib/endpoint-config-test.spec.ts @snyk/nebula
 test/jest/unit/lib/formatters/iac-output/ @snyk/group-infrastructure-as-code
 test/jest/unit/lib/formatters/test/format-test-results.spec.ts @snyk/hammer @snyk/snyk-open-source @snyk/magma
 test/jest/unit/iac/ @snyk/group-infrastructure-as-code
 test/jest/unit/lib/iac/ @snyk/group-infrastructure-as-code
 test/jest/acceptance/iac/ @snyk/group-infrastructure-as-code
 test/jest/acceptance/snyk-apps @snyk/moose
+src/lib/code-config.ts @snyk/nebula
 src/lib/errors/describe-required-argument-error.ts @snyk/group-infrastructure-as-code
 src/lib/errors/describe-exclusive-argument-error.ts @snyk/group-infrastructure-as-code
 src/lib/errors/no-supported-sast-files-found.ts @snyk/zenith

--- a/config.default.json
+++ b/config.default.json
@@ -4,7 +4,6 @@
   "devDeps": false,
   "PRUNE_DEPS_THRESHOLD": 40000,
   "MAX_PATH_COUNT": 1500000,
-  "CODE_CLIENT_PROXY_URL": "https://deeproxy.snyk.io",
   "NPM_TREE_SIZE_LIMIT": 6.0e6,
   "YARN_TREE_SIZE_LIMIT": 6.0e6
 }

--- a/src/lib/code-config.ts
+++ b/src/lib/code-config.ts
@@ -1,0 +1,11 @@
+import config from './config';
+
+export function getCodeClientProxyUrl() {
+  return (
+    config.CODE_CLIENT_PROXY_URL ||
+    config.API.replace(/snyk\.io.*/, 'snyk.io').replace(
+      /\/\/(app\.)?/,
+      '//deeproxy.',
+    )
+  );
+}

--- a/src/lib/plugins/sast/analysis.ts
+++ b/src/lib/plugins/sast/analysis.ts
@@ -19,6 +19,7 @@ import { getProxyForUrl } from 'proxy-from-env';
 import { bootstrap } from 'global-agent';
 import chalk from 'chalk';
 import * as debugLib from 'debug';
+import { getCodeClientProxyUrl } from '../../code-config';
 
 const debug = debugLib('snyk-code');
 
@@ -54,7 +55,7 @@ async function getCodeAnalysis(
   const source = 'snyk-cli';
   const baseURL = isLocalCodeEngineEnabled
     ? sastSettings.localCodeEngine.url
-    : config.CODE_CLIENT_PROXY_URL;
+    : getCodeClientProxyUrl();
 
   // TODO(james) This mirrors the implementation in request.ts and we need to use this for deeproxy calls
   // This ensures we support lowercase http(s)_proxy values as well

--- a/test/jest/unit/lib/endpoint-config-test.spec.ts
+++ b/test/jest/unit/lib/endpoint-config-test.spec.ts
@@ -1,0 +1,29 @@
+import * as codeConfig from '../../../../src/lib/code-config';
+import config from '../../../../src/lib/config';
+
+describe('Testing deeproxy URL', () => {
+  const configApiDefault = config.API;
+  const codeClientUrlDefault = config.CODE_CLIENT_PROXY_URL;
+
+  afterEach(() => {
+    config.API = configApiDefault;
+    config.CODE_CLIENT_PROXY_URL = codeClientUrlDefault;
+  });
+
+  test('uses api URL to determine deeproxy URL when not provided without app. prefix', () => {
+    config.API = 'https://snyk.io/api/v1';
+    expect(codeConfig.getCodeClientProxyUrl()).toBe('https://deeproxy.snyk.io');
+  });
+
+  test('uses api URL to determine deeproxy URL when provided with app. prefix', () => {
+    config.API = 'https://app.snyk.io/api/v1';
+    expect(codeConfig.getCodeClientProxyUrl()).toBe('https://deeproxy.snyk.io');
+  });
+
+  test('uses a custom deeproxy endpoint when provided by SNYK_CODE_CLIENT_PROXY_URL environment', () => {
+    config.CODE_CLIENT_PROXY_URL = 'https://deeproxy.custom.url.snyk.io';
+    expect(codeConfig.getCodeClientProxyUrl()).toBe(
+      'https://deeproxy.custom.url.snyk.io',
+    );
+  });
+});

--- a/test/jest/unit/snyk-code/snyk-code-test.spec.ts
+++ b/test/jest/unit/snyk-code/snyk-code-test.spec.ts
@@ -6,7 +6,6 @@ jest.mock('@snyk/code-client');
 const analyzeFoldersMock = analyzeFolders as jest.Mock;
 
 import { loadJson } from '../../../utils';
-import config from '../../../../src/lib/config';
 import * as checks from '../../../../src/lib/plugins/sast/checks';
 import { config as userConfig } from '../../../../src/lib/user-config';
 import * as analysis from '../../../../src/lib/plugins/sast/analysis';
@@ -16,6 +15,7 @@ import * as analytics from '../../../../src/lib/analytics';
 import snykTest from '../../../../src/cli/commands/test/';
 import { jsonStringifyLargeObject } from '../../../../src/lib/json';
 import { ArgsOptions } from '../../../../src/cli/args';
+import * as codeConfig from '../../../../src/lib/code-config';
 
 const { getCodeAnalysisAndParseResults } = analysis;
 import osName = require('os-name');
@@ -26,7 +26,7 @@ describe('Test snyk code', () => {
   let trackUsageSpy;
   const failedCodeTestMessage = "Failed to run 'code test'";
   const fakeApiKey = '123456789';
-  const baseURL = config.CODE_CLIENT_PROXY_URL;
+  const baseURL = codeConfig.getCodeClientProxyUrl();
   const LCEbaseURL = 'https://my-proxy-server';
   const sampleSarifResponse = loadJson(
     path.join(__dirname, '/../../../fixtures/sast/sample-sarif.json'),


### PR DESCRIPTION
[NEBULA-443](https://snyksec.atlassian.net/browse/NEBULA-443)

We wish that the customer of ST will not need to add this configuration and only configure 'API' value.

Please refer to Jira ticket for more information.
