### PR TITLE
test: Updated FF usage in TF vars deref test

### DIFF
--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -337,13 +337,6 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
       return;
     }
 
-    if (org === 'tf-lang-support') {
-      res.send({
-        ok: true,
-      });
-      return;
-    }
-
     if (featureFlags.has(flag)) {
       const ffEnabled = featureFlags.get(flag);
       if (ffEnabled) {


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Updates the way the `iacTerraformVarSupport` FF is used in the `test/jest/acceptance/iac/test-terraform-var-deref.spec.ts` acceptance tests to match the common practices applied in recent IaC acceptance tests, by:
    - Removing the special FF configuration in the fake server that sets the value for all feature flags to be true when the org name is `tf-lang-support`.
    - Using the `setFeatureFlag` utility function for controlling feature flag values.

#### Where should the reviewer start?

- `test/jest/acceptance/iac/test-terraform-var-deref.spec.ts`

#### How should this be manually tested?

- Run the test file with Jest. 