### PR TITLE
fix: Fixed failing acceptance tests for IaC output

### DIFF
--- a/test/jest/acceptance/iac/iac-output.spec.ts
+++ b/test/jest/acceptance/iac/iac-output.spec.ts
@@ -1,3 +1,4 @@
+import { EOL } from 'os';
 import { FakeServer } from '../../../acceptance/fake-server';
 import { startMockServer } from './helpers';
 
@@ -88,14 +89,17 @@ Target file:       ${filePath}
           `snyk iac test ${filePath} --policy-path=${policyPath}`,
         );
         expect(stdout).toContain(
-          `Test Summary
-
-  Organization: test-org
-
-✔ Files without issues: 0
-✗ Files with issues: 1
-  Ignored issues: 2
-  Total issues: 7 [ 0 critical, 1 high, 2 medium, 4 low ]`,
+          'Test Summary' +
+            EOL.repeat(2) +
+            '  Organization: test-org' +
+            EOL.repeat(2) +
+            '✔ Files without issues: 0' +
+            EOL +
+            '✗ Files with issues: 1' +
+            EOL +
+            '  Ignored issues: 2' +
+            EOL +
+            '  Total issues: 7 [ 0 critical, 1 high, 2 medium, 4 low ]',
         );
       });
     });
@@ -150,14 +154,17 @@ If the issue persists contact support@snyk.io`,
           `snyk iac test ${dirPath} --policy-path=${policyPath}`,
         );
         expect(stdout).toContain(
-          `Test Summary
-
-  Organization: test-org
-
-✔ Files without issues: 0
-✗ Files with issues: 3
-  Ignored issues: 8
-  Total issues: 28 [ 0 critical, 4 high, 8 medium, 16 low ]`,
+          'Test Summary' +
+            EOL.repeat(2) +
+            '  Organization: test-org' +
+            EOL.repeat(2) +
+            '✔ Files without issues: 0' +
+            EOL +
+            '✗ Files with issues: 3' +
+            EOL +
+            '  Ignored issues: 8' +
+            EOL +
+            '  Total issues: 28 [ 0 critical, 4 high, 8 medium, 16 low ]',
         );
       });
     });


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Fixes failing Windows acceptance tests in `test/jest/acceptance/iac/iac-output.spec.ts`, by replacing the newline character instead of `EOL` in the expected output fixtures.

#### Where should the reviewer start?

    test/jest/acceptance/iac/iac-output.spec.ts

#### How should this be manually tested?

- Ensure these acceptance tests now all pass.

#### Any background context you want to provide?

- The tests were originally added in [this PR](https://github.com/snyk/cli/pull/3102). 

#### More information

- [An example for a failing CircleCI pipeline](https://app.circleci.com/pipelines/github/snyk/cli/11574/workflows/7dd53554-f390-43c1-8190-e680642bf076/jobs/89027)