### PR TITLE
refactor: move results formatter utilities into process-results

### DIFF
--- a/src/cli/commands/test/iac/local-execution/file-utils.ts
+++ b/src/cli/commands/test/iac/local-execution/file-utils.ts
@@ -7,7 +7,6 @@ import {
   LOCAL_POLICY_ENGINE_DIR,
 } from './local-cache';
 import { CUSTOM_RULES_TARBALL } from './oci-pull';
-import { isLocalFolder } from '../../../../../lib/detect';
 import { readdirSync } from 'fs';
 import { join } from 'path';
 
@@ -70,38 +69,6 @@ export function computeCustomRulesBundleChecksum(): string | undefined {
   } catch (err) {
     return;
   }
-}
-
-export function computePaths(
-  filePath: string,
-  pathArg = '.',
-): { targetFilePath: string; projectName: string; targetFile: string } {
-  const targetFilePath = path.resolve(filePath, '.');
-
-  // the absolute path is needed to compute the full project path
-  const cmdPath = path.resolve(pathArg);
-
-  let projectPath: string;
-  let targetFile: string;
-  if (!isLocalFolder(cmdPath)) {
-    // if the provided path points to a file, then the project starts at the parent folder of that file
-    // and the target file was provided as the path argument
-    projectPath = path.dirname(cmdPath);
-    targetFile = path.isAbsolute(pathArg)
-      ? path.relative(process.cwd(), pathArg)
-      : pathArg;
-  } else {
-    // otherwise, the project starts at the provided path
-    // and the target file must be the relative path from the project path to the path of the scanned file
-    projectPath = cmdPath;
-    targetFile = path.relative(projectPath, targetFilePath);
-  }
-
-  return {
-    targetFilePath,
-    projectName: path.basename(projectPath),
-    targetFile,
-  };
 }
 
 /**

--- a/src/cli/commands/test/iac/local-execution/process-results/extract-line-number.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/extract-line-number.ts
@@ -1,14 +1,14 @@
-import { IaCErrorCodes } from './types';
-import { CustomError } from '../../../../../lib/errors';
+import { IaCErrorCodes } from '../types';
+import { CustomError } from '../../../../../../lib/errors';
 import {
   CloudConfigFileTypes,
   MapsDocIdToTree,
   getLineNumber,
 } from '@snyk/cloud-config-parser';
-import { UnsupportedFileTypeError } from './file-parser';
-import * as analytics from '../../../../../lib/analytics';
+import { UnsupportedFileTypeError } from '../file-parser';
+import * as analytics from '../../../../../../lib/analytics';
 import * as Debug from 'debug';
-import { getErrorStringCode } from './error-utils';
+import { getErrorStringCode } from '../error-utils';
 const debug = Debug('iac-extract-line-number');
 
 export function getFileTypeForParser(fileType: string): CloudConfigFileTypes {

--- a/src/cli/commands/test/iac/local-execution/process-results/results-formatter.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/results-formatter.ts
@@ -10,17 +10,14 @@ import {
 import { SEVERITY, SEVERITIES } from '../../../../../../lib/snyk-test/common';
 import { IacProjectType } from '../../../../../../lib/iac/constants';
 import { CustomError } from '../../../../../../lib/errors';
-import {
-  extractLineNumber,
-  getFileTypeForParser,
-} from '../extract-line-number';
+import { extractLineNumber, getFileTypeForParser } from './extract-line-number';
 import { getErrorStringCode } from '../error-utils';
 import {
   MapsDocIdToTree,
   getTrees,
   parsePath,
 } from '@snyk/cloud-config-parser';
-import { computePaths } from '../file-utils';
+import { computePaths } from './utils';
 
 const severitiesArray = SEVERITIES.map((s) => s.verboseName);
 

--- a/src/cli/commands/test/iac/local-execution/process-results/share-results-formatter.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/share-results-formatter.ts
@@ -1,9 +1,9 @@
-import { computePaths } from '../file-utils';
 import {
   IacFileScanResult,
   IacShareResultsFormat,
   IaCTestFlags,
 } from '../types';
+import { computePaths } from './utils';
 
 export function formatShareResults(
   scanResults: IacFileScanResult[],

--- a/src/cli/commands/test/iac/local-execution/process-results/utils.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/utils.ts
@@ -1,0 +1,34 @@
+import * as path from 'path';
+import { isLocalFolder } from '../../../../../../lib/detect';
+
+export function computePaths(
+  filePath: string,
+  pathArg = '.',
+): { targetFilePath: string; projectName: string; targetFile: string } {
+  const targetFilePath = path.resolve(filePath, '.');
+
+  // the absolute path is needed to compute the full project path
+  const cmdPath = path.resolve(pathArg);
+
+  let projectPath: string;
+  let targetFile: string;
+  if (!isLocalFolder(cmdPath)) {
+    // if the provided path points to a file, then the project starts at the parent folder of that file
+    // and the target file was provided as the path argument
+    projectPath = path.dirname(cmdPath);
+    targetFile = path.isAbsolute(pathArg)
+      ? path.relative(process.cwd(), pathArg)
+      : pathArg;
+  } else {
+    // otherwise, the project starts at the provided path
+    // and the target file must be the relative path from the project path to the path of the scanned file
+    projectPath = cmdPath;
+    targetFile = path.relative(projectPath, targetFilePath);
+  }
+
+  return {
+    targetFilePath,
+    projectName: path.basename(projectPath),
+    targetFile,
+  };
+}

--- a/src/cli/commands/test/iac/local-execution/types.ts
+++ b/src/cli/commands/test/iac/local-execution/types.ts
@@ -20,7 +20,7 @@ export interface IacFileData extends IacFileInDirectory {
   fileContent: string;
 }
 
-export enum ValidFileType {
+enum ValidFileType {
   Terraform = 'tf',
   JSON = 'json',
   YAML = 'yaml',
@@ -46,11 +46,6 @@ export interface IacFileParseFailure extends IacFileData {
   failureReason: string;
   err: Error;
 }
-
-export type ScanningResults = {
-  scannedFiles: Array<IacFileScanResult>;
-  unscannedFiles: Array<IacFileParseFailure>;
-};
 
 export type ParsingResults = {
   parsedFiles: Array<IacFileParsed>;


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR does some small cleanup of the code so that anything belonging to the `processResults` functionality and results formatter goes in the right folder.

#### How should this be manually tested?

1. `npm run build`
2. `snyk-dev iac test test/fixtures/iac/terraform/sg_open_ssh.tf`

#### Any background context you want to provide?
In https://github.com/snyk/cli/pull/3080 we created this `process-results` folder to hold anything that has to do with displaying issues on the CLI stdout.

#### Screenshots
![Screenshot 2022-04-12 at 16 59 12](https://user-images.githubusercontent.com/81559517/163004570-d8647813-c801-40b4-99ae-c60d37e9c77d.png)


