### PR TITLE
chore: add CLI_V2 to TrackedIntegration enum

### DIFF
--- a/src/lib/analytics/sources.ts
+++ b/src/lib/analytics/sources.ts
@@ -54,6 +54,9 @@ enum TrackedIntegration {
   // DevRel integrations and plugins
   // Netlify plugin: https://github.com/snyk-labs/netlify-plugin-snyk
   NETLIFY_PLUGIN = 'NETLIFY_PLUGIN',
+
+  // CLI_V1_PLUGIN integration
+  CLI_V1_PLUGIN = 'CLI_V1_PLUGIN',
 }
 
 export const getIntegrationName = (args: ArgsOptions[]): string => {


### PR DESCRIPTION
Signed-off-by: Peter Schäfer <101886095+PeterSchafer@users.noreply.github.com>

- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Introduce additional tracked integration name

#### How should this be manually tested?
Run `SNYK_INTEGRATION_NAME=CLI_V2 snyk --debug` and see the IntegrationName in the Analytics output
