### PR TITLE
feat: improve ci detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "adm-zip": "^0.5.9",
         "ansi-escapes": "3.2.0",
         "chalk": "^2.4.2",
+        "ci-info": "^3.3.0",
         "cli-spinner": "0.2.10",
         "configstore": "^5.0.1",
         "debug": "^4.1.1",
@@ -4913,10 +4914,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
-      "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
-      "dev": true
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
+      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw=="
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.2",
@@ -23706,10 +23706,9 @@
       "dev": true
     },
     "ci-info": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
-      "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
-      "dev": true
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
+      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw=="
     },
     "cjs-module-lexer": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "adm-zip": "^0.5.9",
     "ansi-escapes": "3.2.0",
     "chalk": "^2.4.2",
+    "ci-info": "^3.3.0",
     "cli-spinner": "0.2.10",
     "configstore": "^5.0.1",
     "debug": "^4.1.1",

--- a/src/lib/analytics/getStandardData.ts
+++ b/src/lib/analytics/getStandardData.ts
@@ -2,7 +2,7 @@ import * as version from '../version';
 import { v4 as uuidv4 } from 'uuid';
 import * as os from 'os';
 import * as crypto from 'crypto';
-import { isCI } from '../is-ci';
+import { isCI, getCIName, isPullRequest } from '../is-ci';
 import {
   getIntegrationName,
   getIntegrationVersion,
@@ -53,6 +53,8 @@ export async function getStandardData(
     integrationEnvironmentVersion: getIntegrationEnvironmentVersion(args),
     id: shasum.update(seed).digest('hex'),
     ci: isCI(),
+    ciName: getCIName(),
+    pr: isPullRequest(),
     durationMs,
     metrics,
   };

--- a/src/lib/is-ci.ts
+++ b/src/lib/is-ci.ts
@@ -1,22 +1,13 @@
-const ciEnvs = new Set([
-  'SNYK_CI',
-  'CI',
-  'CONTINUOUS_INTEGRATION',
-  'BUILD_ID',
-  'BUILD_NUMBER',
-  'TEAMCITY_VERSION',
-  'TRAVIS',
-  'CIRCLECI',
-  'JENKINS_URL',
-  'HUDSON_URL',
-  'bamboo.buildKey',
-  'PHPCI',
-  'GOCD_SERVER_HOST',
-  'BUILDKITE',
-  'TF_BUILD',
-  'SYSTEM_TEAMFOUNDATIONSERVERURI', // for Azure DevOps Pipelines
-]);
+import * as ci from 'ci-info';
 
 export function isCI(): boolean {
-  return Object.keys(process.env).some((key) => ciEnvs.has(key));
+  return ci.isCI;
+}
+
+export function getCIName(): string {
+  return ci.name || '';
+}
+
+export function isPullRequest(): boolean {
+  return ci.isPR || false;
 }

--- a/test/jest/unit/lib/analytics/getStandardData.spec.ts
+++ b/test/jest/unit/lib/analytics/getStandardData.spec.ts
@@ -14,6 +14,8 @@ describe('getStandardData returns object', () => {
       version: '1.0.0-monorepo',
       id: expect.any(String),
       ci: expect.any(Boolean),
+      ciName: expect.any(String),
+      pr: expect.any(Boolean),
       metrics: {
         network_time: {
           type: 'timer',
@@ -53,6 +55,8 @@ describe('getStandardData returns object', () => {
       version: '1.0.0-monorepo',
       id: expect.any(String),
       ci: expect.any(Boolean),
+      ciName: expect.any(String),
+      pr: expect.any(Boolean),
       metrics: {
         network_time: {
           type: 'timer',


### PR DESCRIPTION
ci-info seems to the be the most popular library to use for CI detection. We can rely on it to detect both current and future CI services.

https://www.npmjs.com/package/ci-info

https://snyk.io/advisor/npm-package/ci-info