### PR TITLE
fix: Unbold severity section titles in IaC test output

### DIFF
--- a/src/lib/formatters/iac-output/v2/issues-list.ts
+++ b/src/lib/formatters/iac-output/v2/issues-list.ts
@@ -23,9 +23,7 @@ export function getIacDisplayedIssues(
       output +=
         EOL +
         severityColor[severity](
-          chalk.bold(
-            `${capitalize(severity)} Severity Issues: ${issues.length}`,
-          ),
+          `${capitalize(severity)} Severity Issues: ${issues.length}`,
         ) +
         EOL.repeat(2);
       output += getIssuesOutput(issues);

--- a/test/jest/unit/lib/formatters/iac-output/issues-list.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/issues-list.spec.ts
@@ -35,20 +35,14 @@ describe('getIacDisplayedIssues', () => {
   it("should include the 'Issues' title", () => {
     const result = getIacDisplayedIssues(resultFixtures, outputMeta);
 
-    expect(result).toContain(chalk.bold.white('Issues'));
+    expect(result).toContain(chalk.white('Issues'));
   });
 
   it('should include a subtitle for each severity with the correct amount of issues', () => {
     const result = getIacDisplayedIssues(resultFixtures, outputMeta);
 
-    expect(result).toContain(
-      severityColor.low(chalk.bold(`Low Severity Issues: 13`)),
-    );
-    expect(result).toContain(
-      severityColor.medium(chalk.bold(`Medium Severity Issues: 4`)),
-    );
-    expect(result).toContain(
-      severityColor.high(chalk.bold(`High Severity Issues: 5`)),
-    );
+    expect(result).toContain(severityColor.low(`Low Severity Issues: 13`));
+    expect(result).toContain(severityColor.medium(`Medium Severity Issues: 4`));
+    expect(result).toContain(severityColor.high(`High Severity Issues: 5`));
   });
 });


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Removes the Bold highlight from the titles of the severity sections in the issues list for the new IaC test output, to align them with [the given design](https://www.figma.com/file/buNFZqr1Uhf4SaifHw4WXE/Snyk-IaC-CLI).

#### Screenshots
- **Before**
    ![image](https://user-images.githubusercontent.com/46415136/163210239-7d675e76-1636-40c1-a2a5-39f4003e574d.png)

- **After**
    ![image](https://user-images.githubusercontent.com/46415136/163209947-0e116eb7-6a25-436f-8c5b-e33078b39613.png)
