### PR TITLE
refactor: Download rules bundles only once per execution

### DIFF
--- a/src/cli/commands/test/iac/index.ts
+++ b/src/cli/commands/test/iac/index.ts
@@ -1,7 +1,7 @@
 import * as Debug from 'debug';
 import { EOL } from 'os';
-const cloneDeep = require('lodash.clonedeep');
-const assign = require('lodash.assign');
+import * as cloneDeep from 'lodash.clonedeep';
+import * as assign from 'lodash.assign';
 import chalk from 'chalk';
 import { MissingArgError } from '../../../../lib/errors';
 

--- a/src/cli/commands/test/iac/index.ts
+++ b/src/cli/commands/test/iac/index.ts
@@ -61,6 +61,13 @@ import {
   formatIacTestSummary,
   getIacDisplayedIssues,
 } from '../../../../lib/formatters/iac-output';
+import { initRules } from './local-execution/rules';
+import {
+  cleanLocalCache,
+  getIacOrgSettings,
+} from './local-execution/measurable-methods';
+import config from '../../../../lib/config';
+import { UnsupportedEntitlementError } from '../../../../lib/errors/unsupported-entitlement-error';
 
 const debug = Debug('snyk-test');
 const SEPARATOR = '\n-------------------------------------------------------\n';
@@ -123,58 +130,78 @@ export default async function(...args: MethodArgs): Promise<TestCommandResult> {
     );
   }
 
-  // Promise waterfall to test all other paths sequentially
-  for (const path of paths) {
-    // Create a copy of the options so a specific test can
-    // modify them i.e. add `options.file` etc. We'll need
-    // these options later.
-    const testOpts = cloneDeep(options);
-    testOpts.path = path;
-    testOpts.projectName = testOpts['project-name'];
+  const orgPublicId = (options.org as string) ?? config.org;
+  const iacOrgSettings = await getIacOrgSettings(orgPublicId);
 
-    let res: (TestResult | TestResult[]) | Error;
-    try {
-      assertIaCOptionsFlags(process.argv);
-      const { results, failures, ignoreCount } = await iacTest(path, testOpts);
+  if (!iacOrgSettings.entitlements?.infrastructureAsCode) {
+    throw new UnsupportedEntitlementError('infrastructureAsCode');
+  }
 
-      iacOutputMeta = {
-        orgName: results[0]?.org,
-        projectName: results[0]?.projectName,
-        gitRemoteUrl: results[0]?.meta?.gitRemoteUrl,
-      };
+  try {
+    const rulesOrigin = await initRules(iacOrgSettings, options);
 
-      res = results;
-      iacScanFailures = failures;
-      iacIgnoredIssuesCount += ignoreCount;
-    } catch (error) {
-      // not throwing here but instead returning error response
-      // for legacy flow reasons.
-      res = formatTestError(error);
-    }
+    for (const path of paths) {
+      // Create a copy of the options so a specific test can
+      // modify them i.e. add `options.file` etc. We'll need
+      // these options later.
+      const testOpts = cloneDeep(options);
+      testOpts.path = path;
+      testOpts.projectName = testOpts['project-name'];
 
-    // Not all test results are arrays in order to be backwards compatible
-    // with scripts that use a callback with test. Coerce results/errors to be arrays
-    // and add the result options to each to be displayed
-    const resArray: any[] = Array.isArray(res) ? res : [res];
-
-    for (let i = 0; i < resArray.length; i++) {
-      const pathWithOptionalProjectName = utils.getPathWithOptionalProjectName(
-        path,
-        resArray[i],
-      );
-      results.push(assign(resArray[i], { path: pathWithOptionalProjectName }));
-      // currently testOpts are identical for each test result returned even if it's for multiple projects.
-      // we want to return the project names, so will need to be crafty in a way that makes sense.
-      if (!testOpts.projectNames) {
-        resultOptions.push(testOpts);
-      } else {
-        resultOptions.push(
-          assign(cloneDeep(testOpts), {
-            projectName: testOpts.projectNames[i],
-          }),
+      let res: (TestResult | TestResult[]) | Error;
+      try {
+        assertIaCOptionsFlags(process.argv);
+        const { results, failures, ignoreCount } = await iacTest(
+          path,
+          testOpts,
+          orgPublicId,
+          iacOrgSettings,
+          rulesOrigin,
         );
+
+        iacOutputMeta = {
+          orgName: results[0]?.org,
+          projectName: results[0]?.projectName,
+          gitRemoteUrl: results[0]?.meta?.gitRemoteUrl,
+        };
+
+        res = results;
+        iacScanFailures = failures;
+        iacIgnoredIssuesCount += ignoreCount;
+      } catch (error) {
+        // not throwing here but instead returning error response
+        // for legacy flow reasons.
+        res = formatTestError(error);
+      }
+
+      // Not all test results are arrays in order to be backwards compatible
+      // with scripts that use a callback with test. Coerce results/errors to be arrays
+      // and add the result options to each to be displayed
+      const resArray: any[] = Array.isArray(res) ? res : [res];
+
+      for (let i = 0; i < resArray.length; i++) {
+        const pathWithOptionalProjectName = utils.getPathWithOptionalProjectName(
+          path,
+          resArray[i],
+        );
+        results.push(
+          assign(resArray[i], { path: pathWithOptionalProjectName }),
+        );
+        // currently testOpts are identical for each test result returned even if it's for multiple projects.
+        // we want to return the project names, so will need to be crafty in a way that makes sense.
+        if (!testOpts.projectNames) {
+          resultOptions.push(testOpts);
+        } else {
+          resultOptions.push(
+            assign(cloneDeep(testOpts), {
+              projectName: testOpts.projectNames[i],
+            }),
+          );
+        }
       }
     }
+  } finally {
+    cleanLocalCache();
   }
 
   const vulnerableResults = results.filter(

--- a/src/cli/commands/test/iac/local-execution/index.ts
+++ b/src/cli/commands/test/iac/local-execution/index.ts
@@ -5,6 +5,7 @@ import {
   IaCErrorCodes,
   IacFileParsed,
   IacFileParseFailure,
+  IacOrgSettings,
   IaCTestFlags,
   RulesOrigin,
   SafeAnalyticsOutput,
@@ -15,18 +16,13 @@ import { TestLimitReachedError } from './usage-tracking';
 import { TestResult } from '../../../../../lib/snyk-test/legacy';
 import {
   applyCustomSeverities,
-  cleanLocalCache,
-  getIacOrgSettings,
   loadContentForFiles,
   parseFiles,
   scanFiles,
   trackUsage,
 } from './measurable-methods';
-import { UnsupportedEntitlementError } from '../../../../../lib/errors/unsupported-entitlement-error';
-import config from '../../../../../lib/config';
 import { findAndLoadPolicy } from '../../../../../lib/policy';
 import { isFeatureFlagSupportedForOrg } from '../../../../../lib/feature-flags';
-import { initRules } from './rules';
 import { NoFilesToScanError } from './file-loader';
 import { processResults } from './process-results';
 import { generateProjectAttributes, generateTags } from '../../../monitor';
@@ -43,124 +39,114 @@ import { FeatureFlagError } from './assert-iac-options-flag';
 export async function test(
   pathToScan: string,
   options: IaCTestFlags,
+  orgPublicId: string,
+  iacOrgSettings: IacOrgSettings,
+  rulesOrigin: RulesOrigin,
 ): Promise<TestReturnValue> {
-  try {
-    const orgPublicId = options.org ?? config.org;
-    const iacOrgSettings = await getIacOrgSettings(orgPublicId);
+  // Parse tags and attributes right now, so we can exit early if the user
+  // provided invalid values.
+  const tags = parseTags(options);
+  const attributes = parseAttributes(options);
 
-    if (!iacOrgSettings.entitlements?.infrastructureAsCode) {
-      throw new UnsupportedEntitlementError('infrastructureAsCode');
-    }
+  const policy = await findAndLoadPolicy(pathToScan, 'iac', options);
 
-    // Parse tags and attributes right now, so we can exit early if the user
-    // provided invalid values.
-    const tags = parseTags(options);
-    const attributes = parseAttributes(options);
+  const isTFVarSupportEnabled = (
+    await isFeatureFlagSupportedForOrg(
+      'iacTerraformVarSupport',
+      iacOrgSettings.meta.org,
+    )
+  ).ok;
 
-    const rulesOrigin = await initRules(iacOrgSettings, options);
+  let allParsedFiles: IacFileParsed[] = [],
+    allFailedFiles: IacFileParseFailure[] = [];
+  const allDirectories = getAllDirectoriesForPath(
+    pathToScan,
+    options.detectionDepth,
+  );
 
-    const policy = await findAndLoadPolicy(pathToScan, 'iac', options);
-
-    const isTFVarSupportEnabled = (
-      await isFeatureFlagSupportedForOrg(
-        'iacTerraformVarSupport',
-        iacOrgSettings.meta.org,
-      )
-    ).ok;
-
-    let allParsedFiles: IacFileParsed[] = [],
-      allFailedFiles: IacFileParseFailure[] = [];
-    const allDirectories = getAllDirectoriesForPath(
+  // we load and parse files directory by directory
+  // because we need all files in the same directory to share the same variable context for Terraform
+  for (const currentDirectory of allDirectories) {
+    const filePathsInDirectory = getFilesForDirectory(
       pathToScan,
-      options.detectionDepth,
+      currentDirectory,
     );
-
-    // we load and parse files directory by directory
-    // because we need all files in the same directory to share the same variable context for Terraform
-    for (const currentDirectory of allDirectories) {
-      const filePathsInDirectory = getFilesForDirectory(
-        pathToScan,
-        currentDirectory,
-      );
-      if (
-        currentDirectory === pathToScan &&
-        shouldLoadVarDefinitionsFile(options, isTFVarSupportEnabled)
-      ) {
-        const varDefinitionsFilePath = options['var-file'];
-        filePathsInDirectory.push(varDefinitionsFilePath);
-      }
-      const filesToParse = await loadContentForFiles(filePathsInDirectory);
-      const { parsedFiles, failedFiles } = await parseFiles(
-        filesToParse,
-        options,
-        isTFVarSupportEnabled,
-      );
-      allParsedFiles = allParsedFiles.concat(parsedFiles);
-      allFailedFiles = allFailedFiles.concat(failedFiles);
+    if (
+      currentDirectory === pathToScan &&
+      shouldLoadVarDefinitionsFile(options, isTFVarSupportEnabled)
+    ) {
+      const varDefinitionsFilePath = options['var-file'];
+      filePathsInDirectory.push(varDefinitionsFilePath);
     }
-
-    // if none of the files were parsed then either we didn't have any IaC files
-    // or there was only one file passed via the CLI and it failed parsing
-    if (allParsedFiles.length === 0) {
-      if (allFailedFiles.length === 1) {
-        throw allFailedFiles[0].err;
-      } else {
-        throw new NoFilesToScanError();
-      }
-    }
-
-    // Duplicate all the files and run them through the custom engine.
-    if (rulesOrigin !== RulesOrigin.Internal) {
-      allParsedFiles.push(
-        ...allParsedFiles.map((file) => ({
-          ...file,
-          engineType: EngineType.Custom,
-        })),
-      );
-    }
-
-    const scannedFiles = await scanFiles(allParsedFiles);
-    const resultsWithCustomSeverities = await applyCustomSeverities(
-      scannedFiles,
-      iacOrgSettings.customPolicies,
-    );
-    const { filteredIssues, ignoreCount } = await processResults(
-      resultsWithCustomSeverities,
-      orgPublicId,
-      iacOrgSettings,
-      policy,
-      tags,
-      attributes,
+    const filesToParse = await loadContentForFiles(filePathsInDirectory);
+    const { parsedFiles, failedFiles } = await parseFiles(
+      filesToParse,
       options,
+      isTFVarSupportEnabled,
     );
-
-    try {
-      await trackUsage(filteredIssues);
-    } catch (e) {
-      if (e instanceof TestLimitReachedError) {
-        throw e;
-      }
-      // If something has gone wrong, err on the side of allowing the user to
-      // run their tests by squashing the error.
-    }
-
-    addIacAnalytics(filteredIssues, {
-      ignoredIssuesCount: ignoreCount,
-      rulesOrigin,
-    });
-
-    // TODO: add support for proper typing of old TestResult interface.
-    return {
-      results: (filteredIssues as unknown) as TestResult[],
-      // NOTE: No file or parsed file data should leave this function.
-      failures: isLocalFolder(pathToScan)
-        ? allFailedFiles.map(removeFileContent)
-        : undefined,
-      ignoreCount,
-    };
-  } finally {
-    cleanLocalCache();
+    allParsedFiles = allParsedFiles.concat(parsedFiles);
+    allFailedFiles = allFailedFiles.concat(failedFiles);
   }
+
+  // if none of the files were parsed then either we didn't have any IaC files
+  // or there was only one file passed via the CLI and it failed parsing
+  if (allParsedFiles.length === 0) {
+    if (allFailedFiles.length === 1) {
+      throw allFailedFiles[0].err;
+    } else {
+      throw new NoFilesToScanError();
+    }
+  }
+
+  // Duplicate all the files and run them through the custom engine.
+  if (rulesOrigin !== RulesOrigin.Internal) {
+    allParsedFiles.push(
+      ...allParsedFiles.map((file) => ({
+        ...file,
+        engineType: EngineType.Custom,
+      })),
+    );
+  }
+
+  const scannedFiles = await scanFiles(allParsedFiles);
+  const resultsWithCustomSeverities = await applyCustomSeverities(
+    scannedFiles,
+    iacOrgSettings.customPolicies,
+  );
+  const { filteredIssues, ignoreCount } = await processResults(
+    resultsWithCustomSeverities,
+    orgPublicId,
+    iacOrgSettings,
+    policy,
+    tags,
+    attributes,
+    options,
+  );
+
+  try {
+    await trackUsage(filteredIssues);
+  } catch (e) {
+    if (e instanceof TestLimitReachedError) {
+      throw e;
+    }
+    // If something has gone wrong, err on the side of allowing the user to
+    // run their tests by squashing the error.
+  }
+
+  addIacAnalytics(filteredIssues, {
+    ignoredIssuesCount: ignoreCount,
+    rulesOrigin,
+  });
+
+  // TODO: add support for proper typing of old TestResult interface.
+  return {
+    results: (filteredIssues as unknown) as TestResult[],
+    // NOTE: No file or parsed file data should leave this function.
+    failures: isLocalFolder(pathToScan)
+      ? allFailedFiles.map(removeFileContent)
+      : undefined,
+    ignoreCount,
+  };
 }
 
 export function removeFileContent({


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR moves the code that downloads and prepares custom and built-in rules at the beginning of the `snyk iac test` command. Before, these tasks were performed for each scanned path, resulting in an amount of unnecessary network calls and file system operations directly proportional to the number of scanned paths. Now, custom and built-in rules are downloaded and prepared only once.

#### Where should the reviewer start?

The code for downloading rules and cleaning up temporary directories has been moved from `src/cli/commands/test/iac/local-execution/index.ts` to `src/cli/commands/test/iac/index.ts`.

Moreover, one test has been removed from `test/jest/unit/iac/index.spec.ts`. The behaviour under test is already exercised by other tests in `test/jest/acceptance/iac/custom-rules.spec.ts`.

#### How should this be manually tested?

Perform a scan of multiple paths by using:

- no custom rules;
- a local bundle of custom rules;
- custom rules downloaded from an OCI registry.

These scenarios should work as before.

#### What are the relevant tickets?

[CFG-1477](https://snyksec.atlassian.net/browse/CFG-1477)