### PR TITLE
[CFG-1776] feat: developer flag to override IaC bundle path

### DIFF
--- a/src/cli/commands/test/iac/local-execution/local-cache.ts
+++ b/src/cli/commands/test/iac/local-execution/local-cache.ts
@@ -9,6 +9,7 @@ import { CustomError } from '../../../../../lib/errors';
 import * as analytics from '../../../../../lib/analytics';
 import ReadableStream = NodeJS.ReadableStream;
 import { getErrorStringCode } from './error-utils';
+import config from '../../../../../lib/config';
 
 const debug = Debug('iac-local-cache');
 
@@ -126,6 +127,14 @@ export async function initLocalCache({
     ) {
       throw new InvalidCustomRules(customRulesPath);
     }
+  }
+
+  // IAC_BUNDLE_PATH is a developer setting that is not useful to most users. It
+  // is not a replacement for custom rules.
+  if (config.IAC_BUNDLE_PATH) {
+    const stream = fs.createReadStream(config.IAC_BUNDLE_PATH);
+    await extractBundle(stream);
+    return;
   }
 
   // We extract the Snyk rules after the custom rules to ensure our files

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -23,6 +23,7 @@ interface Config {
   CACHE_PATH?: string;
   DRIFTCTL_PATH?: string;
   DRIFTCTL_URL?: string;
+  IAC_BUNDLE_PATH?: string;
 }
 
 // TODO: fix the types!


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

When developing certain Snyk IaC features, it can be useful to override
the OPA WASM bundle with a locally-built version. This commit introduces
and environment variable, SNYK_IAC_BUNDLE_PATH, which is not documented
anywhere. This is intended for Snyk IaC developers, and is not useful
for other users. The user-facing equivalent is custom rule bundles.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?

This is useful for https://snyksec.atlassian.net/browse/CFG-1776, which is a spike, but I am actually proposing this PR to be merged, as it is useful for similar development work.

#### Screenshots


#### Additional questions
