### PR TITLE
fix: Exclude error results from IaC test summary

### DIFF
--- a/src/cli/commands/test/iac/index.ts
+++ b/src/cli/commands/test/iac/index.ts
@@ -283,7 +283,7 @@ export default async function(...args: MethodArgs): Promise<TestCommandResult> {
     }
   }
 
-  if (iacOutputMeta && isNewIacOutputSupported) {
+  if (!notSuccess && iacOutputMeta && isNewIacOutputSupported) {
     response += `${EOL}${SEPARATOR}${EOL}`;
 
     const iacTestSummary = `${formatIacTestSummary(


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Fixes the results sent for formatting the test summary to exclude potential error objects. These are generated whenever the test for one of the provided paths results in an error.

#### Where should the reviewer start?

```
src/cli/commands/test/iac/index.ts
```


#### How should this be manually tested?
1. Provide multiple paths, for some of which the test should entirely fail with an error.
2. Ensure the execution does not end with an error message, and that results for valid files are displayed.
3. Ensure the values in the test summary section are valid.

#### Any background context you want to provide?

When providing multiple paths, and having some of which throw an error during the test, these are currently incorrectly included in the results that are being sent for formatting the test summary section. We'd like to ensure errors cannot be included in the results sent for formatting the test summary.

The current behavior in the test flow is that when the test for any of the provided paths results in an error, the entire flow fails and this error is displayed. 

To align with this, when any of the tests for the provided paths results in an error, we do not format the test summary, as it will not be displayed in this case.

#### Screenshots

- Before:
    <img width="1127" alt="image" src="https://user-images.githubusercontent.com/46415136/163456582-473a6389-29b0-4e1f-a198-de3460550d82.png">

- After:
    <img width="1430" alt="image" src="https://user-images.githubusercontent.com/46415136/163457919-e71a4e2b-2a07-433c-b0df-dee19fdd3763.png">