### PR TITLE
chore: add is-iac-drift analytics to update-exclude-policy command

### DIFF
--- a/src/cli/commands/update-exclude-policy.ts
+++ b/src/cli/commands/update-exclude-policy.ts
@@ -11,6 +11,7 @@ import {
   updateExcludeInPolicy,
 } from '../../lib/iac/drift';
 import { Policy } from '../../lib/policy/find-and-load-policy';
+import * as analytics from '../../lib/analytics';
 
 export default async (...args: MethodArgs): Promise<any> => {
   const { options } = processCommandArgs(...args);
@@ -37,6 +38,10 @@ export default async (...args: MethodArgs): Promise<any> => {
     // See https://github.com/nodejs/node/issues/19831
     // The actual error handling behavior is enough for now but may be improved if needed
     const analysis = parseDriftAnalysisResults(fs.readFileSync(0).toString());
+
+    // Add analytics
+    analytics.add('is-iac-drift', true);
+
     let policy: Policy;
     try {
       policy = await snykPolicyLib.load();


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Should add the `is-iac-drift` analytics to the `snyk iac update-exclude-policy` command.

#### How should this be manually tested?

Create a json file that represents your infrastructure drifts

`snyk iac describe --all --json > test.json`

Then, use the command update-exclude-policy command

`cat test.json | snyk iac update-exclude-policy`

You should see the `isIacDrift` analytics in your registry logs

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/CFG-1770

#### Screenshots

<img width="420" alt="image" src="https://user-images.githubusercontent.com/8110579/163584165-bc453ee0-834c-40d7-afbf-e48fe4c3d4a7.png">
