### PR TITLE
fix: set rule index result by security rules mapping

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,6 +22,19 @@
       "console": "integratedTerminal",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
       "args": ["${relativeFile}"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Jest Current File",
+      "console": "integratedTerminal",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["${relativeFile}"],
+      "runtimeArgs": [
+        "--inspect-brk",
+        "${workspaceRoot}/node_modules/.bin/jest",
+        "--runInBand"
+      ]
     }
   ]
 }

--- a/src/lib/plugins/sast/analysis.ts
+++ b/src/lib/plugins/sast/analysis.ts
@@ -174,10 +174,9 @@ function getSecurityResultsOnly(
   securityRules: string[],
 ): Result[] {
   const securityResults = results.reduce((acc: Result[], result: Result) => {
-    const isSecurityResult = securityRules.some(
-      (securityRule) => securityRule === result?.ruleId,
-    );
-    if (isSecurityResult) {
+    const securityRule = securityRules.find((sr) => sr === result?.ruleId);
+    if (securityRule) {
+      result.ruleIndex = securityRules.indexOf(securityRule);
       acc.push(result);
     }
     return acc;

--- a/test/fixtures/sast/sample-sarif.json
+++ b/test/fixtures/sast/sample-sarif.json
@@ -316,7 +316,7 @@
         },
         {
           "ruleId": "javascript/Sqli",
-          "ruleIndex": 3,
+          "ruleIndex": 2,
           "level": "error",
           "message": {
             "text": "Unsanitized input from the HTTP request body flows into find, where it is used in an SQL query. This may result in an SQL Injection vulnerability.",
@@ -461,7 +461,7 @@
         },
         {
           "ruleId": "javascript/NoRateLimitingForExpensiveWebOperation",
-          "ruleIndex": 5,
+          "ruleIndex": 3,
           "level": "warning",
           "message": {
             "text": "This endpoint handler performs a system command execution and does not use a rate-limiting mechanism. It may enable the attackers to perform Denial-of-service attacks. Consider using a rate-limiting middleware such as express-limit.",
@@ -537,7 +537,7 @@
         },
         {
           "ruleId": "javascript/NoRateLimitingForExpensiveWebOperation",
-          "ruleIndex": 6,
+          "ruleIndex": 3,
           "level": "warning",
           "message": {
             "text": "This endpoint handler performs a file system operation and does not use a rate-limiting mechanism. It may enable the attackers to perform Denial-of-service attacks. Consider using a rate-limiting middleware such as express-limit.",
@@ -613,7 +613,7 @@
         },
         {
           "ruleId": "javascript/CommandInjection",
-          "ruleIndex": 7,
+          "ruleIndex": 4,
           "level": "error",
           "message": {
             "text": "Unsanitized input from the HTTP request body flows into child_process.exec, where it is used to build a shell command. This may result in a Command Injection vulnerability.",
@@ -826,7 +826,7 @@
         },
         {
           "ruleId": "javascript/XSS",
-          "ruleIndex": 8,
+          "ruleIndex": 5,
           "level": "error",
           "message": {
             "text": "Unsanitized input from the HTTP request body flows into send, where it is used to render an HTML page returned to the user. This may result in a Cross-Site Scripting attack (XSS).",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Set the `ruleIndex` of a result to match the index of the rule in the security rules map

#### Where should the reviewer start?
`src/lib/plugins/sast/analysis.ts`

#### How should this be manually tested?
run `code test` on a repo, in each result, look for rule index and make sure it matches in the rules array

#### Any background context you want to provide?
When we run a code test, we first alter the rules array to use only security rules. The source of the problem lies when we don't address the `ruleIndex` that is now outdate since the rules indexes have changed.

#### What are the relevant tickets?
[Jira Ticket](https://snyksec.atlassian.net/browse/ZEN-23)

#### Screenshots
N/A

#### Additional comments
I've also fixed the test fixture to match the desired result