### PR TITLE
fix: Remove `none` severity from test summary

### DIFF
--- a/src/lib/formatters/iac-output/v2/test-summary.ts
+++ b/src/lib/formatters/iac-output/v2/test-summary.ts
@@ -66,12 +66,11 @@ function formatCountsSection(testData: IacTestData): string {
 
   let totalIssuesCount = 0;
 
-  const issueCountsBySeverities: { [key in SEVERITY | 'none']: number } = {
+  const issueCountsBySeverities: { [key in SEVERITY]: number } = {
     critical: 0,
     high: 0,
     medium: 0,
     low: 0,
-    none: 0,
   };
 
   testData.results.forEach((iacTestResponse) => {


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Removes the reference to the `none` severity in the test summary formatter for the new CLI output.

#### Where should the reviewer start?

```
src/lib/formatters/iac-output/v2/test-summary.ts
```

#### Any background context you want to provide?

- Having scanned the code to learn more about the usage for the `none` severity for Snyk IaC, it's been concluded that this severity is only available via the custom severities feature. When the test results reach the output formatting stage, issues with the `none` severity are already filtered out, so there's no need to take these into account in the output. 