### PR TITLE
refactor: Extracted output methods and updated color utilities

### DIFF
--- a/src/cli/commands/test/iac/index.ts
+++ b/src/cli/commands/test/iac/index.ts
@@ -27,7 +27,8 @@ import * as utils from '../utils';
 import {
   formatIacTestFailures,
   getIacDisplayErrorFileOutput,
-  shareResultsOutput,
+  initalUserMessageOutput,
+  shouldPrintIacInitialMessage,
 } from '../../../../lib/formatters/iac-output';
 import { getEcosystemForTest, testEcosystem } from '../../../../lib/ecosystems';
 import {
@@ -60,9 +61,9 @@ import { assertIaCOptionsFlags } from './local-execution/assert-iac-options-flag
 import { hasFeatureFlag } from '../../../../lib/feature-flags';
 import {
   formatIacTestSummary,
+  formatShareResultsOutput,
   getIacDisplayedIssues,
 } from '../../../../lib/formatters/iac-output';
-import { colors } from '../../../../lib/formatters/iac-output/v2/color-utils';
 
 const debug = Debug('snyk-test');
 const SEPARATOR = '\n-------------------------------------------------------\n';
@@ -117,12 +118,7 @@ export default async function(...args: MethodArgs): Promise<TestCommandResult> {
   const isNewIacOutputSupported = await hasFeatureFlag('iacCliOutput', options);
 
   if (shouldPrintIacInitialMessage(options, isNewIacOutputSupported)) {
-    console.log(
-      EOL +
-        colors.info.bold(
-          'Snyk testing Infrastructure as Code configuration issues...',
-        ),
-    );
+    console.log(EOL + initalUserMessageOutput);
   }
 
   // Promise waterfall to test all other paths sequentially
@@ -350,7 +346,7 @@ export default async function(...args: MethodArgs): Promise<TestCommandResult> {
     response += spotlightVulnsMsg;
 
     if (isIacShareResultsOptions(options)) {
-      response += colors.info.bold(shareResultsOutput(iacOutputMeta!)) + EOL;
+      response += formatShareResultsOutput(iacOutputMeta!) + EOL;
     }
 
     const error = new Error(response) as any;
@@ -372,7 +368,7 @@ export default async function(...args: MethodArgs): Promise<TestCommandResult> {
   );
 
   if (isIacShareResultsOptions(options)) {
-    response += colors.info.bold(shareResultsOutput(iacOutputMeta!)) + EOL;
+    response += formatShareResultsOutput(iacOutputMeta!) + EOL;
   }
 
   return TestCommandResult.createHumanReadableTestCommandResult(
@@ -395,8 +391,4 @@ function shouldFail(vulnerableResults: any[], failOn: FailOn) {
   }
   // should fail by default when there are vulnerable results
   return vulnerableResults.length > 0;
-}
-
-function shouldPrintIacInitialMessage(options, iacCliOutputFeatureFlag) {
-  return !options.json && !options.sarif && iacCliOutputFeatureFlag;
 }

--- a/src/cli/commands/test/iac/index.ts
+++ b/src/cli/commands/test/iac/index.ts
@@ -62,6 +62,7 @@ import {
   formatIacTestSummary,
   getIacDisplayedIssues,
 } from '../../../../lib/formatters/iac-output';
+import { colors } from '../../../../lib/formatters/iac-output/v2/color-utils';
 
 const debug = Debug('snyk-test');
 const SEPARATOR = '\n-------------------------------------------------------\n';
@@ -118,7 +119,7 @@ export default async function(...args: MethodArgs): Promise<TestCommandResult> {
   if (shouldPrintIacInitialMessage(options, isNewIacOutputSupported)) {
     console.log(
       EOL +
-        chalk.bold(
+        colors.info.bold(
           'Snyk testing Infrastructure as Code configuration issues...',
         ),
     );
@@ -349,7 +350,7 @@ export default async function(...args: MethodArgs): Promise<TestCommandResult> {
     response += spotlightVulnsMsg;
 
     if (isIacShareResultsOptions(options)) {
-      response += chalk.bold.white(shareResultsOutput(iacOutputMeta!)) + EOL;
+      response += colors.info.bold(shareResultsOutput(iacOutputMeta!)) + EOL;
     }
 
     const error = new Error(response) as any;
@@ -371,7 +372,7 @@ export default async function(...args: MethodArgs): Promise<TestCommandResult> {
   );
 
   if (isIacShareResultsOptions(options)) {
-    response += chalk.bold.white(shareResultsOutput(iacOutputMeta!)) + EOL;
+    response += colors.info.bold(shareResultsOutput(iacOutputMeta!)) + EOL;
   }
 
   return TestCommandResult.createHumanReadableTestCommandResult(

--- a/src/lib/formatters/iac-output/index.ts
+++ b/src/lib/formatters/iac-output/index.ts
@@ -10,4 +10,7 @@ export {
   formatIacTestSummary,
   getIacDisplayedIssues,
   formatIacTestFailures,
+  initalUserMessageOutput,
+  shouldPrintIacInitialMessage,
+  formatShareResultsOutput,
 } from './v2';

--- a/src/lib/formatters/iac-output/v2/color-utils.ts
+++ b/src/lib/formatters/iac-output/v2/color-utils.ts
@@ -4,6 +4,8 @@ import { SEVERITY } from '../../../snyk-test/common';
 interface IacOutputColors {
   severities: SeverityColor;
   failure: Chalk;
+  success: Chalk;
+  info: Chalk;
 }
 
 type SeverityColor = {
@@ -18,4 +20,6 @@ export const colors: IacOutputColors = {
     low: chalk.hex('#88879E'),
   },
   failure: chalk.hex('#B81415'),
+  success: chalk.hex('#00BB00'),
+  info: chalk.white,
 };

--- a/src/lib/formatters/iac-output/v2/failures-list.ts
+++ b/src/lib/formatters/iac-output/v2/failures-list.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import { EOL } from 'os';
 
 import { IacFileInDirectory } from '../../../types';
@@ -7,7 +6,7 @@ import { colors } from './color-utils';
 export function formatIacTestFailures(testFailures: IacFileInDirectory[]) {
   const sectionComponents: string[] = [];
 
-  const titleOutput = chalk.bold.white(`Invalid Files: ${testFailures.length}`);
+  const titleOutput = colors.info.bold(`Invalid Files: ${testFailures.length}`);
   sectionComponents.push(titleOutput);
 
   const testFailuresListOutput = formatFailuresList(testFailures);

--- a/src/lib/formatters/iac-output/v2/index.ts
+++ b/src/lib/formatters/iac-output/v2/index.ts
@@ -1,3 +1,8 @@
 export { getIacDisplayedIssues } from './issues-list';
 export { formatIacTestSummary } from './test-summary';
 export { formatIacTestFailures } from './failures-list';
+export {
+  initalUserMessageOutput,
+  shouldPrintIacInitialMessage,
+} from './initial-user-message';
+export { formatShareResultsOutput } from './share-results';

--- a/src/lib/formatters/iac-output/v2/initial-user-message.ts
+++ b/src/lib/formatters/iac-output/v2/initial-user-message.ts
@@ -1,0 +1,13 @@
+import { IaCTestFlags } from '../../../../cli/commands/test/iac/local-execution/types';
+import { colors } from './color-utils';
+
+export const initalUserMessageOutput = colors.info.bold(
+  'Snyk testing Infrastructure as Code configuration issues...',
+);
+
+export function shouldPrintIacInitialMessage(
+  options: IaCTestFlags,
+  iacCliOutputFeatureFlag?: boolean,
+): boolean {
+  return !!(!options.json && !options.sarif && iacCliOutputFeatureFlag);
+}

--- a/src/lib/formatters/iac-output/v2/issues-list.ts
+++ b/src/lib/formatters/iac-output/v2/issues-list.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import { EOL } from 'os';
 import capitalize = require('lodash/capitalize');
 import debug = require('debug');
@@ -15,7 +14,7 @@ export function getIacDisplayedIssues(
 ): string {
   const formattedResults = formatScanResultsNewOutput(results, outputMeta);
 
-  let output = EOL + chalk.bold.white('Issues') + EOL;
+  let output = EOL + colors.info.bold('Issues') + EOL;
 
   ['low', 'medium', 'high', 'critical'].forEach((severity) => {
     if (formattedResults.results[severity]) {
@@ -42,7 +41,7 @@ function getIssuesOutput(issues: FormattedIssue[]) {
   let output = '';
 
   issues.forEach((issue) => {
-    output += chalk.white(`${issue.policyMetadata.title}`) + EOL;
+    output += colors.info(`${issue.policyMetadata.title}`) + EOL;
   });
 
   return output;

--- a/src/lib/formatters/iac-output/v2/share-results.ts
+++ b/src/lib/formatters/iac-output/v2/share-results.ts
@@ -1,0 +1,7 @@
+import { IacOutputMeta } from '../../../types';
+import { shareResultsOutput } from '../v1';
+import { colors } from './color-utils';
+
+export function formatShareResultsOutput(outputMeta: IacOutputMeta) {
+  return colors.info.bold(shareResultsOutput(outputMeta));
+}

--- a/src/lib/formatters/iac-output/v2/test-summary.ts
+++ b/src/lib/formatters/iac-output/v2/test-summary.ts
@@ -1,8 +1,7 @@
-import chalk from 'chalk';
 import { EOL } from 'os';
 import { rightPadWithSpaces } from '../../../right-pad';
 import { SEVERITY } from '../../../snyk-test/common';
-import { color, icon } from '../../../theme';
+import { icon } from '../../../theme';
 import { IacOutputMeta } from '../../../types';
 import { colors } from './color-utils';
 import { IacTestData } from './types';
@@ -14,7 +13,7 @@ export function formatIacTestSummary(
   testData: IacTestData,
   outputMeta: IacOutputMeta,
 ): string {
-  const title = chalk.bold.white('Test Summary');
+  const title = colors.info.bold('Test Summary');
   const summarySections: string[] = [title];
 
   summarySections.push(formatTestMetaSection(outputMeta));
@@ -49,19 +48,19 @@ function formatCountsSection(testData: IacTestData): string {
   const countsSectionProperties: string[] = [];
 
   countsSectionProperties.push(
-    `${chalk.bold(
-      color.status.success(icon.VALID),
-    )} Files without issues: ${chalk.bold.white(`${filesWithoutIssues}`)}`,
+    `${colors.success.bold(
+      icon.VALID,
+    )} Files without issues: ${colors.info.bold(`${filesWithoutIssues}`)}`,
   );
 
   countsSectionProperties.push(
-    `${chalk.bold(
-      color.status.error(icon.ISSUE),
-    )} Files with issues: ${chalk.bold.white(`${filesWithIssues}`)}`,
+    `${colors.failure.bold(icon.ISSUE)} Files with issues: ${colors.info.bold(
+      `${filesWithIssues}`,
+    )}`,
   );
 
   countsSectionProperties.push(
-    `${INDENT}Ignored issues: ${chalk.bold.white(`${testData.ignoreCount}`)}`,
+    `${INDENT}Ignored issues: ${colors.info.bold(`${testData.ignoreCount}`)}`,
   );
 
   let totalIssuesCount = 0;
@@ -81,7 +80,7 @@ function formatCountsSection(testData: IacTestData): string {
   });
 
   countsSectionProperties.push(
-    `${INDENT}Total issues: ${chalk.bold.white(
+    `${INDENT}Total issues: ${colors.info.bold(
       `${totalIssuesCount}`,
     )} [ ${colors.severities.critical(
       `${issueCountsBySeverities.critical} critical`,

--- a/test/jest/unit/lib/formatters/iac-output/v2/failures-list.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/failures-list.spec.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import * as fs from 'fs';
 import * as pathLib from 'path';
 
@@ -19,7 +18,7 @@ describe('formatIacTestFailures', () => {
     const result = formatIacTestFailures(testFailureFixtures);
 
     // Assert
-    expect(result).toContain(chalk.bold.white(`Invalid Files: 5`));
+    expect(result).toContain(colors.info.bold(`Invalid Files: 5`));
   });
 
   it('should include the failures list with the correct values', () => {

--- a/test/jest/unit/lib/formatters/iac-output/v2/initial-user-message.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/initial-user-message.spec.ts
@@ -1,0 +1,54 @@
+import { shouldPrintIacInitialMessage } from '../../../../../../../src/lib/formatters/iac-output';
+
+describe('shouldPrintIacInitialMessage', () => {
+  describe("when the 'iacCliOutputFeatureFlag' flag is provided and the 'json' and 'sarif' options are not provided", () => {
+    it('should return true', () => {
+      // Arrange
+      const testOptions = {};
+      const testIacCliOutputFeatureFlag = true;
+
+      // Act
+      const result = shouldPrintIacInitialMessage(
+        testOptions,
+        testIacCliOutputFeatureFlag,
+      );
+
+      // Assert
+      expect(result).toEqual(true);
+    });
+  });
+
+  describe.each`
+    option
+    ${'json'}
+    ${'sarif'}
+  `("when the '$option' option is provided", ({ option }) => {
+    it('should return false', () => {
+      // Arrange
+      const testOptions = { [option]: true };
+      const testIacCliOutputFeatureFlag = true;
+
+      // Act
+      const result = shouldPrintIacInitialMessage(
+        testOptions,
+        testIacCliOutputFeatureFlag,
+      );
+
+      // Assert
+      expect(result).toEqual(false);
+    });
+  });
+
+  describe("when the 'iacCliOutputFeatureFlag' flag is not provided", () => {
+    it('should return false', () => {
+      // Arrange
+      const testOptions = {};
+
+      // Act
+      const result = shouldPrintIacInitialMessage(testOptions);
+
+      // Assert
+      expect(result).toEqual(false);
+    });
+  });
+});

--- a/test/jest/unit/lib/formatters/iac-output/v2/issues-list.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/issues-list.spec.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as pathLib from 'path';
-import chalk from 'chalk';
 
 import { getIacDisplayedIssues } from '../../../../../../../src/lib/formatters/iac-output';
 import { colors } from '../../../../../../../src/lib/formatters/iac-output/v2/color-utils';
@@ -36,7 +35,7 @@ describe('getIacDisplayedIssues', () => {
   it("should include the 'Issues' title", () => {
     const result = getIacDisplayedIssues(resultFixtures, outputMeta);
 
-    expect(result).toContain(chalk.white('Issues'));
+    expect(result).toContain(colors.info.bold('Issues'));
   });
 
   it('should include a subtitle for each severity with the correct amount of issues', () => {

--- a/test/jest/unit/lib/formatters/iac-output/v2/share-results.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/share-results.spec.ts
@@ -1,0 +1,48 @@
+import config from '../../../../../../../src/lib/config';
+import { formatShareResultsOutput } from '../../../../../../../src/lib/formatters/iac-output';
+import { colors } from '../../../../../../../src/lib/formatters/iac-output/v2/color-utils';
+
+describe('formatShareResultsOutput', () => {
+  it('returns the correct output', () => {
+    // Arrange
+    const testProjectName = 'test-project';
+    const testOrgName = 'test-org';
+
+    // Act
+    const output = formatShareResultsOutput({
+      projectName: testProjectName,
+      orgName: testOrgName,
+    });
+
+    // Assert
+    expect(output).toEqual(
+      colors.info.bold(
+        `Your test results are available at: ${config.ROOT}/org/${testOrgName}/projects under the name ${testProjectName}`,
+      ),
+    );
+  });
+
+  describe('when the gitRemoteUrl is specified', () => {
+    it('returns the correct output', () => {
+      // Arrange
+      const testProjectName = 'test-project';
+      const testOrgName = 'test-org';
+      const testRepoName = 'test/repo';
+      const testGitRemoteUrl = `http://github.com/${testRepoName}.git`;
+
+      // Act
+      const output = formatShareResultsOutput({
+        projectName: testProjectName,
+        orgName: testOrgName,
+        gitRemoteUrl: testGitRemoteUrl,
+      });
+
+      // Assert
+      expect(output).toEqual(
+        colors.info.bold(
+          `Your test results are available at: ${config.ROOT}/org/${testOrgName}/projects under the name ${testRepoName}`,
+        ),
+      );
+    });
+  });
+});

--- a/test/jest/unit/lib/formatters/iac-output/v2/test-summary.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/test-summary.spec.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as pathLib from 'path';
-import chalk from 'chalk';
 
 import { formatIacTestSummary } from '../../../../../../../src/lib/formatters/iac-output';
 import { colors } from '../../../../../../../src/lib/formatters/iac-output/v2/color-utils';
@@ -42,14 +41,14 @@ describe('formatIacTestSummary', () => {
 
     // Assert
     expect(result).toContain(
-      `${chalk.bold.white('Test Summary')}
+      `${colors.info.bold('Test Summary')}
 
   Organization: ${orgName}
 
-${chalk.bold.green('✔')} Files without issues: ${chalk.bold.white('0')}
-${chalk.bold.red('✗')} Files with issues: ${chalk.bold.white('3')}
-  Ignored issues: ${chalk.bold.white(`${ignoreCount}`)}
-  Total issues: ${chalk.bold.white('22')} [ ${colors.severities.critical(
+${colors.success.bold('✔')} Files without issues: ${colors.info.bold('0')}
+${colors.failure.bold('✗')} Files with issues: ${colors.info.bold('3')}
+  Ignored issues: ${colors.info.bold(`${ignoreCount}`)}
+  Total issues: ${colors.info.bold('22')} [ ${colors.severities.critical(
         '0 critical',
       )}, ${colors.severities.high('5 high')}, ${colors.severities.medium(
         '4 medium',
@@ -69,7 +68,7 @@ ${chalk.bold.red('✗')} Files with issues: ${chalk.bold.white('3')}
     );
 
     // Assert
-    expect(result).toContain(`${chalk.bold.white('Test Summary')}`);
+    expect(result).toContain(`${colors.info.bold('Test Summary')}`);
   });
 
   it('should include the counts section with the correct values', () => {
@@ -86,10 +85,12 @@ ${chalk.bold.red('✗')} Files with issues: ${chalk.bold.white('3')}
 
     // Assert
     expect(result).toContain(
-      `${chalk.bold.green('✔')} Files without issues: ${chalk.bold.white('0')}
-${chalk.bold.red('✗')} Files with issues: ${chalk.bold.white('3')}
-  Ignored issues: ${chalk.bold.white(`${ignoreCount}`)}
-  Total issues: ${chalk.bold.white('22')} [ ${colors.severities.critical(
+      `${colors.success.bold('✔')} Files without issues: ${colors.info.bold(
+        '0',
+      )}
+${colors.failure.bold('✗')} Files with issues: ${colors.info.bold('3')}
+  Ignored issues: ${colors.info.bold(`${ignoreCount}`)}
+  Total issues: ${colors.info.bold('22')} [ ${colors.severities.critical(
         '0 critical',
       )}, ${colors.severities.high('5 high')}, ${colors.severities.medium(
         '4 medium',


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Updates the color utilities for the new CLI output to include the `info` and `success` colors,  and applying them to the relevant output sections.
- Extracts output functions and messages for the initial user message and share results, and adds tests for them.

#### Where should the reviewer start?
- `src/lib/formatters/iac-output/v2/color-utils.ts`
- `src/cli/commands/test/iac/index.ts`
