### PR TITLE
feat: Added message for no issues found [CFG-1773]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "jsondiffpatch": "^0.4.1",
         "lodash.assign": "^4.2.0",
         "lodash.camelcase": "^4.3.0",
+        "lodash.capitalize": "^4.2.1",
         "lodash.clonedeep": "^4.5.0",
         "lodash.flatten": "^4.4.0",
         "lodash.get": "^4.4.2",
@@ -12085,6 +12086,11 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
+    "node_modules/lodash.capitalize": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk="
     },
     "node_modules/lodash.clone": {
       "version": "4.5.0",
@@ -29206,6 +29212,11 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
+    "lodash.capitalize": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk="
     },
     "lodash.clone": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "jsondiffpatch": "^0.4.1",
     "lodash.assign": "^4.2.0",
     "lodash.camelcase": "^4.3.0",
+    "lodash.capitalize": "^4.2.1",
     "lodash.clonedeep": "^4.5.0",
     "lodash.flatten": "^4.4.0",
     "lodash.get": "^4.4.2",

--- a/src/lib/formatters/iac-output/v2/issues-list.ts
+++ b/src/lib/formatters/iac-output/v2/issues-list.ts
@@ -1,6 +1,7 @@
 import { EOL } from 'os';
-import capitalize = require('lodash/capitalize');
-import debug = require('debug');
+import * as capitalize from 'lodash.capitalize';
+import * as isEmpty from 'lodash.isempty';
+import * as debug from 'debug';
 
 import { FormattedResult } from '../../../../cli/commands/test/iac/local-execution/types';
 import { IacOutputMeta } from '../../../types';
@@ -12,9 +13,18 @@ export function getIacDisplayedIssues(
   results: FormattedResult[],
   outputMeta: IacOutputMeta,
 ): string {
+  let output = EOL + colors.info.bold('Issues') + EOL;
+
   const formattedResults = formatScanResultsNewOutput(results, outputMeta);
 
-  let output = EOL + colors.info.bold('Issues') + EOL;
+  if (isEmpty(formattedResults.results)) {
+    return (
+      output +
+      EOL +
+      ' '.repeat(2) +
+      colors.success.bold('No vulnerable paths were found!')
+    );
+  }
 
   ['low', 'medium', 'high', 'critical'].forEach((severity) => {
     if (formattedResults.results[severity]) {

--- a/test/jest/acceptance/iac/iac-output.spec.ts
+++ b/test/jest/acceptance/iac/iac-output.spec.ts
@@ -244,6 +244,19 @@ https://support.snyk.io/hc/en-us/articles/360013723877-Test-your-Terraform-files
         expect(stdout).not.toContain('Test Summary');
       });
     });
+
+    describe('with no issues', () => {
+      it('it should display an appropriate message in the issues section', async () => {
+        // Arrange
+        const filePath = 'iac/terraform/vars.tf';
+
+        // Act
+        const { stdout } = await run(`snyk iac test ${filePath}`);
+
+        // Assert
+        expect(stdout).toContain('No vulnerable paths were found!');
+      });
+    });
   });
 
   describe(`without the '${IAC_CLI_OUTPUT_FF}' feature flag`, () => {

--- a/test/jest/unit/lib/formatters/iac-output/v2/issues-list.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/issues-list.spec.ts
@@ -47,4 +47,47 @@ describe('getIacDisplayedIssues', () => {
     );
     expect(result).toContain(colors.severities.high(`High Severity Issues: 5`));
   });
+
+  describe('with no issues', () => {
+    let resultsWithNoIssues: FormattedResult[];
+
+    beforeAll(() => {
+      resultsWithNoIssues = resultFixtures.map((resultFixture) => ({
+        ...resultFixture,
+        result: {
+          ...resultFixture.result,
+          cloudConfigResults: [],
+        },
+      }));
+    });
+
+    it('should display an appropriate message', () => {
+      // Act
+      const result = getIacDisplayedIssues(resultsWithNoIssues, outputMeta);
+
+      // Assert
+      expect(result).toContain(
+        colors.success.bold('No vulnerable paths were found!'),
+      );
+    });
+
+    it('should not display any severity sections', () => {
+      // Act
+      const result = getIacDisplayedIssues(resultsWithNoIssues, outputMeta);
+
+      // Assert
+      expect(result).not.toContain(
+        colors.severities.low('Low Severity Issues'),
+      );
+      expect(result).not.toContain(
+        colors.severities.medium('Medium Severity Issues'),
+      );
+      expect(result).not.toContain(
+        colors.severities.high('High Severity Issues'),
+      );
+      expect(result).not.toContain(
+        colors.severities.critical('Critical Severity Issues'),
+      );
+    });
+  });
 });


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Adds a green `No vulnerable paths were found!` user message for when no issues are found.

#### Where should the reviewer start?

    src/lib/formatters/iac-output/v2/issues-list.ts

#### How should this be manually tested?

- Test a file/path without issues, ensure the new user message appears and matches the design found [here](https://snyk.slack.com/archives/C030UA3U1RB/p1649583059675669).

#### Any background context you want to provide?

Currently, whenever no issues are discovered in the provided paths to test, we display the Issues title, with an empty list below, with none of the severity subsections. See the image below:

![image](https://user-images.githubusercontent.com/46415136/163975000-c14fb58e-8588-45dc-b1c0-a9b46cb6603b.png)

Rather than displaying an empty list, we’d like to display a green user message, that says No vulnerable paths were found!, as can be seen below:

![image](https://user-images.githubusercontent.com/46415136/163975032-6a7230c9-24fb-4bee-8e5e-f1b789dc70c0.png)


#### What are the relevant tickets?

- [CFG-1773](https://snyksec.atlassian.net/browse/CFG-1773)

#### Screenshots

![image](https://user-images.githubusercontent.com/46415136/163975238-ed2312c4-52e2-45bd-88bb-0750182aaac4.png)