### PR TITLE
feat: more logs in code in -d mode

### DIFF
--- a/src/lib/plugins/sast/utils/testEmitter.ts
+++ b/src/lib/plugins/sast/utils/testEmitter.ts
@@ -1,5 +1,6 @@
 import { emitter as codeEmitter } from '@snyk/code-client';
 import { spinner } from '../../../spinner';
+import * as debugLib from 'debug';
 
 export function analysisProgressUpdate(): void {
   let currentMessage = '';
@@ -28,5 +29,9 @@ export function analysisProgressUpdate(): void {
   );
   codeEmitter.on('sendError', (error) => {
     throw error;
+  });
+  codeEmitter.on('apiRequestLog', (data) => {
+    const debug = debugLib('snyk-code');
+    debug('---> API request log ', data);
   });
 }


### PR DESCRIPTION
Adds API request logs in -d mode.

With this change, I was able to solve 2 big problems with CLI/deeproxy -- the short connection timeout problem (fails to scan big-sized repos) and a CDN issue in ST envs for deeproxy, blocking request with 403.

Hence, I think its worth printing API request logs when running in -d mode especially since our error handling is not perfect

![Screenshot 2022-04-19 at 12 33 47](https://user-images.githubusercontent.com/10331835/163986405-bd78d10c-03c8-4df3-a0f1-cb1136667983.png)
)