### PR TITLE
chore: fix help text documentation

### DIFF
--- a/help/cli-commands/iac-test.md
+++ b/help/cli-commands/iac-test.md
@@ -37,7 +37,7 @@ Use to indicate how many subdirectories to search. `DEPTH` must be a number, 0 o
 
 Default: no limit.
 
-Example: `--detection-depth=3` limits search to the specified directory (or the current directory if no `<PATH>` is specified) plus three levels of subdirectories.
+Example: `--detection-depth=4` limits search to the specified directory (or the current directory if no `<PATH>` is specified) plus three levels of subdirectories.
 
 ### `--org=<ORG_ID>`
 

--- a/help/cli-commands/monitor.md
+++ b/help/cli-commands/monitor.md
@@ -41,7 +41,7 @@ Use with `--all-projects` or `--yarn-workspaces` to indicate how many subdirecto
 Default: 4 (the current working directory (0) and 4 subdirectories).
 
 Example: Limit search to the specified directory (or the current directory if no `<PATH>` is specified) plus two levels of subdirectories.\
-`--detection-depth=3`
+`--detection-depth=4`
 
 ### `--exclude=<GLOB>[,<GLOB>]...>`
 

--- a/help/cli-commands/test.md
+++ b/help/cli-commands/test.md
@@ -42,7 +42,7 @@ Use with `--all-projects` or `--yarn-workspaces` to indicate how many subdirecto
 Default: 4 (the current working directory (0) and 4 subdirectories).
 
 Example: Limit search to the specified directory (or the current directory if no `<PATH>` is specified) plus three levels of subdirectories.\
-`--detection-depth=3`
+`--detection-depth=4`
 
 ### `--exclude=<GLOB>[,<GLOB>]...>`
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Fixes incorrect example in help-text.

#### Where should the reviewer start?

Read the help-text associated with the example fix-up.

#### How should this be manually tested?

Likely no reason to. It should just be released.

#### Any background context you want to provide?

The support-team recently got a ticket from Yahoo! Japan suggesting our documentation provides
an incorrect example based on associated help text.
What's unintentionally confusing is this section:
>    Default: 4 (the current working directory and 3 sub-directories).

   Example: Limit search to the specified directory (or the current directory if no <PATH> is

  specified) plus three levels of subdirectories.

   --detection-depth=3

The assumption, based on the helptext, is that the example should be `--detection-depth=4`.
It's either that, or something else happening in our code that needs to be taken in account in the help text.

[Ticket in reference](https://snyk.zendesk.com/agent/tickets/22644)

#### What are the relevant tickets?

* [Ticket](https://snyk.zendesk.com/agent/tickets/22644)

