### PR TITLE
fix: Skip unsupported IaC files

### DIFF
--- a/src/cli/commands/test/iac/local-execution/file-parser.ts
+++ b/src/cli/commands/test/iac/local-execution/file-parser.ts
@@ -38,7 +38,9 @@ export async function parseFiles(
   let nonTfFileData: IacFileData[] = [];
 
   if (!isTFVarSupportEnabled) {
-    nonTfFileData = filesData;
+    nonTfFileData = filesData.filter((fileData) =>
+      ['tf', 'json', 'yaml', 'yml'].includes(fileData.fileType),
+    );
   } else {
     tfFileData = filesData.filter((fileData) =>
       VALID_TERRAFORM_FILE_TYPES.includes(fileData.fileType),

--- a/test/jest/acceptance/iac/test-directory.spec.ts
+++ b/test/jest/acceptance/iac/test-directory.spec.ts
@@ -45,7 +45,7 @@ describe('Directory scan', () => {
     expect(stdout).toContain('Failed to parse YAML file');
     expect(stdout).toContain('Failed to parse JSON file');
     expect(stdout).toContain(
-      '28 projects, 20 contained issues. Failed to test 8 projects.',
+      '28 projects, 20 contained issues. Failed to test 5 projects.',
     );
     expect(exitCode).toBe(1);
   });

--- a/test/jest/acceptance/iac/test-terraform-var-deref.spec.ts
+++ b/test/jest/acceptance/iac/test-terraform-var-deref.spec.ts
@@ -67,6 +67,16 @@ describe('Terraform Language Support', () => {
 
       expect(exitCode).toBe(3);
     });
+
+    it('skips non-supported IaC files in a directory', async () => {
+      const { exitCode, stdout } = await run(
+        `snyk iac test ./iac/terraform/var_deref`,
+      );
+
+      expect(stdout).not.toContain(`a.auto.tfvars`);
+      expect(stdout).not.toContain(`Unsupported file extension`);
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe('with feature flag', () => {

--- a/test/jest/unit/iac/file-parser.spec.ts
+++ b/test/jest/unit/iac/file-parser.spec.ts
@@ -89,7 +89,7 @@ describe('parseFiles', () => {
     expect(failedFiles.length).toEqual(0);
   });
 
-  it('includes unsupported file types in failed files', async () => {
+  it('does not include the unsupported file types in failed files list', async () => {
     const { parsedFiles, failedFiles } = await parseFiles([
       {
         fileContent: 'file.java',
@@ -98,8 +98,7 @@ describe('parseFiles', () => {
       },
     ]);
     expect(parsedFiles.length).toEqual(0);
-    expect(failedFiles.length).toEqual(1);
-    expect(failedFiles[0].err.message).toEqual('Unsupported file extension');
+    expect(failedFiles.length).toEqual(0);
   });
 
   it('throws an error for invalid JSON file types', async () => {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This commit will fix an issue where unsupported IaC files were printed in the scan output for users without the iacTerraformVarSupport flag.
This was due to a refactoring, where a check for the valid IaC files was skipped. 
It is also not considered part of the failedFiles, as it was not tested at all. (I checked the previous behaviour with an older version as well, e.g 1.840.0)

This is now added (hardcoded) for the flow that the flag is off. This flow is planned to be deprecated next week so I chose to do a quick fix for the customers now.

#### How should this be manually tested?
- Make sure the `iacTerraformVarSupport` flag is off.
- Run `snyk-dev iac test test/fixtures/iac/terraform/var_deref` (which contains non supported IaC files such as auto.tfvars) and see that the results do not contain `unsupported file extension anymore`

#### Any background context you want to provide?
The refactored/deleted code was doing the check here before https://github.com/snyk/cli/blob/1c7f002e39d36a805e1b145cbb5b681d7cd6b2f5/src/cli/commands/test/iac-local-execution/file-loader.ts#L59-L60

#### Screenshots
Before:
![image](https://user-images.githubusercontent.com/6989529/164198287-b5b50571-62dc-4c6e-8e3f-03974920852e.png)


After:
![image](https://user-images.githubusercontent.com/6989529/164198261-e4345c17-44e4-45a7-9f44-bba694cd2aba.png)
