### PR TITLE
feat: bump-snyk-mvn-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
         "snyk-module": "3.1.0",
-        "snyk-mvn-plugin": "2.27.0",
+        "snyk-mvn-plugin": "2.28.0",
         "snyk-nodejs-lockfile-parser": "1.38.0",
         "snyk-nuget-plugin": "1.23.4",
         "snyk-php-plugin": "1.9.2",
@@ -16677,9 +16677,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-mvn-plugin": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.27.0.tgz",
-      "integrity": "sha512-oAJQA0fUQeSylB01TX4R2lCsy9gn0pGkI8GQ6wumldK5kIDe6cWscmc7IDAgf9hC3pPDtp6NUrI+JNyB5IMVWQ==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.28.0.tgz",
+      "integrity": "sha512-rKrqp2Jg9CLUOnw+3lMRHdEZ14fF8S/PN6UkY8AefH4swiZ6SpdOJdSKfVzansMomdeM+r5NYZTv0hsahSiekw==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.0",
         "@snyk/dep-graph": "^1.23.1",
@@ -32777,9 +32777,9 @@
       }
     },
     "snyk-mvn-plugin": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.27.0.tgz",
-      "integrity": "sha512-oAJQA0fUQeSylB01TX4R2lCsy9gn0pGkI8GQ6wumldK5kIDe6cWscmc7IDAgf9hC3pPDtp6NUrI+JNyB5IMVWQ==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.28.0.tgz",
+      "integrity": "sha512-rKrqp2Jg9CLUOnw+3lMRHdEZ14fF8S/PN6UkY8AefH4swiZ6SpdOJdSKfVzansMomdeM+r5NYZTv0hsahSiekw==",
       "requires": {
         "@snyk/cli-interface": "2.11.0",
         "@snyk/dep-graph": "^1.23.1",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.17.0",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "2.27.0",
+    "snyk-mvn-plugin": "2.28.0",
     "snyk-nodejs-lockfile-parser": "1.38.0",
     "snyk-nuget-plugin": "1.23.4",
     "snyk-php-plugin": "1.9.2",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Bumps the version of snyk-mvn-plugin

#### Any background context you want to provide?
The new version includes an additional debug log to surface mvn output

#### What are the relevant tickets?
TARDIS-808

