### PR TITLE
chore: Add issues sorting [CFG-1774]

### DIFF
--- a/src/lib/formatters/iac-output/v2/issues-list/index.ts
+++ b/src/lib/formatters/iac-output/v2/issues-list/index.ts
@@ -38,7 +38,16 @@ export function getIacDisplayedIssues(
         `${capitalize(severity)} Severity Issues: ${severityResults.length}`,
       );
 
-      const issuesOutput = severityResults.map(formatIssue).join(EOL.repeat(2));
+      const issuesOutput = severityResults
+        .sort(
+          (severityResult1, severityResult2) =>
+            severityResult1.targetFile.localeCompare(
+              severityResult2.targetFile,
+            ) ||
+            severityResult1.issue.id.localeCompare(severityResult2.issue.id),
+        )
+        .map(formatIssue)
+        .join(EOL.repeat(2));
 
       debug(
         `iac display output - ${severity} severity ${severityResults.length} issues`,

--- a/test/jest/unit/lib/formatters/iac-output/v2/issues-list/index.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/issues-list/index.spec.ts
@@ -59,26 +59,8 @@ describe('getIacDisplayedIssues', () => {
     // Assert
     expect(result).toContain(
       `${colors.severities.low(
-        `[Low] ${chalk.bold('Container could be running with outdated image')}`,
+        `[Low] ${chalk.bold('Container is running without AppArmor profile')}`,
       )}
-Info:    The image policy does not prevent image reuse. The container may run with outdated or unauthorized image
-Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-42
-Path:    [DocId: 0] > spec > template > spec > containers[web] > imagePullPolicy
-File:    k8s.yaml
-Resolve: Set \`imagePullPolicy\` attribute to \`Always\`
-
-${colors.severities.low(
-  `[Low] ${chalk.bold('Container is running with writable root filesystem')}`,
-)}
-Info:    \`readOnlyRootFilesystem\` attribute is not set to \`true\`. Compromised process could abuse writable root filesystem to elevate privileges
-Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-8
-Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > readOnlyRootFilesystem
-File:    k8s.yaml
-Resolve: Set \`securityContext.readOnlyRootFilesystem\` to \`true\`
-
-${colors.severities.low(
-  `[Low] ${chalk.bold('Container is running without AppArmor profile')}`,
-)}
 Info:    The AppArmor profile is not set correctly. AppArmor will not enforce mandatory access control, which can increase the attack vectors.
 Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-32
 Path:    [DocId: 0] > metadata > annotations['container.apparmor.security.beta.kubernetes.io/web']
@@ -95,13 +77,31 @@ File:    k8s.yaml
 Resolve: Set \`resources.limits.memory\` value
 
 ${colors.severities.low(
+  `[Low] ${chalk.bold('Container could be running with outdated image')}`,
+)}
+Info:    The image policy does not prevent image reuse. The container may run with outdated or unauthorized image
+Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-42
+Path:    [DocId: 0] > spec > template > spec > containers[web] > imagePullPolicy
+File:    k8s.yaml
+Resolve: Set \`imagePullPolicy\` attribute to \`Always\`
+
+${colors.severities.low(
   `[Low] ${chalk.bold('Container is running without cpu limit')}`,
 )}
 Info:    CPU limit is not defined. Containers without limits can exceed the capacity of the node, and affect availability/performance of the host and other containers.
 Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-5
 Path:    [DocId: 0] > input > spec > template > spec > containers[web] > resources > limits > cpu
 File:    k8s.yaml
-Resolve: Add \`resources.limits.cpu\` field with required CPU limit value`,
+Resolve: Add \`resources.limits.cpu\` field with required CPU limit value
+
+${colors.severities.low(
+  `[Low] ${chalk.bold('Container is running with writable root filesystem')}`,
+)}
+Info:    \`readOnlyRootFilesystem\` attribute is not set to \`true\`. Compromised process could abuse writable root filesystem to elevate privileges
+Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-8
+Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > readOnlyRootFilesystem
+File:    k8s.yaml
+Resolve: Set \`securityContext.readOnlyRootFilesystem\` to \`true\``,
     );
 
     expect(result).toContain(


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Adds issues sorting in each severity section of the issues list, by file path and security rule public ID in this order of prioritization, both ascending.

#### Where should the reviewer start?

```
src/lib/formatters/iac-output/v2/issues-list/index.ts
```

#### How should this be manually tested?

- Ensure you have the `iacCliOutput` feature flag activated.
- Run the `snyk iac test` command and ensure the issues in each severity section are sorted according to the order stated above.

#### What are the relevant tickets?

- [CFG-1774](https://snyksec.atlassian.net/browse/CFG-1774)

#### More information

- Slack channel: [#feat-iac-cli-output](https://snyk.slack.com/archives/C030UA3U1RB)
- [Relevant thread](https://snyk.slack.com/archives/C030UA3U1RB/p1649681027260669)