### PR TITLE
chore(ci): integrate v2 into release pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -529,6 +529,8 @@ jobs:
     working_directory: /home/circleci/snyk
     steps:
       - checkout
+      - attach_workspace:
+          at: .
       - go/install:
           version: << pipeline.parameters.go_version >>
       - restore_cache:
@@ -539,6 +541,7 @@ jobs:
           environment:
             GOOS: linux
             GOARCH: amd64
+            CLI_V1_LOCATION: ../binary-releases
           command: make build build-test install prefix=. -e
       - run:
           name: Build darwin/amd64
@@ -546,6 +549,7 @@ jobs:
           environment:
             GOOS: darwin
             GOARCH: amd64
+            CLI_V1_LOCATION: ../binary-releases
           command: make build build-test install prefix=. -e
       - run:
           name: Build windows/amd64
@@ -553,6 +557,7 @@ jobs:
           environment:
             GOOS: windows
             GOARCH: amd64
+            CLI_V1_LOCATION: ../binary-releases
           command: make build build-test install prefix=. -e
       - save_cache:
           key: go-mod-{{ arch }}-{{ checksum "cliv2/go.sum" }}
@@ -691,6 +696,7 @@ workflows:
               only:
                 - /^chore\/.+$/
                 - /^.*test.*$/
+                - /^.*v2.*$/
                 - master
       - test-windows:
           name: Acceptance Tests (snyk-win.exe)
@@ -748,65 +754,60 @@ workflows:
             branches:
               only:
                 - master
-  #
-  # Snyk CLI v2 Workflows
-  #
-  v2_test:
-    # Only run on v2 branches
-    when:
-      matches:
-        pattern: '^.*v2.*$'
-        value: << pipeline.git.branch >>
-    jobs:
-      - install:
-          name: Install Dependencies (npm)
+      #
+      # Snyk CLI v2 Workflow Jobs
+      #
       - v2-build-artifacts:
-          name: Build Artifacts (v2)
+          name: v2 / Build Artifacts
+          requires:
+            - Build Artifacts
+          filters:
+            branches:
+              only:
+                - /^.*v2.*$/
+                - master
       - v2-test-linux-amd64:
-          name: Integration Tests (linux/amd64)
+          name: v2 / Integration Tests (linux/amd64)
           requires:
-            - Build Artifacts (v2)
+            - v2 / Build Artifacts
       - v2-test-proxy-linux-amd64:
-          name: Proxy Integration Tests (linux/amd64)
+          name: v2 / Proxy Integration Tests (linux/amd64)
           requires:
-            - Build Artifacts (v2)
+            - v2 / Build Artifacts
       - v2-test-darwin-amd64:
-          name: Integration Tests (darwin/amd64)
+          name: v2 / Integration Tests (darwin/amd64)
           requires:
-            - Build Artifacts (v2)
+            - v2 / Build Artifacts
       - v2-test-windows-amd64:
-          name: Integration Tests (windows/amd64)
+          name: v2 / Integration Tests (windows/amd64)
           requires:
-            - Build Artifacts (v2)
+            - v2 / Build Artifacts
       - v2-test-proxy-windows-amd64:
-          name: Proxy Integration Tests (windows/amd64)
+          name: v2 / Proxy Integration Tests (windows/amd64)
           requires:
-            - Build Artifacts (v2)
+            - v2 / Build Artifacts
       # Tests for backwards compatibility with CLIv1
       - test-linux:
-          name: Jest Acceptance Tests (linux/amd64)
+          name: v2 / Jest Acceptance Tests (linux/amd64)
           context: nodejs-install
           requires:
-            - Build Artifacts (v2)
-            - Install Dependencies (npm)
+            - v2 / Build Artifacts
           test_snyk_command: /home/circleci/snyk/cliv2/bin/snyk_linux_amd64
       - test-windows:
-          name: Jest Acceptance Tests (windows/amd64)
+          name: v2 / Jest Acceptance Tests (windows/amd64)
           context: nodejs-install
           requires:
-            - Build Artifacts (v2)
-            - Install Dependencies (npm)
+            - v2 / Build Artifacts
           test_snyk_command: C:\Users\circleci\snyk\cliv2\bin\snyk_windows_amd64.exe
       - test-macos:
-          name: Jest Acceptance Tests (darwin/amd64)
+          name: v2 / Jest Acceptance Tests (darwin/amd64)
           context: nodejs-install
           requires:
-            - Build Artifacts (v2)
-            - Install Dependencies (npm)
+            - v2 / Build Artifacts
           test_snyk_command: /Users/distiller/snyk/cliv2/bin/snyk_darwin_amd64
       - regression-test:
-          name: Regression Tests (v2)
+          name: v2 / Regression Tests
           context: nodejs-install
           requires:
-            - Build Artifacts (v2)
+            - v2 / Build Artifacts
           test_snyk_command: /mnt/ramdisk/snyk/cliv2/bin/snyk_linux_amd64

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,11 +176,12 @@ git checkout -b docs/contributing
 
 You can use these patterns in your branch name to enable additional checks.
 
-| Pattern             | Examples                                          | Description                                                                                                  |
-| ------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `chore/*`, `*test*` | `chore/change`, `test/change`, `feat/change+test` | Build and test all artifacts. Same as a [release pipeline](#creating-a-release) without the release step.    |
-| `smoke/*`           | `smoke/change`                                    | Run [smoke tests](https://github.com/snyk/cli/actions/workflows/smoke-tests.yml) against the latest release. |
-| default             | `fix/a-bug`                                       | Build and test your changes.                                                                                 |
+| Pattern             | Examples                                          | Description                                                                                                                |
+| ------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `chore/*`, `*test*` | `chore/change`, `test/change`, `feat/change+test` | Build and test all artifacts, excluding CLIv2. Same as a [release pipeline](#creating-a-release) without the release step. |
+| `smoke/*`           | `smoke/change`                                    | Run [smoke tests](https://github.com/snyk/cli/actions/workflows/smoke-tests.yml) against the latest release.               |
+| `*v2*`              | `feat/v2-feature`                                 | Build and test all artifacts, including CLIv2.                                                                             |
+| default             | `fix/a-bug`                                       | Build and test your changes.                                                                                               |
 
 For more information, see: [Pull request checks](#pull-request-checks).
 

--- a/cliv2/Makefile
+++ b/cliv2/Makefile
@@ -50,11 +50,9 @@ endif
 _V1_DOWNLOAD = true
 ifneq ($(CLI_V1_LOCATION), $(_EMPTY)) 
 	ifeq ($(CLI_V1_VERSION_TAG), $(_EMPTY))
-$(error ERROR! CLI_V1_VERSION_TAG needs to be specified)
-		#_V1_DOWNLOAD = true
-	else
-		_V1_DOWNLOAD = false
+		CLI_V1_VERSION_TAG = $(shell cat "$(CLI_V1_LOCATION)/version")
 	endif
+	_V1_DOWNLOAD = false
 endif
 
 
@@ -79,7 +77,7 @@ LOG_PREFIX = --
 # determine the latest cli version if no version was explicitly defined
 $(CACHE_DIR)/version.mk: $(CACHE_DIR)
 ifeq ($(CLI_V1_VERSION_TAG), $(_EMPTY))
-	$(eval CLI_V1_VERSION_TAG := v$(shell curl --fail -# -L https://static.snyk.io/cli/latest/version))
+	CLI_V1_VERSION_TAG = $(shell curl --fail --progress-bar -L https://static.snyk.io/cli/latest/version)
 endif
 	@echo "CLI_V1_VERSION_TAG=$(CLI_V1_VERSION_TAG)\nCLI_V2_VERSION_TAG=$(CLI_V2_VERSION_TAG)" > $(CACHE_DIR)/version.mk
 	@echo "$(LOG_PREFIX) Using cliv1 version ( $(CLI_V1_VERSION_TAG) )"
@@ -107,7 +105,7 @@ $(V2_DIRECTORY)/cliv2.version:
 $(V1_DIRECTORY)/$(V1_EXECUTABLE_NAME): $(V1_DIRECTORY)/cliv1.version
 ifeq ($(_V1_DOWNLOAD), true)
 	@echo "$(LOG_PREFIX) Downloading cliv1 executable ( $(V1_DIRECTORY)/$(V1_EXECUTABLE_NAME) )"
-	@curl --fail -# -Lo $(V1_DIRECTORY)/$(V1_EXECUTABLE_NAME) $(V1_DOWNLOAD_LINK)
+	@curl --fail --progress-bar -Lo $(V1_DIRECTORY)/$(V1_EXECUTABLE_NAME) $(V1_DOWNLOAD_LINK)
 else
 	@echo "$(LOG_PREFIX) Copying cliv1 executable ( $(V1_DIRECTORY)/$(V1_EXECUTABLE_NAME) )"
 	@cp $(CLI_V1_LOCATION)/$(V1_EXECUTABLE_NAME) $(V1_DIRECTORY)/$(V1_EXECUTABLE_NAME)
@@ -116,7 +114,7 @@ endif
 $(V1_DIRECTORY)/$(V1_EXECUTABLE_NAME).$(HASH_STRING): $(V1_DIRECTORY)/$(V1_EXECUTABLE_NAME)
 ifeq ($(_V1_DOWNLOAD), true)
 	@echo "$(LOG_PREFIX) Downloading cliv1 checksum ( $(V1_DIRECTORY)/$(V1_EXECUTABLE_NAME).$(HASH_STRING) )"
-	@curl --fail -# -Lo $(V1_DIRECTORY)/$(V1_EXECUTABLE_NAME).$(HASH_STRING) $(V1_DOWNLOAD_LINK).$(HASH_STRING)
+	@curl --fail --progress-bar -Lo $(V1_DIRECTORY)/$(V1_EXECUTABLE_NAME).$(HASH_STRING) $(V1_DOWNLOAD_LINK).$(HASH_STRING)
 else
 	@echo "$(LOG_PREFIX) Copying cliv1 checksum ( $(V1_DIRECTORY)/$(V1_EXECUTABLE_NAME).$(HASH_STRING) )"
 	@cp $(CLI_V1_LOCATION)/$(V1_EXECUTABLE_NAME).$(HASH_STRING) $(V1_DIRECTORY)/$(V1_EXECUTABLE_NAME).$(HASH_STRING)

--- a/cliv2/internal/cliv2/cliv2.go
+++ b/cliv2/internal/cliv2/cliv2.go
@@ -49,7 +49,7 @@ func NewCLIv2(cacheDirectory string, debugLogger *log.Logger) *CLI {
 		DebugLogger:      debugLogger,
 		CacheDirectory:   cacheDirectory,
 		v1Version:        cliv1.CLIV1Version(),
-		v2Version:        SNYK_CLIV2_VERSION_PART,
+		v2Version:        strings.TrimSpace(SNYK_CLIV2_VERSION_PART),
 		v1BinaryLocation: v1BinaryLocation,
 	}
 
@@ -93,7 +93,7 @@ func (c *CLI) ExtractV1Binary() error {
 }
 
 func (c *CLI) GetFullVersion() string {
-	return strings.TrimSpace(c.v2Version) + "+" + strings.Replace(c.v1Version, "v", "", 1)
+	return c.v2Version + "." + c.v1Version
 }
 
 func (c *CLI) GetIntegrationName() string {


### PR DESCRIPTION
- Move v2's pipeline into v1's pipeline after v1 binaries are built.
- Use locally built v1 binaries for building v2 binaries instead of downloading the latest v1 release.
- Fix v2's versioning to be consistent. Version files no longer contain "v".
    - Previous implementations removed the "v" in "dev" versions.
    - Use `.` instead of `+` for v2 versioning as `+` is whitespace in URLs.
- Run v2 builds and tests on `master`.
- Prefix jobs with "v2 /" to easily differentiate from v1 jobs.