### PR TITLE
feat: support base64 encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@open-policy-agent/opa-wasm": "^1.6.0",
         "@snyk/cli-interface": "2.11.0",
         "@snyk/cloud-config-parser": "^1.14.1",
-        "@snyk/code-client": "^4.10.0",
+        "@snyk/code-client": "^4.11.0",
         "@snyk/dep-graph": "^1.27.1",
         "@snyk/docker-registry-v2-client": "^2.6.1",
         "@snyk/fix": "file:packages/snyk-fix",
@@ -1946,9 +1946,9 @@
       }
     },
     "node_modules/@snyk/code-client": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.10.0.tgz",
-      "integrity": "sha512-aPm9sWSBU09vVgNSaXdq/aEH+fNOU+TGIqgAxYgvtf1LWAjMfbfhicqrm51icQfzdmt3IbJlGNoQ4++dhRcBvA==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.11.0.tgz",
+      "integrity": "sha512-fIRC9C5gR63q5UFIEhs13YIVTA3HZnqmVThKfuqSl0w+HSKBeavxPcHTFyoK8tnMxm5lqDknYDvw0BhbxyrGnQ==",
       "dependencies": {
         "@deepcode/dcignore": "^1.0.4",
         "@snyk/fast-glob": "^3.2.6-patch",
@@ -21234,9 +21234,9 @@
       }
     },
     "@snyk/code-client": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.10.0.tgz",
-      "integrity": "sha512-aPm9sWSBU09vVgNSaXdq/aEH+fNOU+TGIqgAxYgvtf1LWAjMfbfhicqrm51icQfzdmt3IbJlGNoQ4++dhRcBvA==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.11.0.tgz",
+      "integrity": "sha512-fIRC9C5gR63q5UFIEhs13YIVTA3HZnqmVThKfuqSl0w+HSKBeavxPcHTFyoK8tnMxm5lqDknYDvw0BhbxyrGnQ==",
       "requires": {
         "@deepcode/dcignore": "^1.0.4",
         "@snyk/fast-glob": "^3.2.6-patch",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@open-policy-agent/opa-wasm": "^1.6.0",
     "@snyk/cli-interface": "2.11.0",
     "@snyk/cloud-config-parser": "^1.14.1",
-    "@snyk/code-client": "^4.10.0",
+    "@snyk/code-client": "^4.11.0",
     "@snyk/dep-graph": "^1.27.1",
     "@snyk/docker-registry-v2-client": "^2.6.1",
     "@snyk/fix": "file:packages/snyk-fix",

--- a/src/lib/code-config.ts
+++ b/src/lib/code-config.ts
@@ -1,4 +1,5 @@
 import config from './config';
+import { config as userConfig } from './user-config';
 
 export function getCodeClientProxyUrl() {
   const url = new URL(config.API);
@@ -7,4 +8,13 @@ export function getCodeClientProxyUrl() {
     config.CODE_CLIENT_PROXY_URL ||
     domain.replace(/\/\/(app\.)?/, '//deeproxy.')
   );
+}
+
+export function getBase64Encoding(
+  enabled = userConfig.get('use-base64-encoding'),
+): boolean {
+  if (enabled) {
+    return enabled.toLowerCase() === 'true';
+  }
+  return false;
 }

--- a/src/lib/plugins/sast/analysis.ts
+++ b/src/lib/plugins/sast/analysis.ts
@@ -7,6 +7,7 @@ import { ReportingDescriptor, Result } from 'sarif';
 import { SEVERITY } from '../../snyk-test/legacy';
 import { api } from '../../api-token';
 import config from '../../config';
+import { getBase64Encoding } from '../../code-config';
 import { spinner } from '../../spinner';
 import { Options } from '../../types';
 import { SastSettings, Log } from './types';
@@ -57,6 +58,9 @@ async function getCodeAnalysis(
     ? sastSettings.localCodeEngine.url
     : getCodeClientProxyUrl();
 
+  const base64Encoding = getBase64Encoding();
+  debug(`base64 encoding enabled: ${base64Encoding}`);
+
   // TODO(james) This mirrors the implementation in request.ts and we need to use this for deeproxy calls
   // This ensures we support lowercase http(s)_proxy values as well
   // The weird IF around it ensures we don't create an envvar with
@@ -82,7 +86,7 @@ async function getCodeAnalysis(
     ? severityToAnalysisSeverity(options.severityThreshold)
     : AnalysisSeverity.info;
   const result = await analyzeFolders({
-    connection: { baseURL, sessionToken, source, requestId },
+    connection: { baseURL, sessionToken, source, requestId, base64Encoding },
     analysisOptions: { severity },
     fileOptions: { paths: [root] },
     analysisContext: {

--- a/test/jest/acceptance/snyk-code-config/snyk-code-config.spec.ts
+++ b/test/jest/acceptance/snyk-code-config/snyk-code-config.spec.ts
@@ -1,0 +1,13 @@
+import { runSnykCLI } from '../../util/runSnykCLI';
+
+jest.setTimeout(1000 * 60);
+
+test('it does not enable base64 encoding by default', async () => {
+  const { code, stdout } = await runSnykCLI('config get use-base64-encoding', {
+    env: {
+      ...process.env,
+    },
+  });
+  expect(code).toEqual(0);
+  expect(stdout).toEqual('');
+});

--- a/test/jest/unit/snyk-code/snyk-code-config.spec.ts
+++ b/test/jest/unit/snyk-code/snyk-code-config.spec.ts
@@ -1,0 +1,15 @@
+import { getBase64Encoding } from '../../../../src/lib/code-config';
+
+describe('test base64 setting', () => {
+  test('if not defined, base64 encoding is disabled', () => {
+    expect(getBase64Encoding()).toBe(false);
+  });
+
+  test('if set to true, base64 encoding is enabled', () => {
+    expect(getBase64Encoding('true')).toBe(true);
+  });
+
+  test('if set to false, base64 encoding is disabled', () => {
+    expect(getBase64Encoding('false')).toBe(false);
+  });
+});

--- a/test/jest/unit/snyk-code/snyk-code-test.spec.ts
+++ b/test/jest/unit/snyk-code/snyk-code-test.spec.ts
@@ -685,6 +685,7 @@ describe('Test snyk code', () => {
         sessionToken,
         source,
         requestId: 'test-id',
+        base64Encoding: false,
       },
       analysisOptions: {
         severity,
@@ -694,7 +695,10 @@ describe('Test snyk code', () => {
         flow: 'snyk-cli',
         initiator: 'CLI',
         org: expect.anything(),
+        orgDisplayName: undefined,
+        projectName: undefined,
       },
+      languages: undefined,
     };
 
     const sastSettings = {
@@ -777,6 +781,7 @@ describe('Test snyk code', () => {
           sessionToken,
           source,
           requestId: 'test-id',
+          base64Encoding: false,
         },
         analysisOptions: {
           severity,
@@ -786,7 +791,10 @@ describe('Test snyk code', () => {
           flow: 'snyk-cli',
           initiator: 'CLI',
           org: expect.anything(),
+          orgDisplayName: undefined,
+          projectName: undefined,
         },
+        languages: undefined,
       };
 
       const analyzeFoldersSpy = analyzeFoldersMock.mockResolvedValue(


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
- Adds support for base64 encoded payloads when executing `snyk code test`
- Targets single-tenant deployments of Snyk only

#### Where should the reviewer start?
- Changes made to `src/lib/config.ts` to handle the new config key, and `src/lib/plugins/sast/analysis.ts` to handle setting the new `base64Encoding` variable.

#### How should this be manually tested?
- A version of `deeproxy` with base64 encoding support is required (supported from https://github.com/snyk/deeproxy/pull/135 onwards)
- Either:
  - set the `SNYK_CFG_USE_BASE64_ENCODING` environment variable to `true`, or
  - set the `USE_BASE64_ENCODING` config value to `true`
- Execute `snyk code test -d` - the debug entry `snyk-code Base 64 Encoding enabled: true +0ms` should be present
- Validate the request to the `/bundle` endpoint is base64 encoded

#### Any background context you want to provide?
- This is targeted only for single tenant deployments (hence if not set, base64 encoding is disabled as the `deeproxy` service will not accept base64 encoded payloads in multi-tenant).

- See https://github.com/snyk/cli/pull/3162 for a previous iteration of this PR

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/NEBULA-520

#### Screenshots
`-`

#### Additional questions
`-`