### PR TITLE
fix(v2): verify proxy transport by default

### DIFF
--- a/test/jest/acceptance/https.spec.ts
+++ b/test/jest/acceptance/https.spec.ts
@@ -8,13 +8,6 @@ import { isCLIV2 } from '../util/isCLIV2';
 jest.setTimeout(1000 * 30);
 
 describe('https', () => {
-  if (isCLIV2()) {
-    // eslint-disable-next-line jest/no-focused-tests
-    it.only('CLIv2 not yet supported', () => {
-      console.warn('Skipping test as CLIv2 does not support it yet.');
-    });
-  }
-
   let server: FakeServer;
   let env: Record<string, string>;
 
@@ -58,7 +51,11 @@ describe('https', () => {
         env,
       });
 
-      expect(stdout).toContain('certificate has expired');
+      expect(stdout).toContain(
+        isCLIV2()
+          ? 'socket hang up' // cliv2's proxy will drop the connection, but its debug logs will say why.
+          : 'certificate has expired',
+      );
       expect(code).toBe(2);
     });
 


### PR DESCRIPTION
By default goproxy enables `InsecureSkipVerify` which is equivalent to using `--insecure`. This fix works by overriding goproxy's default and adding v2 support for `--insecure`.

I've also removed the manual handling for HTTPS_PROXY as go already handles that using `ProxyFromEnvironment`.

## Useful Links

- goproxy defaults: https://github.com/elazarl/goproxy/blob/a92cc753f88eb1d5f3ca49bd91da71fe815537ca/certs.go#L18-L22