### PR TITLE
test(iac): skip OCI tests due to rate limits

### DIFF
--- a/test/jest/acceptance/iac/custom-rules.spec.ts
+++ b/test/jest/acceptance/iac/custom-rules.spec.ts
@@ -114,7 +114,9 @@ describe('iac test --rules', () => {
   });
 });
 
-describe('custom rules pull from a remote OCI registry', () => {
+// Hits OCI Registry 200 pull rate limit
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip('custom rules pull from a remote OCI registry', () => {
   let run: (
     cmd: string,
     overrides?: Record<string, string>,


### PR DESCRIPTION
OCI registry has a 200 pull rate limit which we're hitting and its blocking pipelines so skip them for now.