### PR TITLE
fix: Support the usage of multiple = in environment variabales

### DIFF
--- a/cliv2/internal/cliv2/cliv2_test.go
+++ b/cliv2/internal/cliv2/cliv2_test.go
@@ -13,8 +13,8 @@ import (
 
 func Test_addIntegrationEnvironment_Fill(t *testing.T) {
 
-	input := []string{"something=1", "in=2", "here=3"}
-	expected := []string{"something=1", "in=2", "here=3", "SNYK_INTEGRATION_NAME=foo", "SNYK_INTEGRATION_VERSION=bar"}
+	input := []string{"something=1", "in=2", "here=3=2"}
+	expected := []string{"something=1", "in=2", "here=3=2", "SNYK_INTEGRATION_NAME=foo", "SNYK_INTEGRATION_VERSION=bar"}
 
 	actual, err := cliv2.AddIntegrationEnvironment(input, "foo", "bar")
 

--- a/cliv2/internal/utils/array.go
+++ b/cliv2/internal/utils/array.go
@@ -18,7 +18,7 @@ func ToKeyValueMap(input []string, splitBy string) map[string]string {
 	result := make(map[string]string)
 
 	for _, a := range input {
-		splittedString := strings.Split(a, splitBy)
+		splittedString := strings.SplitN(a, splitBy, 2)
 		if len(splittedString) == 2 {
 			key := splittedString[0]
 			value := splittedString[1]


### PR DESCRIPTION
Signed-off-by: Peter Schäfer <101886095+PeterSchafer@users.noreply.github.com>

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
It support environment variables of the format `key=value=morevalue`

