### PR TITLE
fix: add diagnostics to .Net manifest parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.28.2",
         "snyk-nodejs-lockfile-parser": "1.38.0",
-        "snyk-nuget-plugin": "1.23.4",
+        "snyk-nuget-plugin": "1.23.5",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.25.0",
         "snyk-python-plugin": "1.23.1",
@@ -16769,9 +16769,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-nuget-plugin": {
-      "version": "1.23.4",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.23.4.tgz",
-      "integrity": "sha512-7dGo8VP+kelwwQIENCDcPTZElHhIVcpbR6f4lNY7Hr49ehiGWZSAQir1/jjwj35HZchlYuNvfKJxDSeuXeaicQ==",
+      "version": "1.23.5",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.23.5.tgz",
+      "integrity": "sha512-PUcCo2fiGQmyprRj5+W22c9UINtQLiofhCjDSARTX186G28/xS4y8eiER5vq6JQ6NXQogTj2MF/QsnQ41R8FzA==",
       "dependencies": {
         "debug": "^4.1.1",
         "dotnet-deps-parser": "5.1.0",
@@ -32855,9 +32855,9 @@
       }
     },
     "snyk-nuget-plugin": {
-      "version": "1.23.4",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.23.4.tgz",
-      "integrity": "sha512-7dGo8VP+kelwwQIENCDcPTZElHhIVcpbR6f4lNY7Hr49ehiGWZSAQir1/jjwj35HZchlYuNvfKJxDSeuXeaicQ==",
+      "version": "1.23.5",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.23.5.tgz",
+      "integrity": "sha512-PUcCo2fiGQmyprRj5+W22c9UINtQLiofhCjDSARTX186G28/xS4y8eiER5vq6JQ6NXQogTj2MF/QsnQ41R8FzA==",
       "requires": {
         "debug": "^4.1.1",
         "dotnet-deps-parser": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.28.2",
     "snyk-nodejs-lockfile-parser": "1.38.0",
-    "snyk-nuget-plugin": "1.23.4",
+    "snyk-nuget-plugin": "1.23.5",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.25.0",
     "snyk-python-plugin": "1.23.1",


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Upgrades snyk-nuget-plugin version so it would contain more detailed error handling/diagnostics for an edge-case.

#### Any background context you want to provide?
For NuGet cache for .Net frameworks, the folder name should be in format of [package name].[semantic version]
Since it is pretty much framework internals, the code assumes it is always the case. This change adds some diagnostics & logging for cases where the NuGet cache folders do not adhere to such format
See https://github.com/snyk/snyk-nuget-plugin/pull/118 for more details
