### PR TITLE
feat: deprecation notice when user run `snyk iac report`

### DIFF
--- a/src/cli/commands/report/index.ts
+++ b/src/cli/commands/report/index.ts
@@ -1,7 +1,7 @@
 import { MethodArgs } from '../../args';
 import { IaCTestFlags } from '../test/iac/local-execution/types';
 import { TestCommandResult } from '../types';
-import test from '../test';
+import test from '../test/iac/';
 import { hasFeatureFlag } from '../../../lib/feature-flags';
 import { Options } from '../../../lib/types';
 import { UnsupportedFeatureFlagError } from '../../../lib/errors';
@@ -21,7 +21,7 @@ export default async function report(
 
   options.report = true;
 
-  return await test(...paths, options);
+  return await test(true, ...paths, options);
 }
 
 async function assertReportSupported(options: IaCTestFlags) {

--- a/src/cli/commands/test/iac/index.ts
+++ b/src/cli/commands/test/iac/index.ts
@@ -78,7 +78,11 @@ const SEPARATOR = '\n-------------------------------------------------------\n';
 
 // TODO: avoid using `as any` whenever it's possible
 
-export default async function(...args: MethodArgs): Promise<TestCommandResult> {
+// The hardcoded `isReportCommand` argument is temporary and will be removed together with the `snyk iac report` command deprecation
+export default async function(
+  isReportCommand: boolean,
+  ...args: MethodArgs
+): Promise<TestCommandResult> {
   const { options: originalOptions, paths } = processCommandArgs(...args);
 
   const options = setDefaultTestOptions(originalOptions);
@@ -378,7 +382,14 @@ export default async function(...args: MethodArgs): Promise<TestCommandResult> {
     response += spotlightVulnsMsg;
 
     if (isIacShareResultsOptions(options)) {
-      response += formatShareResultsOutput(iacOutputMeta!) + EOL;
+      response += formatShareResultsOutput(iacOutputMeta!) + EOL.repeat(2);
+      if (isReportCommand) {
+        response += chalk.red.bold(
+          'Warning:' +
+            EOL +
+            "We will be deprecating support for the 'snyk iac report' command by mid-June and 'snyk iac test --report' will become the default command for using our share results functionality.",
+        );
+      }
     }
 
     const error = new Error(response) as any;
@@ -400,7 +411,14 @@ export default async function(...args: MethodArgs): Promise<TestCommandResult> {
   );
 
   if (isIacShareResultsOptions(options)) {
-    response += formatShareResultsOutput(iacOutputMeta!) + EOL;
+    response += formatShareResultsOutput(iacOutputMeta!) + EOL.repeat(2);
+    if (isReportCommand) {
+      response += chalk.red.bold(
+        'Warning:' +
+          EOL +
+          "We will be deprecating support for the 'snyk iac report' command by mid-June and 'snyk iac test --report' will become the default command for using our share results functionality.",
+      );
+    }
   }
 
   return TestCommandResult.createHumanReadableTestCommandResult(

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -53,7 +53,7 @@ export default async function test(
   const { options: originalOptions, paths } = processCommandArgs(...args);
 
   if (originalOptions.iac) {
-    return await iacTestCommand(...args);
+    return await iacTestCommand(false, ...args);
   }
 
   const options = setDefaultTestOptions(originalOptions);

--- a/test/jest/acceptance/iac/report.spec.ts
+++ b/test/jest/acceptance/iac/report.spec.ts
@@ -1,5 +1,6 @@
 import { startMockServer } from './helpers';
 import { FakeServer } from '../../../acceptance/fake-server';
+import { EOL } from 'os';
 
 jest.setTimeout(50_000);
 
@@ -65,6 +66,15 @@ describe('iac report', () => {
           },
         ],
       }),
+    );
+  });
+
+  it('outputs a deprecation warning message', async () => {
+    const { stdout } = await run(`snyk iac report ./iac/arm/rule_test.json`);
+    expect(stdout).toContain(
+      'Warning:' +
+        EOL +
+        "We will be deprecating support for the 'snyk iac report' command by mid-June and 'snyk iac test --report' will become the default command for using our share results functionality.",
     );
   });
 

--- a/test/jest/unit/iac/report.spec.ts
+++ b/test/jest/unit/iac/report.spec.ts
@@ -1,5 +1,5 @@
 import * as featureFlags from '../../../../src/lib/feature-flags';
-import * as runTest from '../../../../src/cli/commands/test';
+import * as runTest from '../../../../src/cli/commands/test/iac';
 import report from '../../../../src/cli/commands/report';
 import { ArgsOptions } from '../../../../src/cli/args';
 import { UnsupportedFeatureFlagError } from '../../../../src/lib/errors';
@@ -36,6 +36,7 @@ describe('report', () => {
     // Assert
     expect(runTestSpy).toBeCalledTimes(1);
     expect(runTestSpy).toHaveBeenCalledWith(
+      true,
       fakePath,
       expect.objectContaining(iacTestOptions),
     );


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
We would like to remove the command `snyk iac report` in the least disruptive way, this PR adds a deprecation notice / warning when a user runs the command `snyk iac report` that let them know when are we planning to remove the command and which command and flag are replacing it.

#### How should this be manually tested?
1. Run `snyk iac report`
2. Check that the warning is being printed at the end of output
3. Run `snyk iac test --report`
4. Check that a warning is not being printed 

#### What are the relevant tickets?
https://snyksec.atlassian.net/jira/software/c/projects/CFG/boards/301?modal=detail&selectedIssue=CFG-1794

#### Screenshots
<img width="1267" alt="image" src="https://user-images.githubusercontent.com/71096571/166250798-d7bad8f3-fb46-4f81-8822-830ab0194e2d.png">
