### PR TITLE
chore: bump cloud config parser to v1.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "dependencies": {
         "@open-policy-agent/opa-wasm": "^1.6.0",
         "@snyk/cli-interface": "2.11.0",
-        "@snyk/cloud-config-parser": "^1.13.1",
+        "@snyk/cloud-config-parser": "^1.14.1",
         "@snyk/code-client": "^4.10.0",
         "@snyk/dep-graph": "^1.27.1",
         "@snyk/docker-registry-v2-client": "^2.6.1",
@@ -1917,9 +1917,9 @@
       }
     },
     "node_modules/@snyk/cloud-config-parser": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.13.1.tgz",
-      "integrity": "sha512-PWtcANOvL51qpVkHIG+6332Cb//xf8eQKOcje8vFfl0tAEkDuNXmoPrIeZfVs/+1GxIqtLSDSGCVd5GLfxumgw==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.14.1.tgz",
+      "integrity": "sha512-TPqhoOejqyDmMXQUZ3W4ih3+cpIRHohncvfjYUfjH6dSUxVUywUEL08MnyIJgHVAdupvh8Mn4ufEsu9RyrVS2g==",
       "dependencies": {
         "esprima": "^4.0.1",
         "peggy": "^1.2.0",
@@ -21211,9 +21211,9 @@
       }
     },
     "@snyk/cloud-config-parser": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.13.1.tgz",
-      "integrity": "sha512-PWtcANOvL51qpVkHIG+6332Cb//xf8eQKOcje8vFfl0tAEkDuNXmoPrIeZfVs/+1GxIqtLSDSGCVd5GLfxumgw==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.14.1.tgz",
+      "integrity": "sha512-TPqhoOejqyDmMXQUZ3W4ih3+cpIRHohncvfjYUfjH6dSUxVUywUEL08MnyIJgHVAdupvh8Mn4ufEsu9RyrVS2g==",
       "requires": {
         "esprima": "^4.0.1",
         "peggy": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@open-policy-agent/opa-wasm": "^1.6.0",
     "@snyk/cli-interface": "2.11.0",
-    "@snyk/cloud-config-parser": "^1.13.1",
+    "@snyk/cloud-config-parser": "^1.14.1",
     "@snyk/code-client": "^4.10.0",
     "@snyk/dep-graph": "^1.27.1",
     "@snyk/docker-registry-v2-client": "^2.6.1",


### PR DESCRIPTION
Bumps up the version of our cloud-config-parser: https://github.com/snyk/cloud-config-parser/pull/42

The new version of the cloud-config-parser returns -1 when an exact lineNumber could not be found and we returned the "closest" match instead.

Functionality wise, this should not be a breaking change for the CLI. It would just avoid the situation where we were returning "incorrect" lineNumbers.

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### How should this be manually tested?

Get a file that used to provide a wrong linenumber, eg https://github.com/snyk/snyk-iac-cloudformation/blob/main/billing-alerts.yml used to provide `2` in some issues when we could not find the exact path. Now it should return `-1` for json, or nothing for sarif

Run `snyk iac test billing-alerts.yml --json` 
Run `snyk iac test billing-alerts.yml --sarif` 

#### What are the relevant tickets?
relevant to:
https://snyksec.atlassian.net/browse/CFG-1781

#### Screenshots
--json now and before:

![image](https://user-images.githubusercontent.com/6989529/166424861-791a2798-de57-43c6-8ee9-3fd250bbd01c.png)

--sarif now and before:

![image](https://user-images.githubusercontent.com/6989529/166425114-34644ff9-8a75-4afc-a5ef-64e47a4a56ff.png)
