### PR TITLE
Fix analytics test to work with CLIv2

### DIFF
--- a/test/jest/acceptance/analytics.spec.ts
+++ b/test/jest/acceptance/analytics.spec.ts
@@ -4,18 +4,10 @@ import {
   createProjectFromWorkspace,
 } from '../util/createProject';
 import { runSnykCLI } from '../util/runSnykCLI';
-import { isCLIV2 } from '../util/isCLIV2';
 
 jest.setTimeout(1000 * 30);
 
 describe('analytics module', () => {
-  if (isCLIV2()) {
-    // eslint-disable-next-line jest/no-focused-tests
-    it.only('CLIv2 not yet supported', () => {
-      console.warn('Skipping test as CLIv2 does not support it yet.');
-    });
-  }
-
   let server;
   let env: Record<string, string>;
 
@@ -48,7 +40,7 @@ describe('analytics module', () => {
 
   it('sends analytics for `snyk test` with no vulns found', async () => {
     const project = await createProjectFromWorkspace('npm-package');
-    const { code } = await runSnykCLI('test', {
+    const { code } = await runSnykCLI('test --debug', {
       cwd: project.path(),
       env,
     });
@@ -298,7 +290,7 @@ describe('analytics module', () => {
 
   it('uses OAUTH token if set', async () => {
     const project = await createProjectFromWorkspace('npm-package');
-    const { code } = await runSnykCLI('version', {
+    const { code } = await runSnykCLI('test woof', {
       cwd: project.path(),
       env: {
         ...env,


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Fixes the test `test/jest/acceptance/analytics.spec.ts` - `uses OAUTH token if set` by making it use the `snyk woof` rather than `snyk version` because `snyk version` doesn't do analytics in CLIv2 (yet).
