### PR TITLE
Fix proxy behavior test to work with cliv2

### DIFF
--- a/test/jest/acceptance/proxy-behavior.spec.ts
+++ b/test/jest/acceptance/proxy-behavior.spec.ts
@@ -9,16 +9,9 @@ const FAKE_HTTP_PROXY = `http://localhost:${fakeServerPort}`;
 jest.setTimeout(1000 * 60 * 1);
 
 describe('Proxy configuration behavior', () => {
-  if (isCLIV2()) {
-    // eslint-disable-next-line jest/no-focused-tests
-    it.only('CLIv2 not yet supported', () => {
-      console.warn('Skipping test as CLIv2 does not support it yet.');
-    });
-  }
-
   describe('*_PROXY against HTTPS host', () => {
     it('tries to connect to the HTTPS_PROXY when HTTPS_PROXY is set', async () => {
-      const { code, stderr } = await runSnykCLI(`woof -d`, {
+      const { code, stderr } = await runSnykCLI(`woof --debug`, {
         env: {
           ...process.env,
           HTTPS_PROXY: FAKE_HTTP_PROXY,
@@ -29,9 +22,21 @@ describe('Proxy configuration behavior', () => {
       expect(code).toBe(0);
 
       // It will *attempt* to connect to a FAKE_HTTP_PROXY (and fails, because it's not a real proxy server)
-      expect(stderr).toContain(
-        `Error: connect ECONNREFUSED 127.0.0.1:${fakeServerPort}`,
+
+      // When running this test against a v2 artifact, we need to look for a message like:
+      //   - locally (darwin_amd64): `Cannot read TLS response from mitm'd server proxyconnect tcp: dial tcp 127.0.0.1:12345: connect: connection refused`
+      //   - on Windows in CirclCI: `Cannot read TLS response from mitm'd server proxyconnect tcp: dial tcp [::1]:12345: connectex: No connection could be made because the target machine actively refused it`
+      //   - on some other systems in CirclCI: `Cannot read TLS response from mitm'd server proxyconnect tcp: dial tcp [::1]:12345: connect: connection refused`
+      // Here is a regex that matches any of these scenarios:
+      const cliv2MessageRegex = new RegExp(
+        `Cannot read TLS response from mitm'd server proxyconnect tcp: dial tcp (127\\.0\\.0\\.1|\\[::1\\]):${fakeServerPort}: (connectex: No connection could be made|connect: connection refused)`,
       );
+      // When running this for v1, the message is more predictable:
+      // `Error: connect ECONNREFUSED 127.0.0.1:${fakeServerPort}`
+      const expectedMessageRegex = isCLIV2()
+        ? cliv2MessageRegex
+        : `Error: connect ECONNREFUSED 127.0.0.1:${fakeServerPort}`;
+      expect(stderr).toMatch(expectedMessageRegex);
     });
 
     it('does not try to connect to the HTTP_PROXY when it is set', async () => {


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Makes the `test/jest/acceptance/analytics.spec.ts` - `sends analytics for `snyk test` with no vulns found` test work with CLIv2. The error message is different in CLIv2 since it goes through the Go proxy.