### PR TITLE
iac describe: `--all` flag should show unmanaged, managed and drift

### DIFF
--- a/src/lib/iac/drift/driftctl.ts
+++ b/src/lib/iac/drift/driftctl.ts
@@ -148,7 +148,7 @@ const generateScanFlags = (
     args.push('--strict');
   }
 
-  if (options.deep) {
+  if (options.deep || options.all) {
     args.push('--deep');
   }
 

--- a/test/jest/acceptance/iac/describe.spec.ts
+++ b/test/jest/acceptance/iac/describe.spec.ts
@@ -96,7 +96,7 @@ describe('iac describe', () => {
     // First invocation of driftctl scan triggered by describe cmd
     expect(output).toContain('DCTL_IS_SNYK=true');
     expect(output).toContain(
-      `ARGS=scan --no-version-check --output json://stdout --config-dir ${paths.cache} --to aws+tf`,
+      `ARGS=scan --no-version-check --output json://stdout --deep --config-dir ${paths.cache} --to aws+tf`,
     );
 
     // no second invocation with console output
@@ -129,7 +129,7 @@ describe('iac describe', () => {
     // First invocation of driftctl scan triggered by describe cmd
     expect(output).toContain('DCTL_IS_SNYK=true');
     expect(output).toContain(
-      `ARGS=scan --no-version-check --output json://stdout --config-dir ${paths.cache} --to aws+tf`,
+      `ARGS=scan --no-version-check --output json://stdout --deep --config-dir ${paths.cache} --to aws+tf`,
     );
 
     // Second invocation of driftctl fmt triggered by describe cmd
@@ -180,7 +180,7 @@ describe('iac describe', () => {
       // First invocation of driftctl scan triggered by describe cmd
       expect(output).toContain('DCTL_IS_SNYK=true');
       expect(output).toContain(
-        `ARGS=scan --no-version-check --output json://stdout --config-dir ${paths.cache} --to aws+tf`,
+        `ARGS=scan --no-version-check --output json://stdout --deep --config-dir ${paths.cache} --to aws+tf`,
       );
 
       // Second invocation of driftctl fmt triggered by describe cmd

--- a/test/jest/unit/lib/iac/drift.spec.ts
+++ b/test/jest/unit/lib/iac/drift.spec.ts
@@ -52,6 +52,44 @@ describe('driftctl integration', () => {
     ]);
   });
 
+  it('describe: --all enable deep mode', () => {
+    {
+      const args = generateArgs(
+        { kind: 'describe', all: true } as DescribeOptions,
+        [],
+      );
+      expect(args).toEqual([
+        'scan',
+        '--no-version-check',
+        '--output',
+        'json://stdout',
+        '--deep',
+        '--config-dir',
+        paths.cache,
+        '--to',
+        'aws+tf',
+      ]);
+    }
+
+    {
+      const args = generateArgs(
+        { kind: 'describe', all: true, deep: true } as DescribeOptions,
+        [],
+      );
+      expect(args).toEqual([
+        'scan',
+        '--no-version-check',
+        '--output',
+        'json://stdout',
+        '--deep',
+        '--config-dir',
+        paths.cache,
+        '--to',
+        'aws+tf',
+      ]);
+    }
+  });
+
   it('describe: passing options generate correct arguments', () => {
     const args = generateArgs(
       {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR simply inject the `--deep` flag to driftctl if we use `iac describe --all`

#### Where should the reviewer start?

`src/lib/iac/drift/driftctl.ts`

#### How should this be manually tested?

`snyk iac describe --all`

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/CFG-1812