### PR TITLE
fix: cliv2 unsupported combination version + —json-file-output

### DIFF
--- a/cliv2/internal/cliv2/cliv2.go
+++ b/cliv2/internal/cliv2/cliv2.go
@@ -114,6 +114,16 @@ func (c *CLI) printVersion() {
 	fmt.Println(c.GetFullVersion())
 }
 
+func (c *CLI) commandVersion(passthroughArgs []string) int {
+	if utils.Contains(passthroughArgs, "--json-file-output") {
+		fmt.Println("The following option combination is not currently supported: version + json-file-output")
+		return SNYK_EXIT_CODE_ERROR
+	} else {
+		c.printVersion()
+		return SNYK_EXIT_CODE_OK
+	}
+}
+
 func determineHandler(passthroughArgs []string) Handler {
 	result := V1_DEFAULT
 
@@ -205,7 +215,7 @@ func (c *CLI) Execute(wrapperProxyPort int, fullPathToCert string, passthroughAr
 
 	switch {
 	case handler == V2_VERSION:
-		c.printVersion()
+		returnCode = c.commandVersion(passthroughArgs)
 	default:
 		returnCode = c.executeV1Default(wrapperProxyPort, fullPathToCert, passthroughArgs)
 	}

--- a/test/jest/acceptance/cli-args.spec.ts
+++ b/test/jest/acceptance/cli-args.spec.ts
@@ -3,7 +3,6 @@ import { UnsupportedOptionCombinationError } from '../../../src/lib/errors/unsup
 import { runSnykCLI } from '../util/runSnykCLI';
 import { fakeServer } from '../../acceptance/fake-server';
 import { createProject } from '../util/createProject';
-import { isCLIV2 } from '../util/isCLIV2';
 
 const isWindows =
   require('os-name')()
@@ -13,13 +12,6 @@ const isWindows =
 jest.setTimeout(1000 * 60 * 5);
 
 describe('cli args', () => {
-  if (isCLIV2()) {
-    // eslint-disable-next-line jest/no-focused-tests
-    it.only('CLIv2 not yet supported', () => {
-      console.warn('Skipping test as CLIv2 does not support it yet.');
-    });
-  }
-
   let server;
   let env: Record<string, string>;
 


### PR DESCRIPTION
* re-enable disabled test for cliv2

Signed-off-by: Peter Schäfer <101886095+PeterSchafer@users.noreply.github.com>

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Mimic cliv1 behaviour in cliv2 for unsupported command options 

#### How should this be manually tested?
Execute the snyk cliv2 with the parameter `version —json-file-output`
