### PR TITLE
chore: Added an invalid files count to the test summary section [CFG-1787]

### DIFF
--- a/src/cli/commands/test/iac/index.ts
+++ b/src/cli/commands/test/iac/index.ts
@@ -319,6 +319,7 @@ export default async function(
     const iacTestSummary = `${formatIacTestSummary(
       {
         results,
+        failures: iacScanFailures,
         ignoreCount: iacIgnoredIssuesCount,
       },
       iacOutputMeta,

--- a/src/lib/formatters/iac-output/v2/test-summary.ts
+++ b/src/lib/formatters/iac-output/v2/test-summary.ts
@@ -60,6 +60,12 @@ function formatCountsSection(testData: IacTestData): string {
   );
 
   countsSectionProperties.push(
+    `${INDENT}Invalid files: ${colors.info.bold(
+      `${testData.failures?.length ?? 0}`,
+    )}`,
+  );
+
+  countsSectionProperties.push(
     `${INDENT}Ignored issues: ${colors.info.bold(`${testData.ignoreCount}`)}`,
   );
 

--- a/src/lib/formatters/iac-output/v2/types.ts
+++ b/src/lib/formatters/iac-output/v2/types.ts
@@ -1,6 +1,8 @@
 import { IacTestResponse } from '../../../snyk-test/iac-test-result';
+import { IacFileInDirectory } from '../../../types';
 
 export interface IacTestData {
   ignoreCount: number;
   results: IacTestResponse[];
+  failures?: IacFileInDirectory[];
 }

--- a/test/jest/acceptance/iac/iac-output.spec.ts
+++ b/test/jest/acceptance/iac/iac-output.spec.ts
@@ -83,9 +83,11 @@ describe('iac test output', () => {
           EOL +
           '✗ Files with issues: 3' +
           EOL +
+          '  Invalid files: 1' +
+          EOL +
           '  Ignored issues: 8' +
           EOL +
-          '  Total issues: 28 [ 0 critical, 4 high, 8 medium, 16 low ]',
+          '  Total issues: ',
       );
     });
 

--- a/test/jest/unit/iac/process-results/fixtures/scan-failures.json
+++ b/test/jest/unit/iac/process-results/fixtures/scan-failures.json
@@ -1,0 +1,12 @@
+[
+    {
+        "filePath": "test/fixtures/iac/terraform/sg_open_ssh_invalid_go_templates.tf",
+        "fileType": "tf",
+        "failureReason": "Failed to parse Terraform file"
+    },
+    {
+        "filePath": "test/fixtures/iac/terraform/sg_open_ssh_invalid_hcl2.tf",
+        "fileType": "tf",
+        "failureReason": "Failed to parse Terraform file"
+    }
+]

--- a/test/jest/unit/lib/formatters/iac-output/v2/test-summary.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/test-summary.spec.ts
@@ -4,9 +4,11 @@ import * as pathLib from 'path';
 import { formatIacTestSummary } from '../../../../../../../src/lib/formatters/iac-output';
 import { colors } from '../../../../../../../src/lib/formatters/iac-output/v2/color-utils';
 import { IacTestResponse } from '../../../../../../../src/lib/snyk-test/iac-test-result';
+import { IacFileInDirectory } from '../../../../../../../src/lib/types';
 
 describe('formatIacTestSummary', () => {
   let resultFixtures: IacTestResponse[];
+  let scanFailureFixtures: IacFileInDirectory[];
 
   beforeAll(async () => {
     resultFixtures = JSON.parse(
@@ -25,6 +27,23 @@ describe('formatIacTestSummary', () => {
         'utf8',
       ),
     );
+
+    scanFailureFixtures = JSON.parse(
+      fs.readFileSync(
+        pathLib.join(
+          __dirname,
+          '..',
+          '..',
+          '..',
+          '..',
+          'iac',
+          'process-results',
+          'fixtures',
+          'scan-failures.json',
+        ),
+        'utf8',
+      ),
+    );
   });
 
   it("should include the 'Test Summary' title", () => {
@@ -35,26 +54,14 @@ describe('formatIacTestSummary', () => {
 
     // Act
     const result = formatIacTestSummary(
-      { ignoreCount, results: resultFixtures as any },
+      { ignoreCount, results: resultFixtures },
       { orgName, projectName },
     );
 
     // Assert
-    expect(result).toContain(
-      `${colors.info.bold('Test Summary')}
-
-  Organization: ${orgName}
-
-${colors.success.bold('✔')} Files without issues: ${colors.info.bold('0')}
-${colors.failure.bold('✗')} Files with issues: ${colors.info.bold('3')}
-  Ignored issues: ${colors.info.bold(`${ignoreCount}`)}
-  Total issues: ${colors.info.bold('22')} [ ${colors.severities.critical(
-        '0 critical',
-      )}, ${colors.severities.high('5 high')}, ${colors.severities.medium(
-        '4 medium',
-      )}, ${colors.severities.low('13 low')} ]`,
-    );
+    expect(result).toContain(`${colors.info.bold('Test Summary')}`);
   });
+
   it('should include the test meta properties section with the correct values', () => {
     // Arrange
     const orgName = 'test-org-name';
@@ -63,12 +70,12 @@ ${colors.failure.bold('✗')} Files with issues: ${colors.info.bold('3')}
 
     // Act
     const result = formatIacTestSummary(
-      { ignoreCount, results: resultFixtures as any },
+      { ignoreCount, results: resultFixtures },
       { orgName, projectName },
     );
 
     // Assert
-    expect(result).toContain(`${colors.info.bold('Test Summary')}`);
+    expect(result).toContain(`Organization: ${orgName}`);
   });
 
   it('should include the counts section with the correct values', () => {
@@ -79,7 +86,7 @@ ${colors.failure.bold('✗')} Files with issues: ${colors.info.bold('3')}
 
     // Act
     const result = formatIacTestSummary(
-      { ignoreCount, results: resultFixtures as any },
+      { ignoreCount, results: resultFixtures, failures: scanFailureFixtures },
       { orgName, projectName },
     );
 
@@ -89,6 +96,7 @@ ${colors.failure.bold('✗')} Files with issues: ${colors.info.bold('3')}
         '0',
       )}
 ${colors.failure.bold('✗')} Files with issues: ${colors.info.bold('3')}
+  Invalid files: ${colors.info.bold(`${scanFailureFixtures.length}`)}
   Ignored issues: ${colors.info.bold(`${ignoreCount}`)}
   Total issues: ${colors.info.bold('22')} [ ${colors.severities.critical(
         '0 critical',
@@ -96,5 +104,23 @@ ${colors.failure.bold('✗')} Files with issues: ${colors.info.bold('3')}
         '4 medium',
       )}, ${colors.severities.low('13 low')} ]`,
     );
+  });
+
+  describe('when a failures list is not provided', () => {
+    it('should indicate 0 invalid files', () => {
+      // Arrange
+      const orgName = 'test-org-name';
+      const projectName = 'test-project-name';
+      const ignoreCount = 3;
+
+      // Act
+      const result = formatIacTestSummary(
+        { ignoreCount, results: resultFixtures },
+        { orgName, projectName },
+      );
+
+      // Assert
+      expect(result).toContain(`Invalid files: ${colors.info.bold('0')}`);
+    });
   });
 });


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Adds the invalid files count to the test summary section, to increase its visibility. This change is based on this design.

#### Where should the reviewer start?

    src/lib/formatters/iac-output/v2/test-summary.ts


#### How should this be manually tested?

- Test a directory with any number of invalid files (including none), and ensure that the correct number of invalid files appears in the test summary section.

#### Any background context you want to provide?

In [the new test output design](https://www.figma.com/file/buNFZqr1Uhf4SaifHw4WXE/CLI-IaC-Output-Improvements?node-id=0%3A1), we are currently not displaying the number of files that failed to be tested in the test summary section, but it's included in the title for the test failures section.
We would like to add it to the test summary section as well, to increase visibility.


#### What are the relevant tickets?

- [CFG-1787](https://snyksec.atlassian.net/browse/CFG-1787)

#### Screenshots

![image](https://user-images.githubusercontent.com/46415136/166938881-e13d8dc2-d534-440f-bcf5-a139ff24a4ff.png)