### PR TITLE
feat: update code client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@open-policy-agent/opa-wasm": "^1.6.0",
         "@snyk/cli-interface": "2.11.0",
         "@snyk/cloud-config-parser": "^1.14.1",
-        "@snyk/code-client": "^4.11.0",
+        "@snyk/code-client": "^4.11.1",
         "@snyk/dep-graph": "^1.27.1",
         "@snyk/docker-registry-v2-client": "^2.6.1",
         "@snyk/fix": "file:packages/snyk-fix",
@@ -1946,9 +1946,9 @@
       }
     },
     "node_modules/@snyk/code-client": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.11.0.tgz",
-      "integrity": "sha512-fIRC9C5gR63q5UFIEhs13YIVTA3HZnqmVThKfuqSl0w+HSKBeavxPcHTFyoK8tnMxm5lqDknYDvw0BhbxyrGnQ==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.11.1.tgz",
+      "integrity": "sha512-DwRPljCxT+EKPREXW5IUvZBFz+lluDFzbReUnUPwnQA55GwOb4csJzFlxri9gn+p10H7GPLfoFDTiwhE7iyJBg==",
       "dependencies": {
         "@deepcode/dcignore": "^1.0.4",
         "@snyk/fast-glob": "^3.2.6-patch",
@@ -21234,9 +21234,9 @@
       }
     },
     "@snyk/code-client": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.11.0.tgz",
-      "integrity": "sha512-fIRC9C5gR63q5UFIEhs13YIVTA3HZnqmVThKfuqSl0w+HSKBeavxPcHTFyoK8tnMxm5lqDknYDvw0BhbxyrGnQ==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.11.1.tgz",
+      "integrity": "sha512-DwRPljCxT+EKPREXW5IUvZBFz+lluDFzbReUnUPwnQA55GwOb4csJzFlxri9gn+p10H7GPLfoFDTiwhE7iyJBg==",
       "requires": {
         "@deepcode/dcignore": "^1.0.4",
         "@snyk/fast-glob": "^3.2.6-patch",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@open-policy-agent/opa-wasm": "^1.6.0",
     "@snyk/cli-interface": "2.11.0",
     "@snyk/cloud-config-parser": "^1.14.1",
-    "@snyk/code-client": "^4.11.0",
+    "@snyk/code-client": "^4.11.1",
     "@snyk/dep-graph": "^1.27.1",
     "@snyk/docker-registry-v2-client": "^2.6.1",
     "@snyk/fix": "file:packages/snyk-fix",


### PR DESCRIPTION
Updates the code client to the latest version.

This update means Code-client will now retry on 500 failures when making downstream calls. 

Code-client change [here](https://github.com/snyk/code-client/pull/145) 