### PR TITLE
chore(ci): add linter to v2 pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,6 +527,20 @@ jobs:
   #
   # Snyk CLI v2 Jobs
   #
+  v2-lint:
+    executor: linux
+    working_directory: /home/circleci/snyk
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - go/install:
+          version: << pipeline.parameters.go_version >>
+      - run:
+          name: Lint
+          working_directory: ./cliv2
+          command: make lint
+
   v2-build-artifacts:
     executor: linux
     working_directory: /home/circleci/snyk
@@ -823,6 +837,13 @@ workflows:
       #
       # Snyk CLI v2 Workflow Jobs
       #
+      - v2-lint:
+          name: v2 / Lint
+          filters:
+            branches:
+              only:
+                - /^.*v2.*$/
+                - master
       - v2-build-artifacts:
           name: v2 / Build Artifacts
           requires:

--- a/cliv2/Makefile
+++ b/cliv2/Makefile
@@ -171,6 +171,14 @@ whiteboxtest:
 .PHONY: test
 test: whiteboxtest blackboxtest
 
+.PHONY: lint
+lint:
+	./scripts/lint.sh
+
+.PHONY: format
+format:
+	gofmt -w -l -e .
+
 .PHONY: $(SIGN_SCRIPT)
 $(SIGN_SCRIPT): 
 	@echo "$(LOG_PREFIX) Running $(SIGN_SCRIPT) ( $(BUILD_DIR) )"
@@ -213,6 +221,8 @@ install:
 .PHONY: help
 help:
 	@echo "Main targets:"
+	@echo "$(LOG_PREFIX) lint"
+	@echo "$(LOG_PREFIX) format"
 	@echo "$(LOG_PREFIX) build"
 	@echo "$(LOG_PREFIX) sign"
 	@echo "$(LOG_PREFIX) build-test"

--- a/cliv2/internal/certs/certs.go
+++ b/cliv2/internal/certs/certs.go
@@ -34,9 +34,9 @@ func MakeSelfSignedCert(certName string, dnsNames []string, debugLogger *log.Log
 			x509.KeyUsageKeyAgreement |
 			x509.KeyUsageCertSign, // needed for sure
 
-		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
-		IsCA: true,
+		IsCA:                  true,
 	}
 
 	for _, dnsName := range dnsNames {

--- a/cliv2/scripts/lint.sh
+++ b/cliv2/scripts/lint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running gofmt"
+
+# gofmt does not fail if issues are found so check if unformatted files are listed
+GOFMT_RESULT="$(gofmt -l -e .)"
+if test -n "${GOFMT_RESULT}"; then
+  echo "${GOFMT_RESULT}"
+  echo "Formatting issues found. Run 'make format' to fix them.";
+  exit 1;
+fi
+echo "No formatting issues found."


### PR DESCRIPTION
Adding linter step to ensure we are following gofmt formatting and avoid misalignment across commit diffs.

gofmt does not fail on unformatted files so I added a wrapper script to do so.