### PR TITLE
test(v2): upstreamProxy no longer defined

### DIFF
--- a/cliv2/cmd/cliv2/main_test.go
+++ b/cliv2/cmd/cliv2/main_test.go
@@ -8,12 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_getEnvVariables(t *testing.T) {
-	upstreamProxy := ""
+func Test_MainWithErrorCode(t *testing.T) {
 	cacheDirectory := ""
 
 	variables := main.EnvironmentVariables{
-		UpstreamProxy: upstreamProxy,
 		CacheDirectory: cacheDirectory,
 	}
 
@@ -21,30 +19,15 @@ func Test_getEnvVariables(t *testing.T) {
 	assert.Equal(t, err, 0)
 }
 
-func Test_getEnvVariables_no_proxy (t *testing.T) {
-	upstreamProxy := "MADE_UP_NAME"
-	cacheDirectory := ""
-
-	variables := main.EnvironmentVariables{
-		UpstreamProxy: upstreamProxy,
-		CacheDirectory: cacheDirectory,
-	}
-
-	err := main.MainWithErrorCode(variables, os.Args[1:])
-	assert.Equal(t, err, 2)
-}
-
-func Test_getEnvVariables_no_cache(t *testing.T) {
-	upstreamProxy := ""
+func Test_MainWithErrorCode_no_cache(t *testing.T) {
 	cacheDirectory := "MADE_UP_NAME"
 
 	variables := main.EnvironmentVariables{
-		UpstreamProxy: upstreamProxy,
 		CacheDirectory: cacheDirectory,
 	}
 
 	mainErr := main.MainWithErrorCode(variables, os.Args[1:])
-	
+
 	assert.Equal(t, mainErr, 0)
 	assert.DirExists(t, cacheDirectory)
 }

--- a/cliv2/internal/proxy/proxy_test.go
+++ b/cliv2/internal/proxy/proxy_test.go
@@ -19,7 +19,7 @@ import (
 func Test_closingProxyDeletesTempCert(t *testing.T) {
 	debugLogger := log.New(os.Stderr, "", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile)
 
-	wp, err := proxy.NewWrapperProxy("", "", "", debugLogger)
+	wp, err := proxy.NewWrapperProxy(false, "", "", debugLogger)
 	assert.Nil(t, err)
 
 	port, err := wp.Start()
@@ -36,7 +36,7 @@ func Test_closingProxyDeletesTempCert(t *testing.T) {
 func Test_canGoThroughProxy(t *testing.T) {
 	debugLogger := log.New(os.Stderr, "", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile)
 
-	wp, err := proxy.NewWrapperProxy("", "", "", debugLogger)
+	wp, err := proxy.NewWrapperProxy(false, "", "", debugLogger)
 	assert.Nil(t, err)
 
 	port, err := wp.Start()
@@ -82,7 +82,7 @@ func Test_xSnykCliVersionHeaderIsReplaced(t *testing.T) {
 	debugLogger := log.New(os.Stderr, "", log.Ldate|log.Ltime|log.Lmicroseconds|log.Lshortfile)
 
 	expectedVersion := "the-cli-version"
-	wp, err := proxy.NewWrapperProxy("", "", expectedVersion, debugLogger)
+	wp, err := proxy.NewWrapperProxy(false, "", expectedVersion, debugLogger)
 	assert.Nil(t, err)
 
 	port, err := wp.Start()


### PR DESCRIPTION
Should have been removed in #3184 but tests weren't running.