### PR TITLE
test: Fix tests depending on the name of the cloned repository

### DIFF
--- a/test/jest/unit/iac/process-results/share-results-formatters.fixtures.ts
+++ b/test/jest/unit/iac/process-results/share-results-formatters.fixtures.ts
@@ -1,12 +1,17 @@
+import * as path from 'path';
 import {
   anotherPolicyStub,
   policyStub,
   yetAnotherPolicyStub,
 } from '../results-formatter.fixtures';
 
+const projectDirectoryName = path.basename(
+  path.resolve(__dirname, '..', '..', '..', '..', '..'),
+);
+
 export const expectedFormattedResultsForShareResults = [
   {
-    projectName: 'snyk',
+    projectName: projectDirectoryName,
     targetFile: 'dont-care.yaml',
     filePath: 'dont-care.yaml',
     fileType: 'yaml',

--- a/test/jest/unit/iac/results-formatter.fixtures.ts
+++ b/test/jest/unit/iac/results-formatter.fixtures.ts
@@ -9,6 +9,10 @@ import { IacProjectType } from '../../../../src/lib/iac/constants';
 import { SEVERITY } from '../../../../src/lib/snyk-test/common';
 import { AnnotatedIacIssue } from '../../../../src/lib/snyk-test/iac-test-result';
 
+const projectDirectoryName = path.basename(
+  path.resolve(__dirname, '..', '..', '..', '..'),
+);
+
 // TODO this file should be in the process-results directory. Moving this file,
 // though, will affect the test suite format-test-meta.spec.ts, which references
 // it. This file has been left here in order to avoid a complex review with
@@ -157,7 +161,7 @@ function generateFormattedResults(options) {
     dependencyCount: 0,
     ignoreSettings: null,
     licensesPolicy: null,
-    projectName: 'snyk',
+    projectName: projectDirectoryName,
     meta: {
       ...meta,
       policy: '',

--- a/test/jest/unit/lib/commands/fix/get-display-path.spec.ts
+++ b/test/jest/unit/lib/commands/fix/get-display-path.spec.ts
@@ -1,6 +1,10 @@
 import * as pathLib from 'path';
 import { getDisplayPath } from '../../../../../../src/cli/commands/fix/get-display-path';
 
+const projectDirectoryName = pathLib.basename(
+  pathLib.resolve(__dirname, '..', '..', '..', '..', '..', '..'),
+);
+
 describe('getDisplayPath', () => {
   it('paths that do not exist on disk returned as is', () => {
     const displayPath = getDisplayPath('semver@2.3.1');
@@ -8,7 +12,7 @@ describe('getDisplayPath', () => {
   });
   it('current path is displayed as .', () => {
     const displayPath = getDisplayPath(process.cwd());
-    expect(displayPath).toEqual('snyk');
+    expect(displayPath).toEqual(projectDirectoryName);
   });
   it('a local path is returned as relative path to current dir', () => {
     const displayPath = getDisplayPath(`test${pathLib.sep}fixtures`);


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR fixes some unit tests whose behaviour depend on the name of the clone of this repository. These tests always pass on CI because we always clone this repository in a `snyk` directory, but may fail locally if the project is cloned in a directory of a different name.

#### Where should the reviewer start?

You can review this PR test by test, and ignore the tests that don't belong to you.

#### How should this be manually tested?

Clone this repository in a directory that is not named `snyk` and run all the unit tests with `npm run test:unit`.