### PR TITLE
fix: SARIF output for IaC

### DIFF
--- a/src/lib/formatters/iac-output/v1/index.ts
+++ b/src/lib/formatters/iac-output/v1/index.ts
@@ -144,7 +144,7 @@ export function createSarifOutputForIac(
   try {
     repoRoot = getRepoRoot();
   } catch {
-    repoRoot = basePath;
+    repoRoot = pathLib.join(basePath, '/'); // the slash at the end is required, otherwise the artifactLocation.uri starts with a slash
   }
   const issues = iacTestResponses.reduce((collect: ResponseIssues, res) => {
     if (res.result) {

--- a/src/lib/formatters/iac-output/v1/index.ts
+++ b/src/lib/formatters/iac-output/v1/index.ts
@@ -5,7 +5,6 @@ import * as pathLib from 'path';
 import { pathToFileURL } from 'url';
 import upperFirst = require('lodash.upperfirst');
 import camelCase = require('lodash.camelcase');
-import { execSync } from 'child_process';
 
 import {
   IacTestResponse,
@@ -21,6 +20,7 @@ import { getSeverityValue } from '../../get-severity-value';
 import { getIssueLevel } from '../../sarif-output';
 import { getVersion } from '../../../version';
 import config from '../../../config';
+import { getRepoRoot } from './utils';
 const debug = Debug('iac-output');
 
 function formatIacIssue(
@@ -140,7 +140,12 @@ export function createSarifOutputForIac(
   const basePath = isLocalFolder(iacTestResponses[0].path)
     ? pathLib.resolve('.', iacTestResponses[0].path)
     : pathLib.resolve('.');
-  const repoRoot = getRepoRoot(basePath);
+  let repoRoot: string;
+  try {
+    repoRoot = getRepoRoot();
+  } catch {
+    repoRoot = basePath;
+  }
   const issues = iacTestResponses.reduce((collect: ResponseIssues, res) => {
     if (res.result) {
       // targetFile is the computed relative path of the scanned file
@@ -295,19 +300,6 @@ export function mapIacTestResponseToSarifResults(
       ],
     };
   });
-}
-
-function getRepoRoot(basePath: string) {
-  try {
-    const cwd = process.cwd();
-    const stdout = execSync('git rev-parse --show-toplevel', {
-      encoding: 'utf8',
-      cwd,
-    });
-    return stdout.trim() + '/';
-  } catch {
-    return basePath;
-  }
 }
 
 function getPathRelativeToRepoRoot(

--- a/src/lib/formatters/iac-output/v1/utils.ts
+++ b/src/lib/formatters/iac-output/v1/utils.ts
@@ -1,0 +1,10 @@
+import { execSync } from 'child_process';
+
+export function getRepoRoot() {
+  const cwd = process.cwd();
+  const stdout = execSync('git rev-parse --show-toplevel', {
+    encoding: 'utf8',
+    cwd,
+  });
+  return stdout.trim() + '/';
+}


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This PR fixes a problem in the GitHub action where the incorrect `PROJECTROOT` is computed (without a `/` at the end) when there is no `git` command.

#### Where should the reviewer start?
The commits show how the code was refactored so it's easier to test, a test added to make sure we don't re-introduce this regression, and the actual fix.

#### How should this be manually tested?
It's hard to test manually because we all have `git` and we don't want to delete it just for this use case. Can see the failure here though: https://github.com/teodora-sandu/terraform-lambda-api-gateway/runs/6322494869?check_suite_focus=true

#### Any background context you want to provide?
In https://github.com/snyk/cli/commit/30746efb0cc9b3dc5d466af5603af9abf76e59a2 we can see the regression. The reason we didn't catch it is because the GitHub action acceptance tests in https://github.com/snyk/snyk/blob/0447fcd47b6e2e6d3850a26a3c6b584a1851d510/test/jest/acceptance/iac/github-action/iac.spec.ts would use `git` and so never run into this path. 

#### What are the relevant tickets?
Slack thread: https://snyk.slack.com/archives/CRV0PMFDH/p1651699191381929

