### PR TITLE
fix: Ensure that IaC shared results paths use forward slashes

### DIFF
--- a/src/cli/commands/test/iac/local-execution/process-results/share-results-formatter.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/share-results-formatter.ts
@@ -46,11 +46,12 @@ function computePaths(
   const currentDirectoryName = path.basename(currentDirectory);
   const absoluteFilePath = path.resolve(filePath);
   const relativeFilePath = path.relative(currentDirectory, absoluteFilePath);
+  const unixRelativeFilePath = relativeFilePath.split(path.sep).join('/');
 
   return {
     targetFilePath: absoluteFilePath,
     projectName: currentDirectoryName,
-    targetFile: relativeFilePath,
+    targetFile: unixRelativeFilePath,
   };
 }
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR ensures that the paths generated during an IaC scan and shared with the app always use forward slashes, independently of the platform where `snyk` runs.

#### How should this be manually tested?

Run `snyk iac test --report` on Windows and verify that the results are correctly shared with the app and use forward slashes.