### PR TITLE
chore: Update test error message color [CFG-1385]

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -46,6 +46,7 @@ import { SarifFileOutputEmptyError } from '../lib/errors/empty-sarif-output-erro
 import { InvalidDetectionDepthValue } from '../lib/errors/invalid-detection-depth-value';
 import { obfuscateArgs } from '../lib/utils';
 import { EXIT_CODES } from './exit-codes';
+import { hasFeatureFlag } from '../lib/feature-flags';
 
 const debug = Debug('snyk');
 
@@ -121,7 +122,11 @@ async function handleError(args, error) {
     console.log(output);
   } else {
     if (!args.options.quiet) {
-      const result = errors.message(error);
+      const shouldUseNewIacOutput =
+        args.options.iac &&
+        (await hasFeatureFlag('iacCliOutput', args.options));
+
+      const result = errors.message(error, shouldUseNewIacOutput);
       if (args.options.copy) {
         copy(result);
         console.log('Result copied to clipboard');

--- a/src/lib/errors/legacy-errors.js
+++ b/src/lib/errors/legacy-errors.js
@@ -3,6 +3,9 @@ const chalk = require('chalk');
 const { SEVERITIES } = require('../snyk-test/common');
 const { errorMessageWithRetry } = require('./error-with-retry');
 const analytics = require('../analytics');
+const {
+  colors: iacOutputColors,
+} = require('../formatters/iac-output/v2/color-utils');
 
 const errors = {
   connect: 'Check your network connection, failed to connect to Snyk API',
@@ -71,7 +74,7 @@ module.exports = function error(command) {
   return Promise.reject(e);
 };
 
-module.exports.message = function(error) {
+module.exports.message = function(error, shouldUseNewIacOutput) {
   let message = error; // defaults to a string (which is super unlikely)
   if (error instanceof Error) {
     if (error.code === 'VULNS') {
@@ -87,7 +90,9 @@ module.exports.message = function(error) {
       errors[error.code || error.message];
     if (message) {
       message = message.replace(/(%s)/g, error.message).trim();
-      message = chalk.bold.red(message);
+      message = shouldUseNewIacOutput
+        ? iacOutputColors.failure.bold(message)
+        : chalk.bold.red(message);
     } else if (error.code) {
       // means it's a code error
       message =


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Adjusts the color for test failure messages to the new IaC output color scheme.

#### Where should the reviewer start?
    src/lib/errors/legacy-errors.js


#### How should this be manually tested?

- Execute the `snyk iac test` command in a way that'd make it fail, such as testing a non-existing path, or scanning a path with no supported IaC files.

#### Any background context you want to provide?

Currently in the new output, whenever a test flow fails, an output with only the error message is produced. This error message has the original shade of red used for errors/failures in the previous test output format. In the new test output format, we’ve defined a new shade of red which we would like to apply here as well.

#### What are the relevant tickets?

- [CFG-1835](https://snyksec.atlassian.net/browse/CFG-1835)


#### Screenshots

![Screen Shot 2022-05-09 at 18 15 23](https://user-images.githubusercontent.com/46415136/167441426-dd0cb8c7-3359-4f5d-abec-8da12734d556.png)