### PR TITLE
fix: git targets for variadic paths

### DIFF
--- a/src/cli/commands/test/iac/local-execution/index.ts
+++ b/src/cli/commands/test/iac/local-execution/index.ts
@@ -121,6 +121,7 @@ export async function test(
     tags,
     attributes,
     options,
+    pathToScan,
   );
 
   try {

--- a/src/cli/commands/test/iac/local-execution/process-results/index.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/index.ts
@@ -18,6 +18,7 @@ export async function processResults(
   tags: Tag[] | undefined,
   attributes: ProjectAttributes | undefined,
   options: IaCTestFlags,
+  pathToScan: string,
 ): Promise<{
   filteredIssues: FormattedResult[];
   ignoreCount: number;
@@ -33,6 +34,7 @@ export async function processResults(
       policy,
       tags,
       attributes,
+      pathToScan,
     }));
   }
 

--- a/src/cli/commands/test/iac/local-execution/process-results/share-results-formatter.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/share-results-formatter.ts
@@ -1,6 +1,9 @@
 import { IacFileScanResult, IacShareResultsFormat } from '../types';
 import * as path from 'path';
-import { getRepositoryRootForPath } from '../../../../../../lib/iac/git';
+import {
+  getRepositoryRootForPath,
+  getWorkingDirectoryForPath,
+} from '../../../../../../lib/iac/git';
 
 export function formatShareResults(
   scanResults: IacFileScanResult[],
@@ -59,6 +62,6 @@ function getGitRootOrCwd(currentPath: string): string {
   try {
     return getRepositoryRootForPath(currentPath);
   } catch (e) {
-    return process.cwd();
+    return getWorkingDirectoryForPath(currentPath);
   }
 }

--- a/src/cli/commands/test/iac/local-execution/process-results/share-results.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/share-results.ts
@@ -13,6 +13,7 @@ export async function formatAndShareResults({
   policy,
   tags,
   attributes,
+  pathToScan,
 }: {
   results: IacFileScanResult[];
   options: IaCTestFlags;
@@ -20,6 +21,7 @@ export async function formatAndShareResults({
   policy: Policy | undefined;
   tags?: Tag[];
   attributes?: ProjectAttributes;
+  pathToScan: string;
 }): Promise<ShareResultsOutput> {
   const isCliReportEnabled = await isFeatureFlagSupportedForOrg(
     'iacCliShareResults',
@@ -37,5 +39,6 @@ export async function formatAndShareResults({
     tags,
     attributes,
     options,
+    pathToScan,
   });
 }

--- a/src/lib/iac/cli-share-results.ts
+++ b/src/lib/iac/cli-share-results.ts
@@ -19,6 +19,7 @@ import { AuthFailedError, ValidationError } from '../errors';
 const debug = Debug('iac-cli-share-results');
 import { ProjectAttributes, Tag } from '../types';
 import { TestLimitReachedError } from '../../cli/commands/test/iac/local-execution/usage-tracking';
+import { getWorkingDirectoryForPath } from './git';
 
 export async function shareResults({
   results,
@@ -26,14 +27,19 @@ export async function shareResults({
   tags,
   attributes,
   options,
+  pathToScan,
 }: {
   results: IacShareResultsFormat[];
   policy: Policy | undefined;
   tags?: Tag[];
   attributes?: ProjectAttributes;
   options?: IaCTestFlags;
+  pathToScan: string;
 }): Promise<ShareResultsOutput> {
-  const gitTarget = (await getInfo(false)) as GitTarget;
+  const gitTarget = (await getInfo({
+    isFromContainer: false,
+    cwd: getWorkingDirectoryForPath(pathToScan),
+  })) as GitTarget;
   const scanResults = results.map((result) =>
     convertIacResultToScanResult(result, policy, gitTarget, options),
   );

--- a/src/lib/iac/git.ts
+++ b/src/lib/iac/git.ts
@@ -1,20 +1,22 @@
-import { execSync } from 'child_process';
 import { statSync } from 'fs';
 import { dirname } from 'path';
+import * as childProcess from 'child_process';
 
 export function getRepositoryRootForPath(p: string) {
   return getRepositoryRoot(getWorkingDirectoryForPath(p));
 }
 
 export function getRepositoryRoot(cwd?: string) {
-  const stdout = execSync('git rev-parse --show-toplevel', {
-    encoding: 'utf8',
+  const proc = childProcess.spawnSync('git', ['rev-parse', '--show-toplevel'], {
     cwd,
   });
-  return stdout.trim();
+  if (proc.status !== 0) {
+    throw new Error();
+  }
+  return proc.stdout.toString().trim();
 }
 
-function getWorkingDirectoryForPath(p: string) {
+export function getWorkingDirectoryForPath(p: string) {
   if (statSync(p).isDirectory()) {
     return p;
   }

--- a/src/lib/project-metadata/index.ts
+++ b/src/lib/project-metadata/index.ts
@@ -18,11 +18,11 @@ export async function getInfo(
 ): Promise<GitTarget | ContainerTarget | null> {
   const isFromContainer = options.docker || options.isDocker || false;
   for (const builder of TARGET_BUILDERS) {
-    const target = await builder.getInfo(
+    const target = await builder.getInfo({
       isFromContainer,
       scannedProject,
       packageInfo,
-    );
+    });
 
     if (target) {
       const remoteUrl = options['remote-repo-url'];

--- a/src/lib/project-metadata/target-builders/container.ts
+++ b/src/lib/project-metadata/target-builders/container.ts
@@ -2,11 +2,15 @@ import { DepTree } from '../../types';
 import { ContainerTarget } from '../types';
 import { ScannedProject } from '@snyk/cli-interface/legacy/common';
 
-export async function getInfo(
-  isFromContainer: boolean,
-  scannedProject: ScannedProject,
-  packageInfo?: DepTree,
-): Promise<ContainerTarget | null> {
+export async function getInfo({
+  isFromContainer,
+  scannedProject,
+  packageInfo,
+}: {
+  isFromContainer: boolean;
+  scannedProject: ScannedProject;
+  packageInfo?: DepTree;
+}): Promise<ContainerTarget | null> {
   // safety check
   if (!isFromContainer) {
     return null;

--- a/src/lib/project-metadata/target-builders/git.ts
+++ b/src/lib/project-metadata/target-builders/git.ts
@@ -5,9 +5,13 @@ import { GitTarget } from '../types';
 // for scp-like syntax [user@]server:project.git
 const originRegex = /(.+@)?(.+):(.+$)/;
 
-export async function getInfo(
-  isFromContainer: boolean,
-): Promise<GitTarget | null> {
+export async function getInfo({
+  isFromContainer,
+  cwd,
+}: {
+  isFromContainer: boolean;
+  cwd?: string;
+}): Promise<GitTarget | null> {
   // safety check
   if (isFromContainer) {
     return null;
@@ -17,7 +21,7 @@ export async function getInfo(
 
   try {
     const origin: string | null | undefined = (
-      await subProcess.execute('git', ['remote', 'get-url', 'origin'])
+      await subProcess.execute('git', ['remote', 'get-url', 'origin'], { cwd })
     ).trim();
 
     if (origin) {
@@ -44,7 +48,9 @@ export async function getInfo(
 
   try {
     target.branch = (
-      await subProcess.execute('git', ['rev-parse', '--abbrev-ref', 'HEAD'])
+      await subProcess.execute('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+        cwd,
+      })
     ).trim();
   } catch (err) {
     // Swallowing exception since we don't want to break the monitor if there is a problem

--- a/src/lib/sub-process.ts
+++ b/src/lib/sub-process.ts
@@ -3,7 +3,7 @@ import * as childProcess from 'child_process';
 export function execute(
   command: string,
   args: string[],
-  options?: { cwd: string },
+  options?: { cwd: string | undefined },
 ): Promise<string> {
   const spawnOptions: childProcess.SpawnOptions = { shell: true };
   if (options && options.cwd) {

--- a/test/jest/unit/iac/cli-share-results.spec.ts
+++ b/test/jest/unit/iac/cli-share-results.spec.ts
@@ -35,7 +35,11 @@ describe('CLI Share Results', () => {
   });
 
   it("converts the results to Envelope's ScanResult interface - without .snyk policies", async () => {
-    await shareResults({ results: scanResults, policy: undefined });
+    await shareResults({
+      results: scanResults,
+      policy: undefined,
+      pathToScan: 'test/fixtures/iac/arm',
+    });
 
     expect(envelopeFormattersSpy.mock.calls.length).toBe(2);
 
@@ -53,7 +57,11 @@ describe('CLI Share Results', () => {
   });
 
   it("converts the results to Envelope's ScanResult interface - with .snyk policies", async () => {
-    await shareResults({ results: scanResults, policy: snykPolicy });
+    await shareResults({
+      results: scanResults,
+      policy: snykPolicy,
+      pathToScan: 'test/fixtures/iac/arm',
+    });
 
     expect(envelopeFormattersSpy.mock.calls.length).toBe(2);
 
@@ -87,6 +95,7 @@ describe('CLI Share Results', () => {
         options: {
           'target-reference': testTargetRef,
         },
+        pathToScan: 'test/fixtures/iac/arm',
       });
 
       expect(envelopeFormattersSpy.mock.calls.length).toBe(2);
@@ -109,29 +118,12 @@ describe('CLI Share Results', () => {
     });
   });
 
-  it("converts the results to Envelope's ScanResult interface - with .snyk policies (2)", async () => {
-    await shareResults({ results: scanResults, policy: snykPolicy });
-
-    expect(envelopeFormattersSpy.mock.calls.length).toBe(2);
-
-    const [firstCall, secondCall] = envelopeFormattersSpy.mock.calls;
-    expect(firstCall[0]).toEqual(scanResults[0]);
-    expect(secondCall[0]).toEqual(scanResults[1]);
-
-    const [
-      firstCallResult,
-      secondCallResult,
-    ] = envelopeFormattersSpy.mock.results;
-    expect(firstCallResult.value).toEqual(
-      expectedEnvelopeFormatterResultsWithPolicy[0],
-    );
-    expect(secondCallResult.value).toEqual(
-      expectedEnvelopeFormatterResultsWithPolicy[1],
-    );
-  });
-
   it('forwards value to iac-cli-share-results endpoint', async () => {
-    await shareResults({ results: scanResults, policy: undefined });
+    await shareResults({
+      results: scanResults,
+      policy: undefined,
+      pathToScan: 'test/fixtures/iac/arm',
+    });
 
     expect(requestSpy.mock.calls.length).toBe(1);
 
@@ -152,6 +144,7 @@ describe('CLI Share Results', () => {
       options: {
         org: 'my-custom-org',
       },
+      pathToScan: 'test/fixtures/iac/arm',
     });
 
     expect(requestSpy.mock.calls.length).toBe(1);

--- a/test/jest/unit/iac/process-results/share-results-formatters.spec.ts
+++ b/test/jest/unit/iac/process-results/share-results-formatters.spec.ts
@@ -1,8 +1,15 @@
 import { formatShareResults } from '../../../../../src/cli/commands/test/iac/local-execution/process-results/share-results-formatter';
 import { generateScanResults } from '../results-formatter.fixtures';
 import { expectedFormattedResultsForShareResults } from './share-results-formatters.fixtures';
+import * as git from '../../../../../src/lib/iac/git';
 
 describe('formatShareResults', () => {
+  beforeAll(() => {
+    jest
+      .spyOn(git, 'getWorkingDirectoryForPath')
+      .mockImplementation(() => process.cwd());
+  });
+
   it('returns the formatted results', () => {
     const IacShareResultsFormatResults = formatShareResults(
       generateScanResults(),

--- a/test/tap/get-remote-url.test.ts
+++ b/test/tap/get-remote-url.test.ts
@@ -6,7 +6,9 @@ test('getInfo returns null for isFromContainer=true', async (t) => {
   const {
     getInfo,
   } = require('../../src/lib/project-metadata/target-builders/git');
-  const gitInfo = await getInfo(true);
+  const gitInfo = await getInfo({
+    isFromContainer: true,
+  });
   t.same(gitInfo, null);
 });
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Currently when the user is running `snyk iac test --report {path1} {path2}` where `path1` and `path2` are git repo directories we group all the projects in the platform under one dropdown menu which is named after the current working directory, this is not the behaviour our users are expecting because from their point of view they are scanning 2 different directories so the projects should be grouped up into 2 different groups.
This PR fixes this issue by adding to the `git` commands we are executing the context of the path we are currently scanning.

#### How should this be manually tested?
Run `snyk iac test --report {path1} {path2}` before the change and after and check the difference.
In addition to that, `getInfo` is being used by other products in their `monitor` command so we should check that this change doesn't affect them.

#### What are the relevant tickets?
https://snyksec.atlassian.net/jira/software/c/projects/CFG/boards/301?modal=detail&selectedIssue=CFG-1756
