### PR TITLE
feat: upgrade code client to 4.12.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@open-policy-agent/opa-wasm": "^1.6.0",
         "@snyk/cli-interface": "2.11.0",
         "@snyk/cloud-config-parser": "^1.14.1",
-        "@snyk/code-client": "^4.11.1",
+        "@snyk/code-client": "^4.12.2",
         "@snyk/dep-graph": "^1.27.1",
         "@snyk/docker-registry-v2-client": "^2.6.1",
         "@snyk/fix": "file:packages/snyk-fix",
@@ -1946,9 +1946,9 @@
       }
     },
     "node_modules/@snyk/code-client": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.11.1.tgz",
-      "integrity": "sha512-DwRPljCxT+EKPREXW5IUvZBFz+lluDFzbReUnUPwnQA55GwOb4csJzFlxri9gn+p10H7GPLfoFDTiwhE7iyJBg==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.12.2.tgz",
+      "integrity": "sha512-RZL7/+cug9s63fPqBIdNyc5RvoL48QVi6JdSZR9Ipk7JX08SkK/yPB9wO/a4SITLUcVpEIUD6VR5ipLfrhygAQ==",
       "dependencies": {
         "@deepcode/dcignore": "^1.0.4",
         "@snyk/fast-glob": "^3.2.6-patch",
@@ -1963,7 +1963,7 @@
         "lodash.pick": "^4.4.0",
         "lodash.union": "^4.6.0",
         "multimatch": "^5.0.0",
-        "needle": "^3.0.0",
+        "needle": "~3.0.0",
         "p-map": "^3.0.0",
         "uuid": "^8.3.2",
         "yaml": "^1.10.2"
@@ -21234,9 +21234,9 @@
       }
     },
     "@snyk/code-client": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.11.1.tgz",
-      "integrity": "sha512-DwRPljCxT+EKPREXW5IUvZBFz+lluDFzbReUnUPwnQA55GwOb4csJzFlxri9gn+p10H7GPLfoFDTiwhE7iyJBg==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.12.2.tgz",
+      "integrity": "sha512-RZL7/+cug9s63fPqBIdNyc5RvoL48QVi6JdSZR9Ipk7JX08SkK/yPB9wO/a4SITLUcVpEIUD6VR5ipLfrhygAQ==",
       "requires": {
         "@deepcode/dcignore": "^1.0.4",
         "@snyk/fast-glob": "^3.2.6-patch",
@@ -21251,7 +21251,7 @@
         "lodash.pick": "^4.4.0",
         "lodash.union": "^4.6.0",
         "multimatch": "^5.0.0",
-        "needle": "^3.0.0",
+        "needle": "~3.0.0",
         "p-map": "^3.0.0",
         "uuid": "^8.3.2",
         "yaml": "^1.10.2"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@open-policy-agent/opa-wasm": "^1.6.0",
     "@snyk/cli-interface": "2.11.0",
     "@snyk/cloud-config-parser": "^1.14.1",
-    "@snyk/code-client": "^4.11.1",
+    "@snyk/code-client": "^4.12.2",
     "@snyk/dep-graph": "^1.27.1",
     "@snyk/docker-registry-v2-client": "^2.6.1",
     "@snyk/fix": "file:packages/snyk-fix",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Upgrades `code-client` to `4.12.2` to correctly support:
- retries on `500` errors (https://github.com/snyk/code-client/pull/145)
- pin version of `needle` to prevent issues with proxy/global-agent: https://github.com/snyk/code-client/pull/148
- improve the UX of compression/encoding (https://github.com/snyk/code-client/pull/149)