### PR TITLE
feat: Update 'Invalid Files' section for IaC [CFG-1834]

### DIFF
--- a/src/lib/formatters/iac-output/v2/failures/list.ts
+++ b/src/lib/formatters/iac-output/v2/failures/list.ts
@@ -6,7 +6,7 @@ import { colors } from '../color-utils';
 export function formatIacTestFailures(testFailures: IacFileInDirectory[]) {
   const sectionComponents: string[] = [];
 
-  const titleOutput = colors.info.bold(`Invalid Files: ${testFailures.length}`);
+  const titleOutput = colors.info.bold(`Test Failures`);
   sectionComponents.push(titleOutput);
 
   const testFailuresListOutput = formatFailuresList(testFailures);

--- a/test/jest/acceptance/iac/iac-output.spec.ts
+++ b/test/jest/acceptance/iac/iac-output.spec.ts
@@ -123,7 +123,7 @@ Target file:       ${dirPath}/`);
       const { stdout } = await run(`snyk iac test ${dirPath}`);
 
       // Assert
-      expect(stdout).not.toContain('Invalid Files');
+      expect(stdout).not.toContain('Test Failures');
     });
 
     describe.each`
@@ -241,7 +241,7 @@ https://support.snyk.io/hc/en-us/articles/360013723877-Test-your-Terraform-files
     });
 
     describe('with no issues', () => {
-      it('it should display an appropriate message in the issues section', async () => {
+      it('should display an appropriate message in the issues section', async () => {
         // Arrange
         const filePath = 'iac/terraform/vars.tf';
 

--- a/test/jest/unit/lib/formatters/iac-output/v2/failures/list.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/failures/list.spec.ts
@@ -13,12 +13,12 @@ const testFailureFixtures: IacFileInDirectory[] = JSON.parse(
 );
 
 describe('formatIacTestFailures', () => {
-  it('should include the "Invalid Files: X" title with the correct value', () => {
+  it('should include the "Invalid files: X" title with the correct value', () => {
     // Act
     const result = formatIacTestFailures(testFailureFixtures);
 
     // Assert
-    expect(result).toContain(colors.info.bold(`Invalid Files: 5`));
+    expect(result).toContain(colors.info.bold(`Test Failures`));
   });
 
   it('should include the failures list with the correct values', () => {


### PR DESCRIPTION
CFG-1834 - Part 1

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- It renames the `Invalid Files` Tile to `Test Failures`.
- It removes the count from the tile section.

#### How should this be manually tested?
- FF on
- `snyk iac test test/fixtures/iac/kubernetes`

Running a test on a single invalid file, is still the same and displays the generic error "No valid files message":
`snyk-dev iac test test/fixtures/iac/kubernetes/pod-invalid.yaml`


#### What are the relevant tickets?
CFG-1834

#### Screenshots
![image](https://user-images.githubusercontent.com/6989529/167831182-dfecd5a0-6392-4499-be36-fcb1ef4832f5.png)



or on a single invalid file (no change):

![image](https://user-images.githubusercontent.com/6989529/167675847-4723e607-5c9f-448f-abda-8522078e5b5f.png)


#### Additional questions
