### PR TITLE
chore: update go version to 1.18 for generics

### DIFF
--- a/.circleci/chocolatey.config
+++ b/.circleci/chocolatey.config
@@ -5,6 +5,6 @@
     <package id="sbt" version="1.5.5" />
     <package id="awscli" version="2.4.12" />
     <package id="nodejs" version="16.14.2" />
-    <package id="go" version="1.17.8" />
+    <package id="go" version="1.18.2" />
     <package id="mitmproxy" version="7.0.4" />
 </packages>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ parameters:
   go_version:
     type: string
     # https://go.dev/doc/devel/release
-    default: '1.17.8'
+    default: '1.18.2'
   mitmproxy_version:
     type: string
     # https://go.dev/doc/devel/release

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/cli/cliv2
 
-go 1.17
+go 1.18
 
 require (
 	github.com/elazarl/goproxy v0.0.0-20220328115640-894aeddb713e


### PR DESCRIPTION
Update Go version to 1.18 to support generics
