### PR TITLE
fix: ignore errors on multiple paths if there were some results [CFG-1784]

### DIFF
--- a/test/jest/acceptance/iac/test-directory.spec.ts
+++ b/test/jest/acceptance/iac/test-directory.spec.ts
@@ -113,10 +113,7 @@ describe('Directory scan', () => {
       expect(exitCode).toBe(1);
     });
 
-    //TODO: this test fails until we fix the bug:
-    // if one of the two paths fail due to not finding valid IaC files,
-    // then it will override the valid results of the first scan
-    it.skip('outputs both results and failures for first path when the last path is empty or non-existent', async () => {
+    it('outputs both results and failures for first path when the last path is empty or non-existent', async () => {
       const { stdout, exitCode } = await run(
         `snyk iac test ./iac/arm non-existing-dir`,
       );
@@ -124,7 +121,8 @@ describe('Directory scan', () => {
       expect(stdout).toContain('Testing rule_test.json.');
       expect(stdout).toContain('Testing invalid_rule_test.json.');
       expect(stdout).toContain('Failed to parse JSON file');
-      expect(stdout).toContain('Failed to parse Terraform file');
+      expect(stdout).toContain('Testing non-existing-dir...');
+      expect(stdout).toContain('Could not find any valid IaC files');
       expect(exitCode).toBe(1);
     });
   });


### PR DESCRIPTION
This commit fixes a bug where if we had multiple paths in a scan, and one of them threw an error, the entire scan was failing.
Now we are going to still show success results if there are any, and not fail the entire scan. 
Before we were treating the success and failures as the only possible options, but now I extended it to also have a "partial" success, when both sucess and errors were found.

The bug affected both the legacy output and the new output.

For the legacy we reverted to the old behaviour, showing the error when we scanned it.
For the new output we construct these errors in the end, and there's another ticket in play that does that, so I thought I'll open a seperate PR for that ticket to add it. (CFG-1834, CFG-1836)

P.S. the reason that the error is not bold red is that we don't store this type of error as an `iacScanFailures` during the scan.  A failure is different than a "fatal" error.
https://github.com/snyk/cli/blob/6da59aff54754047270b680f9fc3efed0bfcae80/src/cli/commands/test/iac/index.ts#L133-L136

We catch it later and we don't store it in that array. 
Then, when we format all the failures we don't have this error in there: 
https://github.com/snyk/cli/blob/6da59aff54754047270b680f9fc3efed0bfcae80/src/cli/commands/test/iac/index.ts#L286

CFG-1784

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### How should this be manually tested?

You need to run these scenarios twice, one with the `iacCliOutput` FF on and one with the FF off.

1. Single directory that does not exist: - both outputs
`snyk-dev iac test non-existing-folder` 
![image](https://user-images.githubusercontent.com/6989529/168246410-75bc278a-12dc-4a8f-9fe8-3ee794da0d46.png)

2. Single file that does not exist: - both outputs
`snyk-dev iac test file-abc.tf`
![image](https://user-images.githubusercontent.com/6989529/168246509-ca98da37-acaa-4ef0-a73e-63076a54d1d2.png)

3a. Multiple directories (both successful) - old output
`snyk-dev iac test test/fixtures/iac/kubernetes test/fixtures/iac/terraform/var_deref/nested_var_deref/`
![image](https://user-images.githubusercontent.com/6989529/168246806-ce127ead-24db-4372-8feb-a6d9ee07770a.png)

3b Multiple directories (both successful) - new output
![image](https://user-images.githubusercontent.com/6989529/168249369-0f175a68-dde7-4130-8a8b-927724a3f70b.png)


4a. Multiple directories (one fails, order of paths does not matter) - old output
` snyk-dev iac test non-existing-folder test/fixtures/iac/kubernetes`
![image](https://user-images.githubusercontent.com/6989529/168247197-b413ae37-c06d-4b8a-a999-0eecdb5bb874.png)
![image](https://user-images.githubusercontent.com/6989529/168247243-cc51e37c-f1d3-45ce-a433-0eaea68478ed.png)


4b. Multiple directories (one fails, order of paths does not matter) - new output
![image](https://user-images.githubusercontent.com/6989529/168247521-2f176fc8-34a6-43d7-b104-d71bfe1bf3ec.png)
![image](https://user-images.githubusercontent.com/6989529/168247559-c4589fdf-5dd1-4dbc-a1be-da4fb5c9467d.png)

5a. one filepath fails - one directory succeeds - old output
![image](https://user-images.githubusercontent.com/6989529/168247778-6e8f4fa0-6758-44cf-a84b-af936f4e3b8c.png)
![image](https://user-images.githubusercontent.com/6989529/168247803-e863f9ca-1ba6-4401-b054-edcefc7e8856.png)

5b new output - same as 4b. no error reported.

#### What are the relevant tickets?
CFG-1784