### PR TITLE
fix: use correct auth header for api requests

### DIFF
--- a/src/cli/commands/test/iac/local-execution/org-settings/get-iac-org-settings.ts
+++ b/src/cli/commands/test/iac/local-execution/org-settings/get-iac-org-settings.ts
@@ -2,7 +2,7 @@ import { IaCErrorCodes, IacOrgSettings } from '../types';
 import { Payload } from '../../../../../../lib/snyk-test/types';
 import config from '../../../../../../lib/config';
 import { isCI } from '../../../../../../lib/is-ci';
-import { api } from '../../../../../../lib/api-token';
+import { getAuthHeader } from '../../../../../../lib/api-token';
 import { makeRequest } from '../../../../../../lib/request';
 import { CustomError } from '../../../../../../lib/errors';
 import { getErrorStringCode } from '../error-utils';
@@ -17,7 +17,7 @@ export function getIacOrgSettings(
     qs: { org: publicOrgId },
     headers: {
       'x-is-ci': isCI(),
-      authorization: `token ${api()}`,
+      authorization: getAuthHeader(),
     },
   };
 

--- a/src/cli/commands/test/iac/local-execution/usage-tracking.ts
+++ b/src/cli/commands/test/iac/local-execution/usage-tracking.ts
@@ -1,6 +1,6 @@
 import { makeRequest } from '../../../../../lib/request';
 import config from '../../../../../lib/config';
-import { api as getApiToken } from '../../../../../lib/api-token';
+import { getAuthHeader } from '../../../../../lib/api-token';
 import { CustomError } from '../../../../../lib/errors';
 
 export async function trackUsage(
@@ -15,7 +15,7 @@ export async function trackUsage(
   const trackingResponse = await makeRequest({
     method: 'POST',
     headers: {
-      Authorization: `token ${getApiToken()}`,
+      Authorization: getAuthHeader(),
     },
     url: `${config.API}/track-iac-usage/cli`,
     body: { results: trackingData },

--- a/src/lib/authorization.ts
+++ b/src/lib/authorization.ts
@@ -1,6 +1,6 @@
-import * as snyk from './';
-import { makeRequest } from './request';
+import { getAuthHeader } from './api-token';
 import config from './config';
+import { makeRequest } from './request';
 
 export async function actionAllowed(
   action: string,
@@ -14,7 +14,7 @@ export async function actionAllowed(
       url: config.API + '/authorization/' + action,
       json: true,
       headers: {
-        authorization: 'token ' + snyk.api,
+        authorization: getAuthHeader(),
       },
       qs: org && { org },
     });

--- a/src/lib/plugins/sast/checks.ts
+++ b/src/lib/plugins/sast/checks.ts
@@ -1,6 +1,6 @@
 import { makeRequest } from '../../request';
 
-import { api as getApiToken } from '../../api-token';
+import { getAuthHeader } from '../../api-token';
 import config from '../../config';
 import { assembleQueryString } from '../../snyk-test/common';
 import { SastSettings, TrackUsageResponse } from './types';
@@ -9,7 +9,7 @@ export async function getSastSettingsForOrg(org): Promise<SastSettings> {
   const response = await makeRequest({
     method: 'GET',
     headers: {
-      Authorization: `token ${getApiToken()}`,
+      Authorization: getAuthHeader(),
     },
     qs: assembleQueryString({ org }),
     url: `${config.API}/cli-config/settings/sast`,
@@ -24,7 +24,7 @@ export async function trackUsage(org): Promise<TrackUsageResponse> {
   const response = await makeRequest({
     method: 'POST',
     headers: {
-      Authorization: `token ${getApiToken()}`,
+      Authorization: getAuthHeader(),
     },
     qs: assembleQueryString({ org }),
     url: `${config.API}/track-sast-usage/cli`,

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -817,7 +817,7 @@ async function assembleRemotePayloads(root, options): Promise<Payload[]> {
       json: true,
       headers: {
         'x-is-ci': isCI(),
-        authorization: 'token ' + snyk.api,
+        authorization: getAuthHeader(),
       },
     },
   ];


### PR DESCRIPTION
This is an immediate fix to ensure we use the correct header based on if SNYK_OAUTH_TOKEN is used.
We'll look into improving the auth experience in CLI in the near future.