### PR TITLE
chore: refactor the user message for custom rules

### DIFF
--- a/src/cli/commands/test/iac/index.ts
+++ b/src/cli/commands/test/iac/index.ts
@@ -32,7 +32,6 @@ import {
   getIacDisplayErrorFileOutput,
   iacTestTitle,
   shouldLogUserMessages,
-  spinnerFailureMessage,
   spinnerMessage,
   spinnerSuccessMessage,
 } from '../../../../lib/formatters/iac-output';
@@ -102,9 +101,9 @@ export default async function(
   }
 
   try {
-    testSpinner?.start(spinnerMessage);
-
     const rulesOrigin = await initRules(iacOrgSettings, options);
+
+    testSpinner?.start(spinnerMessage);
 
     for (const path of paths) {
       // Create a copy of the options so a specific test can
@@ -197,7 +196,7 @@ export default async function(
   if (isPartialSuccess) {
     testSpinner?.succeed(spinnerSuccessMessage);
   } else {
-    testSpinner?.fail(spinnerFailureMessage + EOL);
+    testSpinner?.stop();
   }
 
   // resultOptions is now an array of 1 or more options used for

--- a/src/cli/commands/test/iac/index.ts
+++ b/src/cli/commands/test/iac/index.ts
@@ -58,6 +58,11 @@ import {
 import config from '../../../../lib/config';
 import { UnsupportedEntitlementError } from '../../../../lib/errors/unsupported-entitlement-error';
 import * as ora from 'ora';
+import { RulesOrigin } from './local-execution/types';
+import {
+  customRulesMessage,
+  customRulesReportMessage,
+} from '../../../../lib/formatters/iac-output/v2/user-messages';
 
 const debug = Debug('snyk-test');
 const SEPARATOR = '\n-------------------------------------------------------\n';
@@ -102,6 +107,18 @@ export default async function(
 
   try {
     const rulesOrigin = await initRules(iacOrgSettings, options);
+    if (
+      rulesOrigin !== RulesOrigin.Internal &&
+      !(options.sarif || options.json)
+    ) {
+      let userMessage = `${customRulesMessage}${EOL}`;
+
+      if (options.report) {
+        userMessage += `${customRulesReportMessage}${EOL}`;
+      }
+
+      console.log(userMessage);
+    }
 
     testSpinner?.start(spinnerMessage);
 

--- a/src/cli/commands/test/iac/local-execution/rules.ts
+++ b/src/cli/commands/test/iac/local-execution/rules.ts
@@ -7,8 +7,8 @@ import {
   OCIRegistryURLComponents,
   RulesOrigin,
 } from './types';
+import { EOL } from 'os';
 import { UnsupportedEntitlementFlagError } from './assert-iac-options-flag';
-import chalk from 'chalk';
 import {
   extractOCIRegistryURLComponents,
   FailedToBuildOCIArtifactError,
@@ -21,6 +21,10 @@ import { config as userConfig } from '../../../../../lib/user-config';
 import { isValidUrl } from './url-utils';
 import { CustomError } from '../../../../../lib/errors';
 import { getErrorStringCode } from './error-utils';
+import {
+  customRulesMessage,
+  customRulesReportMessage,
+} from '../../../../../lib/formatters/iac-output/v2/user-messages';
 
 export async function initRules(
   iacOrgSettings: IacOrgSettings,
@@ -46,14 +50,13 @@ export async function initRules(
     (isOCIRegistryURLProvided || customRulesPath) &&
     !(options.sarif || options.json)
   ) {
-    let userMessage = 'Using custom rules to generate misconfigurations.';
+    let userMessage = `${customRulesMessage}${EOL}`;
 
     if (options.report) {
-      userMessage +=
-        "\nPlease note that your custom rules will not be sent to the Snyk platform, and will not be available on the project's page.";
+      userMessage += `${customRulesReportMessage}${EOL}`;
     }
 
-    console.log(chalk.hex('#ff9b00')(userMessage));
+    console.log(userMessage);
   }
 
   if (isOCIRegistryURLProvided && customRulesPath) {

--- a/src/cli/commands/test/iac/local-execution/rules.ts
+++ b/src/cli/commands/test/iac/local-execution/rules.ts
@@ -7,7 +7,6 @@ import {
   OCIRegistryURLComponents,
   RulesOrigin,
 } from './types';
-import { EOL } from 'os';
 import { UnsupportedEntitlementFlagError } from './assert-iac-options-flag';
 import {
   extractOCIRegistryURLComponents,
@@ -21,10 +20,6 @@ import { config as userConfig } from '../../../../../lib/user-config';
 import { isValidUrl } from './url-utils';
 import { CustomError } from '../../../../../lib/errors';
 import { getErrorStringCode } from './error-utils';
-import {
-  customRulesMessage,
-  customRulesReportMessage,
-} from '../../../../../lib/formatters/iac-output/v2/user-messages';
 
 export async function initRules(
   iacOrgSettings: IacOrgSettings,
@@ -45,19 +40,6 @@ export async function initRules(
   }
 
   const isOCIRegistryURLProvided = checkOCIRegistryURLProvided(iacOrgSettings);
-
-  if (
-    (isOCIRegistryURLProvided || customRulesPath) &&
-    !(options.sarif || options.json)
-  ) {
-    let userMessage = `${customRulesMessage}${EOL}`;
-
-    if (options.report) {
-      userMessage += `${customRulesReportMessage}${EOL}`;
-    }
-
-    console.log(userMessage);
-  }
 
   if (isOCIRegistryURLProvided && customRulesPath) {
     throw new FailedToExecuteCustomRulesError();

--- a/src/lib/formatters/iac-output/index.ts
+++ b/src/lib/formatters/iac-output/index.ts
@@ -13,7 +13,6 @@ export {
   iacTestTitle,
   spinnerMessage,
   spinnerSuccessMessage,
-  spinnerFailureMessage,
   shouldLogUserMessages,
   formatShareResultsOutput,
   failuresTipOutput,

--- a/src/lib/formatters/iac-output/v2/failures/list.ts
+++ b/src/lib/formatters/iac-output/v2/failures/list.ts
@@ -1,12 +1,12 @@
 import { EOL } from 'os';
 
 import { IacFileInDirectory } from '../../../../types';
-import { colors } from '../color-utils';
+import { colors, contentPadding } from '../utils';
 
 export function formatIacTestFailures(testFailures: IacFileInDirectory[]) {
   const sectionComponents: string[] = [];
 
-  const titleOutput = colors.info.bold(`Test Failures`);
+  const titleOutput = colors.title(`Test Failures`);
   sectionComponents.push(titleOutput);
 
   const testFailuresListOutput = formatFailuresList(testFailures);
@@ -49,10 +49,11 @@ function formatFailure(
   failureReason: string,
   testFailures: IacFileInDirectory[],
 ): string {
-  const pathPrefix = 'Path: ';
+  const pathPrefix = contentPadding + 'Path: ';
   const pathLeftPadding = ' '.repeat(pathPrefix.length);
 
   return (
+    contentPadding +
     colors.failure.bold(failureReason) +
     EOL +
     pathPrefix +

--- a/src/lib/formatters/iac-output/v2/failures/tip.ts
+++ b/src/lib/formatters/iac-output/v2/failures/tip.ts
@@ -1,7 +1,7 @@
 import { EOL } from 'os';
 import { contactSupportMessage, reTryMessage } from '../../../../common';
-import { colors } from '../color-utils';
+import { colors } from '../utils';
 
-export const failuresTipOutput = colors.failure.bold(
+export const failuresTipOutput = colors.info.bold(
   reTryMessage + EOL + contactSupportMessage,
 );

--- a/src/lib/formatters/iac-output/v2/index.ts
+++ b/src/lib/formatters/iac-output/v2/index.ts
@@ -4,7 +4,6 @@ export {
   iacTestTitle,
   spinnerMessage,
   spinnerSuccessMessage,
-  spinnerFailureMessage,
   shouldLogUserMessages,
 } from './user-messages';
 export { formatShareResultsOutput } from './share-results';

--- a/src/lib/formatters/iac-output/v2/issues-list/index.ts
+++ b/src/lib/formatters/iac-output/v2/issues-list/index.ts
@@ -4,7 +4,7 @@ import * as isEmpty from 'lodash.isempty';
 import * as debug from 'debug';
 
 import { IacOutputMeta } from '../../../../types';
-import { colors } from '../color-utils';
+import { colors, contentPadding } from '../utils';
 import { formatScanResultsNewOutput } from './formatters';
 import { formatIssue } from './issue';
 import { SEVERITY } from '../../../../snyk-test/common';
@@ -23,7 +23,7 @@ export function getIacDisplayedIssues(
     return (
       titleOutput +
       EOL +
-      ' '.repeat(2) +
+      contentPadding +
       colors.success.bold('No vulnerable paths were found!')
     );
   }
@@ -34,7 +34,7 @@ export function getIacDisplayedIssues(
       const severityResults: FormattedOutputResult[] =
         formattedResults.results[severity];
 
-      const titleOutput = colors.severities[severity](
+      const titleOutput = colors.title(
         `${capitalize(severity)} Severity Issues: ${severityResults.length}`,
       );
 

--- a/src/lib/formatters/iac-output/v2/issues-list/issue.ts
+++ b/src/lib/formatters/iac-output/v2/issues-list/issue.ts
@@ -4,7 +4,7 @@ import { EOL } from 'os';
 import { iacRemediationTypes } from '../../../../iac/constants';
 
 import { printPath } from '../../../remediation-based-format-issues';
-import { colors } from '../color-utils';
+import { colors, contentPadding } from '../utils';
 import { FormattedOutputResult } from './types';
 import { AnnotatedIacIssue } from '../../../../snyk-test/iac-test-result';
 
@@ -13,7 +13,13 @@ export function formatIssue(result: FormattedOutputResult): string {
 
   const propertiesOutput = formatProperties(result);
 
-  return titleOutput + EOL + propertiesOutput;
+  return (
+    contentPadding +
+    titleOutput +
+    EOL +
+    contentPadding +
+    propertiesOutput.join(EOL + contentPadding)
+  );
 }
 
 function formatTitle(issue: AnnotatedIacIssue): string {
@@ -25,7 +31,7 @@ function formatTitle(issue: AnnotatedIacIssue): string {
   return titleOutput;
 }
 
-function formatProperties(result: FormattedOutputResult): string {
+function formatProperties(result: FormattedOutputResult): string[] {
   const remediationKey = iacRemediationTypes?.[result.projectType];
 
   const properties = [
@@ -55,10 +61,8 @@ function formatProperties(result: FormattedOutputResult): string {
     ...properties.map(([key]) => key.length),
   );
 
-  return properties
-    .map(
-      ([key, value]) =>
-        `${key}: ${' '.repeat(maxPropertyNameLength - key.length)}${value}`,
-    )
-    .join(EOL);
+  return properties.map(
+    ([key, value]) =>
+      `${key}: ${' '.repeat(maxPropertyNameLength - key.length)}${value}`,
+  );
 }

--- a/src/lib/formatters/iac-output/v2/share-results.ts
+++ b/src/lib/formatters/iac-output/v2/share-results.ts
@@ -1,6 +1,6 @@
 import { IacOutputMeta } from '../../../types';
 import { shareResultsOutput } from '../v1';
-import { colors } from './color-utils';
+import { colors } from './utils';
 
 export function formatShareResultsOutput(outputMeta: IacOutputMeta) {
   return colors.info.bold(shareResultsOutput(outputMeta));

--- a/src/lib/formatters/iac-output/v2/test-summary.ts
+++ b/src/lib/formatters/iac-output/v2/test-summary.ts
@@ -3,7 +3,7 @@ import { rightPadWithSpaces } from '../../../right-pad';
 import { SEVERITY } from '../../../snyk-test/common';
 import { icon } from '../../../theme';
 import { IacOutputMeta } from '../../../types';
-import { colors } from './color-utils';
+import { colors } from './utils';
 import { IacTestData } from './types';
 
 const PAD_LENGTH = 19; // chars to align

--- a/src/lib/formatters/iac-output/v2/user-messages.ts
+++ b/src/lib/formatters/iac-output/v2/user-messages.ts
@@ -1,5 +1,5 @@
 import { IaCTestFlags } from '../../../../cli/commands/test/iac/local-execution/types';
-import { colors } from './color-utils';
+import { colors } from './utils';
 
 /**
  * Displayed as the title of the test output.
@@ -19,10 +19,17 @@ export const spinnerMessage = colors.info(
 export const spinnerSuccessMessage = colors.info('Test completed.');
 
 /**
- * Displayed when a test fails.
+ * Message for using custom rules.
  */
-export const spinnerFailureMessage = colors.info(
-  'Unable to complete the test.',
+export const customRulesMessage = colors.info(
+  'Using custom rules to generate misconfigurations.',
+);
+
+/**
+ * Message for using custom rules.
+ */
+export const customRulesReportMessage = colors.info(
+  "Please note that your custom rules will not be sent to the Snyk platform, and will not be available on the project's page.",
 );
 
 /**

--- a/src/lib/formatters/iac-output/v2/utils.ts
+++ b/src/lib/formatters/iac-output/v2/utils.ts
@@ -6,6 +6,7 @@ interface IacOutputColors {
   failure: Chalk;
   success: Chalk;
   info: Chalk;
+  title: Chalk;
 }
 
 type SeverityColor = {
@@ -14,12 +15,15 @@ type SeverityColor = {
 
 export const colors: IacOutputColors = {
   severities: {
-    critical: chalk.hex('#AB191A'),
-    high: chalk.hex('#CE501A'),
-    medium: chalk.hex('#D68000'),
-    low: chalk.hex('#88879E'),
+    critical: chalk.magenta,
+    high: chalk.red,
+    medium: chalk.yellow,
+    low: chalk.white,
   },
-  failure: chalk.hex('#B81415'),
-  success: chalk.hex('#00BB00'),
+  failure: chalk.red,
+  success: chalk.green,
   info: chalk.white,
+  title: chalk.white.bold,
 };
+
+export const contentPadding = ' '.repeat(2);

--- a/test/jest/acceptance/iac/iac-output.spec.ts
+++ b/test/jest/acceptance/iac/iac-output.spec.ts
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 import { EOL } from 'os';
 import * as pathLib from 'path';
 import {
-  spinnerFailureMessage,
   spinnerMessage,
   spinnerSuccessMessage,
 } from '../../../../src/lib/formatters/iac-output';
@@ -82,17 +81,17 @@ describe('iac test output', () => {
           EOL.repeat(2) +
           'Medium Severity Issues: 1' +
           EOL.repeat(2) +
-          '[Medium] Azure Firewall Network Rule Collection allows public access' +
+          '  [Medium] Azure Firewall Network Rule Collection allows public access' +
           EOL +
-          'Info:    That inbound traffic is allowed to a resource from any source instead of a restricted range. That potentially everyone can access your resource' +
+          '  Info:    That inbound traffic is allowed to a resource from any source instead of a restricted range. That potentially everyone can access your resource' +
           EOL +
-          'Rule:    https://snyk.io/security-rules/SNYK-CC-TF-20' +
+          '  Rule:    https://snyk.io/security-rules/SNYK-CC-TF-20' +
           EOL +
-          'Path:    resources[1] > properties > networkRuleCollections[0] > properties > rules[0] > sourceAddresses' +
+          '  Path:    resources[1] > properties > networkRuleCollections[0] > properties > rules[0] > sourceAddresses' +
           EOL +
-          'File:    ./iac/arm/rule_test.json' +
+          '  File:    ./iac/arm/rule_test.json' +
           EOL +
-          'Resolve: Set `properties.networkRuleCollections.properties.rules.sourceAddresses` attribute to specific IP range only, e.g. `192.168.1.0/24`',
+          '  Resolve: Set `properties.networkRuleCollections.properties.rules.sourceAddresses` attribute to specific IP range only, e.g. `192.168.1.0/24`',
       );
     });
 
@@ -169,7 +168,6 @@ Target file:       ${dirPath}/`);
             `snyk iac test ${dataFormatFlag} ./iac/arm/rule_test.json`,
           );
           expect(stdout).not.toContain(chalk.reset(spinnerMessage));
-          expect(stdout).not.toContain(chalk.reset(spinnerFailureMessage));
           expect(stdout).not.toContain(chalk.reset(spinnerSuccessMessage));
         });
       },
@@ -186,29 +184,37 @@ Target file:       ${dirPath}/`);
 
           // Assert
           expect(stdout).toContain(
-            'Failed to parse JSON file' +
+            '  Failed to parse JSON file' +
               EOL +
-              `Path: ${pathLib.join('iac', 'arm', 'invalid_rule_test.json')}` +
+              `  Path: ${pathLib.join(
+                'iac',
+                'arm',
+                'invalid_rule_test.json',
+              )}` +
               EOL.repeat(2) +
-              'Failed to parse YAML file' +
+              '  Failed to parse YAML file' +
               EOL +
-              `Path: ${pathLib.join(
+              `  Path: ${pathLib.join(
                 'iac',
                 'cloudformation',
                 'invalid-cfn.yml',
               )}` +
               EOL +
-              `      ${pathLib.join('iac', 'kubernetes', 'helm-config.yaml')}` +
+              `        ${pathLib.join(
+                'iac',
+                'kubernetes',
+                'helm-config.yaml',
+              )}` +
               EOL.repeat(2) +
-              'Failed to parse Terraform file' +
+              '  Failed to parse Terraform file' +
               EOL +
-              `Path: ${pathLib.join(
+              `  Path: ${pathLib.join(
                 'iac',
                 'terraform',
                 'sg_open_ssh_invalid_go_templates.tf',
               )}` +
               EOL +
-              `      ${pathLib.join(
+              `        ${pathLib.join(
                 'iac',
                 'terraform',
                 'sg_open_ssh_invalid_hcl2.tf',
@@ -234,17 +240,6 @@ Target file:       ${dirPath}/`);
     });
 
     describe('with only test failures', () => {
-      it('should the test failure message', async () => {
-        // Arrange
-        const dirPath = 'iac/only-invalid';
-
-        // Act
-        const { stdout } = await run(`snyk iac test ${dirPath}`);
-
-        // Assert
-        expect(stdout).toContain('Unable to complete the test.');
-      });
-
       it('should display the failure reason for the first failed test', async () => {
         // Arrange
         const dirPath = 'iac/only-invalid';

--- a/test/jest/unit/lib/formatters/iac-output/v2/failures/list.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/failures/list.spec.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as pathLib from 'path';
 
 import { formatIacTestFailures } from '../../../../../../../../src/lib/formatters/iac-output';
-import { colors } from '../../../../../../../../src/lib/formatters/iac-output/v2/color-utils';
+import { colors } from '../../../../../../../../src/lib/formatters/iac-output/v2/utils';
 import { IacFileInDirectory } from '../../../../../../../../src/lib/types';
 
 const testFailureFixtures: IacFileInDirectory[] = JSON.parse(
@@ -26,47 +26,46 @@ describe('formatIacTestFailures', () => {
     const result = formatIacTestFailures(testFailureFixtures);
 
     // Assert
-    expect(result).toContain(
-      `${colors.failure.bold('Failed to parse JSON file')}
-Path: ${pathLib.join(
-        'test',
-        'fixtures',
-        'iac',
-        'arm',
-        'invalid_rule_test.json',
-      )}
+    const expected = `  ${colors.failure.bold('Failed to parse JSON file')}
+  Path: ${pathLib.join(
+    'test',
+    'fixtures',
+    'iac',
+    'arm',
+    'invalid_rule_test.json',
+  )}
 
-${colors.failure.bold('Failed to parse YAML file')}
-Path: ${pathLib.join(
-        'test',
-        'fixtures',
-        'iac',
-        'cloudformation',
-        'invalid-cfn.yml',
-      )}
-      ${pathLib.join(
-        'test',
-        'fixtures',
-        'iac',
-        'kubernetes',
-        'helm-config.yaml',
-      )}
+  ${colors.failure.bold('Failed to parse YAML file')}
+  Path: ${pathLib.join(
+    'test',
+    'fixtures',
+    'iac',
+    'cloudformation',
+    'invalid-cfn.yml',
+  )}
+        ${pathLib.join(
+          'test',
+          'fixtures',
+          'iac',
+          'kubernetes',
+          'helm-config.yaml',
+        )}
 
-${colors.failure.bold('Failed to parse Terraform file')}
-Path: ${pathLib.join(
-        'test',
-        'fixtures',
-        'iac',
-        'terraform',
-        'sg_open_ssh_invalid_go_templates.tf',
-      )}
-      ${pathLib.join(
-        'test',
-        'fixtures',
-        'iac',
-        'terraform',
-        'sg_open_ssh_invalid_hcl2.tf',
-      )}`,
-    );
+  ${colors.failure.bold('Failed to parse Terraform file')}
+  Path: ${pathLib.join(
+    'test',
+    'fixtures',
+    'iac',
+    'terraform',
+    'sg_open_ssh_invalid_go_templates.tf',
+  )}
+        ${pathLib.join(
+          'test',
+          'fixtures',
+          'iac',
+          'terraform',
+          'sg_open_ssh_invalid_hcl2.tf',
+        )}`;
+    expect(result).toContain(expected);
   });
 });

--- a/test/jest/unit/lib/formatters/iac-output/v2/issues-list/index.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/issues-list/index.spec.ts
@@ -3,7 +3,7 @@ import * as pathLib from 'path';
 import chalk from 'chalk';
 import { IacOutputMeta } from '../../../../../../../../src/lib/types';
 import { getIacDisplayedIssues } from '../../../../../../../../src/lib/formatters/iac-output';
-import { colors } from '../../../../../../../../src/lib/formatters/iac-output/v2/color-utils';
+import { colors } from '../../../../../../../../src/lib/formatters/iac-output/v2/utils';
 import { FormattedResult } from '../../../../../../../../src/cli/commands/test/iac/local-execution/types';
 
 describe('getIacDisplayedIssues', () => {
@@ -42,11 +42,9 @@ describe('getIacDisplayedIssues', () => {
   it('should include a subtitle for each severity with the correct amount of issues', () => {
     const result = getIacDisplayedIssues(resultFixtures, outputMeta);
 
-    expect(result).toContain(colors.severities.low(`Low Severity Issues: 13`));
-    expect(result).toContain(
-      colors.severities.medium(`Medium Severity Issues: 4`),
-    );
-    expect(result).toContain(colors.severities.high(`High Severity Issues: 5`));
+    expect(result).toContain(colors.title(`Low Severity Issues: 13`));
+    expect(result).toContain(colors.title(`Medium Severity Issues: 4`));
+    expect(result).toContain(colors.title(`High Severity Issues: 5`));
   });
 
   it('should include the correct issues in each severity section, and display the correct issue details', () => {
@@ -58,94 +56,96 @@ describe('getIacDisplayedIssues', () => {
 
     // Assert
     expect(result).toContain(
-      `${colors.severities.low(
+      `  ${colors.severities.low(
         `[Low] ${chalk.bold('Container is running without AppArmor profile')}`,
       )}
-Info:    The AppArmor profile is not set correctly. AppArmor will not enforce mandatory access control, which can increase the attack vectors.
-Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-32
-Path:    [DocId: 0] > metadata > annotations['container.apparmor.security.beta.kubernetes.io/web']
-File:    k8s.yaml
-Resolve: Add \`container.apparmor.security.beta.kubernetes.io/<container-name>\` annotation with value \`runtime/default\` or \`localhost/<name-of-profile\`
+  Info:    The AppArmor profile is not set correctly. AppArmor will not enforce mandatory access control, which can increase the attack vectors.
+  Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-32
+  Path:    [DocId: 0] > metadata > annotations['container.apparmor.security.beta.kubernetes.io/web']
+  File:    k8s.yaml
+  Resolve: Add \`container.apparmor.security.beta.kubernetes.io/<container-name>\` annotation with value \`runtime/default\` or \`localhost/<name-of-profile\`
 
-${colors.severities.low(
-  `[Low] ${chalk.bold('Container is running without memory limit')}`,
-)}
-Info:    Memory limit is not defined. Containers without memory limits are more likely to be terminated when the node runs out of memory
-Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-4
-Path:    [DocId: 0] > input > spec > template > spec > containers[web] > resources > limits > memory
-File:    k8s.yaml
-Resolve: Set \`resources.limits.memory\` value
+  ${colors.severities.low(
+    `[Low] ${chalk.bold('Container is running without memory limit')}`,
+  )}
+  Info:    Memory limit is not defined. Containers without memory limits are more likely to be terminated when the node runs out of memory
+  Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-4
+  Path:    [DocId: 0] > input > spec > template > spec > containers[web] > resources > limits > memory
+  File:    k8s.yaml
+  Resolve: Set \`resources.limits.memory\` value
 
-${colors.severities.low(
-  `[Low] ${chalk.bold('Container could be running with outdated image')}`,
-)}
-Info:    The image policy does not prevent image reuse. The container may run with outdated or unauthorized image
-Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-42
-Path:    [DocId: 0] > spec > template > spec > containers[web] > imagePullPolicy
-File:    k8s.yaml
-Resolve: Set \`imagePullPolicy\` attribute to \`Always\`
+  ${colors.severities.low(
+    `[Low] ${chalk.bold('Container could be running with outdated image')}`,
+  )}
+  Info:    The image policy does not prevent image reuse. The container may run with outdated or unauthorized image
+  Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-42
+  Path:    [DocId: 0] > spec > template > spec > containers[web] > imagePullPolicy
+  File:    k8s.yaml
+  Resolve: Set \`imagePullPolicy\` attribute to \`Always\`
 
-${colors.severities.low(
-  `[Low] ${chalk.bold('Container is running without cpu limit')}`,
-)}
-Info:    CPU limit is not defined. Containers without limits can exceed the capacity of the node, and affect availability/performance of the host and other containers.
-Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-5
-Path:    [DocId: 0] > input > spec > template > spec > containers[web] > resources > limits > cpu
-File:    k8s.yaml
-Resolve: Add \`resources.limits.cpu\` field with required CPU limit value
+  ${colors.severities.low(
+    `[Low] ${chalk.bold('Container is running without cpu limit')}`,
+  )}
+  Info:    CPU limit is not defined. Containers without limits can exceed the capacity of the node, and affect availability/performance of the host and other containers.
+  Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-5
+  Path:    [DocId: 0] > input > spec > template > spec > containers[web] > resources > limits > cpu
+  File:    k8s.yaml
+  Resolve: Add \`resources.limits.cpu\` field with required CPU limit value
 
-${colors.severities.low(
-  `[Low] ${chalk.bold('Container is running with writable root filesystem')}`,
-)}
-Info:    \`readOnlyRootFilesystem\` attribute is not set to \`true\`. Compromised process could abuse writable root filesystem to elevate privileges
-Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-8
-Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > readOnlyRootFilesystem
-File:    k8s.yaml
-Resolve: Set \`securityContext.readOnlyRootFilesystem\` to \`true\``,
+  ${colors.severities.low(
+    `[Low] ${chalk.bold('Container is running with writable root filesystem')}`,
+  )}
+  Info:    \`readOnlyRootFilesystem\` attribute is not set to \`true\`. Compromised process could abuse writable root filesystem to elevate privileges
+  Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-8
+  Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > readOnlyRootFilesystem
+  File:    k8s.yaml
+  Resolve: Set \`securityContext.readOnlyRootFilesystem\` to \`true\``,
     );
 
     expect(result).toContain(
-      `${colors.severities.medium(
+      `  ${colors.severities.medium(
         `[Medium] ${chalk.bold(
           'Container is running without root user control',
         )}`,
       )}
-Info:    Container is running without root user control. Container could be running with full administrative privileges
-Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-10
-Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > runAsNonRoot
-File:    k8s.yaml
-Resolve: Set \`securityContext.runAsNonRoot\` to \`true\`
+  Info:    Container is running without root user control. Container could be running with full administrative privileges
+  Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-10
+  Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > runAsNonRoot
+  File:    k8s.yaml
+  Resolve: Set \`securityContext.runAsNonRoot\` to \`true\`
 
-${colors.severities.medium(
-  `[Medium] ${chalk.bold('Container does not drop all default capabilities')}`,
-)}
-Info:    All default capabilities are not explicitly dropped. Containers are running with potentially unnecessary privileges
-Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-6
-Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > capabilities > drop
-File:    k8s.yaml
-Resolve: Add \`ALL\` to \`securityContext.capabilities.drop\` list, and add only required capabilities in \`securityContext.capabilities.add\`
+  ${colors.severities.medium(
+    `[Medium] ${chalk.bold(
+      'Container does not drop all default capabilities',
+    )}`,
+  )}
+  Info:    All default capabilities are not explicitly dropped. Containers are running with potentially unnecessary privileges
+  Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-6
+  Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > capabilities > drop
+  File:    k8s.yaml
+  Resolve: Add \`ALL\` to \`securityContext.capabilities.drop\` list, and add only required capabilities in \`securityContext.capabilities.add\`
 
-${colors.severities.medium(
-  `[Medium] ${chalk.bold(
-    'Container is running without privilege escalation control',
-  )}`,
-)}
-Info:    \`allowPrivilegeEscalation\` attribute is not set to \`false\`. Processes could elevate current privileges via known vectors, for example SUID binaries
-Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-9
-Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > allowPrivilegeEscalation
-File:    k8s.yaml
-Resolve: Set \`securityContext.allowPrivilegeEscalation\` to \`false\``,
+  ${colors.severities.medium(
+    `[Medium] ${chalk.bold(
+      'Container is running without privilege escalation control',
+    )}`,
+  )}
+  Info:    \`allowPrivilegeEscalation\` attribute is not set to \`false\`. Processes could elevate current privileges via known vectors, for example SUID binaries
+  Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-9
+  Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > allowPrivilegeEscalation
+  File:    k8s.yaml
+  Resolve: Set \`securityContext.allowPrivilegeEscalation\` to \`false\``,
     );
 
     expect(result).toContain(
-      `${colors.severities.high(
+      `  ${colors.severities.high(
         `[High] ${chalk.bold('Container is running in privileged mode')}`,
       )}
-Info:    Container is running in privileged mode. Compromised container could potentially modify the underlying host’s kernel by loading unauthorized modules (i.e. drivers).
-Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-1
-Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > privileged
-File:    k8s.yaml
-Resolve: Remove \`securityContext.privileged\` attribute, or set value to \`false\``,
+  Info:    Container is running in privileged mode. Compromised container could potentially modify the underlying host’s kernel by loading unauthorized modules (i.e. drivers).
+  Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-1
+  Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > privileged
+  File:    k8s.yaml
+  Resolve: Remove \`securityContext.privileged\` attribute, or set value to \`false\``,
     );
   });
 

--- a/test/jest/unit/lib/formatters/iac-output/v2/share-results.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/share-results.spec.ts
@@ -1,6 +1,6 @@
 import config from '../../../../../../../src/lib/config';
 import { formatShareResultsOutput } from '../../../../../../../src/lib/formatters/iac-output';
-import { colors } from '../../../../../../../src/lib/formatters/iac-output/v2/color-utils';
+import { colors } from '../../../../../../../src/lib/formatters/iac-output/v2/utils';
 
 describe('formatShareResultsOutput', () => {
   it('returns the correct output', () => {

--- a/test/jest/unit/lib/formatters/iac-output/v2/test-summary.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/test-summary.spec.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as pathLib from 'path';
 
 import { formatIacTestSummary } from '../../../../../../../src/lib/formatters/iac-output';
-import { colors } from '../../../../../../../src/lib/formatters/iac-output/v2/color-utils';
+import { colors } from '../../../../../../../src/lib/formatters/iac-output/v2/utils';
 import { IacTestResponse } from '../../../../../../../src/lib/snyk-test/iac-test-result';
 import { IacFileInDirectory } from '../../../../../../../src/lib/types';
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This PR refactors the rules initialisation component in the IaC test flow so it's not doing any output formatting.

#### Where should the reviewer start?
This PR moves a few lines of code from one location to another but it also means that in the case of some errors (e.g. both the `--rules` flag and the OCI registry URL are configured, custom rules entitlement is missing, the custom rules bundle is invalid), then we don't print a message that says `Using custom rules to generate misconfigurations.`. I don't think there's any added benefit of printing this line in those error cases. If anything, it adds some extra clutter. But I'm open to other opinions. 

#### How should this be manually tested?
1. `npm run build`
2. `snyk-dev iac test ./test/fixtures/iac/terraform --rules=bundle.tar.gz` with missing bundle for error case

#### Any background context you want to provide?
Required from https://github.com/snyk/cli/pull/3225. The standard for printing CLI output now is that in each component of the test flow we don't do any formatting of the output. The `src/cli/commands/test/iac/index.ts` file should do all the formatting (newlines, for example). See comment: https://github.com/snyk/cli/pull/3225#discussion_r873141586.

#### Screenshots
![Screenshot 2022-05-16 at 11 37 39](https://user-images.githubusercontent.com/81559517/168575417-8da883d5-39d6-4f84-a9b5-46c152a9dff6.png)
![Screenshot 2022-05-16 at 11 38 15](https://user-images.githubusercontent.com/81559517/168575413-cdf0aa20-8eeb-4d6f-af6d-80a5ec7f4427.png)

