### PR TITLE
chore(ci): split versioning from build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,6 +277,20 @@ jobs:
             - dist/
             - packages/*/dist
             - pysrc
+  version:
+    executor: docker-node
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_npm
+      - run:
+          name: Deciding version
+          command: make binary-releases/version
+      - persist_to_workspace:
+          root: .
+          paths:
+            - binary-releases/version
   regression-test:
     parameters:
       test_snyk_command:
@@ -764,12 +778,10 @@ workflows:
           context: nodejs-install
           requires:
             - Build
-      - build-artifacts:
-          name: Build Artifacts
-          context:
-            - snyk-cli-pgp-signing
+      - version:
+          name: Version
           requires:
-            - Build
+            - Install
           filters:
             branches:
               only:
@@ -777,6 +789,13 @@ workflows:
                 - /^.*test.*$/
                 - /^.*v2.*$/
                 - master
+      - build-artifacts:
+          name: Build Artifacts
+          context:
+            - snyk-cli-pgp-signing
+          requires:
+            - Build
+            - Version
       - test-windows:
           name: Acceptance Tests (snyk-win.exe)
           context: nodejs-install

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+#!make
+#
+# This Makefile is only for building release artifacts. Use `npm run` for CLIv1 scripts.
+#
+# Documentation: https://www.gnu.org/software/make/manual/make.html
+#
+
+# First target is default when running `make`.
+.PHONY: help
+help:
+	@echo 'Usage: make <target>'
+	@echo
+	@echo 'This Makefile is currently only for building release artifacts.'
+	@echo 'Use `npm run` for CLIv1 scripts.'
+
+binary-releases:
+	mkdir binary-releases
+
+binary-releases/version: | binary-releases
+	./release-scripts/next-version.sh > binary-releases/version

--- a/release-scripts/make-binaries.sh
+++ b/release-scripts/make-binaries.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-mkdir binary-releases
+# Do not run this file locally. To build release artifacts, see CONTRIBUTING.
 
 mv "$(npm pack --workspace '@snyk/fix')" binary-releases/snyk-fix.tgz
 mv "$(npm pack --workspace '@snyk/protect')" binary-releases/snyk-protect.tgz
@@ -48,8 +48,7 @@ gpg --clear-sign --local-user=1F4B9569 --passphrase="$SNYK_CODE_SIGNING_GPG_PASS
 cat sha256sums.txt.asc
 popd
 
-BUILD_VERSION="$(jq -r '.version' package.json)"
-echo "${BUILD_VERSION}" > binary-releases/version
+BUILD_VERSION="$(cat binary-releases/version)"
 
 cp ./release-scripts/release.json binary-releases/release.json
 if [[ $(uname -s) == "Darwin" ]];then

--- a/release-scripts/next-version.sh
+++ b/release-scripts/next-version.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Checks the latest version of Snyk CLI on npm and decides the next version.
+# Only output the next version to stdout. All other output should go to stderr.
+
+CURRENT_VERSION="$(npm view snyk version)"
+RELEASE_BRANCH="master"
+if [ "${CIRCLE_BRANCH:-}" == "${RELEASE_BRANCH}" ]; then
+    NEXT_VERSION="$(npx semver "${CURRENT_VERSION}" -i minor)"
+else
+    NEXT_VERSION="${CURRENT_VERSION}-dev.$(git rev-parse HEAD)"
+fi
+echo "Current version: ${CURRENT_VERSION}" 1>&2
+echo "Next version:    ${NEXT_VERSION}" 1>&2
+
+echo "${NEXT_VERSION}"

--- a/release-scripts/prepare-packages-for-release.sh
+++ b/release-scripts/prepare-packages-for-release.sh
@@ -1,15 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CURRENT_VERSION="$(npm view snyk version)"
-RELEASE_BRANCH="master"
-if [ "${CIRCLE_BRANCH}" == "${RELEASE_BRANCH}" ]; then
-  NEXT_VERSION="$(npx semver "${CURRENT_VERSION}" -i minor)"
-else
-  NEXT_VERSION="${CURRENT_VERSION}-dev.$(git rev-parse HEAD)"
-fi
-echo "Current version: ${CURRENT_VERSION}"
-echo "Next version: ${NEXT_VERSION}"
-
-npm version "${NEXT_VERSION}" --no-git-tag-version --workspaces --include-workspace-root
+BUILD_VERSION="$(cat binary-releases/version)"
+npm version "${BUILD_VERSION}" --no-git-tag-version --workspaces --include-workspace-root
 npx ts-node ./release-scripts/prune-dependencies-in-packagejson.ts


### PR DESCRIPTION
Build job needs to be split so that we can parallelise it, but we only want to version bump once.

This change introduces a Makefile for CLIv1 which will gradually grow to include more build steps.