### PR TITLE
chore: Add a temporary `IAC_OUTPUT_V2` configuration for New CLI Output

### DIFF
--- a/src/cli/commands/test/iac/index.ts
+++ b/src/cli/commands/test/iac/index.ts
@@ -85,7 +85,8 @@ export default async function(
   let iacIgnoredIssuesCount = 0;
   let iacOutputMeta: IacOutputMeta | undefined;
 
-  const isNewIacOutputSupported = await hasFeatureFlag('iacCliOutput', options);
+  const isNewIacOutputSupported =
+    config.IAC_OUTPUT_V2 || (await hasFeatureFlag('iacCliOutput', options));
 
   if (shouldLogUserMessages(options, isNewIacOutputSupported)) {
     console.log(EOL + iacTestTitle + EOL);

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -23,6 +23,7 @@ interface Config {
   DRIFTCTL_PATH?: string;
   DRIFTCTL_URL?: string;
   IAC_BUNDLE_PATH?: string;
+  IAC_OUTPUT_V2?: boolean;
 }
 
 // TODO: fix the types!


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Creates a temporary `IAC_OUTPUT_V2 ` environment variable for enabling the New CLI Output feature.

#### Where should the reviewer start?

```
src/cli/commands/test/iac/index.ts
```

#### How should this be manually tested?

- Ensure the new output is available by configuring either the feature flag or the temporary environment variable.
- Ensure the new output is not available when neither is configured.

#### Any background context you want to provide?

- As part of the closed-beta release for this feature, we'd like to increase reachability for this feature and get as many users to test different use-cases and flows of the IaC test command. To do so, [it's been suggested](https://snyk.slack.com/archives/CS61093QC/p1652882875746809) that we create a temporary environment variable which can enable thie feature.

### Additinoal information

- [Relevant Slack thread](https://snyk.slack.com/archives/CS61093QC/p1652882875746809)
- [PR used for reference](https://github.com/snyk/cli/pull/3139)