### PR TITLE
chore(ci): split release metadata from build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -483,6 +483,26 @@ jobs:
       - run:
           name: Building artifacts
           command: ./release-scripts/make-binaries.sh
+      - persist_to_workspace:
+          root: .
+          paths:
+            - binary-releases
+  prepare-release:
+    executor: docker-node
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_npm
+      - run:
+          name: Signing shasums
+          command: make binary-releases/sha256sums.txt.asc
+      - run:
+          name: Making release.json
+          command: make binary-releases/release.json
+      - run:
+          name: Making release notes
+          command: make binary-releases/RELEASE_NOTES.md
       - store_artifacts:
           path: ./binary-releases
       - run:
@@ -788,8 +808,6 @@ workflows:
                 - master
       - build-artifacts:
           name: Build Artifacts
-          context:
-            - snyk-cli-pgp-signing
           requires:
             - Build
             - Version
@@ -823,10 +841,17 @@ workflows:
           requires:
             - Build Artifacts
           test_snyk_command: /mnt/ramdisk/snyk/binary-releases/snyk-linux
+      - prepare-release:
+          name: Prepare Release
+          context:
+            - snyk-cli-pgp-signing
+          requires:
+            - Build Artifacts
       - should-release:
           name: Release?
           type: approval
           requires:
+            - Prepare Release
             - Lint
             - Tap Tests
             - Jest Tests (Linux, Node v12.22.11)

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,6 @@ prepack: binary-releases/version
 clean-prepack:
 	git checkout package.json package-lock.json packages/*/package.json packages/*/package-lock.json
 	rm -f prepack
+
+binary-releases/release.json: binary-releases/version $(wildcard binary-releases/*.sha256)
+	./release-scripts/release.json.sh

--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,10 @@ clean-prepack:
 
 binary-releases/release.json: binary-releases/version $(wildcard binary-releases/*.sha256)
 	./release-scripts/release.json.sh
+
+# --commit-path is forwarded to `git log <path>`.
+#   We're using this to remove CLIv2 changes in v1's changelogs.
+#   :(exclude) syntax: https://git-scm.com/docs/gitglossary.html#Documentation/gitglossary.txt-exclude
+# Release notes uses version from package.json so we need to prepack beforehand.
+binary-releases/RELEASE_NOTES.md: prepack | binary-releases
+	npx conventional-changelog-cli -p angular -l -r 1 --commit-path ':(exclude)cliv2' > binary-releases/RELEASE_NOTES.md

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ clean-prepack:
 	git checkout package.json package-lock.json packages/*/package.json packages/*/package-lock.json
 	rm -f prepack
 
+binary-releases/sha256sums.txt.asc: $(wildcard binary-releases/*.sha256)
+	./release-scripts/sha256sums.txt.asc.sh
+
 binary-releases/release.json: binary-releases/version $(wildcard binary-releases/*.sha256)
 	./release-scripts/release.json.sh
 

--- a/release-scripts/make-binaries.sh
+++ b/release-scripts/make-binaries.sh
@@ -50,29 +50,7 @@ gpg --clear-sign --local-user=1F4B9569 --passphrase="$SNYK_CODE_SIGNING_GPG_PASS
 cat sha256sums.txt.asc
 popd
 
-BUILD_VERSION="$(cat binary-releases/version)"
-
-cp ./release-scripts/release.json binary-releases/release.json
-if [[ $(uname -s) == "Darwin" ]];then
-    echo "this is Mac"
-    sed -i "" "s|1.0.0-monorepo|${BUILD_VERSION}|g" binary-releases/release.json
-    sed -i "" "s|snyk-alpine-sha256|$(cat binary-releases/snyk-alpine.sha256)|" binary-releases/release.json
-    sed -i "" "s|snyk-linux-sha256|$(cat binary-releases/snyk-linux.sha256)|" binary-releases/release.json
-    sed -i "" "s|snyk-linux-arm64-sha256|$(cat binary-releases/snyk-linux-arm64.sha256)|" binary-releases/release.json
-    sed -i "" "s|snyk-macos-sha256|$(cat binary-releases/snyk-macos.sha256)|" binary-releases/release.json
-    sed -i "" "s|snyk-win.exe-sha256|$(cat binary-releases/snyk-win.exe.sha256)|" binary-releases/release.json
-else
-    echo "this is Linux"
-    sed -i "s|1.0.0-monorepo|${BUILD_VERSION}|g" binary-releases/release.json
-    sed -i "s|snyk-alpine-sha256|$(cat binary-releases/snyk-alpine.sha256)|" binary-releases/release.json
-    sed -i "s|snyk-linux-sha256|$(cat binary-releases/snyk-linux.sha256)|" binary-releases/release.json
-    sed -i "s|snyk-linux-arm64-sha256|$(cat binary-releases/snyk-linux-arm64.sha256)|" binary-releases/release.json
-    sed -i "s|snyk-macos-sha256|$(cat binary-releases/snyk-macos.sha256)|" binary-releases/release.json
-    sed -i "s|snyk-win.exe-sha256|$(cat binary-releases/snyk-win.exe.sha256)|" binary-releases/release.json
-fi
-
-# sanity check if release.json is a valid JSON
-jq '.' binary-releases/release.json
+make binary-releases/release.json
 
 # --commit-path is forwarded to `git log <path>`.
 #     We're use this to remove CLIv2 changes in v1's changelogs.

--- a/release-scripts/make-binaries.sh
+++ b/release-scripts/make-binaries.sh
@@ -51,10 +51,6 @@ cat sha256sums.txt.asc
 popd
 
 make binary-releases/release.json
-
-# --commit-path is forwarded to `git log <path>`.
-#     We're use this to remove CLIv2 changes in v1's changelogs.
-# :(exclude) syntax: https://git-scm.com/docs/gitglossary.html#Documentation/gitglossary.txt-exclude
-npx conventional-changelog-cli -p angular -l -r 1 --commit-path ':(exclude)cliv2' > binary-releases/RELEASE_NOTES.md
+make binary-releases/RELEASE_NOTES.md
 
 ls -la

--- a/release-scripts/make-binaries.sh
+++ b/release-scripts/make-binaries.sh
@@ -39,17 +39,7 @@ shasum -a 256 snyk-fix.tgz > snyk-fix.tgz.sha256
 shasum -a 256 snyk-protect.tgz > snyk-protect.tgz.sha256
 shasum -a 256 snyk.tgz > snyk.tgz.sha256
 
-# GPG signed shasums file
-cat ./*.sha256 >> sha256sums.txt
-
-echo "Importing PGP key"
-echo "$SNYK_CODE_SIGNING_PGP_PRIVATE" | base64 --decode | gpg --import --batch --passphrase="$SNYK_CODE_SIGNING_GPG_PASSPHRASE"
-
-echo "Signing shasums file"
-gpg --clear-sign --local-user=1F4B9569 --passphrase="$SNYK_CODE_SIGNING_GPG_PASSPHRASE" --pinentry-mode=loopback --armor --batch sha256sums.txt
-cat sha256sums.txt.asc
-popd
-
+make binary-releases/sha256sums.txt.asc
 make binary-releases/release.json
 make binary-releases/RELEASE_NOTES.md
 

--- a/release-scripts/make-binaries.sh
+++ b/release-scripts/make-binaries.sh
@@ -39,8 +39,4 @@ shasum -a 256 snyk-fix.tgz > snyk-fix.tgz.sha256
 shasum -a 256 snyk-protect.tgz > snyk-protect.tgz.sha256
 shasum -a 256 snyk.tgz > snyk.tgz.sha256
 
-make binary-releases/sha256sums.txt.asc
-make binary-releases/release.json
-make binary-releases/RELEASE_NOTES.md
-
 ls -la

--- a/release-scripts/release.json.sh
+++ b/release-scripts/release.json.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_FILE="binary-releases/release.json"
+
+cp ./release-scripts/release.json "${OUTPUT_FILE}"
+
+if [[ $(uname -s) == "Darwin" ]];then
+    echo "this is Mac"
+    sed -i "" "s|1.0.0-monorepo|$(cat binary-releases/version)|g" "${OUTPUT_FILE}"
+    sed -i "" "s|snyk-alpine-sha256|$(cat binary-releases/snyk-alpine.sha256)|" "${OUTPUT_FILE}"
+    sed -i "" "s|snyk-linux-sha256|$(cat binary-releases/snyk-linux.sha256)|" "${OUTPUT_FILE}"
+    sed -i "" "s|snyk-linux-arm64-sha256|$(cat binary-releases/snyk-linux-arm64.sha256)|" "${OUTPUT_FILE}"
+    sed -i "" "s|snyk-macos-sha256|$(cat binary-releases/snyk-macos.sha256)|" "${OUTPUT_FILE}"
+    sed -i "" "s|snyk-win.exe-sha256|$(cat binary-releases/snyk-win.exe.sha256)|" "${OUTPUT_FILE}"
+else
+    echo "this is Linux"
+    sed -i "s|1.0.0-monorepo|$(cat binary-releases/version)|g" "${OUTPUT_FILE}"
+    sed -i "s|snyk-alpine-sha256|$(cat binary-releases/snyk-alpine.sha256)|" "${OUTPUT_FILE}"
+    sed -i "s|snyk-linux-sha256|$(cat binary-releases/snyk-linux.sha256)|" "${OUTPUT_FILE}"
+    sed -i "s|snyk-linux-arm64-sha256|$(cat binary-releases/snyk-linux-arm64.sha256)|" "${OUTPUT_FILE}"
+    sed -i "s|snyk-macos-sha256|$(cat binary-releases/snyk-macos.sha256)|" "${OUTPUT_FILE}"
+    sed -i "s|snyk-win.exe-sha256|$(cat binary-releases/snyk-win.exe.sha256)|" "${OUTPUT_FILE}"
+fi
+
+# sanity check if release.json is a valid JSON
+jq '.' "${OUTPUT_FILE}"

--- a/release-scripts/sha256sums.txt.asc.sh
+++ b/release-scripts/sha256sums.txt.asc.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat binary-releases/*.sha256 > binary-releases/sha256sums.txt
+
+echo "Importing PGP key"
+echo "${SNYK_CODE_SIGNING_PGP_PRIVATE}" \
+    | base64 --decode \
+    | gpg --import --batch --passphrase "${SNYK_CODE_SIGNING_GPG_PASSPHRASE}"
+
+echo "Signing shasums file"
+gpg \
+    --clear-sign \
+    --local-user=1F4B9569 \
+    --passphrase="${SNYK_CODE_SIGNING_GPG_PASSPHRASE}" \
+    --pinentry-mode=loopback \
+    --armor \
+    --batch binary-releases/sha256sums.txt
+
+rm binary-releases/sha256sums.txt
+cat binary-releases/sha256sums.txt.asc


### PR DESCRIPTION
We want to parallelise the "Build Artifacts" job, and after all those jobs are done, we can generate release metadata. So generating release metadata should be in its own job.

I've split Makefile migrations into separate commits to make reviews easier.

More information: https://www.notion.so/snyk/CLI-Speed-Up-Time-to-Build-in-CI-0d7ce418ecd14fa0bd8fac1ac391eea1