### PR TITLE
feat: unmanaged support for remote-repo-url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "rimraf": "^2.6.3",
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.19.3",
+        "snyk-cpp-plugin": "2.20.0",
         "snyk-docker-plugin": "^4.35.2",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.18.1",
@@ -16184,9 +16184,9 @@
       }
     },
     "node_modules/snyk-cpp-plugin": {
-      "version": "2.19.3",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.19.3.tgz",
-      "integrity": "sha512-gNFf0FRuhT6+GHbSvZEm19cfkgL2hvNzUueH0rmqxVCYQBHbLtx6ZAh4FD39AHFOWTb8+zTY/LU0WM7jIm4DfA==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.20.0.tgz",
+      "integrity": "sha512-MYsoeQg2JRZ2aLF4IDiWSnRmqV37H+mRDhQ5snTwznIpMi7Jx8hRAgbE3x04ZEKvgSyRCpeFz+lbu8RPQ5/7+w==",
       "dependencies": {
         "@snyk/dep-graph": "^1.19.3",
         "@types/minimatch": "^3.0.5",
@@ -32396,9 +32396,9 @@
       }
     },
     "snyk-cpp-plugin": {
-      "version": "2.19.3",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.19.3.tgz",
-      "integrity": "sha512-gNFf0FRuhT6+GHbSvZEm19cfkgL2hvNzUueH0rmqxVCYQBHbLtx6ZAh4FD39AHFOWTb8+zTY/LU0WM7jIm4DfA==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.20.0.tgz",
+      "integrity": "sha512-MYsoeQg2JRZ2aLF4IDiWSnRmqV37H+mRDhQ5snTwznIpMi7Jx8hRAgbE3x04ZEKvgSyRCpeFz+lbu8RPQ5/7+w==",
       "requires": {
         "@snyk/dep-graph": "^1.19.3",
         "@types/minimatch": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "rimraf": "^2.6.3",
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
-    "snyk-cpp-plugin": "2.19.3",
+    "snyk-cpp-plugin": "2.20.0",
     "snyk-docker-plugin": "^4.35.2",
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.18.1",


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This allows users to make use of the `--remote-repo-url` flag on the cli and override the value, e.g. `--remote-repo-url=dan-local`:
![image](https://user-images.githubusercontent.com/15086861/169503519-033d9d4c-3d71-4ca3-9ccb-c87a490386cc.png)

