### PR TITLE
chore: Implement new test failure message [CFG-1861]

### DIFF
--- a/src/lib/errors/formatted-custom-error.ts
+++ b/src/lib/errors/formatted-custom-error.ts
@@ -1,0 +1,16 @@
+import chalk from 'chalk';
+import { CustomError } from '.';
+
+export class FormattedCustomError extends CustomError {
+  public formattedUserMessage: string;
+
+  constructor(
+    message: string,
+    formattedUserMessage: string,
+    userMessage?: string,
+  ) {
+    super(message);
+    this.userMessage = userMessage || chalk.reset(formattedUserMessage);
+    this.formattedUserMessage = formattedUserMessage;
+  }
+}

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -26,3 +26,4 @@ export { FeatureNotSupportedByPackageManagerError } from './feature-not-supporte
 export { DockerImageNotFoundError } from './docker-image-not-found-error';
 export { NotFoundError } from './not-found-error';
 export { errorMessageWithRetry } from './error-with-retry';
+export { FormattedCustomError } from './formatted-custom-error';

--- a/src/lib/errors/legacy-errors.js
+++ b/src/lib/errors/legacy-errors.js
@@ -3,6 +3,7 @@ const chalk = require('chalk');
 const { SEVERITIES } = require('../snyk-test/common');
 const { errorMessageWithRetry } = require('./error-with-retry');
 const analytics = require('../analytics');
+const { FormattedCustomError } = require('./formatted-custom-error');
 
 const errors = {
   connect: 'Check your network connection, failed to connect to Snyk API',
@@ -86,8 +87,12 @@ module.exports.message = function(error) {
       codes[error.code || error.message] ||
       errors[error.code || error.message];
     if (message) {
-      message = message.replace(/(%s)/g, error.message).trim();
-      message = chalk.bold.red(message);
+      if (error instanceof FormattedCustomError) {
+        message = error.formattedUserMessage;
+      } else {
+        message = message.replace(/(%s)/g, error.message).trim();
+        message = chalk.bold.red(message);
+      }
     } else if (error.code) {
       // means it's a code error
       message =

--- a/src/lib/formatters/iac-output/index.ts
+++ b/src/lib/formatters/iac-output/index.ts
@@ -10,6 +10,7 @@ export {
   formatIacTestSummary,
   getIacDisplayedIssues,
   formatIacTestFailures,
+  formatFailuresList,
   iacTestTitle,
   spinnerMessage,
   spinnerSuccessMessage,
@@ -18,4 +19,5 @@ export {
   shouldLogUserMessages,
   formatShareResultsOutput,
   failuresTipOutput,
+  IaCTestFailure,
 } from './v2';

--- a/src/lib/formatters/iac-output/v2/failures/index.ts
+++ b/src/lib/formatters/iac-output/v2/failures/index.ts
@@ -1,2 +1,2 @@
-export { formatIacTestFailures } from './list';
+export { formatIacTestFailures, formatFailuresList } from './list';
 export { failuresTipOutput } from './tip';

--- a/src/lib/formatters/iac-output/v2/failures/list.ts
+++ b/src/lib/formatters/iac-output/v2/failures/list.ts
@@ -37,7 +37,7 @@ function groupTestFailuresByFailureReason(
   }, {});
 }
 
-function formatFailuresList(testFailures: IaCTestFailure[]) {
+export function formatFailuresList(testFailures: IaCTestFailure[]): string {
   const testFailuresByReason = groupTestFailuresByFailureReason(testFailures);
   return Object.entries(testFailuresByReason)
     .map(([failureReason, testFailures]) =>

--- a/src/lib/formatters/iac-output/v2/index.ts
+++ b/src/lib/formatters/iac-output/v2/index.ts
@@ -9,4 +9,9 @@ export {
   customRulesReportMessage,
 } from './user-messages';
 export { formatShareResultsOutput } from './share-results';
-export { formatIacTestFailures, failuresTipOutput } from './failures';
+export {
+  formatIacTestFailures,
+  formatFailuresList,
+  failuresTipOutput,
+} from './failures';
+export { IaCTestFailure } from './types';

--- a/test/jest/acceptance/iac/iac-output.spec.ts
+++ b/test/jest/acceptance/iac/iac-output.spec.ts
@@ -214,15 +214,48 @@ Target file:       ${dirPath}/`);
     });
 
     describe('with only test failures', () => {
-      it('should display the failure reason for the first failed test', async () => {
-        const dirPath = 'iac/only-invalid';
-        const { stdout } = await run(`snyk iac test ${dirPath}`);
+      it('should display the test failures list', async () => {
+        const invalidPaths = [
+          pathLib.join('iac', 'only-invalid'),
+          pathLib.join('iac', 'cloudformation', 'invalid-cfn.yml'),
+          pathLib.join(
+            'iac',
+            'terraform',
+            'sg_open_ssh_invalid_go_templates.tf',
+          ),
+          pathLib.join('iac', 'terraform', 'sg_open_ssh_invalid_hcl2.tf'),
+          pathLib.join('does', 'not', 'exist'),
+        ];
+        const { stdout } = await run(`snyk iac test ${invalidPaths.join(' ')}`);
 
         expect(stdout).toContain(
-          `Could not find any valid infrastructure as code files. Supported file extensions are tf, yml, yaml & json.
-More information can be found by running \`snyk iac test --help\` or through our documentation:
-https://support.snyk.io/hc/en-us/articles/360012429477-Test-your-Kubernetes-files-with-our-CLI-tool
-https://support.snyk.io/hc/en-us/articles/360013723877-Test-your-Terraform-files-with-our-CLI-tool`,
+          '  Could not find any valid IaC files' +
+            EOL +
+            `  Path: ${pathLib.join('iac', 'only-invalid')}` +
+            EOL +
+            `        ${pathLib.join('does', 'not', 'exist')}` +
+            EOL.repeat(2) +
+            '  Failed to parse YAML file' +
+            EOL +
+            `  Path: ${pathLib.join(
+              'iac',
+              'cloudformation',
+              'invalid-cfn.yml',
+            )}` +
+            EOL.repeat(2) +
+            '  Failed to parse Terraform file' +
+            EOL +
+            `  Path: ${pathLib.join(
+              'iac',
+              'terraform',
+              'sg_open_ssh_invalid_go_templates.tf',
+            )}` +
+            EOL +
+            `        ${pathLib.join(
+              'iac',
+              'terraform',
+              'sg_open_ssh_invalid_hcl2.tf',
+            )}`,
         );
       });
 


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Implements the new test failure message format, according to [this design](https://www.figma.com/file/buNFZqr1Uhf4SaifHw4WXE/Snyk-IaC-CLI?node-id=1684%3A15297).

#### Where should the reviewer start?

```
src/cli/commands/test/iac/index.ts
```

#### Notes for the reviewer

- This review includes a new class called `FormattedCustomError`, which extends `CustomError`. This class can shift user message formatting from the CLI's error handling middleware, to the error class. The class adds a boolean flag called `isFormatted`, which is set to `true`. This indicates to the error handling middleware whether or not to format the user message.
- The change above was inspired by [this PR comment](https://github.com/snyk/cli/pull/3218#discussion_r868306574).
- For errors that are related to the flow, and not particular paths, such as initializing the local cache, fetching/initializing custom rules, fetching org settings, etc., the error format does not change.

#### How should this be manually tested?

1. Run `SNYK_IAC_OUTPUT_V2=true snyk iac test` with one or more paths that cannot complete the test successfully or have no files that were successfully scanned. 
2. Ensure the test failure message is aligned with the design and that the values are correct.
3. Run `SNYK_IAC_OUTPUT_V2=true snyk iac test` with one or more paths, some of which can be paths for which the test cannot be completed successfully.
4. Ensure the output was not changed for these flows.

#### Any background context you want to provide?

In the context of this ticket, test failures are considered to be the cases in which there are no valid files which were successfully scanned, and the test only resulted in failures. This includes but isn’t limited to:

- Given a path to a file, failing to test this file.
- Given a path to a directory, failing to test all files in this directory.
- Given a path to a directory with no files to test.
- Failing to set up the environment for the test (e.g., downloading the security rules bundle, setting up the local cache, fetching the org settings, fetching remote custom rules, using invalid custom rules, etc.)
- Given multiple paths of files/dirs, with all of them resulting in failures, either path-based or file-based.

When the entire test flow fails, in the original output format, we’d only display the failure reason of the first failing path, with no further output. We’d like to modify that and adapt it to the design of the new output format.

#### What are the relevant tickets?

- [CFG-1861](https://snyksec.atlassian.net/browse/CFG-1861)

#### Screenshots

![image](https://user-images.githubusercontent.com/46415136/169775905-759cf200-3e94-4876-a1c6-4033f8f69736.png)
