### PR TITLE
fix: (iac) last error does not override previous

### DIFF
--- a/src/cli/commands/test/iac/index.ts
+++ b/src/cli/commands/test/iac/index.ts
@@ -132,7 +132,7 @@ export default async function(
         };
 
         res = results;
-        iacScanFailures = failures ? failures : [];
+        iacScanFailures = [...iacScanFailures, ...(failures || [])];
         iacIgnoredIssuesCount += ignoreCount;
       } catch (error) {
         res = formatTestError(error);
@@ -141,7 +141,6 @@ export default async function(
       // Not all test results are arrays in order to be backwards compatible
       // with scripts that use a callback with test. Coerce results/errors to be arrays
       // and add the result options to each to be displayed
-      // TODO: Similarly to above, do we actually need to convert this to an array?
       const resArray: any[] = Array.isArray(res) ? res : [res];
 
       for (let i = 0; i < resArray.length; i++) {

--- a/test/jest/acceptance/iac/test-directory.spec.ts
+++ b/test/jest/acceptance/iac/test-directory.spec.ts
@@ -104,9 +104,8 @@ describe('Directory scan', () => {
       );
       //directory scan shows relative path to cwd  in output
       expect(stdout).toContain('Testing sg_open_ssh.tf');
-      //TODO: currently the failures show only for the second path->cloudformation so this will fail:
-      // expect(stdout).toContain('Testing sg_open_ssh_invalid_hcl2.tf');
-      // expect(stdout).toContain('Failed to parse Terraform file');
+      expect(stdout).toContain('Testing sg_open_ssh_invalid_hcl2.tf');
+      expect(stdout).toContain('Failed to parse Terraform file');
       expect(stdout).toContain('Testing aurora-valid.yml');
       expect(stdout).toContain('Testing invalid-cfn.yml');
       expect(stdout).toContain('Failed to parse YAML file');


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?


Small regression that happened after we merged https://github.com/snyk/cli/pull/3239.
I had a refactor before merging and accidentally changed the line that stores all the failures, resulting in our scan showing just the last path's failures in the output.

I switched it back to store all failures in the for loop, so now we are going to see all of them in the output.
The test validates the behaviour.

for  `snyk-dev iac test test/fixtures/iac/terraform/ test/fixtures/iac/cloudformation/`, we will see all errors for both outputs:
<img width="1036" alt="image" src="https://user-images.githubusercontent.com/6989529/169779159-14fdd446-563e-448c-95bb-9a26f8c84ab2.png">

<img width="1207" alt="image" src="https://user-images.githubusercontent.com/6989529/169779289-e3ccdeed-ef17-470c-b9af-106602e69d40.png">
