### PR TITLE
refactor: create only one project group per execution

### DIFF
--- a/src/cli/commands/test/iac/local-execution/index.ts
+++ b/src/cli/commands/test/iac/local-execution/index.ts
@@ -23,7 +23,7 @@ import {
 } from './measurable-methods';
 import { findAndLoadPolicy } from '../../../../../lib/policy';
 import { NoFilesToScanError } from './file-loader';
-import { processResults } from './process-results';
+import { ResultsProcessor } from './process-results';
 import { generateProjectAttributes, generateTags } from '../../../monitor';
 import {
   getAllDirectoriesForPath,
@@ -35,9 +35,9 @@ import { getErrorStringCode } from './error-utils';
 // this method executes the local processing engine and then formats the results to adapt with the CLI output.
 // this flow is the default GA flow for IAC scanning.
 export async function test(
+  resultsProcessor: ResultsProcessor,
   pathToScan: string,
   options: IaCTestFlags,
-  orgPublicId: string,
   iacOrgSettings: IacOrgSettings,
   rulesOrigin: RulesOrigin,
 ): Promise<TestReturnValue> {
@@ -110,15 +110,11 @@ export async function test(
     iacOrgSettings.customPolicies,
   );
 
-  const { filteredIssues, ignoreCount } = await processResults(
+  const { filteredIssues, ignoreCount } = await resultsProcessor.processResults(
     resultsWithCustomSeverities,
-    orgPublicId,
-    iacOrgSettings,
     policy,
     tags,
     attributes,
-    options,
-    pathToScan,
   );
 
   try {

--- a/src/cli/commands/test/iac/local-execution/measurable-methods.ts
+++ b/src/cli/commands/test/iac/local-execution/measurable-methods.ts
@@ -1,6 +1,7 @@
 import { parseFiles } from './file-parser';
 import { scanFiles } from './file-scanner';
-import { formatScanResults } from './process-results/results-formatter';
+import { formatScanResults as formatScanResultsV1 } from './process-results/v1/results-formatter';
+import { formatScanResults as formatScanResultsV2 } from './process-results/v2/results-formatter';
 import { trackUsage } from './usage-tracking';
 import { cleanLocalCache, initLocalCache } from './local-cache';
 import { applyCustomSeverities } from './org-settings/apply-custom-severities';
@@ -82,8 +83,13 @@ const measurableCleanLocalCache = performanceAnalyticsDecorator(
   PerformanceAnalyticsKey.CacheCleanup,
 );
 
-const measurableFormatScanResults = performanceAnalyticsDecorator(
-  formatScanResults,
+const measurableFormatScanResultsV1 = performanceAnalyticsDecorator(
+  formatScanResultsV1,
+  PerformanceAnalyticsKey.ResultFormatting,
+);
+
+const measurableFormatScanResultsV2 = performanceAnalyticsDecorator(
+  formatScanResultsV2,
   PerformanceAnalyticsKey.ResultFormatting,
 );
 
@@ -109,7 +115,8 @@ export {
   measurableScanFiles as scanFiles,
   measurableGetIacOrgSettings as getIacOrgSettings,
   measurableApplyCustomSeverities as applyCustomSeverities,
-  measurableFormatScanResults as formatScanResults,
+  measurableFormatScanResultsV1 as formatScanResultsV1,
+  measurableFormatScanResultsV2 as formatScanResultsV2,
   measurableTrackUsage as trackUsage,
   measurableCleanLocalCache as cleanLocalCache,
   measurableLocalTest as localTest,

--- a/src/cli/commands/test/iac/local-execution/process-results/v1/extract-line-number.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/v1/extract-line-number.ts
@@ -1,14 +1,14 @@
-import { IaCErrorCodes } from '../types';
-import { CustomError } from '../../../../../../lib/errors';
+import { IaCErrorCodes } from '../../types';
+import { CustomError } from '../../../../../../../lib/errors';
 import {
   CloudConfigFileTypes,
   MapsDocIdToTree,
   getLineNumber,
 } from '@snyk/cloud-config-parser';
-import { UnsupportedFileTypeError } from '../file-parser';
-import * as analytics from '../../../../../../lib/analytics';
+import { UnsupportedFileTypeError } from '../../file-parser';
+import * as analytics from '../../../../../../../lib/analytics';
 import * as Debug from 'debug';
-import { getErrorStringCode } from '../error-utils';
+import { getErrorStringCode } from '../../error-utils';
 const debug = Debug('iac-extract-line-number');
 
 export function getFileTypeForParser(fileType: string): CloudConfigFileTypes {

--- a/src/cli/commands/test/iac/local-execution/process-results/v1/index.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/v1/index.ts
@@ -1,0 +1,47 @@
+import { filterIgnoredIssues } from './policy';
+import { formatAndShareResults } from './share-results';
+import { formatScanResultsV1 } from '../../measurable-methods';
+import { Policy } from '../../../../../../../lib/policy/find-and-load-policy';
+import { ProjectAttributes, Tag } from '../../../../../../../lib/types';
+import {
+  FormattedResult,
+  IacFileScanResult,
+  IacOrgSettings,
+  IaCTestFlags,
+} from '../../types';
+
+export async function processResults(
+  resultsWithCustomSeverities: IacFileScanResult[],
+  orgPublicId: string,
+  iacOrgSettings: IacOrgSettings,
+  policy: Policy | undefined,
+  tags: Tag[] | undefined,
+  attributes: ProjectAttributes | undefined,
+  options: IaCTestFlags,
+  pathToScan: string,
+): Promise<{ filteredIssues: FormattedResult[]; ignoreCount: number }> {
+  let projectPublicIds: Record<string, string> = {};
+  let gitRemoteUrl: string | undefined;
+
+  if (options.report) {
+    ({ projectPublicIds, gitRemoteUrl } = await formatAndShareResults({
+      results: resultsWithCustomSeverities,
+      options,
+      orgPublicId,
+      policy,
+      tags,
+      attributes,
+      pathToScan,
+    }));
+  }
+
+  const formattedResults = formatScanResultsV1(
+    resultsWithCustomSeverities,
+    options,
+    iacOrgSettings.meta,
+    projectPublicIds,
+    gitRemoteUrl,
+  );
+
+  return filterIgnoredIssues(policy, formattedResults);
+}

--- a/src/cli/commands/test/iac/local-execution/process-results/v1/policy.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/v1/policy.ts
@@ -1,5 +1,5 @@
-import { FormattedResult, PolicyMetadata } from '../types';
-import { Policy } from '../../../../../../lib/policy/find-and-load-policy';
+import { FormattedResult, PolicyMetadata } from '../../types';
+import { Policy } from '../../../../../../../lib/policy/find-and-load-policy';
 
 export function filterIgnoredIssues(
   policy: Policy | undefined,

--- a/src/cli/commands/test/iac/local-execution/process-results/v1/results-formatter.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/v1/results-formatter.ts
@@ -1,0 +1,203 @@
+import {
+  EngineType,
+  FormattedResult,
+  IaCErrorCodes,
+  IacFileScanResult,
+  IaCTestFlags,
+  PolicyMetadata,
+  TestMeta,
+} from '../../types';
+import {
+  SEVERITY,
+  SEVERITIES,
+} from '../../../../../../../lib/snyk-test/common';
+import { IacProjectType } from '../../../../../../../lib/iac/constants';
+import { CustomError } from '../../../../../../../lib/errors';
+import { extractLineNumber, getFileTypeForParser } from './extract-line-number';
+import { getErrorStringCode } from '../../error-utils';
+import {
+  MapsDocIdToTree,
+  getTrees,
+  parsePath,
+} from '@snyk/cloud-config-parser';
+import * as path from 'path';
+import { isLocalFolder } from '../../../../../../../lib/detect';
+
+const severitiesArray = SEVERITIES.map((s) => s.verboseName);
+
+export function formatScanResults(
+  scanResults: IacFileScanResult[],
+  options: IaCTestFlags,
+  meta: TestMeta,
+  projectPublicIds: Record<string, string>,
+  gitRemoteUrl?: string,
+): FormattedResult[] {
+  try {
+    const groupedByFile = scanResults.reduce((memo, scanResult) => {
+      const res = formatScanResult(scanResult, meta, options);
+
+      if (memo[scanResult.filePath]) {
+        memo[scanResult.filePath].result.cloudConfigResults.push(
+          ...res.result.cloudConfigResults,
+        );
+      } else {
+        res.meta.gitRemoteUrl = gitRemoteUrl;
+        res.meta.projectId = projectPublicIds[res.targetFile];
+        memo[scanResult.filePath] = res;
+      }
+      return memo;
+    }, {} as { [key: string]: FormattedResult });
+    return Object.values(groupedByFile);
+  } catch (e) {
+    throw new FailedToFormatResults();
+  }
+}
+
+const engineTypeToProjectType = {
+  [EngineType.Kubernetes]: IacProjectType.K8S,
+  [EngineType.Terraform]: IacProjectType.TERRAFORM,
+  [EngineType.CloudFormation]: IacProjectType.CLOUDFORMATION,
+  [EngineType.ARM]: IacProjectType.ARM,
+  [EngineType.Custom]: IacProjectType.CUSTOM,
+};
+
+function formatScanResult(
+  scanResult: IacFileScanResult,
+  meta: TestMeta,
+  options: IaCTestFlags,
+): FormattedResult {
+  const fileType = getFileTypeForParser(scanResult.fileType);
+  const isGeneratedByCustomRule = scanResult.engineType === EngineType.Custom;
+  let treeByDocId: MapsDocIdToTree;
+  try {
+    treeByDocId = getTrees(fileType, scanResult.fileContent);
+  } catch (err) {
+    // we do nothing intentionally.
+    // Even if the building of the tree fails in the external parser,
+    // we still pass an undefined tree and not calculated line number for those
+  }
+
+  const formattedIssues = scanResult.violatedPolicies.map((policy) => {
+    const cloudConfigPath =
+      scanResult.docId !== undefined
+        ? [`[DocId: ${scanResult.docId}]`].concat(parsePath(policy.msg))
+        : policy.msg.split('.');
+
+    const lineNumber: number = treeByDocId
+      ? extractLineNumber(cloudConfigPath, fileType, treeByDocId)
+      : -1;
+
+    return {
+      ...policy,
+      id: policy.publicId,
+      name: policy.title,
+      cloudConfigPath,
+      isIgnored: false,
+      iacDescription: {
+        issue: policy.issue,
+        impact: policy.impact,
+        resolve: policy.resolve,
+      },
+      severity: policy.severity,
+      lineNumber,
+      documentation: !isGeneratedByCustomRule
+        ? `https://snyk.io/security-rules/${policy.publicId}`
+        : undefined,
+      isGeneratedByCustomRule,
+    };
+  });
+
+  const { targetFilePath, projectName, targetFile } = computePaths(
+    scanResult.filePath,
+    options.path,
+  );
+  return {
+    result: {
+      cloudConfigResults: filterPoliciesBySeverity(
+        formattedIssues,
+        options.severityThreshold,
+      ),
+      projectType: scanResult.projectType,
+    },
+    meta: {
+      ...meta,
+      projectId: '', // we do not have a project at this stage
+      policy: '', // we do not have the concept of policy
+    },
+    filesystemPolicy: false, // we do not have the concept of policy
+    vulnerabilities: [],
+    dependencyCount: 0,
+    licensesPolicy: null, // we do not have the concept of license policies
+    ignoreSettings: null,
+    targetFile,
+    projectName,
+    org: meta.org,
+    policy: '', // we do not have the concept of policy
+    isPrivate: true,
+    targetFilePath,
+    packageManager: engineTypeToProjectType[scanResult.engineType],
+  };
+}
+
+export function filterPoliciesBySeverity(
+  violatedPolicies: PolicyMetadata[],
+  severityThreshold?: SEVERITY,
+): PolicyMetadata[] {
+  if (!severityThreshold || severityThreshold === SEVERITY.LOW) {
+    return violatedPolicies.filter((violatedPolicy) => {
+      return violatedPolicy.severity !== 'none';
+    });
+  }
+
+  const severitiesToInclude = severitiesArray.slice(
+    severitiesArray.indexOf(severityThreshold),
+  );
+  return violatedPolicies.filter((policy) => {
+    return (
+      policy.severity !== 'none' &&
+      severitiesToInclude.includes(policy.severity)
+    );
+  });
+}
+
+export class FailedToFormatResults extends CustomError {
+  constructor(message?: string) {
+    super(message || 'Failed to format results');
+    this.code = IaCErrorCodes.FailedToFormatResults;
+    this.strCode = getErrorStringCode(this.code);
+    this.userMessage =
+      'We failed printing the results, please contact support@snyk.io';
+  }
+}
+
+function computePaths(
+  filePath: string,
+  pathArg = '.',
+): { targetFilePath: string; projectName: string; targetFile: string } {
+  const targetFilePath = path.resolve(filePath, '.');
+
+  // the absolute path is needed to compute the full project path
+  const cmdPath = path.resolve(pathArg);
+
+  let projectPath: string;
+  let targetFile: string;
+  if (!isLocalFolder(cmdPath)) {
+    // if the provided path points to a file, then the project starts at the parent folder of that file
+    // and the target file was provided as the path argument
+    projectPath = path.dirname(cmdPath);
+    targetFile = path.isAbsolute(pathArg)
+      ? path.relative(process.cwd(), pathArg)
+      : pathArg;
+  } else {
+    // otherwise, the project starts at the provided path
+    // and the target file must be the relative path from the project path to the path of the scanned file
+    projectPath = cmdPath;
+    targetFile = path.relative(projectPath, targetFilePath);
+  }
+
+  return {
+    targetFilePath,
+    projectName: path.basename(projectPath),
+    targetFile,
+  };
+}

--- a/src/cli/commands/test/iac/local-execution/process-results/v1/share-results-formatter.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/v1/share-results-formatter.ts
@@ -1,9 +1,9 @@
-import { IacFileScanResult, IacShareResultsFormat } from '../types';
+import { IacFileScanResult, IacShareResultsFormat } from '../../types';
 import * as path from 'path';
 import {
   getRepositoryRootForPath,
   getWorkingDirectoryForPath,
-} from '../../../../../../lib/iac/git';
+} from '../../../../../../../lib/iac/git';
 
 export function formatShareResults(
   scanResults: IacFileScanResult[],

--- a/src/cli/commands/test/iac/local-execution/process-results/v1/share-results.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/v1/share-results.ts
@@ -1,0 +1,48 @@
+import { isFeatureFlagSupportedForOrg } from '../../../../../../../lib/feature-flags';
+import { shareResults } from '../../../../../../../lib/iac/cli-share-results';
+import { Policy } from '../../../../../../../lib/policy/find-and-load-policy';
+import { ProjectAttributes, Tag } from '../../../../../../../lib/types';
+import { FeatureFlagError } from '../../assert-iac-options-flag';
+import { formatShareResults } from './share-results-formatter';
+import {
+  IacFileScanResult,
+  IaCTestFlags,
+  ShareResultsOutput,
+} from '../../types';
+
+export async function formatAndShareResults({
+  results,
+  options,
+  orgPublicId,
+  policy,
+  tags,
+  attributes,
+  pathToScan,
+}: {
+  results: IacFileScanResult[];
+  options: IaCTestFlags;
+  orgPublicId: string;
+  policy: Policy | undefined;
+  tags?: Tag[];
+  attributes?: ProjectAttributes;
+  pathToScan: string;
+}): Promise<ShareResultsOutput> {
+  const isCliReportEnabled = await isFeatureFlagSupportedForOrg(
+    'iacCliShareResults',
+    orgPublicId,
+  );
+  if (!isCliReportEnabled.ok) {
+    throw new FeatureFlagError('report', 'iacCliShareResults');
+  }
+
+  const formattedResults = formatShareResults(results);
+
+  return await shareResults({
+    results: formattedResults,
+    policy,
+    tags,
+    attributes,
+    options,
+    pathToScan,
+  });
+}

--- a/src/cli/commands/test/iac/local-execution/process-results/v2/cli-share-results.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/v2/cli-share-results.ts
@@ -1,0 +1,110 @@
+import config from '../../../../../../../lib/config';
+import { makeRequest } from '../../../../../../../lib/request';
+import { getAuthHeader } from '../../../../../../../lib/api-token';
+import {
+  IacShareResultsFormat,
+  IaCTestFlags,
+  ShareResultsOutput,
+} from '../../types';
+import { convertIacResultToScanResult } from '../../../../../../../lib/iac/envelope-formatters';
+import { Policy } from '../../../../../../../lib/policy/find-and-load-policy';
+import { getInfo } from '../../../../../../../lib/project-metadata/target-builders/git';
+import { GitTarget } from '../../../../../../../lib/ecosystems/types';
+import { Contributor } from '../../../../../../../lib/types';
+import * as analytics from '../../../../../../../lib/analytics';
+import { getContributors } from '../../../../../../../lib/monitor/dev-count-analysis';
+import * as Debug from 'debug';
+import {
+  AuthFailedError,
+  ValidationError,
+} from '../../../../../../../lib/errors';
+import * as pathLib from 'path';
+
+const debug = Debug('iac-cli-share-results');
+import { ProjectAttributes, Tag } from '../../../../../../../lib/types';
+import { TestLimitReachedError } from '../../usage-tracking';
+import { getRepositoryRootForPath } from '../../../../../../../lib/iac/git';
+
+export async function shareResults({
+  results,
+  policy,
+  tags,
+  attributes,
+  options,
+  projectRoot,
+}: {
+  results: IacShareResultsFormat[];
+  policy: Policy | undefined;
+  tags?: Tag[];
+  attributes?: ProjectAttributes;
+  options?: IaCTestFlags;
+  projectRoot: string;
+}): Promise<ShareResultsOutput> {
+  const gitTarget = await readGitInfoForProjectRoot(projectRoot);
+  const scanResults = results.map((result) =>
+    convertIacResultToScanResult(result, policy, gitTarget, options),
+  );
+
+  let contributors: Contributor[] = [];
+  if (gitTarget.remoteUrl) {
+    if (analytics.allowAnalytics()) {
+      try {
+        contributors = await getContributors();
+      } catch (err) {
+        debug('error getting repo contributors', err);
+      }
+    }
+  }
+  const { res, body } = await makeRequest({
+    method: 'POST',
+    url: `${config.API}/iac-cli-share-results`,
+    json: true,
+    qs: { org: options?.org ?? config.org },
+    headers: {
+      authorization: getAuthHeader(),
+    },
+    body: {
+      scanResults,
+      contributors,
+      tags,
+      attributes,
+    },
+  });
+
+  switch (res.statusCode) {
+    case 401:
+      throw AuthFailedError();
+    case 422:
+      throw new ValidationError(
+        res.body.error ?? 'An error occurred, please contact Snyk support',
+      );
+    case 429:
+      throw new TestLimitReachedError();
+  }
+
+  return { projectPublicIds: body, gitRemoteUrl: gitTarget?.remoteUrl };
+}
+
+async function readGitInfoForProjectRoot(
+  projectRoot: string,
+): Promise<GitTarget> {
+  const repositoryRoot = getRepositoryRootForPath(projectRoot);
+
+  const resolvedRepositoryRoot = pathLib.resolve(repositoryRoot);
+  const resolvedProjectRoot = pathLib.resolve(projectRoot);
+
+  if (resolvedRepositoryRoot != resolvedProjectRoot) {
+    return {};
+  }
+
+  const gitInfo = await getInfo({
+    isFromContainer: false,
+    cwd: projectRoot,
+  });
+
+  if (gitInfo) {
+    return gitInfo;
+  }
+
+  return {};
+}

--- a/src/cli/commands/test/iac/local-execution/process-results/v2/extract-line-number.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/v2/extract-line-number.ts
@@ -1,0 +1,52 @@
+import { IaCErrorCodes } from '../../types';
+import { CustomError } from '../../../../../../../lib/errors';
+import {
+  CloudConfigFileTypes,
+  MapsDocIdToTree,
+  getLineNumber,
+} from '@snyk/cloud-config-parser';
+import { UnsupportedFileTypeError } from '../../file-parser';
+import * as analytics from '../../../../../../../lib/analytics';
+import * as Debug from 'debug';
+import { getErrorStringCode } from '../../error-utils';
+const debug = Debug('iac-extract-line-number');
+
+export function getFileTypeForParser(fileType: string): CloudConfigFileTypes {
+  switch (fileType) {
+    case 'yaml':
+    case 'yml':
+      return CloudConfigFileTypes.YAML;
+    case 'json':
+      return CloudConfigFileTypes.JSON;
+    case 'tf':
+      return CloudConfigFileTypes.TF;
+    default:
+      throw new UnsupportedFileTypeError(fileType);
+  }
+}
+
+export function extractLineNumber(
+  cloudConfigPath: string[],
+  fileType: CloudConfigFileTypes,
+  treeByDocId: MapsDocIdToTree,
+): number {
+  try {
+    return getLineNumber(cloudConfigPath, fileType, treeByDocId);
+  } catch {
+    const err = new FailedToExtractLineNumberError();
+    analytics.add('error-code', err.code);
+    debug('Parser library failed. Could not assign lineNumber to issue');
+    return -1;
+  }
+}
+
+class FailedToExtractLineNumberError extends CustomError {
+  constructor(message?: string) {
+    super(
+      message || 'Parser library failed. Could not assign lineNumber to issue',
+    );
+    this.code = IaCErrorCodes.FailedToExtractLineNumberError;
+    this.strCode = getErrorStringCode(this.code);
+    this.userMessage = ''; // Not a user facing error.
+  }
+}

--- a/src/cli/commands/test/iac/local-execution/process-results/v2/index.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/v2/index.ts
@@ -1,0 +1,51 @@
+import { filterIgnoredIssues } from './policy';
+import { formatAndShareResults } from './share-results';
+import { formatScanResultsV2 } from '../../measurable-methods';
+import { Policy } from '../../../../../../../lib/policy/find-and-load-policy';
+import { ProjectAttributes, Tag } from '../../../../../../../lib/types';
+import {
+  FormattedResult,
+  IacFileScanResult,
+  IacOrgSettings,
+  IaCTestFlags,
+} from '../../types';
+
+export async function processResults(
+  resultsWithCustomSeverities: IacFileScanResult[],
+  orgPublicId: string,
+  iacOrgSettings: IacOrgSettings,
+  policy: Policy | undefined,
+  tags: Tag[] | undefined,
+  attributes: ProjectAttributes | undefined,
+  options: IaCTestFlags,
+  projectRoot: string,
+): Promise<{
+  filteredIssues: FormattedResult[];
+  ignoreCount: number;
+}> {
+  let projectPublicIds: Record<string, string> = {};
+  let gitRemoteUrl: string | undefined;
+
+  if (options.report) {
+    ({ projectPublicIds, gitRemoteUrl } = await formatAndShareResults({
+      results: resultsWithCustomSeverities,
+      options,
+      orgPublicId,
+      policy,
+      tags,
+      attributes,
+      projectRoot,
+    }));
+  }
+
+  const formattedResults = formatScanResultsV2(
+    resultsWithCustomSeverities,
+    options,
+    iacOrgSettings.meta,
+    projectPublicIds,
+    projectRoot,
+    gitRemoteUrl,
+  );
+
+  return filterIgnoredIssues(policy, formattedResults);
+}

--- a/src/cli/commands/test/iac/local-execution/process-results/v2/policy.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/v2/policy.ts
@@ -1,0 +1,92 @@
+import { FormattedResult, PolicyMetadata } from '../../types';
+import { Policy } from '../../../../../../../lib/policy/find-and-load-policy';
+
+export function filterIgnoredIssues(
+  policy: Policy | undefined,
+  results: FormattedResult[],
+) {
+  if (!policy) {
+    return { filteredIssues: results, ignoreCount: 0 };
+  }
+  const vulns = results.map((res) =>
+    policy.filter(toIaCVulnAdapter(res), undefined, 'exact'),
+  );
+  const ignoreCount: number = vulns.reduce(
+    (totalIgnored, vuln) => totalIgnored + vuln.filtered.ignore.length,
+    0,
+  );
+  const filteredIssues = vulns.map((vuln) => toFormattedResult(vuln));
+  return { filteredIssues, ignoreCount };
+}
+
+type IacVulnAdapter = {
+  vulnerabilities: {
+    id: string;
+    from: string[];
+  }[];
+  originalResult: FormattedResult;
+  filtered?: { ignore: any[] };
+};
+
+// This is a total cop-out. The type I really want is AnnotatedIacIssue from
+// src/lib/snyk-test/iac-test-result.ts, but that appears to only be used in the
+// legacy flow and I gave up on adapting it to work in both flows. By the time
+// this code is called, cloudConfigPath is present on the result object.
+type AnnotatedResult = PolicyMetadata & {
+  cloudConfigPath: string[];
+};
+
+function toIaCVulnAdapter(result: FormattedResult): IacVulnAdapter {
+  return {
+    vulnerabilities: result.result.cloudConfigResults.map(
+      (cloudConfigResult) => {
+        const annotatedResult = cloudConfigResult as AnnotatedResult;
+
+        // Copy the cloudConfigPath array to avoid modifying the original with
+        // splice.
+        // Insert the targetFile into the path so that it is taken into account
+        // when determining whether an ignore rule should be applied.
+        const path = [...annotatedResult.cloudConfigPath];
+        path.splice(0, 0, result.targetFile);
+
+        return {
+          id: cloudConfigResult.id as string,
+          from: path,
+        };
+      },
+    ),
+    originalResult: result,
+  };
+}
+
+function toFormattedResult(adapter: IacVulnAdapter): FormattedResult {
+  const original = adapter.originalResult;
+  const filteredCloudConfigResults = original.result.cloudConfigResults.filter(
+    (res) => {
+      return adapter.vulnerabilities.some((vuln) => {
+        if (vuln.id !== res.id) {
+          return false;
+        }
+
+        // Unfortunately we are forced to duplicate the logic in
+        // toIaCVulnAdapter so that we're comparing path components properly,
+        // including target file context. As that logic changes, so must this.
+        const annotatedResult = res as AnnotatedResult;
+        const significantPath = [...annotatedResult.cloudConfigPath];
+        significantPath.splice(0, 0, original.targetFile);
+
+        if (vuln.from.length !== significantPath.length) {
+          return false;
+        }
+        for (let i = 0; i < vuln.from.length; i++) {
+          if (vuln.from[i] !== significantPath[i]) {
+            return false;
+          }
+        }
+        return true;
+      });
+    },
+  );
+  original.result.cloudConfigResults = filteredCloudConfigResults;
+  return original;
+}

--- a/src/cli/commands/test/iac/local-execution/process-results/v2/results-formatter.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/v2/results-formatter.ts
@@ -6,19 +6,22 @@ import {
   IaCTestFlags,
   PolicyMetadata,
   TestMeta,
-} from '../types';
-import { SEVERITY, SEVERITIES } from '../../../../../../lib/snyk-test/common';
-import { IacProjectType } from '../../../../../../lib/iac/constants';
-import { CustomError } from '../../../../../../lib/errors';
+} from '../../types';
+import {
+  SEVERITY,
+  SEVERITIES,
+} from '../../../../../../../lib/snyk-test/common';
+import { IacProjectType } from '../../../../../../../lib/iac/constants';
+import { CustomError } from '../../../../../../../lib/errors';
 import { extractLineNumber, getFileTypeForParser } from './extract-line-number';
-import { getErrorStringCode } from '../error-utils';
+import { getErrorStringCode } from '../../error-utils';
 import {
   MapsDocIdToTree,
   getTrees,
   parsePath,
 } from '@snyk/cloud-config-parser';
 import * as path from 'path';
-import { isLocalFolder } from '../../../../../../lib/detect';
+import { isLocalFolder } from '../../../../../../../lib/detect';
 
 const severitiesArray = SEVERITIES.map((s) => s.verboseName);
 
@@ -27,11 +30,12 @@ export function formatScanResults(
   options: IaCTestFlags,
   meta: TestMeta,
   projectPublicIds: Record<string, string>,
+  porjectRoot: string,
   gitRemoteUrl?: string,
 ): FormattedResult[] {
   try {
     const groupedByFile = scanResults.reduce((memo, scanResult) => {
-      const res = formatScanResult(scanResult, meta, options);
+      const res = formatScanResult(scanResult, meta, options, porjectRoot);
 
       if (memo[scanResult.filePath]) {
         memo[scanResult.filePath].result.cloudConfigResults.push(
@@ -62,6 +66,7 @@ function formatScanResult(
   scanResult: IacFileScanResult,
   meta: TestMeta,
   options: IaCTestFlags,
+  projectRoot: string,
 ): FormattedResult {
   const fileType = getFileTypeForParser(scanResult.fileType);
   const isGeneratedByCustomRule = scanResult.engineType === EngineType.Custom;
@@ -105,6 +110,7 @@ function formatScanResult(
   });
 
   const { targetFilePath, projectName, targetFile } = computePaths(
+    projectRoot,
     scanResult.filePath,
     options.path,
   );
@@ -168,6 +174,7 @@ export class FailedToFormatResults extends CustomError {
 }
 
 function computePaths(
+  projectRoot: string,
   filePath: string,
   pathArg = '.',
 ): { targetFilePath: string; projectName: string; targetFile: string } {
@@ -194,7 +201,7 @@ function computePaths(
 
   return {
     targetFilePath,
-    projectName: path.basename(projectPath),
+    projectName: path.basename(projectRoot),
     targetFile,
   };
 }

--- a/src/cli/commands/test/iac/local-execution/process-results/v2/share-results-formatter.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/v2/share-results-formatter.ts
@@ -1,0 +1,60 @@
+import { IacFileScanResult, IacShareResultsFormat } from '../../types';
+import * as path from 'path';
+
+export function formatShareResults(
+  projectRoot: string,
+  scanResults: IacFileScanResult[],
+): IacShareResultsFormat[] {
+  const resultsGroupedByFilePath = groupByFilePath(scanResults);
+
+  return resultsGroupedByFilePath.map((result) => {
+    const { projectName, targetFile } = computePaths(
+      projectRoot,
+      result.filePath,
+    );
+
+    return {
+      projectName,
+      targetFile,
+      filePath: result.filePath,
+      fileType: result.fileType,
+      projectType: result.projectType,
+      violatedPolicies: result.violatedPolicies,
+    };
+  });
+}
+
+function groupByFilePath(scanResults: IacFileScanResult[]) {
+  const groupedByFilePath = scanResults.reduce((memo, scanResult) => {
+    scanResult.violatedPolicies.forEach((violatedPolicy) => {
+      violatedPolicy.docId = scanResult.docId;
+    });
+    if (memo[scanResult.filePath]) {
+      memo[scanResult.filePath].violatedPolicies.push(
+        ...scanResult.violatedPolicies,
+      );
+    } else {
+      memo[scanResult.filePath] = scanResult;
+    }
+    return memo;
+  }, {} as Record<string, IacFileScanResult>);
+
+  return Object.values(groupedByFilePath);
+}
+
+function computePaths(
+  projectRoot: string,
+  filePath: string,
+): { targetFilePath: string; projectName: string; targetFile: string } {
+  const projectDirectory = path.resolve(projectRoot);
+  const currentDirectoryName = path.basename(projectDirectory);
+  const absoluteFilePath = path.resolve(filePath);
+  const relativeFilePath = path.relative(projectDirectory, absoluteFilePath);
+  const unixRelativeFilePath = relativeFilePath.split(path.sep).join('/');
+
+  return {
+    targetFilePath: absoluteFilePath,
+    projectName: currentDirectoryName,
+    targetFile: unixRelativeFilePath,
+  };
+}

--- a/src/cli/commands/test/iac/local-execution/process-results/v2/share-results.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/v2/share-results.ts
@@ -1,10 +1,14 @@
-import { isFeatureFlagSupportedForOrg } from '../../../../../../lib/feature-flags';
-import { shareResults } from '../../../../../../lib/iac/cli-share-results';
-import { Policy } from '../../../../../../lib/policy/find-and-load-policy';
-import { ProjectAttributes, Tag } from '../../../../../../lib/types';
-import { FeatureFlagError } from '../assert-iac-options-flag';
+import { isFeatureFlagSupportedForOrg } from '../../../../../../../lib/feature-flags';
+import { shareResults } from './cli-share-results';
+import { Policy } from '../../../../../../../lib/policy/find-and-load-policy';
+import { ProjectAttributes, Tag } from '../../../../../../../lib/types';
+import { FeatureFlagError } from '../../assert-iac-options-flag';
 import { formatShareResults } from './share-results-formatter';
-import { IacFileScanResult, IaCTestFlags, ShareResultsOutput } from '../types';
+import {
+  IacFileScanResult,
+  IaCTestFlags,
+  ShareResultsOutput,
+} from '../../types';
 
 export async function formatAndShareResults({
   results,
@@ -13,7 +17,7 @@ export async function formatAndShareResults({
   policy,
   tags,
   attributes,
-  pathToScan,
+  projectRoot,
 }: {
   results: IacFileScanResult[];
   options: IaCTestFlags;
@@ -21,7 +25,7 @@ export async function formatAndShareResults({
   policy: Policy | undefined;
   tags?: Tag[];
   attributes?: ProjectAttributes;
-  pathToScan: string;
+  projectRoot: string;
 }): Promise<ShareResultsOutput> {
   const isCliReportEnabled = await isFeatureFlagSupportedForOrg(
     'iacCliShareResults',
@@ -31,7 +35,7 @@ export async function formatAndShareResults({
     throw new FeatureFlagError('report', 'iacCliShareResults');
   }
 
-  const formattedResults = formatShareResults(results);
+  const formattedResults = formatShareResults(projectRoot, results);
 
   return await shareResults({
     results: formattedResults,
@@ -39,6 +43,6 @@ export async function formatAndShareResults({
     tags,
     attributes,
     options,
-    pathToScan,
+    projectRoot,
   });
 }

--- a/src/cli/commands/test/iac/scan.ts
+++ b/src/cli/commands/test/iac/scan.ts
@@ -1,0 +1,156 @@
+import * as cloneDeep from 'lodash.clonedeep';
+import * as assign from 'lodash.assign';
+
+import {
+  IacFileInDirectory,
+  IacOutputMeta,
+  Options,
+  TestOptions,
+} from '../../../../lib/types';
+import { TestResult } from '../../../../lib/snyk-test/legacy';
+
+import * as utils from '../utils';
+import { spinnerMessage } from '../../../../lib/formatters/iac-output';
+
+import { test as iacTest } from './local-execution';
+import { formatTestError } from '../format-test-error';
+
+import { assertIaCOptionsFlags } from './local-execution/assert-iac-options-flag';
+import { initRules } from './local-execution/rules/rules';
+import { cleanLocalCache } from './local-execution/measurable-methods';
+import * as ora from 'ora';
+import { IacOrgSettings } from './local-execution/types';
+import * as pathLib from 'path';
+import { CustomError } from '../../../../lib/errors';
+import { OciRegistry } from './local-execution/rules/oci-registry';
+import {
+  MultipleGroupsResultsProcessor,
+  ResultsProcessor,
+  SingleGroupResultsProcessor,
+} from './local-execution/process-results';
+
+export async function scan(
+  iacOrgSettings: IacOrgSettings,
+  options: any,
+  testSpinner: ora.Ora | undefined,
+  paths: string[],
+  orgPublicId: string,
+  buildOciRules: () => OciRegistry,
+  projectRoot?: string,
+): Promise<{
+  iacOutputMeta: IacOutputMeta | undefined;
+  iacScanFailures: IacFileInDirectory[];
+  iacIgnoredIssuesCount: number;
+  results: any[];
+  resultOptions: (Options & TestOptions)[];
+}> {
+  const results = [] as any[];
+  const resultOptions: Array<Options & TestOptions> = [];
+
+  let iacOutputMeta: IacOutputMeta | undefined;
+  let iacScanFailures: IacFileInDirectory[] = [];
+  let iacIgnoredIssuesCount = 0;
+
+  try {
+    const rulesOrigin = await initRules(buildOciRules, iacOrgSettings, options);
+
+    testSpinner?.start(spinnerMessage);
+
+    for (const path of paths) {
+      // Create a copy of the options so a specific test can
+      // modify them i.e. add `options.file` etc. We'll need
+      // these options later.
+      const testOpts = cloneDeep(options);
+      testOpts.path = path;
+      testOpts.projectName = testOpts['project-name'];
+
+      let res: (TestResult | TestResult[]) | Error;
+      try {
+        assertIaCOptionsFlags(process.argv);
+
+        let resultsProcessor: ResultsProcessor;
+
+        if (projectRoot) {
+          if (pathLib.relative(projectRoot, path).includes('..')) {
+            throw new CurrentWorkingDirectoryTraversalError();
+          }
+
+          resultsProcessor = new SingleGroupResultsProcessor(
+            projectRoot,
+            orgPublicId,
+            iacOrgSettings,
+            testOpts,
+          );
+        } else {
+          resultsProcessor = new MultipleGroupsResultsProcessor(
+            path,
+            orgPublicId,
+            iacOrgSettings,
+            testOpts,
+          );
+        }
+
+        const { results, failures, ignoreCount } = await iacTest(
+          resultsProcessor,
+          path,
+          testOpts,
+          iacOrgSettings,
+          rulesOrigin,
+        );
+        iacOutputMeta = {
+          orgName: results[0]?.org,
+          projectName: results[0]?.projectName,
+          gitRemoteUrl: results[0]?.meta?.gitRemoteUrl,
+        };
+
+        res = results;
+        iacScanFailures = [...iacScanFailures, ...(failures || [])];
+        iacIgnoredIssuesCount += ignoreCount;
+      } catch (error) {
+        res = formatTestError(error);
+      }
+
+      // Not all test results are arrays in order to be backwards compatible
+      // with scripts that use a callback with test. Coerce results/errors to be arrays
+      // and add the result options to each to be displayed
+      const resArray: any[] = Array.isArray(res) ? res : [res];
+
+      for (let i = 0; i < resArray.length; i++) {
+        const pathWithOptionalProjectName = utils.getPathWithOptionalProjectName(
+          path,
+          resArray[i],
+        );
+        results.push(
+          assign(resArray[i], { path: pathWithOptionalProjectName }),
+        );
+        // currently testOpts are identical for each test result returned even if it's for multiple projects.
+        // we want to return the project names, so will need to be crafty in a way that makes sense.
+        if (!testOpts.projectNames) {
+          resultOptions.push(testOpts);
+        } else {
+          resultOptions.push(
+            assign(cloneDeep(testOpts), {
+              projectName: testOpts.projectNames[i],
+            }),
+          );
+        }
+      }
+    }
+  } finally {
+    cleanLocalCache();
+  }
+
+  return {
+    iacOutputMeta,
+    iacScanFailures,
+    iacIgnoredIssuesCount,
+    results,
+    resultOptions,
+  };
+}
+
+class CurrentWorkingDirectoryTraversalError extends CustomError {
+  constructor() {
+    super('Path is outside the current working directory');
+  }
+}

--- a/test/jest/unit/iac/index.spec.ts
+++ b/test/jest/unit/iac/index.spec.ts
@@ -53,6 +53,7 @@ import {
 } from '../../../../src/cli/commands/test/iac/local-execution/types';
 import { IacProjectType } from '../../../../src/lib/iac/constants';
 
+import { MultipleGroupsResultsProcessor } from '../../../../src/cli/commands/test/iac/local-execution/process-results';
 const parsedFiles: IacFileParsed[] = [
   {
     engineType: EngineType.Terraform,
@@ -104,10 +105,17 @@ describe('test()', () => {
     it('returns the unparsable files excluding content', async () => {
       const opts: IaCTestFlags = {};
 
+      const resultsProcessor = new MultipleGroupsResultsProcessor(
+        './storage/',
+        'org-name',
+        iacOrgSettings,
+        opts,
+      );
+
       const { failures } = await test(
+        resultsProcessor,
         './storage/',
         opts,
-        'org-name',
         iacOrgSettings,
         RulesOrigin.Internal,
       );

--- a/test/jest/unit/iac/process-results/policy.spec.ts
+++ b/test/jest/unit/iac/process-results/policy.spec.ts
@@ -1,4 +1,4 @@
-import { filterIgnoredIssues } from '../../../../../src/cli/commands/test/iac/local-execution/process-results/policy';
+import { filterIgnoredIssues } from '../../../../../src/cli/commands/test/iac/local-execution/process-results/v1/policy';
 import { FormattedResult } from '../../../../../src/cli/commands/test/iac/local-execution/types';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/test/jest/unit/iac/process-results/results-formatter.spec.ts
+++ b/test/jest/unit/iac/process-results/results-formatter.spec.ts
@@ -1,7 +1,7 @@
 import {
   filterPoliciesBySeverity,
   formatScanResults,
-} from '../../../../../src/cli/commands/test/iac/local-execution/process-results/results-formatter';
+} from '../../../../../src/cli/commands/test/iac/local-execution/process-results/v1/results-formatter';
 import { SEVERITY } from '../../../../../src/lib/snyk-test/common';
 import {
   expectedFormattedResultsWithLineNumber,

--- a/test/jest/unit/iac/process-results/share-results-formatters.spec.ts
+++ b/test/jest/unit/iac/process-results/share-results-formatters.spec.ts
@@ -1,4 +1,4 @@
-import { formatShareResults } from '../../../../../src/cli/commands/test/iac/local-execution/process-results/share-results-formatter';
+import { formatShareResults } from '../../../../../src/cli/commands/test/iac/local-execution/process-results/v1/share-results-formatter';
 import { generateScanResults } from '../results-formatter.fixtures';
 import { expectedFormattedResultsForShareResults } from './share-results-formatters.fixtures';
 import * as git from '../../../../../src/lib/iac/git';


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR changes the behaviour of the `iac test` command when multiple paths are passed on the command line. This PR changes the behaviour of the `--report` flag, too. The implemented behaviour is the following:

- `iac test` recursively scans the current working directory by default.
- If one or more paths are passed on the command line, those paths must be relative to the current working directory.
- If one or more paths are passed on the command line, only those files or directories are scanned. If a path is a directory, it will be recursively scanned.
- If the `--report` flag is used, the `iac test` command creates one project group in the platform named after the name of the current working directory.
- If the current working directory is a Git repository, additional information will be extracted and attached to the projects and the project group.

#### Where should the reviewer start?

This PR extracts the scan logic into [src/cli/commands/test/iac/scan.ts](./src/cli/commands/test/iac/scan.ts). You can start the review fro there.

#### How should this be manually tested?

Move anywhere on the file system and run `snyk iac test ..`. The command will fail with an error, because the only provided path is outside of the current working directory.

```
$ snyk iac test ..

Testing .....

Path ".." is outside the current working directory
```

Move in the root of this repository and run `snyk iac test --report`. This command creates only one project group in the platform, named after this repository. All the project names will be the paths of the IaC files in this repository, relative from the current working directory.

![image](https://user-images.githubusercontent.com/404227/169825081-ddd6cc8d-4655-40dc-b557-20820f613ee4.png)

Move into the [test/fixtures/iac](./test/fixtures/iac) directory and run `snyk iac test --report`. The command creates only one project group named `iac`, because the current working directory is not a Git repository. All the project names are relative from the current working directory.

![image](https://user-images.githubusercontent.com/404227/169825647-f3aeb7b4-adee-434b-81a7-0e971dc8e7b3.png)

#### Any background context you want to provide?

This behaviour has been discussed in [this document](https://docs.google.com/document/d/1ZzsYEKEtJsz79ZdzfywuBQ7sJt4LCcvqjehLdVL6ldY/edit?usp=sharing). The document contains additional links to interesting conversations that shaped the implementation in this PR.

#### What are the relevant tickets?

[CFG-1840](https://snyksec.atlassian.net/browse/CFG-1840)
