### PR TITLE
test: disable iac oci registries tests

### DIFF
--- a/test/jest/acceptance/iac/custom-rules.spec.ts
+++ b/test/jest/acceptance/iac/custom-rules.spec.ts
@@ -114,7 +114,9 @@ describe('iac test --rules', () => {
   });
 });
 
-describe('custom rules pull from a remote OCI registry', () => {
+// skipping this as we have many flakes recently
+// to be re-written in CFG-1847
+describe.skip('custom rules pull from a remote OCI registry', () => {
   let run: (
     cmd: string,
     overrides?: Record<string, string>,


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Skipping this test suite as we see more and more flakes. These tests do network requests outside of our control, and we have decided to replace them with less brittle tests that test the API integration itself in https://snyksec.atlassian.net/browse/CFG-1847. 
We also test this scenario in other systems, less frequently.

In the meantime, we skip these to prevent the pipeline failing because of flakiness. It will also reduce the time of our acceptance tests: 
<img width="623" alt="image" src="https://user-images.githubusercontent.com/6989529/169805275-3ee7fede-f99c-4b28-bcdd-09c5c1c9dd97.png">
