### PR TITLE
chore: Added files to only-invalid fixtures

### DIFF
--- a/test/fixtures/iac/only-invalid/helm-config.yaml
+++ b/test/fixtures/iac/only-invalid/helm-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.myapp }}
+  labels:
+    app: {{ template "myapp.name" . }}
+    chart: {{ template "myapp.chart" . }}
+    release: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http

--- a/test/jest/acceptance/iac/iac-output.spec.ts
+++ b/test/jest/acceptance/iac/iac-output.spec.ts
@@ -175,6 +175,12 @@ Target file:       ${dirPath}/`);
                 'kubernetes',
                 'helm-config.yaml',
               )}` +
+              EOL +
+              `        ${pathLib.join(
+                'iac',
+                'only-invalid',
+                'helm-config.yaml',
+              )}` +
               EOL.repeat(2) +
               '  Failed to parse Terraform file' +
               EOL +
@@ -218,12 +224,7 @@ Target file:       ${dirPath}/`);
         const dirPath = 'iac/only-invalid';
         const { stdout } = await run(`snyk iac test ${dirPath}`);
 
-        expect(stdout).toContain(
-          `Could not find any valid infrastructure as code files. Supported file extensions are tf, yml, yaml & json.
-More information can be found by running \`snyk iac test --help\` or through our documentation:
-https://support.snyk.io/hc/en-us/articles/360012429477-Test-your-Kubernetes-files-with-our-CLI-tool
-https://support.snyk.io/hc/en-us/articles/360013723877-Test-your-Terraform-files-with-our-CLI-tool`,
-        );
+        expect(stdout).toContain(`We were unable to parse the YAML file`);
       });
 
       it('should not show the issues section', async () => {
@@ -403,12 +404,7 @@ If the issue persists contact support@snyk.io`,
         const dirPath = 'iac/only-invalid';
         const { stdout } = await run(`snyk iac test ${dirPath}`);
 
-        expect(stdout).toContain(
-          `Could not find any valid infrastructure as code files. Supported file extensions are tf, yml, yaml & json.
-More information can be found by running \`snyk iac test --help\` or through our documentation:
-https://support.snyk.io/hc/en-us/articles/360012429477-Test-your-Kubernetes-files-with-our-CLI-tool
-https://support.snyk.io/hc/en-us/articles/360013723877-Test-your-Terraform-files-with-our-CLI-tool`,
-        );
+        expect(stdout).toContain(`We were unable to parse the YAML file`);
       });
 
       it('should not show file issue lists', async () => {

--- a/test/jest/acceptance/iac/test-directory.spec.ts
+++ b/test/jest/acceptance/iac/test-directory.spec.ts
@@ -45,7 +45,7 @@ describe('Directory scan', () => {
     expect(stdout).toContain('Failed to parse YAML file');
     expect(stdout).toContain('Failed to parse JSON file');
     expect(stdout).toContain(
-      '28 projects, 20 contained issues. Failed to test 5 projects.',
+      '28 projects, 20 contained issues. Failed to test 6 projects.',
     );
     expect(exitCode).toBe(1);
   });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Adds fixtures to the invalid IaC file fixtures directory.

#### Where should the reviewer start?

```
 test/fixtures/iac/only-invalid
```