### PR TITLE
test: add multiple paths json,sarif cases

### DIFF
--- a/test/jest/acceptance/iac/iac-output.spec.ts
+++ b/test/jest/acceptance/iac/iac-output.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../../src/lib/formatters/iac-output';
 
 import { FakeServer } from '../../../acceptance/fake-server';
-import { startMockServer } from './helpers';
+import { isValidJSONString, startMockServer } from './helpers';
 
 const IAC_CLI_OUTPUT_FF = 'iacCliOutput';
 
@@ -141,6 +141,16 @@ Target file:       ${dirPath}/`);
           );
           expect(stdout).not.toContain(chalk.reset(spinnerMessage));
           expect(stdout).not.toContain(chalk.reset(spinnerSuccessMessage));
+        });
+
+        it(`should return results with multiple paths`, async () => {
+          const { stdout, exitCode } = await run(
+            `snyk iac test ${dataFormatFlag} ./iac/arm/rule_test.json ./iac/cloudformation/`,
+          );
+          expect(isValidJSONString(stdout)).toBe(true);
+          expect(stdout).toContain('"id": "SNYK-CC-TF-20",');
+          expect(stdout).toContain('"id": "SNYK-CC-AWS-422",');
+          expect(exitCode).toBe(1);
         });
       },
     );

--- a/test/jest/acceptance/iac/test-directory.spec.ts
+++ b/test/jest/acceptance/iac/test-directory.spec.ts
@@ -1,20 +1,24 @@
-import { startMockServer, isValidJSONString } from './helpers';
+import { isValidJSONString, startMockServer } from './helpers';
+import { FakeServer } from '../../../acceptance/fake-server';
+
+const IAC_CLI_OUTPUT_FF = 'iacCliOutput';
 
 jest.setTimeout(50000);
 
 describe('Directory scan', () => {
+  let server: FakeServer;
   let run: (
     cmd: string,
   ) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
   let teardown: () => void;
 
   beforeAll(async () => {
-    const result = await startMockServer();
-    run = result.run;
-    teardown = result.teardown;
+    ({ server, run, teardown } = await startMockServer());
   });
 
-  afterAll(async () => teardown());
+  afterAll(async () => {
+    await teardown();
+  });
 
   it('scans all files in a directory with Kubernetes files', async () => {
     const { stdout, exitCode } = await run(`snyk iac test ./iac/kubernetes/`);
@@ -98,9 +102,9 @@ describe('Directory scan', () => {
   });
 
   describe('Variadic - multiple path scans', () => {
-    it('outputs both results and failures combined when scanning two paths', async () => {
+    it('outputs both results and failures combined when scanning three paths', async () => {
       const { stdout, exitCode } = await run(
-        `snyk iac test ./iac/terraform ./iac/cloudformation`,
+        `snyk iac test ./iac/terraform ./iac/cloudformation ./iac/arm`,
       );
       //directory scan shows relative path to cwd  in output
       expect(stdout).toContain('Testing sg_open_ssh.tf');
@@ -109,9 +113,41 @@ describe('Directory scan', () => {
       expect(stdout).toContain('Testing aurora-valid.yml');
       expect(stdout).toContain('Testing invalid-cfn.yml');
       expect(stdout).toContain('Failed to parse YAML file');
+      expect(stdout).toContain('Testing rule_test.json');
+      expect(stdout).toContain('Testing invalid_rule_test.json');
+      expect(stdout).toContain('Failed to parse JSON file');
       expect(exitCode).toBe(1);
     });
 
+    it('outputs both results and failures combined with --json flag', async () => {
+      const { stdout, exitCode } = await run(
+        `snyk iac test ./iac/terraform ./iac/cloudformation --json`,
+      );
+
+      expect(isValidJSONString(stdout)).toBe(true);
+      expect(stdout).toContain('"id": "SNYK-CC-TF-1",');
+      expect(stdout).toContain('"id": "SNYK-CC-TF-124",');
+      expect(stdout).toContain('"packageManager": "terraformconfig",');
+      expect(stdout).toContain('"projectType": "terraformconfig",');
+      expect(stdout).toContain('"id": "SNYK-CC-AWS-422",');
+      expect(stdout).toContain('"packageManager": "cloudformationconfig",');
+      expect(stdout).toContain('"projectType": "cloudformationconfig",');
+      expect(exitCode).toBe(1);
+    });
+
+    it('outputs both results and failures combined with --sarif flag', async () => {
+      const { stdout, exitCode } = await run(
+        `snyk iac test ./iac/terraform ./iac/cloudformation --sarif`,
+      );
+
+      expect(isValidJSONString(stdout)).toBe(true);
+      expect(stdout).toContain('"ruleId": "SNYK-CC-TF-1",');
+      expect(stdout).toContain('"ruleId": "SNYK-CC-TF-124",');
+      expect(stdout).toContain('"ruleId": "SNYK-CC-AWS-422",');
+      expect(exitCode).toBe(1);
+    });
+
+    // regression test to check the case that an invalid path would override the overall output
     it('outputs both results and failures for first path when the last path is empty or non-existent', async () => {
       const { stdout, exitCode } = await run(
         `snyk iac test ./iac/arm non-existing-dir`,
@@ -123,6 +159,80 @@ describe('Directory scan', () => {
       expect(stdout).toContain('Testing non-existing-dir...');
       expect(stdout).toContain('Could not find any valid IaC files');
       expect(exitCode).toBe(1);
+    });
+
+    it('outputs issues and errors when one of the paths fails, with --json flag', async () => {
+      const { stdout, exitCode } = await run(
+        `snyk iac test ./iac/arm non-existing-dir --json`,
+      );
+      expect(isValidJSONString(stdout)).toBe(true);
+      expect(stdout).toContain('"id": "SNYK-CC-TF-20",');
+      expect(stdout).toContain('"ok": false');
+      expect(stdout).toContain('"error": "Could not find any valid IaC files"');
+      expect(stdout).toContain('"path": "non-existing-dir"');
+      expect(exitCode).toBe(3);
+    });
+
+    // document the existing bug to fix, when one path fails entirely, sarif fails with:
+    // An unknown error occurred. Please run with `-d` and include full trace when reporting to Snyk
+    it.skip('outputs issues and errors when one of the paths fails, with --sarif flag', async () => {
+      const { stdout, exitCode } = await run(
+        `snyk iac test ./iac/arm non-existing-dir --sarif`,
+      );
+      expect(isValidJSONString(stdout)).toBe(true);
+      expect(stdout).toContain('"results"');
+      expect(stdout).toContain('"ok": false');
+      expect(stdout).toContain('"error": "Could not find any valid IaC files"');
+      expect(stdout).toContain('"path": "non-existing-dir"');
+      expect(exitCode).toBe(1);
+    });
+
+    //TODO: this test suite is a duplicate of the existing cases, only checking json and sarif flags combinations
+    // delete when FF is removed and new IaC Cli output becomes default (after GA)
+    describe('with iacCliOutput FF true', () => {
+      beforeEach(() => {
+        server.setFeatureFlag(IAC_CLI_OUTPUT_FF, true);
+      });
+      afterEach(() => {
+        server.restore();
+      });
+
+      it('outputs issues and errors when one of the paths fails, with --json flag and iacCliOutput FF true', async () => {
+        const { stdout, exitCode } = await run(
+          `snyk iac test ./iac/arm non-existing-dir --json`,
+        );
+        expect(isValidJSONString(stdout)).toBe(true);
+        expect(stdout).toContain('"id": "SNYK-CC-TF-20",');
+        expect(stdout).toContain('"ok": false');
+        expect(stdout).toContain(
+          '"error": "Could not find any valid IaC files"',
+        );
+        expect(stdout).toContain('"path": "non-existing-dir"');
+        expect(exitCode).toBe(3);
+      });
+      it('outputs both results and failures combined with --json flag and iacCliOutput FF true', async () => {
+        const { stdout, exitCode } = await run(
+          `snyk iac test ./iac/terraform ./iac/cloudformation --json`,
+        );
+
+        expect(isValidJSONString(stdout)).toBe(true);
+        expect(stdout).toContain('"id": "SNYK-CC-TF-1",');
+        expect(stdout).toContain('"id": "SNYK-CC-TF-124",');
+        expect(stdout).toContain('"id": "SNYK-CC-AWS-422",');
+        expect(exitCode).toBe(1);
+      });
+
+      it('outputs both results and failures combined with --sarif flag, flag on', async () => {
+        const { stdout, exitCode } = await run(
+          `snyk iac test ./iac/terraform ./iac/cloudformation --sarif`,
+        );
+
+        expect(isValidJSONString(stdout)).toBe(true);
+        expect(stdout).toContain('"ruleId": "SNYK-CC-TF-1",');
+        expect(stdout).toContain('"ruleId": "SNYK-CC-TF-124",');
+        expect(stdout).toContain('"ruleId": "SNYK-CC-AWS-422",');
+        expect(exitCode).toBe(1);
+      });
     });
   });
 
@@ -146,6 +256,14 @@ describe('Directory scan', () => {
         expect(stdout).toContain('"ok": false');
         expect(exitCode).toBe(1);
       });
+
+      it('returns 1 even if some files failed to parse - using --sarif flag', async () => {
+        const { exitCode, stderr } = await run(
+          `snyk iac test ./iac/kubernetes/  --sarif`,
+        );
+        expect(stderr).toBe('');
+        expect(exitCode).toBe(1);
+      });
     });
 
     describe('No Issues found', () => {
@@ -163,6 +281,15 @@ describe('Directory scan', () => {
         );
         expect(stderr).toBe('');
         expect(stdout).toContain('"ok": true');
+        expect(exitCode).toBe(0);
+      });
+
+      it('returns 0 even if some files failed to parse - using --sarif flag', async () => {
+        const { exitCode, stderr, stdout } = await run(
+          `snyk iac test ./iac/no_vulnerabilities/  --severity-threshold=high  --sarif`,
+        );
+        expect(stderr).toBe('');
+        expect(stdout).toContain('"results": []');
         expect(exitCode).toBe(0);
       });
     });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Adds tests for the old and new output to check scenarios of multiple paths, such as:

- three multiple paths - all successful
- two multiple paths - one successful, one non existent -> test that we have both results and failures
- the same scenarios with/without json, sarif flags 

The json,sarif flag scenarios are duplicate in the test-directory.spec.ts with a note "TODO" to delete them once the FF is removed and the new iac output is the default.

There is one test that I added and skiped: one that we have a success path and an invalid path for sarif.
This is an existing bug which was not introduced now. It was easy to add the test as I was adding the rest at the same time, but it is skipped until it's fixed in another PR. 
I added it here for visibility and documentation in the meantime, but I can remove it if there are objections.

Note: 
I will create some smaller subsets of fixtures for testing paths and edge cases in a new PR later this week to make the tests smaller, easier to understand and faster.