### PR TITLE
feat: validate custom rules [CFG-1865]

### DIFF
--- a/src/cli/commands/test/iac/local-execution/index.ts
+++ b/src/cli/commands/test/iac/local-execution/index.ts
@@ -107,12 +107,19 @@ export async function test(
       })),
     );
   }
+  // NOTE: No file or parsed file data should leave this function.
+  let failures = isLocalFolder(pathToScan)
+    ? allFailedFiles.map(removeFileContent)
+    : [];
 
-  const scannedFiles = await scanFiles(allParsedFiles);
+  const { scannedFiles, failedScans } = await scanFiles(allParsedFiles);
+  failures = [...failures, ...failedScans];
+
   const resultsWithCustomSeverities = await applyCustomSeverities(
     scannedFiles,
     iacOrgSettings.customPolicies,
   );
+
   const { filteredIssues, ignoreCount } = await processResults(
     resultsWithCustomSeverities,
     orgPublicId,
@@ -142,10 +149,7 @@ export async function test(
   // TODO: add support for proper typing of old TestResult interface.
   return {
     results: (filteredIssues as unknown) as TestResult[],
-    // NOTE: No file or parsed file data should leave this function.
-    failures: isLocalFolder(pathToScan)
-      ? allFailedFiles.map(removeFileContent)
-      : undefined,
+    failures,
     ignoreCount,
   };
 }

--- a/test/jest/unit/iac/file-scanner.spec.ts
+++ b/test/jest/unit/iac/file-scanner.spec.ts
@@ -1,23 +1,27 @@
 import * as path from 'path';
 import {
-  scanFiles,
   clearPolicyEngineCache,
+  scanFiles,
+  validateResultFromCustomRules,
 } from '../../../../src/cli/commands/test/iac/local-execution/file-scanner';
+import * as localCacheModule from '../../../../src/cli/commands/test/iac/local-execution/local-cache';
 import { LOCAL_POLICY_ENGINE_DIR } from '../../../../src/cli/commands/test/iac/local-execution/local-cache';
 import {
   EngineType,
   IacFileParsed,
+  IacFileScanResult,
 } from '../../../../src/cli/commands/test/iac/local-execution/types';
 
 import {
-  paresdKubernetesFileStub,
-  parsedTerraformFileStub,
-  parsedArmFileStub,
+  expectedViolatedPoliciesForArm,
   expectedViolatedPoliciesForK8s,
   expectedViolatedPoliciesForTerraform,
-  expectedViolatedPoliciesForArm,
+  paresdKubernetesFileStub,
+  parsedArmFileStub,
+  parsedTerraformFileStub,
 } from './file-scanner.fixtures';
-import * as localCacheModule from '../../../../src/cli/commands/test/iac/local-execution/local-cache';
+import { SEVERITY } from '../../../../src/lib/snyk-test/common';
+import { IacProjectType } from '../../../../src/lib/iac/constants';
 
 describe('scanFiles', () => {
   const parsedFiles: Array<IacFileParsed> = [
@@ -70,14 +74,14 @@ describe('scanFiles', () => {
           }
         });
 
-      const scanResults = await scanFiles(parsedFiles);
-      expect(scanResults[0].violatedPolicies).toEqual(
+      const { scannedFiles } = await scanFiles(parsedFiles);
+      expect(scannedFiles[0].violatedPolicies).toEqual(
         expectedViolatedPoliciesForK8s,
       );
-      expect(scanResults[1].violatedPolicies).toEqual(
+      expect(scannedFiles[1].violatedPolicies).toEqual(
         expectedViolatedPoliciesForTerraform,
       );
-      expect(scanResults[2].violatedPolicies).toEqual(
+      expect(scannedFiles[2].violatedPolicies).toEqual(
         expectedViolatedPoliciesForArm,
       );
       spy.mockReset();
@@ -89,5 +93,136 @@ describe('scanFiles', () => {
     it('throws an error', async () => {
       await expect(scanFiles(parsedFiles)).rejects.toThrow();
     });
+  });
+});
+
+describe('validateResultFromCustomRules', () => {
+  const result: IacFileScanResult = {
+    filePath: 'path/to/file',
+    fileType: 'tf',
+    jsonContent: {},
+    fileContent: '',
+    projectType: IacProjectType.CUSTOM,
+    engineType: EngineType.Custom,
+    violatedPolicies: [
+      {
+        publicId: 'CUSTOM-RULE-VALID',
+        subType: '',
+        title: '',
+        severity: SEVERITY.LOW,
+        msg: 'input.resource',
+        issue: '',
+        impact: '',
+        resolve: '',
+        references: [],
+      },
+      {
+        publicId: 'CUSTOM-RULE-INVALID-SEVERITY',
+        subType: '',
+        title: '',
+        severity: 'none',
+        msg: 'input.resource',
+        issue: '',
+        impact: '',
+        resolve: '',
+        references: [],
+      },
+      {
+        publicId: 'custom-rule-invalid-lowercase-publicid',
+        subType: '',
+        title: '',
+        severity: SEVERITY.LOW,
+        msg: 'input.resource',
+        issue: '',
+        impact: '',
+        resolve: '',
+        references: [],
+      },
+      {
+        publicId: 'SNYK-CC-CUSTOM-RULE-INVALID',
+        subType: '',
+        title: '',
+        severity: SEVERITY.LOW,
+        msg: 'input.resource',
+        issue: '',
+        impact: '',
+        resolve: '',
+        references: [],
+      },
+    ],
+  };
+
+  it('does not filter out valid policies', () => {
+    const { validatedResult, invalidIssues } = validateResultFromCustomRules(
+      result,
+    );
+    expect(validatedResult.violatedPolicies).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ publicId: 'CUSTOM-RULE-VALID' }),
+      ]),
+    );
+    expect(invalidIssues.length).toEqual(3);
+  });
+
+  it('filters out policies with invalid severity', () => {
+    const { validatedResult, invalidIssues } = validateResultFromCustomRules(
+      result,
+    );
+    expect(validatedResult.violatedPolicies).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ publicId: 'CUSTOM-RULE-INVALID-SEVERITY' }),
+      ]),
+    );
+    expect(invalidIssues.length).toEqual(3);
+    expect(invalidIssues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          failureReason:
+            'Invalid severity level for custom rule CUSTOM-RULE-INVALID-SEVERITY. Change to low, medium, high, or critical',
+        }),
+      ]),
+    );
+  });
+
+  it('filters out policies with lowercase publicId', () => {
+    const { validatedResult, invalidIssues } = validateResultFromCustomRules(
+      result,
+    );
+    expect(validatedResult.violatedPolicies).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          publicId: 'custom-rule-invalid-lowercase-publicid',
+        }),
+      ]),
+    );
+    expect(invalidIssues.length).toEqual(3);
+    expect(invalidIssues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          failureReason:
+            'Invalid non-uppercase publicId for custom rule custom-rule-invalid-lowercase-publicid. Change to CUSTOM-RULE-INVALID-LOWERCASE-PUBLICID',
+        }),
+      ]),
+    );
+  });
+
+  it('filters out policies with conflicting publicId', () => {
+    const { validatedResult, invalidIssues } = validateResultFromCustomRules(
+      result,
+    );
+    expect(validatedResult.violatedPolicies).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ publicId: 'SNYK-CC-CUSTOM-RULE-INVALID' }),
+      ]),
+    );
+    expect(invalidIssues.length).toEqual(3);
+    expect(invalidIssues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          failureReason:
+            'Invalid publicId for custom rule SNYK-CC-CUSTOM-RULE-INVALID. Change to a publicId that does not start with SNYK-CC-',
+        }),
+      ]),
+    );
   });
 });

--- a/test/jest/unit/iac/index.spec.ts
+++ b/test/jest/unit/iac/index.spec.ts
@@ -17,7 +17,12 @@ jest.mock(
   '../../../../src/cli/commands/test/iac/local-execution/file-scanner',
   () => {
     return {
-      scanFiles: async () => [],
+      scanFiles: async () => {
+        return {
+          scannedFiles: [],
+          failedScans: [],
+        };
+      },
     };
   },
 );


### PR DESCRIPTION
-  [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR adds validation for issues generated from custom rules. This enhances the current custom rule behaviour (e.g. if a custom had a type in `severity` then the CLI would throw a random error, but now we tell them about the problem) and prepares us for when we will store these issues in our database using the `--report` flag. 

#### Where should the reviewer start?

- In `src/cli/commands/test/iac/local-execution/file-scanner.ts`, we added a new function `validateResultFromCustomRules`, which contains the validation
- In the same file, the `scanFiles` function now returns an extra array, `failedScans`, that contains custom rules that failed the scanning; we chose to put this code here because it doesn't fit well in `processResults`, which is only for display
- In `src/cli/commands/test/iac/local-execution/index.ts`, we get the `failedScans` from this function and include them in the overall `failures` returned by the test command, so that they can be grouped under `Test Failures` in the new CLI output and also printed in the old CLI output

We are removing the `Invalid files` count in https://github.com/snyk/cli/pull/3268 so there's no risk of custom rules validation failures showing up in there.

#### How should this be manually tested?

1. Clone https://github.com/snyk/custom-rules-examples to get some custom rules
2. Install `snyk-iac-rules`: https://github.com/snyk/snyk-iac-rules
3. Modify any of the rules to have an invalid `publicId` (e.g. lowercase or starting with `SNYK-CC-`), or `severity` (some random string) or `msg` (e.g. `SELECT * FROM orgs`) 
4. Build a local bundle: `snyk-iac-rules build`
5. Build the local CLI: `npm run build`
6. Run the rules to see them in the results: `snyk-dev iac test ./rules/CUSTOM-RULE-1/fixtures --rules=bundle.tar.gz` 
7. Run the rules and send them to the Platform: `snyk-dev iac test ./rules/CUSTOM-RULE-1/fixtures --rules=bundle.tar.gz --report`

Here is a valid bundle I ran tests with:
[valid.tar.gz](https://github.com/snyk/cli/files/8761787/valid.tar.gz)

Here are some invalid bundles I ran tests with:
[lowercase.tar.gz](https://github.com/snyk/cli/files/8761782/lowercase.tar.gz)
[severity.tar.gz](https://github.com/snyk/cli/files/8761783/severity.tar.gz)
[snyk.tar.gz](https://github.com/snyk/cli/files/8761785/snyk.tar.gz)

#### Any background context you want to provide?
Investigation notes: https://www.notion.so/snyk/IaC-CLI-Share-Results-Custom-Rules-38c3792fd8a041ef8d9fd23c2b4d825d

Relevant Slack thread on Design: https://snyk.slack.com/archives/C02UUBNJH4J/p1653304131064199

Relevant Slack thread on Content: https://snyk.slack.com/archives/CM5LMKKQR/p1653404088692759

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CFG-1865

#### Screenshots
- with Snyk internal rules only
![Screenshot 2022-05-23 at 20 13 11](https://user-images.githubusercontent.com/81559517/169890151-6fb0da2f-d57c-42d7-93f3-cf74a8d3717f.png)

- with both Snyk internal rules and valid Custom Rules
![Screenshot 2022-05-23 at 20 13 44](https://user-images.githubusercontent.com/81559517/169890264-fd38e047-ffae-433d-9f60-8c858b3f1d29.png)
![Screenshot 2022-05-23 at 20 13 49](https://user-images.githubusercontent.com/81559517/169890270-20ca91ac-7674-4b24-92eb-3fbdb71aea12.png)

- with both Snyk internal rules and some invalid Custom Rules
![Screenshot 2022-05-25 at 10 02 45](https://user-images.githubusercontent.com/81559517/170225026-3e8aa5f0-b2e1-4e62-8b74-f6c4886aa332.png)
![Screenshot 2022-05-23 at 20 19 55](https://user-images.githubusercontent.com/81559517/169891073-ec5f18f5-fe58-4d6f-bdb2-d04d0e93eef1.png)
![Screenshot 2022-05-23 at 20 20 49](https://user-images.githubusercontent.com/81559517/169891259-90f39a26-5f10-46b9-8c89-7e0b43ad803c.png)

- with both Snyk internal rules and all invalid Custom Rules
![Screenshot 2022-05-24 at 09 35 33](https://user-images.githubusercontent.com/81559517/169987783-54684249-9f30-4a32-916b-5b4018c6a389.png)

- with only some invalid Custom Rules
![Screenshot 2022-05-23 at 20 19 08](https://user-images.githubusercontent.com/81559517/169891093-c3c72c03-4b93-4acc-b4b6-56c90be5b0b1.png)
- with all invalid Custom Rules
![Screenshot 2022-05-24 at 09 34 19](https://user-images.githubusercontent.com/81559517/169987605-182cba09-bfb0-482e-a672-a0367bc0e285.png)

- with only one and invalid Custom Rule
![Screenshot 2022-05-24 at 09 35 11](https://user-images.githubusercontent.com/81559517/169987765-361c0387-8da3-4994-9caf-d4053540cde5.png)

- with the old CLI output:
![Screenshot 2022-05-24 at 09 38 45](https://user-images.githubusercontent.com/81559517/169988459-fe8edfa2-a864-4699-ba2e-6e08a88773fd.png)
