### PR TITLE
chore: Removed the `Inalid files` count from the `Test Summary` section [CFG-1873]

### DIFF
--- a/src/lib/formatters/iac-output/v2/test-summary.ts
+++ b/src/lib/formatters/iac-output/v2/test-summary.ts
@@ -60,12 +60,6 @@ function formatCountsSection(testData: IacTestData): string {
   );
 
   countsSectionProperties.push(
-    `${INDENT}Invalid files: ${colors.info.bold(
-      `${testData.failures?.length ?? 0}`,
-    )}`,
-  );
-
-  countsSectionProperties.push(
     `${INDENT}Ignored issues: ${colors.info.bold(`${testData.ignoreCount}`)}`,
   );
 

--- a/test/jest/acceptance/iac/iac-output.spec.ts
+++ b/test/jest/acceptance/iac/iac-output.spec.ts
@@ -98,8 +98,6 @@ describe('iac test output', () => {
           EOL +
           '✗ Files with issues: 3' +
           EOL +
-          '  Invalid files: 1' +
-          EOL +
           '  Ignored issues: 8' +
           EOL +
           '  Total issues: ',

--- a/test/jest/unit/lib/formatters/iac-output/v2/test-summary.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/test-summary.spec.ts
@@ -4,11 +4,9 @@ import * as pathLib from 'path';
 import { formatIacTestSummary } from '../../../../../../../src/lib/formatters/iac-output';
 import { colors } from '../../../../../../../src/lib/formatters/iac-output/v2/utils';
 import { IacTestResponse } from '../../../../../../../src/lib/snyk-test/iac-test-result';
-import { IacFileInDirectory } from '../../../../../../../src/lib/types';
 
 describe('formatIacTestSummary', () => {
   let resultFixtures: IacTestResponse[];
-  let scanFailureFixtures: IacFileInDirectory[];
 
   beforeAll(async () => {
     resultFixtures = JSON.parse(
@@ -23,23 +21,6 @@ describe('formatIacTestSummary', () => {
           'process-results',
           'fixtures',
           'formatted-results.json',
-        ),
-        'utf8',
-      ),
-    );
-
-    scanFailureFixtures = JSON.parse(
-      fs.readFileSync(
-        pathLib.join(
-          __dirname,
-          '..',
-          '..',
-          '..',
-          '..',
-          'iac',
-          'process-results',
-          'fixtures',
-          'scan-failures.json',
         ),
         'utf8',
       ),
@@ -86,7 +67,7 @@ describe('formatIacTestSummary', () => {
 
     // Act
     const result = formatIacTestSummary(
-      { ignoreCount, results: resultFixtures, failures: scanFailureFixtures },
+      { ignoreCount, results: resultFixtures },
       { orgName, projectName },
     );
 
@@ -96,7 +77,6 @@ describe('formatIacTestSummary', () => {
         '0',
       )}
 ${colors.failure.bold('✗')} Files with issues: ${colors.info.bold('3')}
-  Invalid files: ${colors.info.bold(`${scanFailureFixtures.length}`)}
   Ignored issues: ${colors.info.bold(`${ignoreCount}`)}
   Total issues: ${colors.info.bold('22')} [ ${colors.severities.critical(
         '0 critical',
@@ -104,23 +84,5 @@ ${colors.failure.bold('✗')} Files with issues: ${colors.info.bold('3')}
         '4 medium',
       )}, ${colors.severities.low('13 low')} ]`,
     );
-  });
-
-  describe('when a failures list is not provided', () => {
-    it('should indicate 0 invalid files', () => {
-      // Arrange
-      const orgName = 'test-org-name';
-      const projectName = 'test-project-name';
-      const ignoreCount = 3;
-
-      // Act
-      const result = formatIacTestSummary(
-        { ignoreCount, results: resultFixtures },
-        { orgName, projectName },
-      );
-
-      // Assert
-      expect(result).toContain(`Invalid files: ${colors.info.bold('0')}`);
-    });
   });
 });


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Removes the `Invalid files` count from the `Test Summary` section.

#### Where should the reviewer start?

```
src/lib/formatters/iac-output/v2/test-summary.ts
```

#### How should this be manually tested?

- Execute the IaC test with the following command:
    ```
    SNYK_IAC_OUTPUT_V2=true snyk-dev iac test
    ```
- Ensure the `Test Summary` section does not include the `Invalid files` count.


#### Any background context you want to provide?

Following the discussion in [this Slack thread](https://snyk.slack.com/archives/C030UA3U1RB/p1653229220797339), it’s been decided that due to the currently ambiguous terminology in the IaC test results, the failure-based counts will not be added to the Test Summary section for the MVP, but rather added later once the flow implementation around multiple paths is refined.

For now, we’d like to remove the Invalid files count from the Test Summary section.

#### What are the relevant tickets?

- [CFG-1873](https://snyksec.atlassian.net/browse/CFG-1873)

#### Screenshots

![image](https://user-images.githubusercontent.com/46415136/170051424-8522d059-b2b9-474e-808d-76d7339e7b6f.png)
