### PR TITLE
chore: Fix section titles color from bold `info` to title

### DIFF
--- a/src/lib/formatters/iac-output/v2/issues-list/index.ts
+++ b/src/lib/formatters/iac-output/v2/issues-list/index.ts
@@ -15,7 +15,7 @@ export function getIacDisplayedIssues(
   results: FormattedResult[],
   outputMeta: IacOutputMeta,
 ): string {
-  const titleOutput = colors.info.bold('Issues');
+  const titleOutput = colors.title('Issues');
 
   const formattedResults = formatScanResultsNewOutput(results, outputMeta);
 

--- a/src/lib/formatters/iac-output/v2/test-summary.ts
+++ b/src/lib/formatters/iac-output/v2/test-summary.ts
@@ -13,7 +13,7 @@ export function formatIacTestSummary(
   testData: IacTestData,
   outputMeta: IacOutputMeta,
 ): string {
-  const title = colors.info.bold('Test Summary');
+  const title = colors.title('Test Summary');
   const summarySections: string[] = [title];
 
   summarySections.push(formatTestMetaSection(outputMeta));

--- a/test/jest/unit/lib/formatters/iac-output/v2/failures/list.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/failures/list.spec.ts
@@ -15,7 +15,7 @@ const testFailureFixtures: IaCTestFailure[] = JSON.parse(
 describe('formatIacTestFailures', () => {
   it('should include the "Invalid files: X" title with the correct value', () => {
     const result = formatIacTestFailures(testFailureFixtures);
-    expect(result).toContain(colors.info.bold(`Test Failures`));
+    expect(result).toContain(colors.title(`Test Failures`));
   });
 
   it('should include the failures list with the correct values', () => {

--- a/test/jest/unit/lib/formatters/iac-output/v2/issues-list/index.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/issues-list/index.spec.ts
@@ -36,7 +36,7 @@ describe('getIacDisplayedIssues', () => {
   it("should include the 'Issues' title", () => {
     const result = getIacDisplayedIssues(resultFixtures, outputMeta);
 
-    expect(result).toContain(colors.info.bold('Issues'));
+    expect(result).toContain(colors.title('Issues'));
   });
 
   it('should include a subtitle for each severity with the correct amount of issues', () => {

--- a/test/jest/unit/lib/formatters/iac-output/v2/test-summary.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/test-summary.spec.ts
@@ -59,7 +59,7 @@ describe('formatIacTestSummary', () => {
     );
 
     // Assert
-    expect(result).toContain(`${colors.info.bold('Test Summary')}`);
+    expect(result).toContain(`${colors.title('Test Summary')}`);
   });
 
   it('should include the test meta properties section with the correct values', () => {


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
