### PR TITLE
fix: maven nested module scans

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.18.1",
         "snyk-module": "3.1.0",
-        "snyk-mvn-plugin": "2.29.0",
+        "snyk-mvn-plugin": "2.29.1",
         "snyk-nodejs-lockfile-parser": "1.38.0",
         "snyk-nuget-plugin": "1.23.5",
         "snyk-php-plugin": "1.9.2",
@@ -16681,9 +16681,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-mvn-plugin": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.29.0.tgz",
-      "integrity": "sha512-2lJe6B6FpXmmn/qujuGbs2/qubbmucx/xZUPnG9QYpaCH4sp9Iao9BjqoVHxGMrPeifUqX7xcXXuthFITuf3HA==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.29.1.tgz",
+      "integrity": "sha512-wW5uT5ec1/xmfikROkGxv8XDr234m+JCgf5BqWSWo7OEv+xcJag/obOuvu+5LBGn8WfJnRvRAgQ6gndU+oQLHw==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.0",
         "@snyk/dep-graph": "^1.23.1",
@@ -32782,9 +32782,9 @@
       }
     },
     "snyk-mvn-plugin": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.29.0.tgz",
-      "integrity": "sha512-2lJe6B6FpXmmn/qujuGbs2/qubbmucx/xZUPnG9QYpaCH4sp9Iao9BjqoVHxGMrPeifUqX7xcXXuthFITuf3HA==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.29.1.tgz",
+      "integrity": "sha512-wW5uT5ec1/xmfikROkGxv8XDr234m+JCgf5BqWSWo7OEv+xcJag/obOuvu+5LBGn8WfJnRvRAgQ6gndU+oQLHw==",
       "requires": {
         "@snyk/cli-interface": "2.11.0",
         "@snyk/dep-graph": "^1.23.1",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.18.1",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "2.29.0",
+    "snyk-mvn-plugin": "2.29.1",
     "snyk-nodejs-lockfile-parser": "1.38.0",
     "snyk-nuget-plugin": "1.23.5",
     "snyk-php-plugin": "1.9.2",


### PR DESCRIPTION
See https://github.com/snyk/snyk-mvn-plugin/pull/126
Fixing a bug when scanning Maven projects with nested aggregate projects when the project identity was incorrectly set.

