### PR TITLE
chore: remove unused FF from code

### DIFF
--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -333,8 +333,7 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
   app.get(basePath + '/cli-config/feature-flags/:featureFlag', (req, res) => {
     const org = req.query.org;
     const flag = req.params.featureFlag;
-    const disabled = new Set(['optOutFromLocalExecIac']);
-    if (org === 'no-flag' || disabled.has(flag)) {
+    if (org === 'no-flag') {
       res.send({
         ok: false,
         userMessage: `Org ${org} doesn't have '${flag}' feature enabled'`,


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Removing a very old FF that is not used anymore in the code and is also getting removed from registry flags. We don't need it in the fake-server.ts at all.

#### Additional questions
