### PR TITLE
chore: remove reference to apps beta scope for app creation

### DIFF
--- a/help/cli-commands/apps.md
+++ b/help/cli-commands/apps.md
@@ -42,13 +42,13 @@ A comma separated list of redirect URIs. This will form a list of allowed redire
 ### `--scopes=<SCOPES>`
 
 (Required for the `create` command)
-A comma separated list of scopes required by your Snyk App. This will for a list of scopes that your app is allowed to request during authorization.
+A comma separated list of scopes required by your Snyk App. This will form a list of scopes that your app is allowed to request during authorization. You can read more about the allowed scopes in our [docs](https://docs.snyk.io/snyk-apps/getting-started-with-snyk-apps/create-an-app-via-the-api#requesting-scopes).
 
 ## Examples
 
 ### `Create Snyk App`
 
-\$ snyk apps create --experimental --org=48ebb069-472f-40f4-b5bf-d2d103bc02d4 --name='My Awesome App' --redirect-uris=https://example1.com,https://example2.com --scopes=apps:beta
+\$ snyk apps create --experimental --org=48ebb069-472f-40f4-b5bf-d2d103bc02d4 --name='My Awesome App' --redirect-uris=https://example1.com,https://example2.com --scopes=org.read,org.report.read
 
 ### `Create Snyk App Interactive Mode`
 

--- a/src/lib/apps/constants.ts
+++ b/src/lib/apps/constants.ts
@@ -46,7 +46,7 @@ export const CreateAppPromptData = {
   SNYK_APP_SCOPES: {
     name: SNYK_APP_SCOPES,
     message: `Your Snyk App's permission scopes (comma separated list. ${chalk.yellowBright(
-      ' Ex: apps:beta',
+      ' Ex: org.read,org.report.read',
     )})?: `,
   },
   SNYK_APP_ORG_ID: {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Replaces any reference to `apps:beta` scope and updates it with allowed scopes. Along with minor corrections to docs.

#### Any background context you want to provide?

`apps:beta` scope for Snyk Apps was used when we were in the beta phase. It has now been replaced with general scopes.

#### What are the relevant tickets?

[MOOSE-509](https://snyksec.atlassian.net/browse/MOOSE-509?atlOrigin=eyJpIjoiYzg1NTlkYjkwMmJmNDhjZDg0MjY5OGNlZmMzOTkwZDciLCJwIjoiaiJ9)