### PR TITLE
chore(ci): fix build job dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -806,7 +806,7 @@ workflows:
       - version:
           name: Version
           requires:
-            - Install
+            - Build
           filters:
             branches:
               only:
@@ -817,7 +817,6 @@ workflows:
       - build-artifact:
           name: Build (<< matrix.artifact >>)
           requires:
-            - Build
             - Version
           matrix:
             parameters:


### PR DESCRIPTION
It seems like "Build" jobs still start even when the required "Version" job has been filtered. This causes issues as we expect there to be a "binary-releases/version" file for later jobs.

To fix this and unblock pipelines, I've reordered "Version" so the "Build" jobs only require "Version".