### PR TITLE
feat: Add Go 1.18 Dockerfile

### DIFF
--- a/docker/Dockerfile.go-1.8
+++ b/docker/Dockerfile.go-1.8
@@ -1,0 +1,31 @@
+FROM golang:1.18-bullseye
+
+LABEL maintainer="Snyk Ltd"
+
+RUN mkdir /home/node
+WORKDIR /home/node
+
+# Install snyk cli and clean up
+RUN apt-get update && \
+    apt-get install -y build-essential curl git && \
+    curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+    apt-get install -y nodejs && \
+    npm install --global snyk snyk-to-html && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    chmod -R a+wrx /home/node
+
+# The path at which the project is mounted (-v runtime arg)
+ENV PROJECT_PATH /project
+
+COPY docker-entrypoint.sh .
+
+ENV SNYK_INTEGRATION_NAME DOCKER_SNYK_CLI
+
+ENV SNYK_INTEGRATION_VERSION go-1.8
+
+ENTRYPOINT ["./docker-entrypoint.sh"]
+
+# Default command is `snyk test`
+# Override with `docker run ... snyk/snyk-cli <command> <args>`
+CMD ["test"]


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Adds Dockerfile for Golang 1.18 environment

#### Where should the reviewer start?
Review file `/docker/Dockerfile.go-1.18`

#### How should this be manually tested?

1. Build `Dockerfile.go-1.18`
2. Run image locally and use Snyk CLI to test Go project.

#### Any background context you want to provide?
https://hub.docker.com/r/snyk/snyk-cli/ currently does not have an image/tag for Go. This PR aims to add one.

#### What are the relevant tickets?
N/A

#### Screenshots
N/A

#### Additional questions
N/A