### PR TITLE
fix: remove vscode terminal error from go-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.20.0",
         "snyk-docker-plugin": "^4.36.0",
-        "snyk-go-plugin": "1.18.0",
+        "snyk-go-plugin": "1.18.1",
         "snyk-gradle-plugin": "3.18.1",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.29.7",
@@ -16465,9 +16465,9 @@
       }
     },
     "node_modules/snyk-go-plugin": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.18.0.tgz",
-      "integrity": "sha512-9cV+Z3zRt6+7a7mtAfPGjkrLhcswJx90MmHCQijVEstV7bJCgQVbRUiVax0mjfDOB2G4d61Vjb9T1pykfO9dsA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.18.1.tgz",
+      "integrity": "sha512-7tnwE2kGRVPMDy47tGxOi3eXBW/tsdYyY6R3KLw9iFCBKSzf5T8YmXuUlUG506EqaoBhl4A432BcA1VYoNQ9Ow==",
       "dependencies": {
         "@snyk/dep-graph": "^1.23.1",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -32612,9 +32612,9 @@
       }
     },
     "snyk-go-plugin": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.18.0.tgz",
-      "integrity": "sha512-9cV+Z3zRt6+7a7mtAfPGjkrLhcswJx90MmHCQijVEstV7bJCgQVbRUiVax0mjfDOB2G4d61Vjb9T1pykfO9dsA==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.18.1.tgz",
+      "integrity": "sha512-7tnwE2kGRVPMDy47tGxOi3eXBW/tsdYyY6R3KLw9iFCBKSzf5T8YmXuUlUG506EqaoBhl4A432BcA1VYoNQ9Ow==",
       "requires": {
         "@snyk/dep-graph": "^1.23.1",
         "@snyk/graphlib": "2.1.9-patch.3",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.20.0",
     "snyk-docker-plugin": "^4.36.0",
-    "snyk-go-plugin": "1.18.0",
+    "snyk-go-plugin": "1.18.1",
     "snyk-gradle-plugin": "3.18.1",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.29.7",


### PR DESCRIPTION
#### What does this PR do?

This PR adds snyk/snyk-go-plugin#96 which removes an outdated error for VSCode integrated terminal users.
