### PR TITLE
feat: detect JARs in WARs files inside containers [MYC-109]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.20.0",
-        "snyk-docker-plugin": "^4.35.2",
+        "snyk-docker-plugin": "^4.36.0",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.18.1",
         "snyk-module": "3.1.0",
@@ -16315,9 +16315,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "4.35.2",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.35.2.tgz",
-      "integrity": "sha512-X2DUEUIUtco3O2UvEcnRPWYakqHRyeJBLnVQSV1/JeLomak55V5D+Qsotd3iukQ7PUaxVp6nOuh7VREShsW1Tg==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.36.0.tgz",
+      "integrity": "sha512-pczlTUXadqSjWx7X4Mt4+UPUPOwvUo7Qcv7G8DTJlUqNRGYm0XExXC2PUizFcOlD5BYx4NPYYXnNdUXDkGi12Q==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^1.28.0",
@@ -32499,9 +32499,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "4.35.2",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.35.2.tgz",
-      "integrity": "sha512-X2DUEUIUtco3O2UvEcnRPWYakqHRyeJBLnVQSV1/JeLomak55V5D+Qsotd3iukQ7PUaxVp6nOuh7VREShsW1Tg==",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.36.0.tgz",
+      "integrity": "sha512-pczlTUXadqSjWx7X4Mt4+UPUPOwvUo7Qcv7G8DTJlUqNRGYm0XExXC2PUizFcOlD5BYx4NPYYXnNdUXDkGi12Q==",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.20.0",
-    "snyk-docker-plugin": "^4.35.2",
+    "snyk-docker-plugin": "^4.36.0",
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.18.1",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Upgrade `snyk-docker-plugin` to its latest version, that supports
scanning WAR files inside the image, and find nested JAR files within
these WAR archives.


#### What are the relevant tickets?
[MYC-109](https://snyksec.atlassian.net/browse/MYC-109)
