### PR TITLE
fix: remove warning message for custom rules from iac --report

### DIFF
--- a/src/cli/commands/test/iac/local-execution/rules/rules.ts
+++ b/src/cli/commands/test/iac/local-execution/rules/rules.ts
@@ -18,10 +18,7 @@ import { initLocalCache, pull } from '../measurable-methods';
 import { config as userConfig } from '../../../../../../lib/user-config';
 import { CustomError } from '../../../../../../lib/errors';
 import { getErrorStringCode } from '../error-utils';
-import {
-  customRulesMessage,
-  customRulesReportMessage,
-} from '../../../../../../lib/formatters/iac-output';
+import { customRulesMessage } from '../../../../../../lib/formatters/iac-output';
 import { OciRegistry, RemoteOciRegistry } from './oci-registry';
 import { isValidUrl } from '../url-utils';
 
@@ -50,13 +47,7 @@ export async function initRules(
     (isOCIRegistryURLProvided || customRulesPath) &&
     !(options.sarif || options.json)
   ) {
-    let userMessage = `${customRulesMessage}${EOL}`;
-
-    if (options.report) {
-      userMessage += `${customRulesReportMessage}${EOL}`;
-    }
-
-    console.log(userMessage);
+    console.log(`${customRulesMessage}${EOL}`);
   }
 
   if (isOCIRegistryURLProvided && customRulesPath) {

--- a/src/lib/formatters/iac-output/index.ts
+++ b/src/lib/formatters/iac-output/index.ts
@@ -15,7 +15,6 @@ export {
   spinnerMessage,
   spinnerSuccessMessage,
   customRulesMessage,
-  customRulesReportMessage,
   shouldLogUserMessages,
   formatShareResultsOutput,
   failuresTipOutput,

--- a/src/lib/formatters/iac-output/v2/index.ts
+++ b/src/lib/formatters/iac-output/v2/index.ts
@@ -6,7 +6,6 @@ export {
   spinnerSuccessMessage,
   shouldLogUserMessages,
   customRulesMessage,
-  customRulesReportMessage,
 } from './user-messages';
 export { formatShareResultsOutput } from './share-results';
 export {

--- a/src/lib/formatters/iac-output/v2/user-messages.ts
+++ b/src/lib/formatters/iac-output/v2/user-messages.ts
@@ -26,13 +26,6 @@ export const customRulesMessage = colors.info(
 );
 
 /**
- * Message for using custom rules.
- */
-export const customRulesReportMessage = colors.info(
-  "Please note that your custom rules will not be sent to the Snyk platform, and will not be available on the project's page.",
-);
-
-/**
  * @returns whether or not to include user messages in the output.
  */
 export function shouldLogUserMessages(

--- a/test/jest/acceptance/iac/custom-rules.spec.ts
+++ b/test/jest/acceptance/iac/custom-rules.spec.ts
@@ -85,30 +85,5 @@ describe('iac test --rules', () => {
         'Using custom rules to generate misconfigurations.',
       );
     });
-
-    it('should display a warning message for custom rules not being available on the platform', async () => {
-      const { stdout } = await run(
-        `snyk iac ${testedCommand} --rules=./iac/custom-rules/custom.tar.gz ./iac/terraform/sg_open_ssh.tf`,
-      );
-
-      expect(stdout).toContain(
-        "Please note that your custom rules will not be sent to the Snyk platform, and will not be available on the project's page.",
-      );
-    });
-
-    describe.each(['--json', '--sarif'])(
-      'when the %s flag is provided',
-      (testedFormatFlag) => {
-        it('should not display the warning message for the custom rules not being available on the platform', async () => {
-          const { stdout } = await run(
-            `snyk iac ${testedCommand} --rules=./iac/custom-rules/custom.tar.gz ./iac/terraform/sg_open_ssh.tf ${testedFormatFlag}`,
-          );
-
-          expect(stdout).not.toContain(
-            "Please note that your custom rules will not be sent to the Snyk platform, and will not be available on the project's page.",
-          );
-        });
-      },
-    );
   });
 });


### PR DESCRIPTION
This commits removes the warning message we used to display when running `snyk iac test --report`, with custom rules (local or remote ones).
We now support custom rules when sharing results to the platform, so we remove this message.

CFG-1868

### How to test

The ticket can be verified using https://github.com/snyk/custom-rules-examples/

- Install snyk-iac-rules: https://github.com/snyk/snyk-iac-rules
- Build a local bundle: snyk-iac-rules build
- Run the rules to see them in the results: snyk iac test ./rules/CUSTOM-RULE-1/fixtures --rules=bundle.tar.gz 
- Run the rules and send them to the Platform: snyk-dev iac test ./rules/CUSTOM-RULE-1/fixtures --rules=bundle.tar.gz --report 
- Check that no warning message appears now.

Note: You will not see the issues from custom rules populated in the Snyk platform. This is still dependendent on another ticket, sending the results there.

### Screenshots

no warning is displayed anymore


<img width="1002" alt="image" src="https://user-images.githubusercontent.com/6989529/171022273-8084e5e9-e982-46d3-ac53-23a4f9c07311.png">
