### PR TITLE
chore: Added underline for docs URL

### DIFF
--- a/src/lib/formatters/iac-output/v2/issues-list/issue.ts
+++ b/src/lib/formatters/iac-output/v2/issues-list/issue.ts
@@ -45,7 +45,7 @@ function formatProperties(result: FormattedOutputResult): string[] {
       'Rule',
       result.issue.isGeneratedByCustomRule
         ? `custom rule ${result.issue.id}`
-        : result.issue.documentation,
+        : chalk.underline(result.issue.documentation || ''),
     ],
     ['Path', printPath(result.issue.cloudConfigPath, 0)],
     ['File', result.targetFile],

--- a/test/jest/unit/lib/formatters/iac-output/v2/issues-list/index.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/issues-list/index.spec.ts
@@ -60,7 +60,7 @@ describe('getIacDisplayedIssues', () => {
         `[Low] ${chalk.bold('Container is running without AppArmor profile')}`,
       )}
   Info:    The AppArmor profile is not set correctly. AppArmor will not enforce mandatory access control, which can increase the attack vectors.
-  Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-32
+  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-K8S-32')}
   Path:    [DocId: 0] > metadata > annotations['container.apparmor.security.beta.kubernetes.io/web']
   File:    k8s.yaml
   Resolve: Add \`container.apparmor.security.beta.kubernetes.io/<container-name>\` annotation with value \`runtime/default\` or \`localhost/<name-of-profile\`
@@ -69,7 +69,7 @@ describe('getIacDisplayedIssues', () => {
     `[Low] ${chalk.bold('Container is running without memory limit')}`,
   )}
   Info:    Memory limit is not defined. Containers without memory limits are more likely to be terminated when the node runs out of memory
-  Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-4
+  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-K8S-4')}
   Path:    [DocId: 0] > input > spec > template > spec > containers[web] > resources > limits > memory
   File:    k8s.yaml
   Resolve: Set \`resources.limits.memory\` value
@@ -78,7 +78,7 @@ describe('getIacDisplayedIssues', () => {
     `[Low] ${chalk.bold('Container could be running with outdated image')}`,
   )}
   Info:    The image policy does not prevent image reuse. The container may run with outdated or unauthorized image
-  Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-42
+  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-K8S-42')}
   Path:    [DocId: 0] > spec > template > spec > containers[web] > imagePullPolicy
   File:    k8s.yaml
   Resolve: Set \`imagePullPolicy\` attribute to \`Always\`
@@ -87,7 +87,7 @@ describe('getIacDisplayedIssues', () => {
     `[Low] ${chalk.bold('Container is running without cpu limit')}`,
   )}
   Info:    CPU limit is not defined. Containers without limits can exceed the capacity of the node, and affect availability/performance of the host and other containers.
-  Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-5
+  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-K8S-5')}
   Path:    [DocId: 0] > input > spec > template > spec > containers[web] > resources > limits > cpu
   File:    k8s.yaml
   Resolve: Add \`resources.limits.cpu\` field with required CPU limit value
@@ -96,7 +96,7 @@ describe('getIacDisplayedIssues', () => {
     `[Low] ${chalk.bold('Container is running with writable root filesystem')}`,
   )}
   Info:    \`readOnlyRootFilesystem\` attribute is not set to \`true\`. Compromised process could abuse writable root filesystem to elevate privileges
-  Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-8
+  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-K8S-8')}
   Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > readOnlyRootFilesystem
   File:    k8s.yaml
   Resolve: Set \`securityContext.readOnlyRootFilesystem\` to \`true\``,
@@ -109,7 +109,7 @@ describe('getIacDisplayedIssues', () => {
         )}`,
       )}
   Info:    Container is running without root user control. Container could be running with full administrative privileges
-  Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-10
+  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-K8S-10')}
   Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > runAsNonRoot
   File:    k8s.yaml
   Resolve: Set \`securityContext.runAsNonRoot\` to \`true\`
@@ -120,7 +120,7 @@ describe('getIacDisplayedIssues', () => {
     )}`,
   )}
   Info:    All default capabilities are not explicitly dropped. Containers are running with potentially unnecessary privileges
-  Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-6
+  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-K8S-6')}
   Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > capabilities > drop
   File:    k8s.yaml
   Resolve: Add \`ALL\` to \`securityContext.capabilities.drop\` list, and add only required capabilities in \`securityContext.capabilities.add\`
@@ -131,7 +131,7 @@ describe('getIacDisplayedIssues', () => {
     )}`,
   )}
   Info:    \`allowPrivilegeEscalation\` attribute is not set to \`false\`. Processes could elevate current privileges via known vectors, for example SUID binaries
-  Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-9
+  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-K8S-9')}
   Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > allowPrivilegeEscalation
   File:    k8s.yaml
   Resolve: Set \`securityContext.allowPrivilegeEscalation\` to \`false\``,
@@ -142,7 +142,7 @@ describe('getIacDisplayedIssues', () => {
         `[High] ${chalk.bold('Container is running in privileged mode')}`,
       )}
   Info:    Container is running in privileged mode. Compromised container could potentially modify the underlying host’s kernel by loading unauthorized modules (i.e. drivers).
-  Rule:    https://snyk.io/security-rules/SNYK-CC-K8S-1
+  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-K8S-1')}
   Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > privileged
   File:    k8s.yaml
   Resolve: Remove \`securityContext.privileged\` attribute, or set value to \`false\``,


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Adds an underline below security rule documentation URLs

#### Where should the reviewer start?

    src/lib/formatters/iac-output/v2/issues-list/issue.ts

#### How should this be manually tested?

- Run `snyk-dev iac test` and ensure security rule documentation URLs are underlined.
- Run `snyk-dev iac test` with issues generated from custom rules and ensure the `Rule` property was not affected for them.

#### Additional information

- [Slack thread](https://snyk.slack.com/archives/C030UA3U1RB/p1653983832072149)

#### Screenshots

- Before

    ![image](https://user-images.githubusercontent.com/46415136/171135052-0ada149d-6989-4f20-a7a4-76bc8c1cfcdb.png)

- After

    ![image](https://user-images.githubusercontent.com/46415136/171135146-b28cde7d-64df-4042-91e4-548e3ead170f.png)

- After with custom rules:

    <img width="493" alt="image" src="https://user-images.githubusercontent.com/46415136/171136371-30e3f0d8-c5c8-4947-9493-a989e155e579.png">
