### PR TITLE
chore: add condition to diverge to new flow for iac [CFG-1816]

### DIFF
--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -1,0 +1,12 @@
+import chalk from 'chalk';
+import { TestCommandResult } from '../../../types';
+
+export async function test(): Promise<TestCommandResult> {
+  let response = '';
+  response += chalk.bold.green('new flow for UPE integration - TBC...');
+  return TestCommandResult.createHumanReadableTestCommandResult(
+    response,
+    '',
+    '',
+  );
+}

--- a/test/jest/acceptance/iac/experimental.spec.ts
+++ b/test/jest/acceptance/iac/experimental.spec.ts
@@ -1,0 +1,59 @@
+import { startMockServer } from './helpers';
+import { FakeServer } from '../../../acceptance/fake-server';
+
+jest.setTimeout(50_000);
+
+describe('iac --experimental', () => {
+  let server: FakeServer;
+  let run: (
+    cmd: string,
+  ) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+  let teardown: () => void;
+  const upeFeatureFlag = 'iacCliUnifiedEngine';
+
+  beforeAll(async () => {
+    ({ server, run, teardown } = await startMockServer());
+  });
+
+  afterEach(() => {
+    server.restore();
+  });
+
+  afterAll(async () => teardown());
+
+  describe(`"${upeFeatureFlag}" feature flag is ON`, () => {
+    beforeEach(() => {
+      server.setFeatureFlag(upeFeatureFlag, true);
+      server.setFeatureFlag('iacCliOutputRelease', true);
+    });
+
+    it('diverts to the new flow when --experimental flag is used', async () => {
+      const { exitCode, stdout } = await run(
+        `snyk iac test ./iac/arm/rule_test.json --experimental`,
+      );
+      expect(stdout).not.toContain('Snyk Infrastructure as Code');
+      expect(stdout).not.toContain('Issues');
+      expect(exitCode).toBe(0);
+    });
+
+    it('does not divert to the new flow without --experimental flag', async () => {
+      const { exitCode, stdout } = await run(
+        `snyk iac test ./iac/arm/rule_test.json`,
+      );
+      expect(stdout).toContain('Snyk Infrastructure as Code');
+      expect(stdout).toContain('Issues');
+      expect(exitCode).toBe(1);
+    });
+  });
+
+  describe(`"${upeFeatureFlag}" feature flag is OFF`, () => {
+    it('does not divert to the new flow with just --experimental flag', async () => {
+      server.setFeatureFlag(upeFeatureFlag, false);
+      const { exitCode, stdout } = await run(
+        `snyk iac test ./iac/arm/rule_test.json --experimental`,
+      );
+      expect(stdout).toContain('Unsupported flag "--experimental" provided');
+      expect(exitCode).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR adds a divergion from the existing flow to the new flow (TBC) for the UPE integration.

The code currently does nothing. this commit just prepares the directory structure. I added a dummy message for fun :) It can be deleted on the next commit.
I have named the directory v2 but it's open to renaming as we progress with building up this flow.

Also included a simple acceptance test to prove the point of the feature flag and command flag. We can refactor and use this later, when we have actual code. 

#### How to test

follow the same scenarios as the acceptance test.
- with FF on and --experimental
- with FF on , without --experimental
- with FF off, and --experimental
- with FF off, without --experimental
- with typos on the command flag

<img width="781" alt="image" src="https://user-images.githubusercontent.com/6989529/171424836-42fc4393-2368-4ad3-bce7-02613d857630.png">



