### PR TITLE
fix: IaC issue info when impact or description are missing

### DIFF
--- a/src/lib/formatters/iac-output/v2/issues-list/issue.ts
+++ b/src/lib/formatters/iac-output/v2/issues-list/issue.ts
@@ -31,16 +31,26 @@ function formatTitle(issue: AnnotatedIacIssue): string {
   return titleOutput;
 }
 
+function formatInfo(issue: AnnotatedIacIssue): string | undefined {
+  const issueDesc = issue.iacDescription.issue;
+  const issueImpact = issue.iacDescription.impact;
+
+  if (!issueDesc) {
+    return issueImpact;
+  }
+
+  if (!issueImpact) {
+    return issueDesc;
+  }
+
+  return `${issueDesc}${!issueDesc.endsWith('.') ? '.' : ''} ${issueImpact}`;
+}
+
 function formatProperties(result: FormattedOutputResult): string[] {
   const remediationKey = iacRemediationTypes?.[result.projectType];
 
   const properties = [
-    [
-      'Info',
-      `${result.issue.iacDescription.issue}${
-        result.issue.iacDescription.issue.endsWith('.') ? '' : '.'
-      } ${result.issue.iacDescription.impact}`,
-    ],
+    ['Info', formatInfo(result.issue)],
     [
       'Rule',
       result.issue.isGeneratedByCustomRule


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Fixes the issue's `Info` property to display the expected information when either the issue's description, issue's impact or both are missing. This is especially relevant for issues generated by custom rules, in which these fields are not required.

#### Where should the reviewer start?

    src/lib/formatters/iac-output/v2/issues-list/issue.ts

#### How should this be manually tested?

- Generate a custom rules bundle in which one of the custom rules lacks the description, another lacks the impact, and another lacks both.
- Use the `snyk-dev iac test` command to test IaC files which would generate issues from these custom rules.
- Ensure that an issue's `Info` property:
    - When only the issue's description is missing - The issue's impact is displayed.
    - When only the issue's impact is missing - The issue's description is displayed.
    - Weh both the issue's description and impact are missing, the property is not displayed at all.

#### Screenshots

- Before:

    ![image](https://user-images.githubusercontent.com/46415136/172179382-3795d9fa-36fe-4751-a3c4-6cd8b2c2dab8.png)

- After

    ![image](https://user-images.githubusercontent.com/46415136/172179535-2c81b9f2-58fe-42d5-ae25-8019d6b739b8.png)

#### Additional questions
