### PR TITLE
chore: Locate UPE Executable [CFG-1846]

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -35,6 +35,7 @@ const DEBUG_DEFAULT_NAMESPACES = [
   'snyk-test',
   'snyk',
   'snyk-code',
+  'snyk-iac',
   'snyk:find-files',
   'snyk:run-test',
   'snyk:prune',

--- a/src/cli/commands/test/iac/local-execution/types.ts
+++ b/src/cli/commands/test/iac/local-execution/types.ts
@@ -351,6 +351,9 @@ export enum IaCErrorCodes {
 
   // Rules bundle errors.
   InvalidUserRulesBundleError = 1130,
+
+  // Unified Policy Engine executable errors.
+  InvalidUserPolicyEnginePathError = 1140,
 }
 
 export interface TestReturnValue {

--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -1,19 +1,15 @@
 import chalk from 'chalk';
-import { TestCommandResult } from '../../../types';
-import { RulesBundleLocator } from './rules';
-import config from '../../../../../lib/config';
 import envPaths from 'env-paths';
-import * as path from 'path';
+import * as pathLib from 'path';
+import * as testLib from '../../../../../lib/iac/test/v2';
+import { TestConfig } from '../../../../../lib/iac/test/v2';
+import config from '../../../../../lib/config';
+import { TestCommandResult } from '../../../types';
 
 export async function test(): Promise<TestCommandResult> {
-  const bundleLocator = createRulesBundleLocator();
-  const bundlePath = bundleLocator.locateBundle();
+  const testConfig = prepareTestConfig();
 
-  if (bundlePath) {
-    console.log(`found rules bundle at ${bundlePath}`);
-  } else {
-    console.log('no rules bundle found');
-  }
+  await testLib.test(testConfig);
 
   let response = '';
   response += chalk.bold.green('new flow for UPE integration - TBC...');
@@ -24,9 +20,14 @@ export async function test(): Promise<TestCommandResult> {
   );
 }
 
-function createRulesBundleLocator(): RulesBundleLocator {
+function prepareTestConfig(): TestConfig {
   const systemCachePath = config.CACHE_PATH ?? envPaths('snyk').cache;
-  const cachedBundlePath = path.join(systemCachePath, 'iac', 'bundle.tar.gz');
-  const userBundlePath = config.IAC_BUNDLE_PATH;
-  return new RulesBundleLocator(cachedBundlePath, userBundlePath);
+  const iacCachePath = pathLib.join(systemCachePath, 'iac');
+
+  return {
+    cachedBundlePath: pathLib.join(iacCachePath, 'bundle.tar.gz'),
+    userBundlePath: config.IAC_BUNDLE_PATH,
+    cachedPolicyEnginePath: pathLib.join(iacCachePath, 'snyk-iac-test'),
+    userPolicyEnginePath: config.IAC_POLICY_ENGINE_PATH,
+  };
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -23,6 +23,7 @@ interface Config {
   DRIFTCTL_PATH?: string;
   DRIFTCTL_URL?: string;
   IAC_BUNDLE_PATH?: string;
+  IAC_POLICY_ENGINE_PATH?: string;
   IAC_OUTPUT_V2?: boolean;
 }
 

--- a/src/lib/iac/drift/driftctl.ts
+++ b/src/lib/iac/drift/driftctl.ts
@@ -23,6 +23,7 @@ import * as child_process from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as crypto from 'crypto';
+import { isExe } from '../file-utils';
 
 const debug = debugLib('driftctl');
 
@@ -422,18 +423,6 @@ function driftctlUrl(): string {
   }
 
   return `${dctlBaseUrl}/${driftctlVersion}/${driftctlFileName()}`;
-}
-
-function isExe(dctlPath: string): Promise<boolean> {
-  return new Promise<boolean>((resolve) => {
-    fs.access(dctlPath, fs.constants.X_OK, (err) => {
-      if (err) {
-        resolve(false);
-        return;
-      }
-      resolve(true);
-    });
-  });
 }
 
 function createIfNotExists(path: string) {

--- a/src/lib/iac/file-utils.ts
+++ b/src/lib/iac/file-utils.ts
@@ -1,0 +1,11 @@
+import * as fs from 'fs';
+import { promises as fsPromises } from 'fs';
+
+export async function isExe(path: string): Promise<boolean> {
+  try {
+    await fsPromises.access(path, fs.constants.X_OK);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}

--- a/src/lib/iac/test/v2/index.ts
+++ b/src/lib/iac/test/v2/index.ts
@@ -1,0 +1,12 @@
+import { TestConfig } from './types';
+import { setup } from './setup';
+
+export { TestConfig } from './types';
+
+export async function test(testConfig: TestConfig) {
+  await setup(testConfig);
+
+  // TODO: Add the rest of the test steps
+
+  return;
+}

--- a/src/lib/iac/test/v2/setup/index.ts
+++ b/src/lib/iac/test/v2/setup/index.ts
@@ -1,0 +1,8 @@
+import { TestConfig } from '../types';
+import { initRules } from './rules';
+import { initPolicyEngine } from './policy-engine';
+
+export async function setup(testConfig: TestConfig) {
+  await initPolicyEngine(testConfig);
+  await initRules(testConfig);
+}

--- a/src/lib/iac/test/v2/setup/policy-engine.ts
+++ b/src/lib/iac/test/v2/setup/policy-engine.ts
@@ -1,0 +1,66 @@
+import * as createDebugLogger from 'debug';
+import { isExe } from '../../../file-utils';
+import { CustomError } from '../../../../errors';
+import { IaCErrorCodes } from '../../../../../cli/commands/test/iac/local-execution/types';
+import { getErrorStringCode } from '../../../../../cli/commands/test/iac/local-execution/error-utils';
+import { TestConfig } from '../types';
+
+const debugLogger = createDebugLogger('snyk-iac');
+
+export class InvalidUserPolicyEnginePathError extends CustomError {
+  constructor(path: string, message?: string, userMessage?: string) {
+    super(
+      message ||
+        'Failed to find a valid Policy Engine executable in the configured path',
+    );
+    this.code = IaCErrorCodes.InvalidUserPolicyEnginePathError;
+    this.strCode = getErrorStringCode(this.code);
+    this.userMessage =
+      userMessage ||
+      `Could not find a valid Policy Engine executable in the configured path: ${path}` +
+        '\nEnsure the configured path points to a valid Policy Engine executable.';
+  }
+}
+
+export async function lookupLocalPolicyEngine({
+  cachedPolicyEnginePath,
+  userPolicyEnginePath,
+}: TestConfig): Promise<string | undefined> {
+  // Lookup in custom path.
+  if (userPolicyEnginePath) {
+    debugLogger(
+      'User configured IaC Policy Engine executable path detected: %s',
+      userPolicyEnginePath,
+    );
+
+    if (await isExe(userPolicyEnginePath)) {
+      return userPolicyEnginePath;
+    } else {
+      throw new InvalidUserPolicyEnginePathError(userPolicyEnginePath);
+    }
+  }
+  // Lookup in cache.
+  else {
+    if (await isExe(cachedPolicyEnginePath)) {
+      debugLogger(
+        'Found cached Policy Engine executable: %s',
+        cachedPolicyEnginePath,
+      );
+      return cachedPolicyEnginePath;
+    } else {
+      debugLogger(
+        'Policy Engine executable was not cached: %s',
+        cachedPolicyEnginePath,
+      );
+    }
+  }
+}
+
+export async function initPolicyEngine(testConfig: TestConfig) {
+  const localPolicyEnginePath = await lookupLocalPolicyEngine(testConfig);
+  if (localPolicyEnginePath) {
+    return localPolicyEnginePath;
+  }
+
+  // TODO: Download Policy Engine executable
+}

--- a/src/lib/iac/test/v2/setup/rules.ts
+++ b/src/lib/iac/test/v2/setup/rules.ts
@@ -1,8 +1,23 @@
 import * as fs from 'fs';
 import * as tar from 'tar';
-import { CustomError } from '../../../../../lib/errors';
-import { getErrorStringCode } from '../local-execution/error-utils';
-import { IaCErrorCodes } from '../local-execution/types';
+import { CustomError } from '../../../../errors';
+import { getErrorStringCode } from '../../../../../cli/commands/test/iac/local-execution/error-utils';
+import { IaCErrorCodes } from '../../../../../cli/commands/test/iac/local-execution/types';
+import { TestConfig } from '../types';
+
+export async function initRules(testConfig: TestConfig) {
+  const bundleLocator = new RulesBundleLocator(
+    testConfig.cachedBundlePath,
+    testConfig.userBundlePath,
+  );
+  const bundlePath = bundleLocator.locateBundle();
+
+  if (bundlePath) {
+    console.log(`found rules bundle at ${bundlePath}`);
+  } else {
+    console.log('no rules bundle found');
+  }
+}
 
 export class RulesBundleLocator {
   constructor(

--- a/src/lib/iac/test/v2/types.ts
+++ b/src/lib/iac/test/v2/types.ts
@@ -1,0 +1,6 @@
+export interface TestConfig {
+  cachedBundlePath: string;
+  cachedPolicyEnginePath: string;
+  userBundlePath?: string;
+  userPolicyEnginePath?: string;
+}

--- a/test/jest/acceptance/iac/experimental.spec.ts
+++ b/test/jest/acceptance/iac/experimental.spec.ts
@@ -1,3 +1,4 @@
+import * as pathLib from 'path';
 import { startMockServer } from './helpers';
 import { FakeServer } from '../../../acceptance/fake-server';
 
@@ -7,9 +8,10 @@ describe('iac --experimental', () => {
   let server: FakeServer;
   let run: (
     cmd: string,
+    env?: Record<string, string>,
   ) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
   let teardown: () => void;
-  const upeFeatureFlag = 'iacCliUnifiedEngine';
+  const cliUnifiedEngineFeatureFlag = 'iacCliUnifiedEngine';
 
   beforeAll(async () => {
     ({ server, run, teardown } = await startMockServer());
@@ -21,34 +23,64 @@ describe('iac --experimental', () => {
 
   afterAll(async () => teardown());
 
-  describe(`"${upeFeatureFlag}" feature flag is ON`, () => {
+  describe(`"${cliUnifiedEngineFeatureFlag}" feature flag is ON`, () => {
     beforeEach(() => {
-      server.setFeatureFlag(upeFeatureFlag, true);
+      server.setFeatureFlag(cliUnifiedEngineFeatureFlag, true);
       server.setFeatureFlag('iacCliOutputRelease', true);
     });
 
-    it('diverts to the new flow when --experimental flag is used', async () => {
-      const { exitCode, stdout } = await run(
-        `snyk iac test ./iac/arm/rule_test.json --experimental`,
-      );
-      expect(stdout).not.toContain('Snyk Infrastructure as Code');
-      expect(stdout).not.toContain('Issues');
-      expect(exitCode).toBe(0);
+    describe('with the --experimental flag', () => {
+      it('diverts to the new flow', async () => {
+        const { exitCode, stdout } = await run(
+          `snyk iac test ./iac/arm/rule_test.json --experimental`,
+        );
+        expect(stdout).not.toContain('Snyk Infrastructure as Code');
+        expect(stdout).not.toContain('Issues');
+        expect(exitCode).toBe(0);
+      });
+
+      describe('when a custom Policy Engine executable path is configured ', () => {
+        // TODO: Add this test when we start generate actual test output.
+        describe('when the path does not lead to a valid executable', () => {
+          it.todo('uses the Policy Engine executable from the custom path');
+        });
+
+        describe('when the path does not lead to a valid executable', () => {
+          it('Shows an error message', async () => {
+            const userPolicyEnginePath = pathLib.join('made', 'up', 'path');
+
+            const { exitCode, stdout } = await run(
+              `snyk iac test ./iac/arm/rule_test.json --experimental`,
+              {
+                SNYK_IAC_POLICY_ENGINE_PATH: userPolicyEnginePath,
+              },
+            );
+
+            expect(exitCode).toBe(2);
+            expect(stdout).toContain(
+              `Could not find a valid Policy Engine executable in the configured path: ${userPolicyEnginePath}` +
+                '\nEnsure the configured path points to a valid Policy Engine executable.',
+            );
+          });
+        });
+      });
     });
 
-    it('does not divert to the new flow without --experimental flag', async () => {
-      const { exitCode, stdout } = await run(
-        `snyk iac test ./iac/arm/rule_test.json`,
-      );
-      expect(stdout).toContain('Snyk Infrastructure as Code');
-      expect(stdout).toContain('Issues');
-      expect(exitCode).toBe(1);
+    describe('without the --experimental flag', () => {
+      it('does not divert to the new flow', async () => {
+        const { exitCode, stdout } = await run(
+          `snyk iac test ./iac/arm/rule_test.json`,
+        );
+        expect(stdout).toContain('Snyk Infrastructure as Code');
+        expect(stdout).toContain('Issues');
+        expect(exitCode).toBe(1);
+      });
     });
   });
 
-  describe(`"${upeFeatureFlag}" feature flag is OFF`, () => {
-    it('does not divert to the new flow with just --experimental flag', async () => {
-      server.setFeatureFlag(upeFeatureFlag, false);
+  describe(`"${cliUnifiedEngineFeatureFlag}" feature flag is OFF`, () => {
+    it('does not divert to the new flow', async () => {
+      server.setFeatureFlag(cliUnifiedEngineFeatureFlag, false);
       const { exitCode, stdout } = await run(
         `snyk iac test ./iac/arm/rule_test.json --experimental`,
       );

--- a/test/jest/unit/lib/iac/test/v2/setup/policy-engine.spec.ts
+++ b/test/jest/unit/lib/iac/test/v2/setup/policy-engine.spec.ts
@@ -1,0 +1,91 @@
+import * as cloneDeep from 'lodash.clonedeep';
+import * as fileUtils from '../../../../../../../../src/lib/iac/file-utils';
+import {
+  InvalidUserPolicyEnginePathError,
+  lookupLocalPolicyEngine,
+} from '../../../../../../../../src/lib/iac/test/v2/setup/policy-engine';
+
+describe('lookupLocalPolicyEngine', () => {
+  const defaultTestConfig = {
+    cachedPolicyEnginePath: `iac/cache/path/snyk-iac-test`,
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('when a user configured path for a Policy Engine executable is not provded', () => {
+    describe('when the Policy Engine executable was cached', () => {
+      it('returns the path to the cached Policy Engine executable', async () => {
+        // Arrange
+        const testConfig = cloneDeep(defaultTestConfig);
+
+        jest
+          .spyOn(fileUtils, 'isExe')
+          .mockImplementationOnce(
+            async (path) => path === testConfig.cachedPolicyEnginePath,
+          );
+
+        // Act
+        const res = await lookupLocalPolicyEngine(testConfig);
+
+        // Assert
+        expect(res).toEqual(testConfig.cachedPolicyEnginePath);
+      });
+    });
+
+    describe('when the Policy Engine was not cached', () => {
+      it('returns no path', async () => {
+        // Arrange
+        const testConfig = cloneDeep(defaultTestConfig);
+
+        // Act
+        const res = await lookupLocalPolicyEngine(testConfig);
+
+        // Assert
+        expect(res).toBeUndefined();
+      });
+    });
+  });
+
+  describe('when a user configured path for a Policy Engine executable is provded', () => {
+    const userPolicyEnginePath = 'user/configured/policy/engine/path';
+
+    describe('when the user configured path points to a valid executable', () => {
+      it('returns the user configured path', async () => {
+        // Arrange
+        const testConfig = {
+          ...cloneDeep(defaultTestConfig),
+          userPolicyEnginePath,
+        };
+
+        jest
+          .spyOn(fileUtils, 'isExe')
+          .mockImplementationOnce(
+            async (path) => path === userPolicyEnginePath,
+          );
+
+        // Act
+        const res = await lookupLocalPolicyEngine(testConfig);
+
+        // Assert
+        expect(res).toEqual(userPolicyEnginePath);
+      });
+    });
+
+    describe('when the user configured path does not point to a valid executable', () => {
+      it('throws an error', async () => {
+        // Arrange
+        const testConfig = {
+          ...cloneDeep(defaultTestConfig),
+          userPolicyEnginePath,
+        };
+
+        // Act + Assert
+        await expect(lookupLocalPolicyEngine(testConfig)).rejects.toThrow(
+          InvalidUserPolicyEnginePathError,
+        );
+      });
+    });
+  });
+});

--- a/test/jest/unit/lib/iac/test/v2/setup/rules.spec.ts
+++ b/test/jest/unit/lib/iac/test/v2/setup/rules.spec.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as tar from 'tar';
 import * as rimraf from 'rimraf';
-import { RulesBundleLocator } from '../../../../../src/cli/commands/test/iac/v2/rules';
+import { RulesBundleLocator } from '../../../../../../../../src/lib/iac/test/v2/setup/rules';
 
 describe('PathRulesBundleLocator', () => {
   let root: string;


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Adds logic for locating the UPE executable, which currently needs to be available locally. At a later stage, we will add a downloading step for when the executable is not cached locally.
- Refactors the pre-test step according to [this proposal](https://snyk.slack.com/archives/C02JMMTLUF9/p1655040737968789).

#### Where should the reviewer start?

    src/lib/iac/test/v2/setup/policy-engine.ts

#### How should this be manually tested?

- Ensure the `iacCliUnifiedEngine` FF is activated.
- Prepare the UPE executable.
- Place it in your CLI's cache directory.
- Run `snyk-dev iac test --experimental -d`
- Ensure the debug logs include `Using cached UPE binary: <path-to-cached-upe>`
- Run `SNYK_IAC_UPE_PATH=<custom-upe-path> snyk-dev iac test --experimental -d`, with a customized path to a UPE executable.
- Ensure the debug logs include `Custom IaC UPE binary path detected in configuration: <path-to-cached-upe>`

#### Any background context you want to provide?

One of the steps in [the pre-test phase](https://miro.com/app/board/uXjVO8qNv4s=/?moveToWidget=3458764524883855643&cot=14) is to locate the UPE binary locally and if we don’t find it to download it, the end result of this step should be a path to the UPE binary.

This ticket will focus on the 1st part of the process which is locating the UPE binary locally.

The implementation of this task will follow [the following diagram](https://miro.com/app/board/uXjVO8qNv4s=/?moveToWidget=3458764525145003511&cot=14).

#### What are the relevant tickets?

- [CFG-1846](https://snyksec.atlassian.net/browse/CFG-1846)