### PR TITLE
chore: locate rules bundle in iac test v2

### DIFF
--- a/src/cli/commands/test/iac/local-execution/types.ts
+++ b/src/cli/commands/test/iac/local-execution/types.ts
@@ -348,6 +348,9 @@ export enum IaCErrorCodes {
 
   // report errors
   UnsupportedReportCommandError = 1120,
+
+  // Rules bundle errors.
+  InvalidUserRulesBundleError = 1130,
 }
 
 export interface TestReturnValue {

--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -1,7 +1,20 @@
 import chalk from 'chalk';
 import { TestCommandResult } from '../../../types';
+import { RulesBundleLocator } from './rules';
+import config from '../../../../../lib/config';
+import envPaths from 'env-paths';
+import * as path from 'path';
 
 export async function test(): Promise<TestCommandResult> {
+  const bundleLocator = createRulesBundleLocator();
+  const bundlePath = bundleLocator.locateBundle();
+
+  if (bundlePath) {
+    console.log(`found rules bundle at ${bundlePath}`);
+  } else {
+    console.log('no rules bundle found');
+  }
+
   let response = '';
   response += chalk.bold.green('new flow for UPE integration - TBC...');
   return TestCommandResult.createHumanReadableTestCommandResult(
@@ -9,4 +22,11 @@ export async function test(): Promise<TestCommandResult> {
     '',
     '',
   );
+}
+
+function createRulesBundleLocator(): RulesBundleLocator {
+  const systemCachePath = config.CACHE_PATH ?? envPaths('snyk').cache;
+  const cachedBundlePath = path.join(systemCachePath, 'iac', 'bundle.tar.gz');
+  const userBundlePath = config.IAC_BUNDLE_PATH;
+  return new RulesBundleLocator(cachedBundlePath, userBundlePath);
 }

--- a/src/cli/commands/test/iac/v2/rules.ts
+++ b/src/cli/commands/test/iac/v2/rules.ts
@@ -1,0 +1,76 @@
+import * as fs from 'fs';
+import * as tar from 'tar';
+import { CustomError } from '../../../../../lib/errors';
+import { getErrorStringCode } from '../local-execution/error-utils';
+import { IaCErrorCodes } from '../local-execution/types';
+
+export class RulesBundleLocator {
+  constructor(
+    private cachedBundlePath: string,
+    private userBundlePath?: string,
+  ) {}
+
+  locateBundle(): string | null {
+    const locatedUserBundle = this.locateUserBundle();
+
+    if (locatedUserBundle) {
+      return locatedUserBundle;
+    }
+
+    return this.locateCachedBundle();
+  }
+
+  private locateUserBundle(): string | null {
+    if (!this.userBundlePath) {
+      return null;
+    }
+
+    if (!fs.existsSync(this.userBundlePath)) {
+      return null;
+    }
+
+    if (!fs.statSync(this.userBundlePath).isFile()) {
+      throw new InvalidUserRulesBundleError('user bundle is not a file');
+    }
+
+    if (!isArchive(this.userBundlePath)) {
+      throw new InvalidUserRulesBundleError('user bundle is not an archive');
+    }
+
+    return this.userBundlePath;
+  }
+
+  private locateCachedBundle(): string | null {
+    if (!fs.existsSync(this.cachedBundlePath)) {
+      return null;
+    }
+
+    if (!fs.statSync(this.cachedBundlePath).isFile()) {
+      return null;
+    }
+
+    if (!isArchive(this.cachedBundlePath)) {
+      return null;
+    }
+
+    return this.cachedBundlePath;
+  }
+}
+
+class InvalidUserRulesBundleError extends CustomError {
+  constructor(message: string) {
+    super(message);
+    this.code = IaCErrorCodes.InvalidUserRulesBundleError;
+    this.strCode = getErrorStringCode(this.code);
+    this.userMessage = `The provided rules bundle is not a valid .tar.gz archive.`;
+  }
+}
+
+function isArchive(file: string): boolean {
+  try {
+    tar.list({ file, sync: true, strict: true });
+  } catch (e) {
+    return false;
+  }
+  return true;
+}

--- a/test/jest/unit/iac/v2/rules.spec.ts
+++ b/test/jest/unit/iac/v2/rules.spec.ts
@@ -1,0 +1,77 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as tar from 'tar';
+import * as rimraf from 'rimraf';
+import { RulesBundleLocator } from '../../../../../src/cli/commands/test/iac/v2/rules';
+
+describe('PathRulesBundleLocator', () => {
+  let root: string;
+  let userBundlePath: string;
+  let cachedBundlePath: string;
+  let bundleLocator: RulesBundleLocator;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync('root-');
+    userBundlePath = path.join(root, 'user-bundle.tar.gz');
+    cachedBundlePath = path.join(root, 'cached-bundle.tar.gz');
+    bundleLocator = new RulesBundleLocator(cachedBundlePath, userBundlePath);
+  });
+
+  afterEach(() => {
+    rimraf.sync(root);
+  });
+
+  it('should return null if the user and cached bundle do not exist', () => {
+    expect(bundleLocator.locateBundle()).toBeNull();
+  });
+
+  it('should return the user bundle if it exists and the cached bundle does not exist', () => {
+    createArchive(userBundlePath);
+    expect(bundleLocator.locateBundle()).toStrictEqual(userBundlePath);
+  });
+
+  it('should return the cached bundle if it exists and the user bundle does not exist', () => {
+    createArchive(cachedBundlePath);
+    expect(bundleLocator.locateBundle()).toStrictEqual(cachedBundlePath);
+  });
+
+  it('should return the user bundle if both user and cached bundles exist', () => {
+    createArchive(userBundlePath);
+    createArchive(cachedBundlePath);
+    expect(bundleLocator.locateBundle()).toStrictEqual(userBundlePath);
+  });
+
+  it('should throw an error if the user bundle is not a file', () => {
+    fs.mkdirSync(userBundlePath);
+    expect(() => bundleLocator.locateBundle()).toThrow(
+      'user bundle is not a file',
+    );
+  });
+
+  it('should return null if the cached bundle is not a file', () => {
+    fs.mkdirSync(cachedBundlePath);
+    expect(bundleLocator.locateBundle()).toBeNull();
+  });
+
+  it('should return the cached bundle if no user bundle is specified', () => {
+    const bundleLocator = new RulesBundleLocator(cachedBundlePath);
+    createArchive(cachedBundlePath);
+    expect(bundleLocator.locateBundle()).toStrictEqual(cachedBundlePath);
+  });
+
+  it('should return an error if the user bundle is not an archive', () => {
+    fs.writeFileSync(userBundlePath, 'not an archive');
+    expect(() => bundleLocator.locateBundle()).toThrow(
+      'user bundle is not an archive',
+    );
+  });
+
+  it('should return null if the cached bundle is not an archive', () => {
+    fs.writeFileSync(cachedBundlePath, 'not an archive');
+    expect(bundleLocator.locateBundle()).toBeNull();
+  });
+});
+
+function createArchive(file: string) {
+  tar.create({ file, gzip: true, sync: true }, [__filename]);
+}


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR adds the logic to locate a rules bundle based on user input and falling back to the local cache if none is found. Please note that, once the bundle is located, the path is currently printed to the console. This is not going to be the final behaviour, but there is no consumer of the bundle path at the moment.

#### Where should the reviewer start?

The bulk of the logic is in `src/cli/commands/test/iac/v2/rules.ts`.

#### How should this be manually tested?

Enable the `iacCliUnifiedEngine` and run `snyk` with different arguments.

Use the bundle provided by the user:

```
SNYK_IAC_BUNDLE_PATH=test/fixtures/iac/custom-rules/custom.tar.gz snyk iac test --experimental
```

Use the bundle from the cache (your system cache might be at a different path):

```
mkdir -p ~/Library/Caches/snyk-nodejs/iac
cp test/fixtures/iac/custom-rules/custom.tar.gz ~/Library/Caches/snyk-nodejs/iac/bundle.tar.gz
snyk iac test --experimental
```

Verify that when both a user bundle and a cached bundle exist, the user bundle is chosen:

```
mkdir -p ~/Library/Caches/snyk-nodejs/iac
cp test/fixtures/iac/custom-rules/custom.tar.gz ~/Library/Caches/snyk-nodejs/iac/bundle.tar.gz
SNYK_IAC_BUNDLE_PATH=test/fixtures/iac/custom-rules/custom.tar.gz snyk iac test --experimental
```

#### What are the relevant tickets?

[CFG-1884](https://snyksec.atlassian.net/browse/CFG-1884)

