### PR TITLE
feat: upgrade to snyk-docker-plugin@4.38.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.20.0",
-        "snyk-docker-plugin": "^4.36.0",
+        "snyk-docker-plugin": "^4.38.0",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.18.1",
         "snyk-module": "3.1.0",
@@ -2275,11 +2275,12 @@
       "link": true
     },
     "node_modules/@snyk/rpm-parser": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@snyk/rpm-parser/-/rpm-parser-2.2.1.tgz",
-      "integrity": "sha512-OAON0bPf3c5fgM/GK9DX0aZErB6SnuRyYlPH0rqI1TXGsKrYnVELhaE6ctNbEfPTQuY9r6q0vM+UYDaFM/YliA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@snyk/rpm-parser/-/rpm-parser-2.3.1.tgz",
+      "integrity": "sha512-mhVLv17Yf3Hw9ftxEHVt7YprhieUS9gpMSYciwc52QtEv6RS+MuW0xgPRpRFdvqd+zHKntL997EKDFwhKDwYoA==",
       "dependencies": {
-        "event-loop-spinner": "^2.0.0"
+        "event-loop-spinner": "^2.2.0",
+        "sql.js": "^1.7.0"
       },
       "engines": {
         "node": ">=8"
@@ -7264,9 +7265,9 @@
       }
     },
     "node_modules/event-loop-spinner": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/event-loop-spinner/-/event-loop-spinner-2.1.0.tgz",
-      "integrity": "sha512-RJ10wL8/F9AlfBgRCvYctJIXSb9XkVmSCK3GGUvPD3dJrvTjDeDT0tmhcbEC6I2NEjNM9xD38HQJ4F/f/gb4VQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/event-loop-spinner/-/event-loop-spinner-2.2.0.tgz",
+      "integrity": "sha512-KB44sV4Mv7uLIkJHJ5qhiZe5um6th2g57nHQL/uqnPHKP2IswoTRWUteEXTJQL4gW++1zqWUni+H2hGkP51c9w==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -16315,13 +16316,13 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.36.0.tgz",
-      "integrity": "sha512-pczlTUXadqSjWx7X4Mt4+UPUPOwvUo7Qcv7G8DTJlUqNRGYm0XExXC2PUizFcOlD5BYx4NPYYXnNdUXDkGi12Q==",
+      "version": "4.38.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.38.0.tgz",
+      "integrity": "sha512-JdDz8Dnb6148k7nrnTOlwM4y1a3qIo+hqUKYB72cj3NFcAuoo2J3tBK/F0MLNlZljrZUGXEyV4utjqeZsVTkEA==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
-        "@snyk/dep-graph": "^1.28.0",
-        "@snyk/rpm-parser": "^2.0.0",
+        "@snyk/dep-graph": "^2.3.0",
+        "@snyk/rpm-parser": "^2.3.1",
         "@snyk/snyk-docker-pull": "^3.7.2",
         "adm-zip": "^0.5.5",
         "chalk": "^2.4.2",
@@ -16333,15 +16334,48 @@
         "gunzip-maybe": "^1.4.2",
         "mkdirp": "^1.0.4",
         "semver": "^7.3.4",
-        "snyk-nodejs-lockfile-parser": "1.37.3",
+        "snyk-nodejs-lockfile-parser": "1.40.0",
         "tar-stream": "^2.1.0",
         "tmp": "^0.2.1",
         "tslib": "^1",
         "uuid": "^8.2.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
       }
+    },
+    "node_modules/snyk-docker-plugin/node_modules/@snyk/dep-graph": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-2.3.0.tgz",
+      "integrity": "sha512-IfHbuYNkkIYD0ExXQuS0oBM7oLoCxKAJG35V62DAfqNCF5FTPjeC5wx03G1b5UIbHmNbfevj6Y+++V5/62IW8w==",
+      "dependencies": {
+        "event-loop-spinner": "^2.1.0",
+        "lodash.clone": "^4.5.0",
+        "lodash.constant": "^3.0.0",
+        "lodash.filter": "^4.6.0",
+        "lodash.foreach": "^4.5.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.map": "^4.6.0",
+        "lodash.reduce": "^4.6.0",
+        "lodash.size": "^4.2.0",
+        "lodash.transform": "^4.6.0",
+        "lodash.union": "^4.6.0",
+        "lodash.values": "^4.3.0",
+        "object-hash": "^3.0.0",
+        "semver": "^7.0.0",
+        "tslib": "^2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/snyk-docker-plugin/node_modules/@snyk/dep-graph/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/snyk-docker-plugin/node_modules/argparse": {
       "version": "2.0.1",
@@ -16381,6 +16415,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/snyk-docker-plugin/node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/snyk-docker-plugin/node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -16396,9 +16438,9 @@
       }
     },
     "node_modules/snyk-docker-plugin/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -16410,9 +16452,9 @@
       }
     },
     "node_modules/snyk-docker-plugin/node_modules/snyk-nodejs-lockfile-parser": {
-      "version": "1.37.3",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.3.tgz",
-      "integrity": "sha512-kpCWluXEEOOnVh91CmwrRU9aQACLzoZ0hZDFRLshOZfDHvMiYjopw6JBq+IGXWpbzXgbQNr5Zzq5p6DcvrHFwA==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.40.0.tgz",
+      "integrity": "sha512-74bofOAZz8WSH5r2hlWs2Mvxii2WgX7D+v+iLh31d98BVCTHzxUQYibMrIWNg/5NIIOijBI87PzOtCiZ4Hr3FA==",
       "dependencies": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -16434,6 +16476,43 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/snyk-docker-plugin/node_modules/snyk-nodejs-lockfile-parser/node_modules/@snyk/dep-graph": {
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.31.0.tgz",
+      "integrity": "sha512-nGSua40dcI/ISDDW46EYSjwVZxdWohb4bDlHFYtudL5bxo0PV9wFA1QeZewKQVeHLVaGkrESXdqQubP0pFf4vA==",
+      "dependencies": {
+        "event-loop-spinner": "^2.1.0",
+        "lodash.clone": "^4.5.0",
+        "lodash.constant": "^3.0.0",
+        "lodash.filter": "^4.6.0",
+        "lodash.foreach": "^4.5.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.keys": "^4.2.0",
+        "lodash.map": "^4.6.0",
+        "lodash.reduce": "^4.6.0",
+        "lodash.size": "^4.2.0",
+        "lodash.transform": "^4.6.0",
+        "lodash.union": "^4.6.0",
+        "lodash.values": "^4.3.0",
+        "object-hash": "^2.0.3",
+        "semver": "^7.0.0",
+        "tslib": "^1.13.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/snyk-docker-plugin/node_modules/snyk-nodejs-lockfile-parser/node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/snyk-docker-plugin/node_modules/tmp": {
@@ -17217,6 +17296,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+    },
+    "node_modules/sql.js": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.7.0.tgz",
+      "integrity": "sha512-qAfft3xkSgHqmmfNugWTp/59PsqIw8gbeao5TZmpmzQQsAJ49de3iDDKuxVixidYs6dkHNksY8m27v2dZNn2jw=="
     },
     "node_modules/ssh2": {
       "version": "1.4.0",
@@ -21583,11 +21667,12 @@
       }
     },
     "@snyk/rpm-parser": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@snyk/rpm-parser/-/rpm-parser-2.2.1.tgz",
-      "integrity": "sha512-OAON0bPf3c5fgM/GK9DX0aZErB6SnuRyYlPH0rqI1TXGsKrYnVELhaE6ctNbEfPTQuY9r6q0vM+UYDaFM/YliA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@snyk/rpm-parser/-/rpm-parser-2.3.1.tgz",
+      "integrity": "sha512-mhVLv17Yf3Hw9ftxEHVt7YprhieUS9gpMSYciwc52QtEv6RS+MuW0xgPRpRFdvqd+zHKntL997EKDFwhKDwYoA==",
       "requires": {
-        "event-loop-spinner": "^2.0.0"
+        "event-loop-spinner": "^2.2.0",
+        "sql.js": "^1.7.0"
       }
     },
     "@snyk/snyk-cocoapods-plugin": {
@@ -25545,9 +25630,9 @@
       "dev": true
     },
     "event-loop-spinner": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/event-loop-spinner/-/event-loop-spinner-2.1.0.tgz",
-      "integrity": "sha512-RJ10wL8/F9AlfBgRCvYctJIXSb9XkVmSCK3GGUvPD3dJrvTjDeDT0tmhcbEC6I2NEjNM9xD38HQJ4F/f/gb4VQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/event-loop-spinner/-/event-loop-spinner-2.2.0.tgz",
+      "integrity": "sha512-KB44sV4Mv7uLIkJHJ5qhiZe5um6th2g57nHQL/uqnPHKP2IswoTRWUteEXTJQL4gW++1zqWUni+H2hGkP51c9w==",
       "requires": {
         "tslib": "^2.1.0"
       },
@@ -32499,13 +32584,13 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.36.0.tgz",
-      "integrity": "sha512-pczlTUXadqSjWx7X4Mt4+UPUPOwvUo7Qcv7G8DTJlUqNRGYm0XExXC2PUizFcOlD5BYx4NPYYXnNdUXDkGi12Q==",
+      "version": "4.38.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.38.0.tgz",
+      "integrity": "sha512-JdDz8Dnb6148k7nrnTOlwM4y1a3qIo+hqUKYB72cj3NFcAuoo2J3tBK/F0MLNlZljrZUGXEyV4utjqeZsVTkEA==",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
-        "@snyk/dep-graph": "^1.28.0",
-        "@snyk/rpm-parser": "^2.0.0",
+        "@snyk/dep-graph": "^2.3.0",
+        "@snyk/rpm-parser": "^2.3.1",
         "@snyk/snyk-docker-pull": "^3.7.2",
         "adm-zip": "^0.5.5",
         "chalk": "^2.4.2",
@@ -32517,13 +32602,45 @@
         "gunzip-maybe": "^1.4.2",
         "mkdirp": "^1.0.4",
         "semver": "^7.3.4",
-        "snyk-nodejs-lockfile-parser": "1.37.3",
+        "snyk-nodejs-lockfile-parser": "1.40.0",
         "tar-stream": "^2.1.0",
         "tmp": "^0.2.1",
         "tslib": "^1",
         "uuid": "^8.2.0"
       },
       "dependencies": {
+        "@snyk/dep-graph": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-2.3.0.tgz",
+          "integrity": "sha512-IfHbuYNkkIYD0ExXQuS0oBM7oLoCxKAJG35V62DAfqNCF5FTPjeC5wx03G1b5UIbHmNbfevj6Y+++V5/62IW8w==",
+          "requires": {
+            "event-loop-spinner": "^2.1.0",
+            "lodash.clone": "^4.5.0",
+            "lodash.constant": "^3.0.0",
+            "lodash.filter": "^4.6.0",
+            "lodash.foreach": "^4.5.0",
+            "lodash.isempty": "^4.4.0",
+            "lodash.isequal": "^4.5.0",
+            "lodash.isfunction": "^3.0.9",
+            "lodash.isundefined": "^3.0.1",
+            "lodash.map": "^4.6.0",
+            "lodash.reduce": "^4.6.0",
+            "lodash.size": "^4.2.0",
+            "lodash.transform": "^4.6.0",
+            "lodash.union": "^4.6.0",
+            "lodash.values": "^4.3.0",
+            "object-hash": "^3.0.0",
+            "semver": "^7.0.0",
+            "tslib": "^2"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+              "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+            }
+          }
+        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -32550,6 +32667,11 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         },
+        "object-hash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+          "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
+        },
         "rimraf": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -32559,17 +32681,17 @@
           }
         },
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "snyk-nodejs-lockfile-parser": {
-          "version": "1.37.3",
-          "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.3.tgz",
-          "integrity": "sha512-kpCWluXEEOOnVh91CmwrRU9aQACLzoZ0hZDFRLshOZfDHvMiYjopw6JBq+IGXWpbzXgbQNr5Zzq5p6DcvrHFwA==",
+          "version": "1.40.0",
+          "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.40.0.tgz",
+          "integrity": "sha512-74bofOAZz8WSH5r2hlWs2Mvxii2WgX7D+v+iLh31d98BVCTHzxUQYibMrIWNg/5NIIOijBI87PzOtCiZ4Hr3FA==",
           "requires": {
             "@snyk/dep-graph": "^1.28.0",
             "@snyk/graphlib": "2.1.9-patch.3",
@@ -32585,6 +32707,39 @@
             "snyk-config": "^4.0.0-rc.2",
             "tslib": "^1.9.3",
             "uuid": "^8.3.0"
+          },
+          "dependencies": {
+            "@snyk/dep-graph": {
+              "version": "1.31.0",
+              "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.31.0.tgz",
+              "integrity": "sha512-nGSua40dcI/ISDDW46EYSjwVZxdWohb4bDlHFYtudL5bxo0PV9wFA1QeZewKQVeHLVaGkrESXdqQubP0pFf4vA==",
+              "requires": {
+                "event-loop-spinner": "^2.1.0",
+                "lodash.clone": "^4.5.0",
+                "lodash.constant": "^3.0.0",
+                "lodash.filter": "^4.6.0",
+                "lodash.foreach": "^4.5.0",
+                "lodash.isempty": "^4.4.0",
+                "lodash.isequal": "^4.5.0",
+                "lodash.isfunction": "^3.0.9",
+                "lodash.isundefined": "^3.0.1",
+                "lodash.keys": "^4.2.0",
+                "lodash.map": "^4.6.0",
+                "lodash.reduce": "^4.6.0",
+                "lodash.size": "^4.2.0",
+                "lodash.transform": "^4.6.0",
+                "lodash.union": "^4.6.0",
+                "lodash.values": "^4.3.0",
+                "object-hash": "^2.0.3",
+                "semver": "^7.0.0",
+                "tslib": "^1.13.0"
+              }
+            },
+            "object-hash": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+              "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="
+            }
           }
         },
         "tmp": {
@@ -33266,6 +33421,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+    },
+    "sql.js": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.7.0.tgz",
+      "integrity": "sha512-qAfft3xkSgHqmmfNugWTp/59PsqIw8gbeao5TZmpmzQQsAJ49de3iDDKuxVixidYs6dkHNksY8m27v2dZNn2jw=="
     },
     "ssh2": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.20.0",
-    "snyk-docker-plugin": "^4.36.0",
+    "snyk-docker-plugin": "^4.38.0",
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.18.1",
     "snyk-module": "3.1.0",

--- a/test/jest/acceptance/snyk-container/container.spec.ts
+++ b/test/jest/acceptance/snyk-container/container.spec.ts
@@ -1,0 +1,29 @@
+import * as os from 'os';
+import { startSnykCLI, TestCLI } from '../../util/startSnykCLI';
+
+describe('snyk container', () => {
+  if (os.platform() === 'win32') {
+    // eslint-disable-next-line jest/no-focused-tests
+    it.only('Windows not yet supported', () => {
+      console.warn(
+        "Skipping as we don't have a Windows-compatible image to test against.",
+      );
+    });
+  }
+
+  let cli: TestCLI | null = null;
+
+  afterEach(async () => {
+    if (cli) {
+      await cli.stop();
+      cli = null;
+    }
+  });
+
+  it('finds dependencies in rpm sqlite databases', async () => {
+    cli = await startSnykCLI(
+      'container test amazonlinux:2022.0.20220504.1 --print-deps',
+    );
+    await expect(cli).toDisplay(`yum @ 4.9.0`, { timeout: 20 * 1000 });
+  });
+});

--- a/webpack.common.ts
+++ b/webpack.common.ts
@@ -48,6 +48,10 @@ export default {
           to: '../gosrc/',
         },
         {
+          from: 'node_modules/sql.js/dist/sql-wasm.wasm',
+          to: './',
+        },
+        {
           from:
             'node_modules/@snyk/java-call-graph-builder/config.default.json',
           to: '../',
@@ -66,6 +70,8 @@ export default {
         loader: 'node-loader',
       },
     ],
+    // noParse avoids breaking sql.js. https://github.com/sql-js/sql.js/issues/406#issuecomment-688594485
+    noParse: /node_modules\/sql\.js\/dist\/sql-wasm\.js$/,
   },
   resolve: {
     extensions: ['.ts', '.js', '.json'],


### PR DESCRIPTION
Notes: https://www.notion.so/snyk/snyk-docker-plugin-sqlite-js-troubleshooting-f6e48ae3da3449c3be819a69b84fbf5e

I'm unable to use `fakeServer` for the test as there's some API which needs to be stubbed. We can revisit and improve this if these tests become unreliable. We can't completely mock out external services anyway as we need access to a Docker base image.

Tests on Windows are skipped as there's no Windows-compatible image we can test against. (If we find one, we can use it)