### PR TITLE
chore: print a warning when the user uses paths outside CWD

### DIFF
--- a/src/cli/commands/test/iac/index.ts
+++ b/src/cli/commands/test/iac/index.ts
@@ -41,6 +41,7 @@ import { UnsupportedEntitlementError } from '../../../../lib/errors/unsupported-
 import * as ora from 'ora';
 import { CustomError, FormattedCustomError } from '../../../../lib/errors';
 import { scan } from './scan';
+import * as path from 'path';
 
 const debug = Debug('snyk-test');
 const SEPARATOR = '\n-------------------------------------------------------\n';
@@ -73,6 +74,10 @@ export default async function(
 
   if (shouldLogUserMessages(options, isNewIacOutputSupported)) {
     console.log(EOL + iacTestTitle + EOL);
+
+    if (paths.some(isOutsideCurrentWorkingDirectory)) {
+      printCurrentWorkingDirectoryTraversalWarning();
+    }
 
     testSpinner = ora({ isSilent: options.quiet, stream: process.stdout });
   }
@@ -316,4 +321,25 @@ export default async function(
     stringifiedJsonData,
     stringifiedSarifData,
   );
+}
+
+function isOutsideCurrentWorkingDirectory(p: string): boolean {
+  return path.relative(process.cwd(), p).includes('..');
+}
+
+function printCurrentWorkingDirectoryTraversalWarning() {
+  let msg = '';
+
+  msg +=
+    'Warning: Scanning paths outside the current working directory is deprecated and' +
+    EOL;
+  msg +=
+    'will be removed in the future. Please see the documentation for further details:' +
+    EOL +
+    EOL;
+  msg +=
+    '  https://docs.snyk.io/products/snyk-infrastructure-as-code/snyk-cli-for-infrastructure-as-code/test-your-configuration-files' +
+    EOL;
+
+  console.log(chalk.yellow(msg));
 }


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR lets the `snyk iac test` command print a warning when the user provides one or more paths to scan that lay outside the current working directory.

#### How should this be manually tested?

Run the command without paths and check that the warning message is not displayed:

```
snyk iac test
```

Run the command with no paths laying outside the current working directory and check that the warning message is not displayed:

```
snyk iac test foo.tf bar.tf
```

Run the command with at least one path laying outside the current working directory and check that the warning message is displayed:

```
snyk iac test foo.tf bar.tf ../baz.tf
```

#### What are the relevant tickets?

[CFG-1967](https://snyksec.atlassian.net/browse/CFG-1967)

#### Screenshots

![image](https://user-images.githubusercontent.com/404227/173091720-8e52ee05-b373-4c55-8271-2699b10802b8.png)

