### PR TITLE
fix: include the custom rules warning if feature flag is not enabled [CFG-1868]

### DIFF
--- a/src/cli/commands/test/iac/scan.ts
+++ b/src/cli/commands/test/iac/scan.ts
@@ -52,7 +52,12 @@ export async function scan(
   let iacIgnoredIssuesCount = 0;
 
   try {
-    const rulesOrigin = await initRules(buildOciRules, iacOrgSettings, options);
+    const rulesOrigin = await initRules(
+      buildOciRules,
+      iacOrgSettings,
+      options,
+      orgPublicId,
+    );
 
     testSpinner?.start(spinnerMessage);
 

--- a/src/lib/formatters/iac-output/index.ts
+++ b/src/lib/formatters/iac-output/index.ts
@@ -15,6 +15,7 @@ export {
   spinnerMessage,
   spinnerSuccessMessage,
   customRulesMessage,
+  customRulesReportMessage,
   shouldLogUserMessages,
   formatShareResultsOutput,
   failuresTipOutput,

--- a/src/lib/formatters/iac-output/v2/index.ts
+++ b/src/lib/formatters/iac-output/v2/index.ts
@@ -6,6 +6,7 @@ export {
   spinnerSuccessMessage,
   shouldLogUserMessages,
   customRulesMessage,
+  customRulesReportMessage,
 } from './user-messages';
 export { formatShareResultsOutput } from './share-results';
 export {

--- a/src/lib/formatters/iac-output/v2/user-messages.ts
+++ b/src/lib/formatters/iac-output/v2/user-messages.ts
@@ -26,6 +26,13 @@ export const customRulesMessage = colors.info(
 );
 
 /**
+ * Message for using custom rules.
+ */
+export const customRulesReportMessage = colors.info(
+  "Please note that your custom rules will not be sent to the Snyk platform, and will not be available on the project's page.",
+);
+
+/**
  * @returns whether or not to include user messages in the output.
  */
 export function shouldLogUserMessages(

--- a/test/jest/unit/iac/rules/rules.spec.ts
+++ b/test/jest/unit/iac/rules/rules.spec.ts
@@ -49,7 +49,9 @@ describe('initRules', () => {
       };
     };
 
-    await expect(initRules(registryBuilder, settings, options)).rejects.toThrow(
+    await expect(
+      initRules(registryBuilder, settings, options, 'orgPublicId'),
+    ).rejects.toThrow(
       'There was an authentication error. Incorrect credentials provided.',
     );
   });
@@ -59,9 +61,9 @@ describe('initRules', () => {
       rules: 'path/to/rules.tgz',
     };
 
-    await expect(initRules(registryBuilder, settings, options)).rejects.toThrow(
-      'Could not execute custom rules mode',
-    );
+    await expect(
+      initRules(registryBuilder, settings, options, 'orgPublicId'),
+    ).rejects.toThrow('Could not execute custom rules mode');
   });
 
   it('should fail if the user is not entitled to use custom rules', async () => {
@@ -77,8 +79,8 @@ describe('initRules', () => {
       },
     };
 
-    await expect(initRules(registryBuilder, settings, options)).rejects.toThrow(
-      'Missing the iacCustomRulesEntitlement entitlement',
-    );
+    await expect(
+      initRules(registryBuilder, settings, options, 'orgPublicId'),
+    ).rejects.toThrow('Missing the iacCustomRulesEntitlement entitlement');
   });
 });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
In https://github.com/snyk/cli/pull/3287, we removed the warning for custom rules completely, but we were meant to only remove it if the feature flag is enabled. 

#### Where should the reviewer start?

Have a look at the previous PR and notice the added feature flag check in this PR. 

#### How should this be manually tested?

The ticket can be verified using https://github.com/snyk/custom-rules-examples/

- Install snyk-iac-rules: https://github.com/snyk/snyk-iac-rules
- Build a local bundle: `snyk-iac-rules build`
- Run the rules to see them in the results: `snyk iac test ./rules/CUSTOM-RULE-1/fixtures --rules=bundle.tar.gz `
- Run the rules and send them to the Platform: `snyk-dev iac test ./rules/CUSTOM-RULE-1/fixtures --rules=bundle.tar.gz --report`
- Check that no warning message appears now.
