### PR TITLE
fix: support HTTP(S) proxies in iac-test

### DIFF
--- a/test/jest/unit/iac/local-cache.spec.ts
+++ b/test/jest/unit/iac/local-cache.spec.ts
@@ -30,6 +30,7 @@ describe('initLocalCache - downloads bundle successfully', () => {
 
     expect(needle.get).toHaveBeenCalledWith(
       expect.stringContaining('bundle.tar.gz'),
+      { rejectUnauthorized: true },
     );
     expect(spy).toHaveBeenCalledWith(mockReadable);
   });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?




Configure HTTP clients to respect HTTP(S)_PROXY environment variables.
Ignore TLS identity verification errors (this is dangerous) when the
`--insecure` flag is passed, matching the behaviour of `snyk test`.







#### Where should the reviewer start?


#### How should this be manually tested?

I manually tested this by building the CLI and running in the 3 following scenarios. First, I ran `mitmdump` (from the mitmproxy package) in the background, bound to tcp:8080.

1. `node ./dist/cli iac test a-cloudformation-file.yaml` works as expected and does not call the proxy
2. `https_proxy=http://localhost:8080 node ./dist/cli iac test a-cloudformation-file.yaml` exits with an error, because I did not configure my local TLS certificate store with a cert from mitmproxy.
3. `https_proxy=http://localhost:8080 node ./dist/cli iac test a-cloudformation-file.yaml --insecure` works, and calls the proxy

#### Any background context you want to provide?

This is intended to be useful for users behind corporate proxies. Ideally no-one will use `--insecure`, and will instead configure a CA from (poorly behaved) HTTPS proxies that do act as MITM proxies, but this is a feature we support elsewhere so it should probably work consistently.

#### What are the relevant tickets?

No ticket AFAIK, this came up informally as part of on-call work: https://snyk.slack.com/archives/CRV0PMFDH/p1654811904912649

#### Screenshots


#### Additional questions
