### PR TITLE
chore(ci): allow running cli-alert check manually

### DIFF
--- a/.github/workflows/cli-alert.yml
+++ b/.github/workflows/cli-alert.yml
@@ -1,6 +1,7 @@
 name: CLI alert
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 * * * *'
 


### PR DESCRIPTION
Mainly for debugging changes in PRs without setting up some complex trigger using filters.

https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/