### PR TITLE
chore: override env variables instead of appending

### DIFF
--- a/cliv2/internal/cliv2/cliv2.go
+++ b/cliv2/internal/cliv2/cliv2.go
@@ -35,6 +35,9 @@ const SNYK_EXIT_CODE_ERROR = 2
 const SNYK_INTEGRATION_NAME = "CLI_V1_PLUGIN"
 const SNYK_INTEGRATION_NAME_ENV = "SNYK_INTEGRATION_NAME"
 const SNYK_INTEGRATION_VERSION_ENV = "SNYK_INTEGRATION_VERSION"
+const SNYK_HTTPS_PROXY_ENV = "HTTPS_PROXY"
+const SNYK_HTTP_PROXY_ENV = "HTTP_PROXY"
+const SNYK_CA_CERTIFICATE_LOCATION_ENV = "NODE_EXTRA_CA_CERTS"
 
 const (
 	V1_DEFAULT Handler = iota
@@ -137,7 +140,7 @@ func determineHandler(passthroughArgs []string) Handler {
 	return result
 }
 
-func AddIntegrationEnvironment(input []string, name string, version string) (result []string, err error) {
+func PrepareV1EnvironmentVariables(input []string, integrationName string, integrationVersion string, proxyAddress string, caCertificateLocation string) (result []string, err error) {
 
 	inputAsMap := utils.ToKeyValueMap(input, "=")
 	result = input
@@ -146,11 +149,17 @@ func AddIntegrationEnvironment(input []string, name string, version string) (res
 	_, integrationVersionExists := inputAsMap[SNYK_INTEGRATION_VERSION_ENV]
 
 	if !integrationNameExists && !integrationVersionExists {
-		inputAsMap[SNYK_INTEGRATION_NAME_ENV] = name
-		inputAsMap[SNYK_INTEGRATION_VERSION_ENV] = version
-		result = utils.ToSlice(inputAsMap, "=")
+		inputAsMap[SNYK_INTEGRATION_NAME_ENV] = integrationName
+		inputAsMap[SNYK_INTEGRATION_VERSION_ENV] = integrationVersion
 	} else if !(integrationNameExists && integrationVersionExists) {
 		err = EnvironmentWarning{message: fmt.Sprintf("Partially defined environment, please ensure to provide both %s and %s together!", SNYK_INTEGRATION_NAME_ENV, SNYK_INTEGRATION_VERSION_ENV)}
+	}
+
+	if err == nil {
+		inputAsMap[SNYK_HTTPS_PROXY_ENV] = proxyAddress
+		inputAsMap[SNYK_HTTP_PROXY_ENV] = proxyAddress
+		inputAsMap[SNYK_CA_CERTIFICATE_LOCATION_ENV] = caCertificateLocation
+		result = utils.ToSlice(inputAsMap, "=")
 	}
 
 	return result, err
@@ -159,15 +168,10 @@ func AddIntegrationEnvironment(input []string, name string, version string) (res
 
 func PrepareV1Command(cmd string, args []string, proxyPort int, caCertLocation string, integrationName string, integrationVersion string) (snykCmd *exec.Cmd, err error) {
 
+	proxyAddress := fmt.Sprintf("http://127.0.0.1:%d", proxyPort)
+
 	snykCmd = exec.Command(cmd, args...)
-	snykCmd.Env = append(os.Environ(),
-		fmt.Sprintf("HTTP_PROXY=http://127.0.0.1:%d", proxyPort),
-		fmt.Sprintf("HTTPS_PROXY=http://127.0.0.1:%d", proxyPort),
-		fmt.Sprintf("NODE_EXTRA_CA_CERTS=%s", caCertLocation),
-	)
-
-	snykCmd.Env, err = AddIntegrationEnvironment(snykCmd.Env, integrationName, integrationVersion)
-
+	snykCmd.Env, err = PrepareV1EnvironmentVariables(os.Environ(), integrationName, integrationVersion, proxyAddress, caCertLocation)
 	snykCmd.Stdin = os.Stdin
 	snykCmd.Stdout = os.Stdout
 	snykCmd.Stderr = os.Stderr

--- a/cliv2/internal/cliv2/cliv2_test.go
+++ b/cliv2/internal/cliv2/cliv2_test.go
@@ -1,22 +1,23 @@
 package cliv2_test
 
 import (
-	"github.com/snyk/cli/cliv2/internal/cliv2"
 	"io/ioutil"
 	"log"
 	"os"
 	"sort"
 	"testing"
 
+	"github.com/snyk/cli/cliv2/internal/cliv2"
+
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_addIntegrationEnvironment_Fill(t *testing.T) {
+func Test_PrepareV1EnvironmentVariables_Fill(t *testing.T) {
 
 	input := []string{"something=1", "in=2", "here=3=2"}
-	expected := []string{"something=1", "in=2", "here=3=2", "SNYK_INTEGRATION_NAME=foo", "SNYK_INTEGRATION_VERSION=bar"}
+	expected := []string{"something=1", "in=2", "here=3=2", "SNYK_INTEGRATION_NAME=foo", "SNYK_INTEGRATION_VERSION=bar", "HTTP_PROXY=proxy", "HTTPS_PROXY=proxy", "NODE_EXTRA_CA_CERTS=cacertlocation"}
 
-	actual, err := cliv2.AddIntegrationEnvironment(input, "foo", "bar")
+	actual, err := cliv2.PrepareV1EnvironmentVariables(input, "foo", "bar", "proxy", "cacertlocation")
 
 	sort.Strings(expected)
 	sort.Strings(actual)
@@ -24,12 +25,12 @@ func Test_addIntegrationEnvironment_Fill(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func Test_addIntegrationEnvironment_DontOverrideExisting(t *testing.T) {
+func Test_PrepareV1EnvironmentVariables_DontOverrideExisting(t *testing.T) {
 
-	input := []string{"something=1", "in=2", "here=3", "SNYK_INTEGRATION_NAME=exists", "SNYK_INTEGRATION_VERSION=already"}
+	input := []string{"something=1", "in=2", "here=3", "SNYK_INTEGRATION_NAME=exists", "SNYK_INTEGRATION_VERSION=already", "HTTP_PROXY=proxy", "HTTPS_PROXY=proxy", "NODE_EXTRA_CA_CERTS=cacertlocation"}
 	expected := input
 
-	actual, err := cliv2.AddIntegrationEnvironment(input, "foo", "bar")
+	actual, err := cliv2.PrepareV1EnvironmentVariables(input, "foo", "bar", "proxy", "cacertlocation")
 
 	sort.Strings(expected)
 	sort.Strings(actual)
@@ -37,12 +38,12 @@ func Test_addIntegrationEnvironment_DontOverrideExisting(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func Test_addIntegrationEnvironment_DontOverrideExisting2(t *testing.T) {
+func Test_PrepareV1EnvironmentVariables_DontOverrideExisting2(t *testing.T) {
 
 	input := []string{"something=1", "in=2", "here=3", "SNYK_INTEGRATION_NAME=exists"}
 	expected := input
 
-	actual, err := cliv2.AddIntegrationEnvironment(input, "foo", "bar")
+	actual, err := cliv2.PrepareV1EnvironmentVariables(input, "foo", "bar", "unused", "unused")
 
 	sort.Strings(expected)
 	sort.Strings(actual)


### PR DESCRIPTION
When creating the environment variables for CLIv1 invocation ensure to override existing ones and not only append environment variables.

Affected Environment Variables are:
* HTTP_PROXY
* HTTPS_PROXY
* NODE_EXTRA_CA_CERTS

- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
It ensures that environment variables are unique and that there is no possible conflict/uncertainty between externally defined and internally set environment variables when being passed to CLIv1.

#### How should this be manually tested?
Run CLIv2 with --debug and use the following environments for testing:
* HTTP_PROXY: 
env: `SNYK_HTTP_PROTOCOL_UPGRADE=0 SNYK_API=http://snyk.io/api/v1 HTTP_PROXY=http://127.0.0.1:3128` 
expected: `dial tcp 127.0.0.1:3128: connect: connection refused`
* HTTPS_PROXY: 
env: `HTTPS_PROXY=https://127.0.0.1:312`
expected: `dial tcp 127.0.0.1:3128: connect: connection refused`
* NODE_EXTRA_CA_CERTS: 
env: `NODE_EXTRA_CA_CERTS=./here`
**NOT** expected: `Warning: Ignoring extra certs from `./here`, load failed: error:02001002:system library:fopen:No such file or directory`
