### PR TITLE
test: ignore node 12 deprecation warnings in assertions

### DIFF
--- a/test/smoke/spec/snyk_code_spec.sh
+++ b/test/smoke/spec/snyk_code_spec.sh
@@ -15,7 +15,11 @@ Describe "Snyk Code test command"
       The output should include "Static code analysis"
       The output should include "✗ [High] SQL Injection"
       The status should be failure
-      The stderr should equal ""
+      if should_have_deprecation_warnings; then 
+        The stderr should not equal ""
+      else
+        The stderr should equal ""
+      fi
     End
   End
 
@@ -25,7 +29,11 @@ Describe "Snyk Code test command"
       The status should be failure # issues found
       The output should include '"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"'
       The output should include '"name": "SnykCode"'
-      The stderr should equal ""
+      if should_have_deprecation_warnings; then 
+        The stderr should not equal ""
+      else
+        The stderr should equal ""
+      fi
       The result of function check_valid_json should be success
     End
   End

--- a/test/smoke/spec/snyk_monitor_spec.sh
+++ b/test/smoke/spec/snyk_monitor_spec.sh
@@ -15,7 +15,11 @@ Describe "Snyk monitor command"
       The status should be success
       The output should include "Explore this snapshot at https://app.snyk.io/org/"
       The output should include "Notifications about newly disclosed issues related to these dependencies will be emailed to you."
-      The stderr should equal ""
+      if should_have_deprecation_warnings; then 
+        The stderr should not equal ""
+      else
+        The stderr should equal ""
+      fi
     End
 
     It "monitors a project when pointing to a folder"
@@ -23,7 +27,11 @@ Describe "Snyk monitor command"
       The status should be success
       The output should include "Explore this snapshot at https://app.snyk.io/org/"
       The output should include "Notifications about newly disclosed issues related to these dependencies will be emailed to you."
-      The stderr should equal ""
+      if should_have_deprecation_warnings; then 
+        The stderr should not equal ""
+      else
+        The stderr should equal ""
+      fi
     End
 
     It "monitors a project when pointing to a file"
@@ -31,7 +39,11 @@ Describe "Snyk monitor command"
       The status should be success
       The output should include "Explore this snapshot at https://app.snyk.io/org/"
       The output should include "Notifications about newly disclosed issues related to these dependencies will be emailed to you."
-      The stderr should equal ""
+      if should_have_deprecation_warnings; then 
+        The stderr should not equal ""
+      else
+        The stderr should equal ""
+      fi 
     End
   End
 

--- a/test/smoke/spec/snyk_test_spec.sh
+++ b/test/smoke/spec/snyk_test_spec.sh
@@ -59,21 +59,33 @@ Describe "Snyk test command"
       When run run_test_in_subfolder
       The status should equal 1
       The output should include "https://snyk.io/vuln/npm:minimatch:20160620"
-      The stderr should equal ""
+      if should_have_deprecation_warnings; then 
+        The stderr should not equal ""
+      else
+        The stderr should equal ""
+      fi
     End
 
     It "finds vulns in a project when pointing to a folder"
       When run snyk test ../fixtures/basic-npm
       The status should be failure # issues found
       The output should include "https://snyk.io/vuln/npm:minimatch:20160620"
-      The stderr should equal ""
+      if should_have_deprecation_warnings; then 
+        The stderr should not equal ""
+      else
+        The stderr should equal ""
+      fi
     End
 
     It "finds vulns in a project when pointing to a file"
       When run snyk test --file=../fixtures/basic-npm/package.json
       The status should be failure # issues found
       The output should include "https://snyk.io/vuln/npm:minimatch:20160620"
-      The stderr should equal ""
+      if should_have_deprecation_warnings; then 
+        The stderr should not equal ""
+      else
+        The stderr should equal ""
+      fi
     End
 
     It "tests a library on a specific version when passed a library@version"

--- a/test/smoke/spec/spec_helper.sh
+++ b/test/smoke/spec/spec_helper.sh
@@ -68,4 +68,14 @@ spec_helper_configure() {
   snyk() {
     eval "${SNYK_COMMAND:=$ORIGINAL_SNYK_EXECUTABLE}" "$@"
   }
+
+  should_have_deprecation_warnings() {
+    #  deprecated node version will show additional stderr output for deprecation notices
+    if command -v node > /dev/null 2>&1; then
+      if node --version | grep -Eq "^v12.*"; then
+        return 0
+      fi
+    fi
+    return 1
+  }
 }


### PR DESCRIPTION
Node 12 support is deprecated, will still support it so we still want tests.
However, we expect stderr output for it, unlike other versions, since we show deprecation warnings.