### PR TITLE
refactor: IaC test v2 setup

### DIFF
--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -29,9 +29,8 @@ function prepareTestConfig(paths: string[]): TestConfig {
 
   return {
     paths,
-    cachedBundlePath: pathLib.join(iacCachePath, 'bundle.tar.gz'),
+    iacCachePath,
     userBundlePath: config.IAC_BUNDLE_PATH,
-    cachedPolicyEnginePath: pathLib.join(iacCachePath, 'snyk-iac-test'),
     userPolicyEnginePath: config.IAC_POLICY_ENGINE_PATH,
   };
 }

--- a/src/lib/iac/file-utils.ts
+++ b/src/lib/iac/file-utils.ts
@@ -9,3 +9,19 @@ export async function isExe(path: string): Promise<boolean> {
     return false;
   }
 }
+
+export async function isExists(path: string): Promise<boolean> {
+  try {
+    await fsPromises.stat(path);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+export async function createDirIfNotExists(path: string): Promise<void> {
+  const isDirExists = await isExists(path);
+  if (!isDirExists) {
+    fsPromises.mkdir(path, { recursive: true });
+  }
+}

--- a/src/lib/iac/test/v2/setup/index.ts
+++ b/src/lib/iac/test/v2/setup/index.ts
@@ -1,9 +1,6 @@
 import { TestConfig } from '../types';
-import { initRules } from './rules';
-import { initPolicyEngine } from './policy-engine';
+import { initLocalCache } from './local-cache';
 
 export async function setup(testConfig: TestConfig) {
-  const policyEnginePath = await initPolicyEngine(testConfig);
-  const rulesBundlePath = await initRules(testConfig);
-  return { policyEnginePath, rulesBundlePath };
+  return await initLocalCache(testConfig);
 }

--- a/src/lib/iac/test/v2/setup/local-cache/index.ts
+++ b/src/lib/iac/test/v2/setup/local-cache/index.ts
@@ -1,0 +1,19 @@
+import { TestConfig } from '../../types';
+import { initRules } from './rules';
+import { initPolicyEngine } from './policy-engine';
+import { createDirIfNotExists } from '../../../../file-utils';
+import { CustomError } from '../../../../../errors';
+import { FailedToInitLocalCacheError } from '../../../../../../cli/commands/test/iac/local-execution/local-cache';
+
+export async function initLocalCache(testConfig: TestConfig) {
+  try {
+    await createDirIfNotExists(testConfig.iacCachePath);
+
+    const policyEnginePath = await initPolicyEngine(testConfig);
+    const rulesBundlePath = await initRules(testConfig);
+
+    return { policyEnginePath, rulesBundlePath };
+  } catch (err) {
+    throw err instanceof CustomError ? err : new FailedToInitLocalCacheError();
+  }
+}

--- a/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/index.ts
+++ b/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/index.ts
@@ -1,0 +1,11 @@
+import { formatPolicyEngineFileName } from './utils';
+
+/**
+ * The Policy Engine release version associated with this Snyk CLI version.
+ */
+export const releaseVersion = '0.1.0';
+
+/**
+ * The Policy Engine executable's file name.
+ */
+export const policyEngineFileName = formatPolicyEngineFileName(releaseVersion);

--- a/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/utils.ts
@@ -1,0 +1,19 @@
+import * as os from 'os';
+
+export function formatPolicyEngineFileName(releaseVersion: string) {
+  let platform = 'Linux';
+  switch (os.platform()) {
+    case 'darwin':
+      platform = 'Darwin';
+      break;
+    case 'win32':
+      platform = 'Windows';
+      break;
+  }
+
+  const arch = os.arch() === 'arm64' ? 'arm64' : 'x86_64';
+
+  const execExt = os.platform() === 'win32' ? '.exe' : '';
+
+  return `snyk-iac-test_${releaseVersion}_${platform}_${arch}${execExt}`;
+}

--- a/src/lib/iac/test/v2/setup/local-cache/policy-engine/index.ts
+++ b/src/lib/iac/test/v2/setup/local-cache/policy-engine/index.ts
@@ -1,0 +1,13 @@
+import { TestConfig } from '../../../types';
+import { InvalidUserPolicyEnginePathError, lookupLocal } from './lookup-local';
+
+export async function initPolicyEngine(testConfig: TestConfig) {
+  const localPolicyEnginePath = await lookupLocal(testConfig);
+  if (localPolicyEnginePath) {
+    return localPolicyEnginePath;
+  }
+
+  // TODO: Download Policy Engine executable
+
+  throw new InvalidUserPolicyEnginePathError('', 'policy engine not found');
+}

--- a/src/lib/iac/test/v2/setup/local-cache/policy-engine/lookup-local.ts
+++ b/src/lib/iac/test/v2/setup/local-cache/policy-engine/lookup-local.ts
@@ -1,9 +1,11 @@
+import * as pathLib from 'path';
 import * as createDebugLogger from 'debug';
-import { isExe } from '../../../file-utils';
-import { CustomError } from '../../../../errors';
-import { IaCErrorCodes } from '../../../../../cli/commands/test/iac/local-execution/types';
-import { getErrorStringCode } from '../../../../../cli/commands/test/iac/local-execution/error-utils';
-import { TestConfig } from '../types';
+import { isExe } from '../../../../../file-utils';
+import { CustomError } from '../../../../../../errors';
+import { IaCErrorCodes } from '../../../../../../../cli/commands/test/iac/local-execution/types';
+import { getErrorStringCode } from '../../../../../../../cli/commands/test/iac/local-execution/error-utils';
+import { TestConfig } from '../../../types';
+import { policyEngineFileName } from './constants';
 
 const debugLogger = createDebugLogger('snyk-iac');
 
@@ -22,8 +24,8 @@ export class InvalidUserPolicyEnginePathError extends CustomError {
   }
 }
 
-export async function lookupLocalPolicyEngine({
-  cachedPolicyEnginePath,
+export async function lookupLocal({
+  iacCachePath,
   userPolicyEnginePath,
 }: TestConfig): Promise<string | undefined> {
   // Lookup in custom path.
@@ -41,6 +43,10 @@ export async function lookupLocalPolicyEngine({
   }
   // Lookup in cache.
   else {
+    const cachedPolicyEnginePath = pathLib.join(
+      iacCachePath,
+      policyEngineFileName,
+    );
     if (await isExe(cachedPolicyEnginePath)) {
       debugLogger(
         'Found cached Policy Engine executable: %s',
@@ -54,18 +60,4 @@ export async function lookupLocalPolicyEngine({
       );
     }
   }
-}
-
-export async function initPolicyEngine(
-  testConfig: TestConfig,
-): Promise<string> {
-  const localPolicyEnginePath = await lookupLocalPolicyEngine(testConfig);
-
-  if (localPolicyEnginePath) {
-    return localPolicyEnginePath;
-  }
-
-  // TODO: Download Policy Engine executable
-
-  throw new InvalidUserPolicyEnginePathError('', 'policy engine not found');
 }

--- a/src/lib/iac/test/v2/setup/local-cache/rules.ts
+++ b/src/lib/iac/test/v2/setup/local-cache/rules.ts
@@ -1,13 +1,21 @@
+import * as pathLib from 'path';
 import * as fs from 'fs';
 import * as tar from 'tar';
-import { CustomError } from '../../../../errors';
-import { getErrorStringCode } from '../../../../../cli/commands/test/iac/local-execution/error-utils';
-import { IaCErrorCodes } from '../../../../../cli/commands/test/iac/local-execution/types';
-import { TestConfig } from '../types';
+import { CustomError } from '../../../../../errors';
+import { getErrorStringCode } from '../../../../../../cli/commands/test/iac/local-execution/error-utils';
+import { IaCErrorCodes } from '../../../../../../cli/commands/test/iac/local-execution/types';
+import { TestConfig } from '../../types';
+
+export const rulesBundleName = 'bundle.tar.gz';
 
 export async function initRules(testConfig: TestConfig): Promise<string> {
+  const cachedBundlePath = pathLib.join(
+    testConfig.iacCachePath,
+    rulesBundleName,
+  );
+
   const bundleLocator = new RulesBundleLocator(
-    testConfig.cachedBundlePath,
+    cachedBundlePath,
     testConfig.userBundlePath,
   );
 

--- a/src/lib/iac/test/v2/types.ts
+++ b/src/lib/iac/test/v2/types.ts
@@ -1,7 +1,6 @@
 export interface TestConfig {
   paths: string[];
-  cachedBundlePath: string;
-  cachedPolicyEnginePath: string;
+  iacCachePath: string;
   userBundlePath?: string;
   userPolicyEnginePath?: string;
 }

--- a/test/jest/unit/lib/iac/drift.spec.ts
+++ b/test/jest/unit/lib/iac/drift.spec.ts
@@ -38,8 +38,8 @@ describe('driftctl integration', () => {
     mockFs.restore();
   });
 
-  it('describe: default arguments are correct', () => {
-    const args = generateArgs({ kind: 'describe' }, []);
+  it('describe: default arguments are correct', async () => {
+    const args = await generateArgs({ kind: 'describe' }, []);
     expect(args).toEqual([
       'scan',
       '--no-version-check',
@@ -52,9 +52,9 @@ describe('driftctl integration', () => {
     ]);
   });
 
-  it('describe: --all enable deep mode', () => {
+  it('describe: --all enable deep mode', async () => {
     {
-      const args = generateArgs(
+      const args = await generateArgs(
         { kind: 'describe', all: true } as DescribeOptions,
         [],
       );
@@ -72,7 +72,7 @@ describe('driftctl integration', () => {
     }
 
     {
-      const args = generateArgs(
+      const args = await generateArgs(
         { kind: 'describe', all: true, deep: true } as DescribeOptions,
         [],
       );
@@ -90,8 +90,8 @@ describe('driftctl integration', () => {
     }
   });
 
-  it('describe: passing options generate correct arguments', () => {
-    const args = generateArgs(
+  it('describe: passing options generate correct arguments', async () => {
+    const args = await generateArgs(
       {
         kind: 'describe',
         'config-dir': 'confdir',
@@ -147,8 +147,8 @@ describe('driftctl integration', () => {
     ]);
   });
 
-  it('describe: from arguments is a coma separated list', () => {
-    const args = generateArgs({
+  it('describe: from arguments is a coma separated list', async () => {
+    const args = await generateArgs({
       kind: 'describe',
       from: 'path1,path2,path3',
     } as DescribeOptions);

--- a/test/jest/unit/lib/iac/test/v2/setup/local-cache/index.spec.ts
+++ b/test/jest/unit/lib/iac/test/v2/setup/local-cache/index.spec.ts
@@ -1,0 +1,156 @@
+import * as pathLib from 'path';
+import * as initPolicyEngineLib from '../../../../../../../../../src/lib/iac/test/v2/setup/local-cache/policy-engine';
+import * as initRulesLib from '../../../../../../../../../src/lib/iac/test/v2/setup/local-cache/rules';
+import * as fileUtils from '../../../../../../../../../src/lib/iac/file-utils';
+import { initLocalCache } from '../../../../../../../../../src/lib/iac/test/v2/setup/local-cache';
+import { TestConfig } from '../../../../../../../../../src/lib/iac/test/v2/types';
+import { FailedToInitLocalCacheError } from '../../../../../../../../../src/cli/commands/test/iac/local-execution/local-cache';
+
+describe('initLocalCache', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('creates the IaC cache directory if it does not exist', async () => {
+    // Arrange
+    const testPolicyEnginePath = 'test-policy-engine-path';
+    const testRulesBundlePath = 'test-rules-bundle-path';
+    const testTestConfig = {
+      iacCachePath: pathLib.join('iac', 'cache', 'path'),
+    } as TestConfig;
+
+    jest
+      .spyOn(initPolicyEngineLib, 'initPolicyEngine')
+      .mockImplementation(async () => testPolicyEnginePath);
+    jest
+      .spyOn(initRulesLib, 'initRules')
+      .mockImplementation(async () => testRulesBundlePath);
+    const createDirIfNotExistsSpy = jest
+      .spyOn(fileUtils, 'createDirIfNotExists')
+      .mockImplementation(async () => undefined);
+
+    // Act
+    await initLocalCache(testTestConfig);
+
+    // Assert
+    expect(createDirIfNotExistsSpy).toHaveBeenCalledWith(
+      testTestConfig.iacCachePath,
+    );
+  });
+
+  it('initializes the Policy Engine executable', async () => {
+    // Arrange
+    const testPolicyEnginePath = 'test-policy-engine-path';
+    const testRulesBundlePath = 'test-rules-bundle-path';
+    const testTestConfig = {
+      iacCachePath: pathLib.join('iac', 'cache', 'path'),
+    } as TestConfig;
+
+    const initPolicyEngineSpy = jest
+      .spyOn(initPolicyEngineLib, 'initPolicyEngine')
+      .mockImplementation(async () => testPolicyEnginePath);
+    jest
+      .spyOn(initRulesLib, 'initRules')
+      .mockImplementation(async () => testRulesBundlePath);
+    jest
+      .spyOn(fileUtils, 'createDirIfNotExists')
+      .mockImplementation(async () => undefined);
+
+    // Act
+    await initLocalCache(testTestConfig);
+
+    // Assert
+    expect(initPolicyEngineSpy).toHaveBeenCalledWith(testTestConfig);
+  });
+
+  it('initializes the rules bundle', async () => {
+    // Arrange
+    const testPolicyEnginePath = 'test-policy-engine-path';
+    const testRulesBundlePath = 'test-rules-bundle-path';
+    const testTestConfig = {
+      iacCachePath: pathLib.join('iac', 'cache', 'path'),
+    } as TestConfig;
+
+    jest
+      .spyOn(initPolicyEngineLib, 'initPolicyEngine')
+      .mockImplementation(async () => testPolicyEnginePath);
+    const initRulesSpy = jest
+      .spyOn(initRulesLib, 'initRules')
+      .mockImplementation(async () => testRulesBundlePath);
+    jest
+      .spyOn(fileUtils, 'createDirIfNotExists')
+      .mockImplementation(async () => undefined);
+
+    // Act
+    await initLocalCache(testTestConfig);
+
+    // Assert
+    expect(initRulesSpy).toHaveBeenCalledWith(testTestConfig);
+  });
+
+  it('returns the cached resrouce paths', async () => {
+    // Arrange
+    const testPolicyEnginePath = 'test-policy-engine-path';
+    const testRulesBundlePath = 'test-rules-bundle-path';
+    const testTestConfig = {
+      iacCachePath: pathLib.join('iac', 'cache', 'path'),
+    } as TestConfig;
+
+    jest
+      .spyOn(initPolicyEngineLib, 'initPolicyEngine')
+      .mockImplementation(async () => testPolicyEnginePath);
+    jest
+      .spyOn(initRulesLib, 'initRules')
+      .mockImplementation(async () => testRulesBundlePath);
+    jest
+      .spyOn(fileUtils, 'createDirIfNotExists')
+      .mockImplementation(async () => undefined);
+
+    const expected = {
+      policyEnginePath: testPolicyEnginePath,
+      rulesBundlePath: testRulesBundlePath,
+    };
+    // Act
+    const res = await initLocalCache(testTestConfig);
+
+    // Assert
+    expect(res).toStrictEqual(expected);
+  });
+
+  describe.each`
+    failingResource               | module                 | methodName
+    ${'cache directory'}          | ${fileUtils}           | ${'createDirIfNotExists'}
+    ${'Policy Engine executable'} | ${initPolicyEngineLib} | ${'initPolicyEngine'}
+    ${'rules bundle'}             | ${initRulesLib}        | ${'initRules'}
+  `(
+    'when the initialization for the $failingResource fails',
+    ({ module, methodName }) => {
+      it('throws an error', async () => {
+        // Arrange
+        const testPolicyEnginePath = 'test-policy-engine-path';
+        const testRulesBundlePath = 'test-rules-bundle-path';
+        const testTestConfig = {
+          iacCachePath: pathLib.join('iac', 'cache', 'path'),
+        } as TestConfig;
+
+        jest
+          .spyOn(initPolicyEngineLib, 'initPolicyEngine')
+          .mockImplementation(async () => testPolicyEnginePath);
+        jest
+          .spyOn(initRulesLib, 'initRules')
+          .mockImplementation(async () => testRulesBundlePath);
+        jest
+          .spyOn(fileUtils, 'createDirIfNotExists')
+          .mockImplementation(async () => undefined);
+        jest.spyOn(module, methodName).mockImplementation(async () => {
+          throw new FailedToInitLocalCacheError();
+        });
+
+        // Act + Assert
+        await expect(initLocalCache(testTestConfig)).rejects.toThrow(
+          FailedToInitLocalCacheError,
+        );
+      });
+    },
+  );
+});

--- a/test/jest/unit/lib/iac/test/v2/setup/local-cache/policy-engine/constants/utils.spec.ts
+++ b/test/jest/unit/lib/iac/test/v2/setup/local-cache/policy-engine/constants/utils.spec.ts
@@ -1,0 +1,35 @@
+import * as os from 'os';
+import { formatPolicyEngineFileName } from '../../../../../../../../../../../src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/utils';
+
+describe('formatPolicyEngineFileName', () => {
+  const testReleaseVersion = '6.6.6';
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe.each`
+    osPlatform              | osArch              | expectedFileName
+    ${'darwin'}             | ${'arm64'}          | ${`snyk-iac-test_${testReleaseVersion}_Darwin_arm64`}
+    ${'darwin'}             | ${'any-other-arch'} | ${`snyk-iac-test_${testReleaseVersion}_Darwin_x86_64`}
+    ${'win32'}              | ${'arm64'}          | ${`snyk-iac-test_${testReleaseVersion}_Windows_arm64.exe`}
+    ${'win32'}              | ${'any-other-arch'} | ${`snyk-iac-test_${testReleaseVersion}_Windows_x86_64.exe`}
+    ${'any-other-platform'} | ${'arm64'}          | ${`snyk-iac-test_${testReleaseVersion}_Linux_arm64`}
+    ${'any-other-platform'} | ${'any-other-arch'} | ${`snyk-iac-test_${testReleaseVersion}_Linux_x86_64`}
+  `(
+    'with `$osPlatform` platform and `$osArch` architecture',
+    ({ osPlatform, osArch, expectedFileName }) => {
+      it(`returns ${expectedFileName}`, () => {
+        // Arrange
+        jest.spyOn(os, 'platform').mockImplementation(() => osPlatform);
+        jest.spyOn(os, 'arch').mockImplementation(() => osArch);
+
+        // Act
+        const res = formatPolicyEngineFileName(testReleaseVersion);
+
+        // Assert
+        expect(res).toEqual(expectedFileName);
+      });
+    },
+  );
+});

--- a/test/jest/unit/lib/iac/test/v2/setup/local-cache/policy-engine/lookup-local.spec.ts
+++ b/test/jest/unit/lib/iac/test/v2/setup/local-cache/policy-engine/lookup-local.spec.ts
@@ -1,14 +1,27 @@
+import * as pathLib from 'path';
 import * as cloneDeep from 'lodash.clonedeep';
-import * as fileUtils from '../../../../../../../../src/lib/iac/file-utils';
+import * as fileUtils from '../../../../../../../../../../src/lib/iac/file-utils';
 import {
   InvalidUserPolicyEnginePathError,
-  lookupLocalPolicyEngine,
-} from '../../../../../../../../src/lib/iac/test/v2/setup/policy-engine';
+  lookupLocal,
+} from '../../../../../../../../../../src/lib/iac/test/v2/setup/local-cache/policy-engine/lookup-local';
 
-describe('lookupLocalPolicyEngine', () => {
+jest.mock(
+  '../../../../../../../../../../src/lib/iac/test/v2/setup/local-cache/policy-engine/constants',
+  () => ({
+    policyEngineFileName: 'policy-engine-test-file-name',
+  }),
+);
+
+describe('lookupLocal', () => {
+  const iacCachePath = pathLib.join('iac', 'cache', 'path');
   const defaultTestConfig = {
-    cachedPolicyEnginePath: `iac/cache/path/snyk-iac-test`,
+    iacCachePath,
   };
+  const cachedPolicyEnginePath = pathLib.join(
+    iacCachePath,
+    'policy-engine-test-file-name',
+  );
 
   afterEach(() => {
     jest.restoreAllMocks();
@@ -22,15 +35,13 @@ describe('lookupLocalPolicyEngine', () => {
 
         jest
           .spyOn(fileUtils, 'isExe')
-          .mockImplementationOnce(
-            async (path) => path === testConfig.cachedPolicyEnginePath,
-          );
+          .mockImplementation(async (path) => path === cachedPolicyEnginePath);
 
         // Act
-        const res = await lookupLocalPolicyEngine(testConfig);
+        const res = await lookupLocal(testConfig);
 
         // Assert
-        expect(res).toEqual(testConfig.cachedPolicyEnginePath);
+        expect(res).toEqual(cachedPolicyEnginePath);
       });
     });
 
@@ -40,7 +51,7 @@ describe('lookupLocalPolicyEngine', () => {
         const testConfig = cloneDeep(defaultTestConfig);
 
         // Act
-        const res = await lookupLocalPolicyEngine(testConfig);
+        const res = await lookupLocal(testConfig);
 
         // Assert
         expect(res).toBeUndefined();
@@ -61,12 +72,10 @@ describe('lookupLocalPolicyEngine', () => {
 
         jest
           .spyOn(fileUtils, 'isExe')
-          .mockImplementationOnce(
-            async (path) => path === userPolicyEnginePath,
-          );
+          .mockImplementation(async (path) => path === userPolicyEnginePath);
 
         // Act
-        const res = await lookupLocalPolicyEngine(testConfig);
+        const res = await lookupLocal(testConfig);
 
         // Assert
         expect(res).toEqual(userPolicyEnginePath);
@@ -82,7 +91,7 @@ describe('lookupLocalPolicyEngine', () => {
         };
 
         // Act + Assert
-        await expect(lookupLocalPolicyEngine(testConfig)).rejects.toThrow(
+        await expect(lookupLocal(testConfig)).rejects.toThrow(
           InvalidUserPolicyEnginePathError,
         );
       });

--- a/test/jest/unit/lib/iac/test/v2/setup/local-cache/rules.spec.ts
+++ b/test/jest/unit/lib/iac/test/v2/setup/local-cache/rules.spec.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as tar from 'tar';
 import * as rimraf from 'rimraf';
-import { RulesBundleLocator } from '../../../../../../../../src/lib/iac/test/v2/setup/rules';
+import { RulesBundleLocator } from '../../../../../../../../../src/lib/iac/test/v2/setup/local-cache/rules';
 
 describe('PathRulesBundleLocator', () => {
   let root: string;


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Fixes the locally cached Policy Engine executable name.
- Adds a local cache initialization step to the test setup which:
    - Wraps the logic for initializing the rules bundle and the Policy Engine executable.
    - Ensures the IaC local cache directory exists.
    - Replaces the specific cache paths for the Policy Engine executable and the rules bundle with an IaC cache path, as it's enough for the former two can be calculated with it.

#### Where should the reviewer start?

- The only logic piece this PR should change, is the name of the locally cached Policy Engine executable the CLI will look for.

#### How should this be manually tested?

- Ensure the IaC test v2 tests still pass.
- Ensure the test files are structured correctly following the refactor.
- Ensure the IaC test v2 flow still behaves the same as before.

#### Any background context you want to provide?

- The refactor in this PR was extracted from #3327, where we add the logic for downloading the Policy Engine executable when it is not found locally.

#### What are the relevant tickets?

- [CFG-1885](https://snyksec.atlassian.net/browse/CFG-1885)