### PR TITLE
chore: scan IaC files with the Policy Engine

### DIFF
--- a/src/cli/commands/test/iac/local-execution/types.ts
+++ b/src/cli/commands/test/iac/local-execution/types.ts
@@ -349,9 +349,13 @@ export enum IaCErrorCodes {
 
   // Rules bundle errors.
   InvalidUserRulesBundleError = 1130,
+  BundleNotFoundError = 1131,
 
   // Unified Policy Engine executable errors.
   InvalidUserPolicyEnginePathError = 1140,
+
+  // Scan errors
+  PolicyEngineScanError = 1150,
 }
 
 export interface TestReturnValue {

--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -5,9 +5,12 @@ import * as testLib from '../../../../../lib/iac/test/v2';
 import { TestConfig } from '../../../../../lib/iac/test/v2';
 import config from '../../../../../lib/config';
 import { TestCommandResult } from '../../../types';
+import { MethodArgs } from '../../../../args';
+import { processCommandArgs } from '../../../process-command-args';
 
-export async function test(): Promise<TestCommandResult> {
-  const testConfig = prepareTestConfig();
+export async function test(...args: MethodArgs): Promise<TestCommandResult> {
+  const { paths } = processCommandArgs(...args);
+  const testConfig = prepareTestConfig(paths);
 
   await testLib.test(testConfig);
 
@@ -20,11 +23,12 @@ export async function test(): Promise<TestCommandResult> {
   );
 }
 
-function prepareTestConfig(): TestConfig {
+function prepareTestConfig(paths: string[]): TestConfig {
   const systemCachePath = config.CACHE_PATH ?? envPaths('snyk').cache;
   const iacCachePath = pathLib.join(systemCachePath, 'iac');
 
   return {
+    paths,
     cachedBundlePath: pathLib.join(iacCachePath, 'bundle.tar.gz'),
     userBundlePath: config.IAC_BUNDLE_PATH,
     cachedPolicyEnginePath: pathLib.join(iacCachePath, 'snyk-iac-test'),

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -61,7 +61,7 @@ export default async function test(
       (await hasFeatureFlag('iacCliUnifiedEngine', options)) &&
       options.experimental
     ) {
-      return await iacTestCommandV2.test();
+      return await iacTestCommandV2.test(...args);
     } else {
       return await iacTestCommand(...args);
     }

--- a/src/lib/iac/test/v2/index.ts
+++ b/src/lib/iac/test/v2/index.ts
@@ -1,12 +1,14 @@
 import { TestConfig } from './types';
 import { setup } from './setup';
+import { scan } from './scan';
 
 export { TestConfig } from './types';
 
 export async function test(testConfig: TestConfig) {
-  await setup(testConfig);
+  const { policyEnginePath, rulesBundlePath } = await setup(testConfig);
 
-  // TODO: Add the rest of the test steps
+  // TODO use the results in a more meaningful way.
+  scan(testConfig, policyEnginePath, rulesBundlePath);
 
   return;
 }

--- a/src/lib/iac/test/v2/scan.ts
+++ b/src/lib/iac/test/v2/scan.ts
@@ -1,0 +1,50 @@
+import { TestConfig } from './types';
+import * as childProcess from 'child_process';
+import { CustomError } from '../../../errors';
+import { IaCErrorCodes } from '../../../../cli/commands/test/iac/local-execution/types';
+import { getErrorStringCode } from '../../../../cli/commands/test/iac/local-execution/error-utils';
+import * as newDebug from 'debug';
+
+const debug = newDebug('snyk-iac');
+
+export function scan(
+  options: TestConfig,
+  policyEnginePath: string,
+  rulesBundlePath: string,
+): any {
+  const args = ['-bundle', rulesBundlePath, ...options.paths];
+
+  const process = childProcess.spawnSync(policyEnginePath, args, {
+    encoding: 'utf-8',
+    stdio: 'pipe',
+  });
+
+  debug('policy engine standard error:\n%s', '\n' + process.stderr);
+
+  if (process.status && process.status !== 0) {
+    throw new ScanError(`invalid exist status: ${process.status}`);
+  }
+
+  if (process.error) {
+    throw new ScanError(`spawning process: ${process.error}`);
+  }
+
+  let output: any;
+
+  try {
+    output = JSON.parse(process.stdout);
+  } catch (e) {
+    throw new ScanError(`invalid output encoding: ${e}`);
+  }
+
+  return output;
+}
+
+class ScanError extends CustomError {
+  constructor(message: string) {
+    super(message);
+    this.code = IaCErrorCodes.PolicyEngineScanError;
+    this.strCode = getErrorStringCode(this.code);
+    this.userMessage = 'An error occurred when running the scan';
+  }
+}

--- a/src/lib/iac/test/v2/setup/index.ts
+++ b/src/lib/iac/test/v2/setup/index.ts
@@ -3,6 +3,7 @@ import { initRules } from './rules';
 import { initPolicyEngine } from './policy-engine';
 
 export async function setup(testConfig: TestConfig) {
-  await initPolicyEngine(testConfig);
-  await initRules(testConfig);
+  const policyEnginePath = await initPolicyEngine(testConfig);
+  const rulesBundlePath = await initRules(testConfig);
+  return { policyEnginePath, rulesBundlePath };
 }

--- a/src/lib/iac/test/v2/setup/policy-engine.ts
+++ b/src/lib/iac/test/v2/setup/policy-engine.ts
@@ -56,11 +56,16 @@ export async function lookupLocalPolicyEngine({
   }
 }
 
-export async function initPolicyEngine(testConfig: TestConfig) {
+export async function initPolicyEngine(
+  testConfig: TestConfig,
+): Promise<string> {
   const localPolicyEnginePath = await lookupLocalPolicyEngine(testConfig);
+
   if (localPolicyEnginePath) {
     return localPolicyEnginePath;
   }
 
   // TODO: Download Policy Engine executable
+
+  throw new InvalidUserPolicyEnginePathError('', 'policy engine not found');
 }

--- a/src/lib/iac/test/v2/setup/rules.ts
+++ b/src/lib/iac/test/v2/setup/rules.ts
@@ -5,18 +5,19 @@ import { getErrorStringCode } from '../../../../../cli/commands/test/iac/local-e
 import { IaCErrorCodes } from '../../../../../cli/commands/test/iac/local-execution/types';
 import { TestConfig } from '../types';
 
-export async function initRules(testConfig: TestConfig) {
+export async function initRules(testConfig: TestConfig): Promise<string> {
   const bundleLocator = new RulesBundleLocator(
     testConfig.cachedBundlePath,
     testConfig.userBundlePath,
   );
+
   const bundlePath = bundleLocator.locateBundle();
 
-  if (bundlePath) {
-    console.log(`found rules bundle at ${bundlePath}`);
-  } else {
-    console.log('no rules bundle found');
+  if (!bundlePath) {
+    throw new BundleNotFoundError('no rules bundle found');
   }
+
+  return bundlePath;
 }
 
 export class RulesBundleLocator {
@@ -78,6 +79,15 @@ class InvalidUserRulesBundleError extends CustomError {
     this.code = IaCErrorCodes.InvalidUserRulesBundleError;
     this.strCode = getErrorStringCode(this.code);
     this.userMessage = `The provided rules bundle is not a valid .tar.gz archive.`;
+  }
+}
+
+class BundleNotFoundError extends CustomError {
+  constructor(message: string) {
+    super(message);
+    this.code = IaCErrorCodes.BundleNotFoundError;
+    this.strCode = getErrorStringCode(this.code);
+    this.userMessage = `No rules bundle could be found.`;
   }
 }
 

--- a/src/lib/iac/test/v2/types.ts
+++ b/src/lib/iac/test/v2/types.ts
@@ -1,4 +1,5 @@
 export interface TestConfig {
+  paths: string[];
   cachedBundlePath: string;
   cachedPolicyEnginePath: string;
   userBundlePath?: string;

--- a/test/jest/acceptance/iac/experimental.spec.ts
+++ b/test/jest/acceptance/iac/experimental.spec.ts
@@ -36,7 +36,12 @@ describe('iac --experimental', () => {
         );
         expect(stdout).not.toContain('Snyk Infrastructure as Code');
         expect(stdout).not.toContain('Issues');
-        expect(exitCode).toBe(0);
+
+        // TODO the command currently doesn't download the engine in case it's
+        // missing, and it causes the command to fail with a non-zero exit code.
+        // This should be fixed as soon as we are able to download the engine.
+
+        expect(exitCode).toBe(2);
       });
 
       describe('when a custom Policy Engine executable path is configured ', () => {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR updates the experimental `iac test` command to execute `snyk-iac-test`, passing to it the rules bundle and the paths to be scanned. The experimental command collects and parses the standard output of the executable, and collects its standard error to be printed to a debug logger.

#### Where should the reviewer start?

Follow the flow from `src/cli/commands/test/iac/v2/index.ts`. The execution of `snyk-iac-test` is in `src/lib/iac/test/v2/scan.ts`.

#### How should this be manually tested?

Set the environment variables to point to the engine and the bundle:

```
export SNYK_IAC_POLICY_ENGINE_PATH=...
export SNYK_IAC_BUNDLE_PATH=...
```

Make sure you have the `iacCliUnifiedEngine` feature flag enabled, and invoke the command like this:

```
snyk iac test --experimental
```

#### What are the relevant tickets?

[CFG-1896](https://snyksec.atlassian.net/browse/CFG-1896)