### PR TITLE
feat: add support for requirements.txt files with BOM encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "snyk-nuget-plugin": "1.23.5",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.25.0",
-        "snyk-python-plugin": "1.23.1",
+        "snyk-python-plugin": "1.24.0",
         "snyk-resolve-deps": "4.7.3",
         "snyk-sbt-plugin": "2.14.0",
         "strip-ansi": "^5.2.0",
@@ -16979,9 +16979,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-python-plugin": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.23.1.tgz",
-      "integrity": "sha512-eX6HRJFIrNErlFUWwmaK9xl+NzKmkNXBk2VvF/HzyIY1jPwr75xsfwIOqEQDFwGR14IHNg+g/y4k4cMLTbZhJw==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.24.0.tgz",
+      "integrity": "sha512-ngmQSFjrWYc8TgFDCJANPV0tfpwoOxr4ZUQYMsuNMPwNjX+wXjdbRBOnKeJAyiy0ysGWCecyOK6RVyp4+nvC9g==",
       "dependencies": {
         "@snyk/cli-interface": "^2.11.2",
         "@snyk/dep-graph": "^1.28.1",
@@ -33100,9 +33100,9 @@
       }
     },
     "snyk-python-plugin": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.23.1.tgz",
-      "integrity": "sha512-eX6HRJFIrNErlFUWwmaK9xl+NzKmkNXBk2VvF/HzyIY1jPwr75xsfwIOqEQDFwGR14IHNg+g/y4k4cMLTbZhJw==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.24.0.tgz",
+      "integrity": "sha512-ngmQSFjrWYc8TgFDCJANPV0tfpwoOxr4ZUQYMsuNMPwNjX+wXjdbRBOnKeJAyiy0ysGWCecyOK6RVyp4+nvC9g==",
       "requires": {
         "@snyk/cli-interface": "^2.11.2",
         "@snyk/dep-graph": "^1.28.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "snyk-nuget-plugin": "1.23.5",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.25.0",
-    "snyk-python-plugin": "1.23.1",
+    "snyk-python-plugin": "1.24.0",
     "snyk-resolve-deps": "4.7.3",
     "snyk-sbt-plugin": "2.14.0",
     "strip-ansi": "^5.2.0",


### PR DESCRIPTION
#### What does this PR do?
Upgrade python plugin version to add support for requirements.txt files with BOM encoding