### PR TITLE
chore: override no_proxy from parent env before launching cliv1

### DIFF
--- a/cliv2/internal/cliv2/cliv2.go
+++ b/cliv2/internal/cliv2/cliv2.go
@@ -37,6 +37,12 @@ const SNYK_INTEGRATION_NAME_ENV = "SNYK_INTEGRATION_NAME"
 const SNYK_INTEGRATION_VERSION_ENV = "SNYK_INTEGRATION_VERSION"
 const SNYK_HTTPS_PROXY_ENV = "HTTPS_PROXY"
 const SNYK_HTTP_PROXY_ENV = "HTTP_PROXY"
+const SNYK_HTTP_NO_PROXY_ENV = "NO_PROXY"
+const SNYK_NPM_PROXY_ENV = "NPM_CONFIG_PROXY"
+const SNYK_NPM_HTTPS_PROXY_ENV = "NPM_CONFIG_HTTPS_PROXY"
+const SNYK_NPM_HTTP_PROXY_ENV = "NPM_CONFIG_HTTP_PROXY"
+const SNYK_NPM_NO_PROXY_ENV = "NPM_CONFIG_NO_PROXY"
+const SNYK_NPM_ALL_PROXY = "ALL_PROXY"
 const SNYK_CA_CERTIFICATE_LOCATION_ENV = "NODE_EXTRA_CA_CERTS"
 
 const (
@@ -159,6 +165,16 @@ func PrepareV1EnvironmentVariables(input []string, integrationName string, integ
 		inputAsMap[SNYK_HTTPS_PROXY_ENV] = proxyAddress
 		inputAsMap[SNYK_HTTP_PROXY_ENV] = proxyAddress
 		inputAsMap[SNYK_CA_CERTIFICATE_LOCATION_ENV] = caCertificateLocation
+
+		// ensure that no existing no_proxy or other configuration causes redirecting internal communication that is meant to stay between cliv1 and cliv2
+		inputAsMap[SNYK_HTTP_NO_PROXY_ENV] = ""
+		inputAsMap[SNYK_NPM_NO_PROXY_ENV] = ""
+		inputAsMap[SNYK_NPM_HTTPS_PROXY_ENV] = ""
+		inputAsMap[SNYK_NPM_HTTP_PROXY_ENV] = ""
+		inputAsMap[SNYK_NPM_PROXY_ENV] = ""
+		inputAsMap[SNYK_NPM_ALL_PROXY] = ""
+
+		inputAsMap = utils.RemoveEmptyValue(inputAsMap)
 		result = utils.ToSlice(inputAsMap, "=")
 	}
 

--- a/cliv2/internal/cliv2/cliv2_test.go
+++ b/cliv2/internal/cliv2/cliv2_test.go
@@ -14,7 +14,16 @@ import (
 
 func Test_PrepareV1EnvironmentVariables_Fill(t *testing.T) {
 
-	input := []string{"something=1", "in=2", "here=3=2"}
+	input := []string{"something=1",
+		"in=2",
+		"here=3=2",
+		"NO_PROXY=something",
+		"NPM_CONFIG_PROXY=something",
+		"NPM_CONFIG_HTTPS_PROXY=something",
+		"NPM_CONFIG_HTTP_PROXY=something",
+		"NPM_CONFIG_NO_PROXY=something",
+		"ALL_PROXY=something",
+	}
 	expected := []string{"something=1", "in=2", "here=3=2", "SNYK_INTEGRATION_NAME=foo", "SNYK_INTEGRATION_VERSION=bar", "HTTP_PROXY=proxy", "HTTPS_PROXY=proxy", "NODE_EXTRA_CA_CERTS=cacertlocation"}
 
 	actual, err := cliv2.PrepareV1EnvironmentVariables(input, "foo", "bar", "proxy", "cacertlocation")

--- a/cliv2/internal/utils/array.go
+++ b/cliv2/internal/utils/array.go
@@ -51,3 +51,15 @@ func ToSlice(input map[string]string, combineBy string) []string {
 
 	return result
 }
+
+func RemoveEmptyValue(input map[string]string) map[string]string {
+	result := make(map[string]string)
+
+	for key, value := range input {
+		if len(value) > 0 {
+			result[key] = value
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
avoid accidental and purposeful redirecting of traffic between cliv1 and cliv2

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Based on the environment variables used on CLIv1 to determine proxy usage or not, this PR tries to ensure that these environment variables can't be specified to redirect traffic between CLIv1 and CLIv2.

See https://github.com/Rob--W/proxy-from-env/blob/master/index.js#L42

Normally whitelisting would be preferable but it might be more difficult to determine which environment variables are actually required. Missing out on any would cause subtle errors, difficult to track down, so blacklisting is used here for now.

Also no performance optimizations are applied following [Beware of Optimizations!](https://clean-code-developer.com/grades/grade-1-red/#Beware_of_Optimizations)

#### How should this be manually tested?
Run cliv2 and set the environment variable `NO_PROXY=*`, which would redirect all traffic and no traffic would pass the cliv2 internal proxy. 
