### PR TITLE
Chore/cliv2 case insensitive env vars

### DIFF
--- a/cliv2/internal/cliv2/cliv2.go
+++ b/cliv2/internal/cliv2/cliv2.go
@@ -37,6 +37,12 @@ const SNYK_INTEGRATION_NAME_ENV = "SNYK_INTEGRATION_NAME"
 const SNYK_INTEGRATION_VERSION_ENV = "SNYK_INTEGRATION_VERSION"
 const SNYK_HTTPS_PROXY_ENV = "HTTPS_PROXY"
 const SNYK_HTTP_PROXY_ENV = "HTTP_PROXY"
+const SNYK_HTTP_NO_PROXY_ENV = "NO_PROXY"
+const SNYK_NPM_PROXY_ENV = "NPM_CONFIG_PROXY"
+const SNYK_NPM_HTTPS_PROXY_ENV = "NPM_CONFIG_HTTPS_PROXY"
+const SNYK_NPM_HTTP_PROXY_ENV = "NPM_CONFIG_HTTP_PROXY"
+const SNYK_NPM_NO_PROXY_ENV = "NPM_CONFIG_NO_PROXY"
+const SNYK_NPM_ALL_PROXY = "ALL_PROXY"
 const SNYK_CA_CERTIFICATE_LOCATION_ENV = "NODE_EXTRA_CA_CERTS"
 
 const (
@@ -156,9 +162,29 @@ func PrepareV1EnvironmentVariables(input []string, integrationName string, integ
 	}
 
 	if err == nil {
+
+		// apply blacklist: ensure that no existing no_proxy or other configuration causes redirecting internal communication that is meant to stay between cliv1 and cliv2
+		blackList := []string{
+			SNYK_HTTPS_PROXY_ENV,
+			SNYK_HTTP_PROXY_ENV,
+			SNYK_CA_CERTIFICATE_LOCATION_ENV,
+			SNYK_HTTP_NO_PROXY_ENV,
+			SNYK_NPM_NO_PROXY_ENV,
+			SNYK_NPM_HTTPS_PROXY_ENV,
+			SNYK_NPM_HTTP_PROXY_ENV,
+			SNYK_NPM_PROXY_ENV,
+			SNYK_NPM_ALL_PROXY,
+		}
+
+		for _, key := range blackList {
+			inputAsMap = utils.Remove(inputAsMap, key)
+		}
+
+		// fill expected values
 		inputAsMap[SNYK_HTTPS_PROXY_ENV] = proxyAddress
 		inputAsMap[SNYK_HTTP_PROXY_ENV] = proxyAddress
 		inputAsMap[SNYK_CA_CERTIFICATE_LOCATION_ENV] = caCertificateLocation
+
 		result = utils.ToSlice(inputAsMap, "=")
 	}
 

--- a/cliv2/internal/utils/array.go
+++ b/cliv2/internal/utils/array.go
@@ -51,3 +51,37 @@ func ToSlice(input map[string]string, combineBy string) []string {
 
 	return result
 }
+
+// Removes a given key from the input map and uses FindKeyCaseInsensitive() for this. The resulting map is being returned.
+func Remove(input map[string]string, key string) map[string]string {
+	found := false
+	key, found = FindKeyCaseInsensitive(input, key)
+	if found {
+		delete(input, key)
+	}
+	return input
+}
+
+// This method determines whether the given key is in the input map, it therefore looks for the exact match and the key in all capital or lower case letters.
+// If the key in any of these versions was found, it'll be returned alongside with a boolean indicating whether or not it was found.
+func FindKeyCaseInsensitive(input map[string]string, key string) (string, bool) {
+
+	found := false
+
+	// look for exact match
+	_, found = input[key]
+
+	// look for lower case match
+	if !found {
+		key = strings.ToLower(key)
+		_, found = input[key]
+	}
+
+	// look for upper case match
+	if !found {
+		key = strings.ToUpper(key)
+		_, found = input[key]
+	}
+
+	return key, found
+}


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Some environment variables, especially around proxy configuration, can have either upper or lower case names. Most environments support this, like node and golang. This PR introduces the ability to also handle both cases of variables in CLIv2 when preparing the environment to launch CLIv1.

Example:
HTTP_PROXY = http_proxy

#### How should this be manually tested?
Using CLIv2 with either environment variable below, should behave the same.

HTTPS_PROXY=http://127.0.0.1:3128
https_proxy=http://127.0.0.1:3128

