### PR TITLE
chore: support blacklisting env variables in upper and lower case let…

### DIFF
--- a/cliv2/internal/cliv2/cliv2.go
+++ b/cliv2/internal/cliv2/cliv2.go
@@ -162,19 +162,29 @@ func PrepareV1EnvironmentVariables(input []string, integrationName string, integ
 	}
 
 	if err == nil {
+
+		// apply blacklist: ensure that no existing no_proxy or other configuration causes redirecting internal communication that is meant to stay between cliv1 and cliv2
+		blackList := []string{
+			SNYK_HTTPS_PROXY_ENV,
+			SNYK_HTTP_PROXY_ENV,
+			SNYK_CA_CERTIFICATE_LOCATION_ENV,
+			SNYK_HTTP_NO_PROXY_ENV,
+			SNYK_NPM_NO_PROXY_ENV,
+			SNYK_NPM_HTTPS_PROXY_ENV,
+			SNYK_NPM_HTTP_PROXY_ENV,
+			SNYK_NPM_PROXY_ENV,
+			SNYK_NPM_ALL_PROXY,
+		}
+
+		for _, key := range blackList {
+			inputAsMap = utils.Remove(inputAsMap, key)
+		}
+
+		// fill expected values
 		inputAsMap[SNYK_HTTPS_PROXY_ENV] = proxyAddress
 		inputAsMap[SNYK_HTTP_PROXY_ENV] = proxyAddress
 		inputAsMap[SNYK_CA_CERTIFICATE_LOCATION_ENV] = caCertificateLocation
 
-		// ensure that no existing no_proxy or other configuration causes redirecting internal communication that is meant to stay between cliv1 and cliv2
-		inputAsMap[SNYK_HTTP_NO_PROXY_ENV] = ""
-		inputAsMap[SNYK_NPM_NO_PROXY_ENV] = ""
-		inputAsMap[SNYK_NPM_HTTPS_PROXY_ENV] = ""
-		inputAsMap[SNYK_NPM_HTTP_PROXY_ENV] = ""
-		inputAsMap[SNYK_NPM_PROXY_ENV] = ""
-		inputAsMap[SNYK_NPM_ALL_PROXY] = ""
-
-		inputAsMap = utils.RemoveEmptyValue(inputAsMap)
 		result = utils.ToSlice(inputAsMap, "=")
 	}
 

--- a/cliv2/internal/cliv2/cliv2_test.go
+++ b/cliv2/internal/cliv2/cliv2_test.go
@@ -12,16 +12,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_PrepareV1EnvironmentVariables_Fill(t *testing.T) {
+func Test_PrepareV1EnvironmentVariables_Fill_and_Filter(t *testing.T) {
 
-	input := []string{"something=1",
+	input := []string{
+		"something=1",
 		"in=2",
 		"here=3=2",
-		"NO_PROXY=something",
+		"no_proxy=something",
 		"NPM_CONFIG_PROXY=something",
 		"NPM_CONFIG_HTTPS_PROXY=something",
 		"NPM_CONFIG_HTTP_PROXY=something",
-		"NPM_CONFIG_NO_PROXY=something",
+		"npm_config_no_proxy=something",
 		"ALL_PROXY=something",
 	}
 	expected := []string{"something=1", "in=2", "here=3=2", "SNYK_INTEGRATION_NAME=foo", "SNYK_INTEGRATION_VERSION=bar", "HTTP_PROXY=proxy", "HTTPS_PROXY=proxy", "NODE_EXTRA_CA_CERTS=cacertlocation"}
@@ -34,10 +35,10 @@ func Test_PrepareV1EnvironmentVariables_Fill(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func Test_PrepareV1EnvironmentVariables_DontOverrideExisting(t *testing.T) {
+func Test_PrepareV1EnvironmentVariables_DontOverrideExistingIntegration(t *testing.T) {
 
-	input := []string{"something=1", "in=2", "here=3", "SNYK_INTEGRATION_NAME=exists", "SNYK_INTEGRATION_VERSION=already", "HTTP_PROXY=proxy", "HTTPS_PROXY=proxy", "NODE_EXTRA_CA_CERTS=cacertlocation"}
-	expected := input
+	input := []string{"something=1", "in=2", "here=3", "SNYK_INTEGRATION_NAME=exists", "SNYK_INTEGRATION_VERSION=already"}
+	expected := []string{"something=1", "in=2", "here=3", "SNYK_INTEGRATION_NAME=exists", "SNYK_INTEGRATION_VERSION=already", "HTTP_PROXY=proxy", "HTTPS_PROXY=proxy", "NODE_EXTRA_CA_CERTS=cacertlocation"}
 
 	actual, err := cliv2.PrepareV1EnvironmentVariables(input, "foo", "bar", "proxy", "cacertlocation")
 
@@ -47,7 +48,20 @@ func Test_PrepareV1EnvironmentVariables_DontOverrideExisting(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func Test_PrepareV1EnvironmentVariables_DontOverrideExisting2(t *testing.T) {
+func Test_PrepareV1EnvironmentVariables_OverrideProxyAndCerts(t *testing.T) {
+
+	input := []string{"something=1", "in=2", "here=3", "http_proxy=exists", "https_proxy=already", "NODE_EXTRA_CA_CERTS=again", "no_proxy=312123"}
+	expected := []string{"something=1", "in=2", "here=3", "SNYK_INTEGRATION_NAME=foo", "SNYK_INTEGRATION_VERSION=bar", "HTTP_PROXY=proxy", "HTTPS_PROXY=proxy", "NODE_EXTRA_CA_CERTS=cacertlocation"}
+
+	actual, err := cliv2.PrepareV1EnvironmentVariables(input, "foo", "bar", "proxy", "cacertlocation")
+
+	sort.Strings(expected)
+	sort.Strings(actual)
+	assert.Equal(t, expected, actual)
+	assert.Nil(t, err)
+}
+
+func Test_PrepareV1EnvironmentVariables_Fail_DontOverrideExisting(t *testing.T) {
 
 	input := []string{"something=1", "in=2", "here=3", "SNYK_INTEGRATION_NAME=exists"}
 	expected := input

--- a/cliv2/internal/utils/array.go
+++ b/cliv2/internal/utils/array.go
@@ -52,14 +52,36 @@ func ToSlice(input map[string]string, combineBy string) []string {
 	return result
 }
 
-func RemoveEmptyValue(input map[string]string) map[string]string {
-	result := make(map[string]string)
+// Removes a given key from the input map and uses FindKeyCaseInsensitive() for this. The resulting map is being returned.
+func Remove(input map[string]string, key string) map[string]string {
+	found := false
+	key, found = FindKeyCaseInsensitive(input, key)
+	if found {
+		delete(input, key)
+	}
+	return input
+}
 
-	for key, value := range input {
-		if len(value) > 0 {
-			result[key] = value
-		}
+// This method determines whether the given key is in the input map, it therefore looks for the exact match and the key in all capital or lower case letters.
+// If the key in any of these versions was found, it'll be returned alongside with a boolean indicating whether or not it was found.
+func FindKeyCaseInsensitive(input map[string]string, key string) (string, bool) {
+
+	found := false
+
+	// look for exact match
+	_, found = input[key]
+
+	// look for lower case match
+	if !found {
+		key = strings.ToLower(key)
+		_, found = input[key]
 	}
 
-	return result
+	// look for upper case match
+	if !found {
+		key = strings.ToUpper(key)
+		_, found = input[key]
+	}
+
+	return key, found
 }


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Some environment variables, especially around proxy configuration, can have either upper or lower case names. Most environments support this, like node and golang. This PR introduces the ability to also handle both cases of variables in CLIv2 when preparing the environment to launch CLIv1.

Example:
HTTP_PROXY = http_proxy

#### How should this be manually tested?
Using CLIv2 with either environment variable below, should behave the same.

HTTPS_PROXY=http://127.0.0.1:3128
https_proxy=http://127.0.0.1:3128
