### PR TITLE
fix: wrong dependencyCount in support of snyk-to-html

### DIFF
--- a/src/lib/ecosystems/resolve-test-facts.ts
+++ b/src/lib/ecosystems/resolve-test-facts.ts
@@ -62,7 +62,11 @@ export async function resolveAndTestFacts(
           vulnerabilities.push(issueData);
         }
 
-        const dependencyCount = response.issues.length;
+        const dependencyCount = response?.depGraphData?.graph?.nodes?.find(
+          (graphNode) => {
+            return graphNode.nodeId === 'root-node';
+          },
+        )?.deps?.length;
 
         results.push({
           issues,

--- a/test/jest/unit/lib/ecosystems/resolve-test-facts.spec.ts
+++ b/test/jest/unit/lib/ecosystems/resolve-test-facts.spec.ts
@@ -110,7 +110,7 @@ describe('resolve and test facts', () => {
       fileSignaturesDetails: {},
       vulnerabilities: [],
       path: 'path',
-      dependencyCount: 0,
+      dependencyCount: 1,
       packageManager: 'Unmanaged (C/C++)',
     });
 
@@ -144,7 +144,7 @@ describe('resolve and test facts', () => {
         fileSignaturesDetails: {},
         vulnerabilities: [],
         path: 'path',
-        dependencyCount: 0,
+        dependencyCount: 1,
         packageManager: 'Unmanaged (C/C++)',
       },
     ]);


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Fix wrong dependencyCount value in support of snyk-to-html

#### Where should the reviewer start?

https://github.com/snyk/snyk-to-html/blob/master/README.md

#### How should this be manually tested?

Run the following commands in the folder of unmanaged project/repo:

to create vulnerability test for unmanaged project/repo:
path_to_git/cli/bin/snyk test --json --unmanaged | path_to_git/snyk-to-html/dist/index.js -o result.json
to build HTML report of received test resluts:
path_to_git/snyk-to-html/dist/index.js -i result.json -o result.html

#### What are the relevant tickets?

[Jira ticket TUN-27](https://snyksec.atlassian.net/browse/TUN-27)

