### PR TITLE
fix: reduce default snyk-gradle-plugin logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "snyk-cpp-plugin": "2.20.0",
         "snyk-docker-plugin": "^4.38.0",
         "snyk-go-plugin": "1.19.0",
-        "snyk-gradle-plugin": "3.20.0",
+        "snyk-gradle-plugin": "3.20.2",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.29.7",
         "snyk-nodejs-lockfile-parser": "1.38.0",
@@ -16582,11 +16582,11 @@
       }
     },
     "node_modules/snyk-gradle-plugin": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.20.0.tgz",
-      "integrity": "sha512-3J2yEw6xBO7xupwCtdNlFn7XBbGKYPGesP1kdDHnNDi60OnLzhQgglMQqyWLgk/U2/RZ7Vw1XS66nWv3wt65Iw==",
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.20.2.tgz",
+      "integrity": "sha512-NI2ULqQGO4pYD2oLgv9RO8WtaQCyra9UXOgDYikq9x8LMlHvRhzLDN83i1tyclFQopSpA0xN1HXEaZQmCbA6dQ==",
       "dependencies": {
-        "@snyk/cli-interface": "2.11.0",
+        "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/java-call-graph-builder": "1.23.6",
         "@types/debug": "^4.1.4",
@@ -16597,6 +16597,17 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/snyk-gradle-plugin/node_modules/@snyk/cli-interface": {
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-2.11.3.tgz",
+      "integrity": "sha512-VQa8nKGQj+gJnRWXzOd5wzinXEjvA/Yna6I34lV2hiTRKA/quttWyzr6AH9KhSovd/4SflUYbu6EKuattrAEMw==",
+      "dependencies": {
+        "@types/graphlib": "^2"
+      },
+      "peerDependencies": {
+        "@snyk/dep-graph": "^1"
       }
     },
     "node_modules/snyk-gradle-plugin/node_modules/ansi-styles": {
@@ -32765,11 +32776,11 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.20.0.tgz",
-      "integrity": "sha512-3J2yEw6xBO7xupwCtdNlFn7XBbGKYPGesP1kdDHnNDi60OnLzhQgglMQqyWLgk/U2/RZ7Vw1XS66nWv3wt65Iw==",
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.20.2.tgz",
+      "integrity": "sha512-NI2ULqQGO4pYD2oLgv9RO8WtaQCyra9UXOgDYikq9x8LMlHvRhzLDN83i1tyclFQopSpA0xN1HXEaZQmCbA6dQ==",
       "requires": {
-        "@snyk/cli-interface": "2.11.0",
+        "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/java-call-graph-builder": "1.23.6",
         "@types/debug": "^4.1.4",
@@ -32779,6 +32790,14 @@
         "tslib": "^2.0.0"
       },
       "dependencies": {
+        "@snyk/cli-interface": {
+          "version": "2.11.3",
+          "resolved": "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-2.11.3.tgz",
+          "integrity": "sha512-VQa8nKGQj+gJnRWXzOd5wzinXEjvA/Yna6I34lV2hiTRKA/quttWyzr6AH9KhSovd/4SflUYbu6EKuattrAEMw==",
+          "requires": {
+            "@types/graphlib": "^2"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "snyk-cpp-plugin": "2.20.0",
     "snyk-docker-plugin": "^4.38.0",
     "snyk-go-plugin": "1.19.0",
-    "snyk-gradle-plugin": "3.20.0",
+    "snyk-gradle-plugin": "3.20.2",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.29.7",
     "snyk-nodejs-lockfile-parser": "1.38.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This PR bumps the snyk-gradle-plugin version to include a change that reduces the amount of logging coming from the Gradle sub-process. Most of the logs are now only visible in debug mode.

#### Any background context you want to provide?
Several customers are seeing rangeErrors when max string length is exceeded due to excessive logging. Reducing default logging should help.

#### What are the relevant tickets?
[TARDIS-994](https://snyksec.atlassian.net/browse/TARDIS-994)
