### PR TITLE
chore: improve the discoverability of the --report flag

### DIFF
--- a/src/cli/commands/test/iac/index.ts
+++ b/src/cli/commands/test/iac/index.ts
@@ -30,9 +30,18 @@ export default async function(...args: MethodArgs): Promise<TestCommandResult> {
 
   const buildOciRegistry = () => buildDefaultOciRegistry(iacOrgSettings);
 
-  const isNewIacOutputSupported =
+  const isNewIacOutputSupported = Boolean(
     config.IAC_OUTPUT_V2 ||
-    (await hasFeatureFlag('iacCliOutputRelease', options));
+      (await hasFeatureFlag('iacCliOutputRelease', options)),
+  );
+
+  const isIacShareCliResultsCustomRulesSupported = Boolean(
+    await hasFeatureFlag('iacShareCliResultsCustomRules', options),
+  );
+
+  const isIacCustomRulesEntitlementEnabled = Boolean(
+    iacOrgSettings.entitlements?.iacCustomRulesEntitlement,
+  );
 
   const testSpinner = buildSpinner({
     options,
@@ -64,6 +73,8 @@ export default async function(...args: MethodArgs): Promise<TestCommandResult> {
     results,
     options,
     isNewIacOutputSupported,
+    isIacShareCliResultsCustomRulesSupported,
+    isIacCustomRulesEntitlementEnabled,
     iacOutputMeta,
     resultOptions,
     iacScanFailures,

--- a/src/lib/formatters/iac-output/v2/index.ts
+++ b/src/lib/formatters/iac-output/v2/index.ts
@@ -8,7 +8,11 @@ export {
   customRulesMessage,
   customRulesReportMessage,
 } from './user-messages';
-export { formatShareResultsOutput } from './share-results';
+export {
+  formatShareResultsOutput,
+  shareResultsTip,
+  shareCustomRulesDisclaimer,
+} from './share-results';
 export {
   formatIacTestFailures,
   formatFailuresList,

--- a/src/lib/formatters/iac-output/v2/share-results.ts
+++ b/src/lib/formatters/iac-output/v2/share-results.ts
@@ -1,7 +1,43 @@
 import { IacOutputMeta } from '../../../types';
-import { shareResultsOutput } from '../v1';
-import { colors } from './utils';
+import config from '../../../config';
+import { EOL } from 'os';
+import { colors, contentPadding } from './utils';
 
-export function formatShareResultsOutput(outputMeta: IacOutputMeta) {
-  return colors.info.bold(shareResultsOutput(outputMeta));
+export function formatShareResultsOutput(iacOutputMeta: IacOutputMeta) {
+  let projectName: string = iacOutputMeta.projectName;
+
+  if (iacOutputMeta.gitRemoteUrl) {
+    // from "http://github.com/snyk/cli.git" to "snyk/cli"
+    projectName = iacOutputMeta.gitRemoteUrl.replace(
+      /^https?:\/\/github.com\/(.*)\.git$/,
+      '$1',
+    );
+  }
+
+  return (
+    colors.title('Report Complete') +
+    EOL +
+    EOL +
+    contentPadding +
+    'Your test results are available at: ' +
+    colors.title(`${config.ROOT}/org/${iacOutputMeta.orgName}/project`) +
+    EOL +
+    contentPadding +
+    'under the name: ' +
+    colors.title(projectName)
+  );
 }
+
+export const shareResultsTip =
+  colors.title('Tip') +
+  EOL +
+  EOL +
+  contentPadding +
+  'New: Share your test results in the Snyk Web UI with the option ' +
+  colors.title('--report');
+
+export const shareCustomRulesDisclaimer =
+  contentPadding +
+  colors.suggestion(
+    'Please note that your custom rules will not be sent to the platform, and will not be available on the projects page.',
+  );

--- a/src/lib/formatters/iac-output/v2/utils.ts
+++ b/src/lib/formatters/iac-output/v2/utils.ts
@@ -7,6 +7,7 @@ interface IacOutputColors {
   success: Chalk;
   info: Chalk;
   title: Chalk;
+  suggestion: Chalk;
 }
 
 type SeverityColor = {
@@ -24,6 +25,7 @@ export const colors: IacOutputColors = {
   success: chalk.green,
   info: chalk.white,
   title: chalk.white.bold,
+  suggestion: chalk.gray,
 };
 
 export const contentPadding = ' '.repeat(2);

--- a/test/jest/unit/lib/formatters/iac-output/v2/share-results.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/share-results.spec.ts
@@ -1,6 +1,10 @@
+import { EOL } from 'os';
 import config from '../../../../../../../src/lib/config';
 import { formatShareResultsOutput } from '../../../../../../../src/lib/formatters/iac-output';
-import { colors } from '../../../../../../../src/lib/formatters/iac-output/v2/utils';
+import {
+  colors,
+  contentPadding,
+} from '../../../../../../../src/lib/formatters/iac-output/v2/utils';
 
 describe('formatShareResultsOutput', () => {
   it('returns the correct output', () => {
@@ -16,9 +20,16 @@ describe('formatShareResultsOutput', () => {
 
     // Assert
     expect(output).toEqual(
-      colors.info.bold(
-        `Your test results are available at: ${config.ROOT}/org/${testOrgName}/projects under the name ${testProjectName}`,
-      ),
+      colors.title('Report Complete') +
+        EOL +
+        EOL +
+        contentPadding +
+        'Your test results are available at: ' +
+        colors.title(`${config.ROOT}/org/${testOrgName}/project`) +
+        EOL +
+        contentPadding +
+        'under the name: ' +
+        colors.title(testProjectName),
     );
   });
 
@@ -39,9 +50,16 @@ describe('formatShareResultsOutput', () => {
 
       // Assert
       expect(output).toEqual(
-        colors.info.bold(
-          `Your test results are available at: ${config.ROOT}/org/${testOrgName}/projects under the name ${testRepoName}`,
-        ),
+        colors.title('Report Complete') +
+          EOL +
+          EOL +
+          contentPadding +
+          'Your test results are available at: ' +
+          colors.title(`${config.ROOT}/org/${testOrgName}/project`) +
+          EOL +
+          contentPadding +
+          'under the name: ' +
+          colors.title(testRepoName),
       );
     });
   });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR improves the discoverability of the `--report` flag when used with the `iac test` command. In particular:

- It adds a suggestion to use the `--report` flag is the user doesn't specify it.
- It improves the message the user receives when he uses `--report`.
- It adds a suggestion regarding sharing of custom rules.

#### How should this be manually tested?

Run the command without the `--report` flag. You will se a tip at the end of the output.

![image](https://user-images.githubusercontent.com/404227/175546102-c7e50853-32f0-4505-9cd2-1b6ecee9f401.png)

Run the command with the `--report` flag. You will see an improved message about the location of the shared results.

![image](https://user-images.githubusercontent.com/404227/175546200-11cad856-4e35-4041-96bf-fc270a699e1c.png)

Run the command with the `--report` flag and with a custom rules bundle. If you have the `iacCustomRulesEntitlement` entitlement, but you don't have the `iacShareCliResultsCustomRules` feature flag, you will see a message in the share results section:

![image](https://user-images.githubusercontent.com/404227/175546759-9ca1d93b-e401-4369-9623-ea37f6c97898.png)

#### What are the relevant tickets?

[CFG-1837](https://snyksec.atlassian.net/browse/CFG-1837)