### PR TITLE
fix: sarif output for iac

### DIFF
--- a/src/cli/commands/test/iac/output.ts
+++ b/src/cli/commands/test/iac/output.ts
@@ -149,7 +149,7 @@ export function buildOutput({
       err.jsonNoVulns = dataToSendNoVulns;
     }
 
-    if (hasErrors) {
+    if (hasErrors && !options.sarif) {
       // Take the code of the first problem to go through error
       // translation.
       // Note: this is done based on the logic done below

--- a/test/jest/acceptance/iac/test-directory.spec.ts
+++ b/test/jest/acceptance/iac/test-directory.spec.ts
@@ -173,17 +173,15 @@ describe('Directory scan', () => {
       expect(exitCode).toBe(3);
     });
 
-    // document the existing bug to fix, when one path fails entirely, sarif fails with:
-    // An unknown error occurred. Please run with `-d` and include full trace when reporting to Snyk
-    it.skip('outputs issues and errors when one of the paths fails, with --sarif flag', async () => {
+    it('filters out errors when one of the paths fails, with --sarif flag', async () => {
       const { stdout, exitCode } = await run(
         `snyk iac test ./iac/arm non-existing-dir --sarif`,
       );
       expect(isValidJSONString(stdout)).toBe(true);
-      expect(stdout).toContain('"results"');
-      expect(stdout).toContain('"ok": false');
-      expect(stdout).toContain('"error": "Could not find any valid IaC files"');
-      expect(stdout).toContain('"path": "non-existing-dir"');
+      expect(stdout).not.toContain(
+        '"error": "Could not find any valid IaC files"',
+      );
+      expect(stdout).not.toContain('"path": "non-existing-dir"');
       expect(exitCode).toBe(1);
     });
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR makes sure that we don't throw an unexpected error when a user provided an invalid path with the `--sarif` flag.

#### How should this be manually tested?

1. `npm run build`
2. `snyk-dev iac test not-existing-directory`
3. `snyk-dev iac test not-existing-directory --sarif`
4. `snyk-dev iac test not-existing-directory test/fixtures/iac/terraform/sg_open_ssh.tf --sarif`
#### Any background context you want to provide?
- When the `--json` flag is provided, we can include errors in the output because the CLI is configured to print them nicely: https://github.com/snyk/cli/blob/7f12b86b1bfb6a03acadf9e545f73fc9870c3e6e/src/cli/main.ts#L115
- For `--sarif`, we throw the legacy "unsupported error" mentioned in the ticket
- Since SARIF is usually used with GitHub, to show vulnerabilities in files, it makes sense to not output errors

In [this thread](https://snyk.slack.com/archives/C1NREQSG0/p1656086883770159), we discover that the CLI doesn't treat errors correctly for SARIF. In order to implement that we'd need to investigate the SARIF structure a bit more, so I've raised https://snyksec.atlassian.net/browse/CFG-2010 to deal with that.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CFG-2003

#### Screenshots
![Screenshot 2022-06-24 at 17 04 17](https://user-images.githubusercontent.com/81559517/175574006-35f00732-30b6-42b6-92b1-8bf773810098.png)
![Screenshot 2022-06-24 at 17 03 37](https://user-images.githubusercontent.com/81559517/175574016-8d5fade8-0e8e-4754-b11f-e9feb853018b.png)

![Screenshot 2022-06-24 at 17 03 59](https://user-images.githubusercontent.com/81559517/175574012-9ed4332c-2771-4c4b-aafc-c4ba57613907.png)