### PR TITLE
fix: isArchive()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@snyk/snyk-cocoapods-plugin": "2.5.2",
         "@snyk/snyk-hex-plugin": "1.1.4",
         "@types/marked": "^4.0.0",
-        "@types/tar": "^6.1.1",
         "abbrev": "^1.1.1",
         "adm-zip": "^0.5.9",
         "ansi-escapes": "3.2.0",
@@ -2698,14 +2697,6 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
     },
-    "node_modules/@types/minipass": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@types/minipass/-/minipass-3.1.2.tgz",
-      "integrity": "sha512-foLGjgrJkUjLG/o2t2ymlZGEoBNBa/TfoUZ7oCTkOjP1T43UGBJspovJou/l3ZuHvye2ewR5cZNtp2zyWgILMA==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/ms": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
@@ -2794,15 +2785,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
-    },
-    "node_modules/@types/tar": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.1.tgz",
-      "integrity": "sha512-8mto3YZfVpqB1CHMaYz1TUYIQfZFbh/QbEq5Hsn6D0ilCfqRVCdalmc89B7vi3jhl9UYIk+dWDABShNfOkv5HA==",
-      "dependencies": {
-        "@types/minipass": "*",
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/treeify": {
       "version": "1.0.0",
@@ -22064,14 +22046,6 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
     },
-    "@types/minipass": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@types/minipass/-/minipass-3.1.2.tgz",
-      "integrity": "sha512-foLGjgrJkUjLG/o2t2ymlZGEoBNBa/TfoUZ7oCTkOjP1T43UGBJspovJou/l3ZuHvye2ewR5cZNtp2zyWgILMA==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/ms": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
@@ -22160,15 +22134,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
-    },
-    "@types/tar": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.1.tgz",
-      "integrity": "sha512-8mto3YZfVpqB1CHMaYz1TUYIQfZFbh/QbEq5Hsn6D0ilCfqRVCdalmc89B7vi3jhl9UYIk+dWDABShNfOkv5HA==",
-      "requires": {
-        "@types/minipass": "*",
-        "@types/node": "*"
-      }
     },
     "@types/treeify": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "@snyk/snyk-cocoapods-plugin": "2.5.2",
     "@snyk/snyk-hex-plugin": "1.1.4",
     "@types/marked": "^4.0.0",
-    "@types/tar": "^6.1.1",
     "abbrev": "^1.1.1",
     "adm-zip": "^0.5.9",
     "ansi-escapes": "3.2.0",

--- a/src/lib/iac/file-utils.ts
+++ b/src/lib/iac/file-utils.ts
@@ -38,7 +38,7 @@ export async function isFile(path: string): Promise<boolean> {
 export async function isArchive(path: string): Promise<boolean> {
   try {
     const tarList = promisify(tar.list);
-    await tarList({ file: path, strict: true, sync: true }, undefined);
+    await tarList({ file: path, strict: true });
     return true;
   } catch (e) {
     return false;


### PR DESCRIPTION
#### What does this PR do?
In https://github.com/snyk/cli/pull/3347 we refactored the `isArchive` function and used `promisify` to make the function async.
In addition to that, we've started to use a new types package named `@types/tar` that added types support of the `tar` package that is being used in the `isArchive` function.

When testing the refactored functionality we found a bug that we didn't catch when working on the PR, the function threw the following error:
```
TypeError: callback not supported for sync tar functions
```
The cause of the error is the `sync: true` option that we used in the function `tar.list`, `promisfy` couldn't use the callback functionality of the function when it was being run as a sync function.
The problem was that the `@types/tar` package didn't let us run the function without this option and when looking at the type itself it looked like the `sync: true` option was being added automatically.

At this point, we understood that the `@types/tar` package doesn't match the version of the `tar` package that we are using, we've tried to uninstall it and run the function without `sync: true` in the function and it fixed the error.

#### Screenshots
<img width="1130" alt="image" src="https://user-images.githubusercontent.com/71096571/175896673-0afa9ca1-1dec-44fc-9875-d49057f6f822.png">

