### PR TITLE
Improve API URL configuration behavior

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -1,6 +1,4 @@
 {
-  "API": "https://snyk.io/api/v1",
-  "API_REST_URL": "https://api.snyk.io/rest",
   "devDeps": false,
   "PRUNE_DEPS_THRESHOLD": 40000,
   "MAX_PATH_COUNT": 1500000,

--- a/src/lib/code-config.ts
+++ b/src/lib/code-config.ts
@@ -6,7 +6,7 @@ export function getCodeClientProxyUrl() {
   const domain = url.origin;
   return (
     config.CODE_CLIENT_PROXY_URL ||
-    domain.replace(/\/\/(app\.)?/, '//deeproxy.')
+    domain.replace(/\/\/(ap[pi]\.)?/, '//deeproxy.')
   );
 }
 

--- a/src/lib/config/api-url.ts
+++ b/src/lib/config/api-url.ts
@@ -1,0 +1,174 @@
+/*
+  This file is trying to make sense from different Snyk API URLs configurations
+
+  API URL settings could be defined in a few ways:
+  - snyk config file with key "endpoint" (including override with SNYK_CFG_ENDPOINT envvar!)
+  - SNYK_API envvar
+  - Snyk REST API had their own envvars to be set
+
+  And API URL itself could (currently) point to multiple places
+  - https://snyk.io/api/v1 (old default)
+  - https://snyk.io/api
+  - https://app.snyk.io/api
+  - https://app.snyk.io/api/v1
+  - https://api.snyk.io/v1
+
+  For Snyk REST API it's a bit simpler:
+  - https://api.snyk.io/rest
+
+
+  There are also other URLs - one for the snyk auth command, one for Snyk Code Proxy
+
+  Idea is to configure a single URL and derive the rest from it.
+  This file handles an internal concept of a Base URL and logic needed to derive the other URLs
+  In a backwards compatible way.
+*/
+
+import * as path from 'path';
+import * as Debug from 'debug';
+import { color } from '../theme';
+
+const debug = Debug('snyk');
+
+/**
+ * @description Get a Base URL for Snyk APIs
+ * @export
+ * @param {string} defaultUrl URL to default to, should be the one defined in the config.default.json file
+ * @param {(string | undefined)} envvarDefinedApiUrl if there is an URL defined in the SNYK_API envvar
+ * @param {(string | undefined)} configDefinedApiUrl if there is an URL defined in the 'endpoint' key of the config
+ * @returns {string} Returns a Base URL - without the /v1. Use this to construct derived URLs
+ */
+export function getBaseApiUrl(
+  defaultUrl: string,
+  envvarDefinedApiUrl?: string,
+  configDefinedApiUrl?: string,
+): string {
+  const defaultBaseApiUrl = stripV1FromApiUrl(defaultUrl);
+  // Use SNYK_API envvar by default
+  if (envvarDefinedApiUrl) {
+    return validateUrlOrReturnDefault(
+      envvarDefinedApiUrl,
+      "'SNYK_API' environment variable",
+      defaultBaseApiUrl,
+    );
+  }
+
+  if (configDefinedApiUrl) {
+    return validateUrlOrReturnDefault(
+      configDefinedApiUrl,
+      "'endpoint' config option. See 'snyk config' command. The value of 'endpoint' is currently set as",
+      defaultBaseApiUrl,
+    );
+  }
+
+  return defaultBaseApiUrl; // Fallback to default
+}
+
+/**
+ * @description Macro to validate user-defined URL and fallback to default if needed
+ * @param {string} urlString "dirty" user defined string coming from config, envvar or a flag
+ * @param {string} optionName For formatting error messages
+ * @param {string} defaultUrl What to return if urlString does not pass
+ * @returns {string}
+ */
+function validateUrlOrReturnDefault(
+  urlString: string,
+  optionName: string,
+  defaultUrl: string,
+): string {
+  const parsedEndpoint = parseURLWithoutThrowing(urlString);
+  // Endpoint option must be a valid URL including protocol
+  if (!parsedEndpoint || !parsedEndpoint.protocol || !parsedEndpoint.host) {
+    console.error(
+      color.status.error(
+        `Invalid ${optionName} '${urlString}'. Value must be a valid URL including protocol. Using default Snyk API URL '${defaultUrl}'`,
+      ),
+    );
+    return defaultUrl;
+  }
+  // TODO: this debug is not printed when using the --debug flag, because flags are parsed after config. Making it async works around this
+  setTimeout(
+    () => debug(`Using a custom Snyk API ${optionName} '${urlString}'`),
+    1,
+  );
+  return stripV1FromApiUrl(urlString);
+}
+
+function parseURLWithoutThrowing(urlString: string): URL | undefined {
+  try {
+    return new URL(urlString);
+  } catch (error) {
+    return undefined;
+  }
+}
+
+/**
+ * @description Removes /v1 suffix from URL if present
+ * @param {string} url
+ * @returns {string}
+ */
+function stripV1FromApiUrl(url: string): string {
+  const parsedUrl = new URL(url);
+  if (/\/v1\/?$/.test(parsedUrl.pathname)) {
+    parsedUrl.pathname = parsedUrl.pathname.replace(/\/v1\/?$/, '/');
+    return parsedUrl.toString();
+  }
+  return url;
+}
+
+export function getV1ApiUrl(baseApiUrl: string): string {
+  const parsedBaseUrl = new URL(baseApiUrl);
+  parsedBaseUrl.pathname = path.join(parsedBaseUrl.pathname, 'v1');
+  return parsedBaseUrl.toString();
+}
+
+/**
+ * @description Return Snyk REST API URL
+ * @export
+ * @param {string} baseApiUrl
+ * @param {string} envvarDefinedRestApiUrl
+ * @param {string} envvarDefinedRestV3Url
+ * @returns {string}
+ */
+export function getRestApiUrl(
+  baseApiUrl: string,
+  envvarDefinedRestApiUrl?: string,
+  envvarDefinedRestV3Url?: string,
+): string {
+  // REST API URL should always look like this: https://api.$DOMAIN/rest
+  const parsedBaseUrl = new URL(baseApiUrl);
+  parsedBaseUrl.pathname = '/rest';
+
+  if (parsedBaseUrl.host?.startsWith('app.')) {
+    // Rewrite app.snyk.io/ to api.snyk.io/rest
+    parsedBaseUrl.host = parsedBaseUrl.host.replace(/^app\./, 'api.');
+  } else if (
+    // Ignore localhosts and URLs with api. already defined
+    !parsedBaseUrl.host?.startsWith('localhost') &&
+    !parsedBaseUrl.host?.startsWith('api.')
+  ) {
+    // Otherwise add the api. subdomain
+    parsedBaseUrl.host = 'api.' + parsedBaseUrl.host;
+  }
+
+  const defaultRestApiUrl = parsedBaseUrl.toString();
+
+  // TODO: notify users they can set just the (SNYK_)API envvar
+  if (envvarDefinedRestV3Url) {
+    return validateUrlOrReturnDefault(
+      envvarDefinedRestV3Url,
+      "'SNYK_API_V3_URL' environment variable",
+      defaultRestApiUrl,
+    );
+  }
+
+  if (envvarDefinedRestApiUrl) {
+    return validateUrlOrReturnDefault(
+      envvarDefinedRestApiUrl,
+      "'SNYK_API_REST_URL' environment variable",
+      defaultRestApiUrl,
+    );
+  }
+
+  return defaultRestApiUrl; // Fallback to default
+}

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -1,6 +1,6 @@
 import * as snykConfig from 'snyk-config';
-import { config as userConfig } from './user-config';
-import * as url from 'url';
+import { config as userConfig } from '../user-config';
+import { getBaseApiUrl, getRestApiUrl, getV1ApiUrl } from './api-url';
 
 const DEFAULT_TIMEOUT = 5 * 60; // in seconds
 interface Config {
@@ -31,23 +31,24 @@ interface Config {
 const config = (snykConfig.loadConfig(
   __dirname + '/../..',
 ) as unknown) as Config;
+const defaultApiUrl = 'https://api.snyk.io';
 
-// allow user config override of the API endpoint
-const endpoint = userConfig.get('endpoint');
-if (endpoint && endpoint !== config.API) {
-  const parsedEndpoint = url.parse(endpoint);
-  // Endpoint option must be a valid URL including protocol
-  if (!parsedEndpoint || !parsedEndpoint.protocol || !parsedEndpoint.host) {
-    console.warn(
-      "Invalid 'endpoint' config option. Endpoint must be a full and valid URL including protocol and for Snyk.io it should contain path to '/api'",
-    );
-  }
-  console.warn(
-    'Using a custom API endpoint from `snyk config` (tip: it should contain path to `/api`):',
-    endpoint,
-  );
-  config.API = endpoint;
-}
+const configDefinedApiUrl = userConfig.get('endpoint');
+const envvarDefinedApiUrl = process.env.SNYK_API;
+
+const snykApiBaseUrl = getBaseApiUrl(
+  defaultApiUrl,
+  envvarDefinedApiUrl,
+  configDefinedApiUrl,
+);
+config.API = getV1ApiUrl(snykApiBaseUrl);
+
+// API_V3_URL is deprecated, but maintaining backwards compatibility
+config.API_REST_URL = getRestApiUrl(
+  snykApiBaseUrl,
+  process.env.API_REST_URL || config.API_REST_URL,
+  process.env.API_V3_URL || config.API_V3_URL,
+);
 
 const disableSuggestions = userConfig.get('disableSuggestions');
 if (disableSuggestions) {
@@ -70,13 +71,9 @@ if (!config.timeout) {
 // this is a bit of an assumption that our web site origin is the same
 // as our API origin, but for now it's okay - RS 2015-10-16
 if (!config.ROOT) {
-  const apiUrl = url.parse(config.API);
+  const apiUrl = new URL(config.API);
+  apiUrl.host = apiUrl.host.replace(/^ap[pi]\./, '');
   config.ROOT = apiUrl.protocol + '//' + apiUrl.host;
-}
-
-// maintain backwards compatibility with older name
-if (config.API_V3_URL) {
-  config.API_REST_URL = config.API_V3_URL;
 }
 
 export default config;

--- a/test/jest/acceptance/snyk-config/snyk-config-endpoint.spec.ts
+++ b/test/jest/acceptance/snyk-config/snyk-config-endpoint.spec.ts
@@ -21,6 +21,7 @@ describe('snyk config endpoint', () => {
       cwd: project.path(),
       env: {
         ...process.env,
+        SNYK_API: undefined,
         SNYK_DISABLE_ANALYTICS: '1',
         XDG_CONFIG_HOME: project.path(),
       },
@@ -41,7 +42,7 @@ describe('snyk config endpoint', () => {
         `config get endpoint`,
         runOptions,
       );
-      expect(stderr).toContain("Invalid 'endpoint' config option.");
+      expect(stderr).toContain("Invalid 'endpoint' config option");
       expect(stdout).toEqual(invalidEndpoint + '\n');
       expect(code).toEqual(0);
     }
@@ -55,7 +56,7 @@ describe('snyk config endpoint', () => {
        *  Error will still be logged as we still validate the pre-existing
        *  invalid value before executing commands.
        */
-      expect(stderr).toContain("Invalid 'endpoint' config option.");
+      expect(stderr).toContain("Invalid 'endpoint' config option");
       expect(stdout).toContain('endpoint updated');
       expect(code).toEqual(0);
     }
@@ -65,7 +66,7 @@ describe('snyk config endpoint', () => {
         `config get endpoint`,
         runOptions,
       );
-      expect(stderr).not.toContain("Invalid 'endpoint' config option.");
+      expect(stderr).not.toContain("Invalid 'endpoint' config option");
       expect(stdout).toEqual(validEndpoint + '\n');
       expect(code).toEqual(0);
     }

--- a/test/jest/unit/config/api-url.spec.ts
+++ b/test/jest/unit/config/api-url.spec.ts
@@ -1,0 +1,155 @@
+import {
+  getBaseApiUrl,
+  getV1ApiUrl,
+  getRestApiUrl,
+} from '../../../../src/lib/config/api-url';
+
+const urls = [
+  {
+    userInput: 'https://snyk.io/api/v1',
+    expectedBase: 'https://snyk.io/api/',
+    expectedV1: 'https://snyk.io/api/v1',
+    expectedRest: 'https://api.snyk.io/rest',
+  },
+  {
+    userInput: 'https://snyk.io/api',
+    expectedBase: 'https://snyk.io/api',
+    expectedV1: 'https://snyk.io/api/v1',
+    expectedRest: 'https://api.snyk.io/rest',
+  },
+  {
+    userInput: 'https://app.snyk.io/api',
+    expectedBase: 'https://app.snyk.io/api',
+    expectedV1: 'https://app.snyk.io/api/v1',
+    expectedRest: 'https://api.snyk.io/rest',
+  },
+  {
+    userInput: 'https://app.snyk.io/api/v1',
+    expectedBase: 'https://app.snyk.io/api/',
+    expectedV1: 'https://app.snyk.io/api/v1',
+    expectedRest: 'https://api.snyk.io/rest',
+  },
+  {
+    userInput: 'https://api.snyk.io/v1',
+    expectedBase: 'https://api.snyk.io/',
+    expectedV1: 'https://api.snyk.io/v1',
+    expectedRest: 'https://api.snyk.io/rest',
+  },
+  {
+    userInput: 'https://api.snyk.io',
+    expectedBase: 'https://api.snyk.io',
+    expectedV1: 'https://api.snyk.io/v1',
+    expectedRest: 'https://api.snyk.io/rest',
+  },
+  {
+    userInput: 'https://api.snyk.io/',
+    expectedBase: 'https://api.snyk.io/',
+    expectedV1: 'https://api.snyk.io/v1',
+    expectedRest: 'https://api.snyk.io/rest',
+  },
+  {
+    userInput: 'https://api.custom.snyk.io',
+    expectedBase: 'https://api.custom.snyk.io',
+    expectedV1: 'https://api.custom.snyk.io/v1',
+    expectedRest: 'https://api.custom.snyk.io/rest',
+  },
+  {
+    userInput: 'http://localhost:9000/',
+    expectedBase: 'http://localhost:9000/',
+    expectedV1: 'http://localhost:9000/v1',
+    expectedRest: 'http://localhost:9000/rest',
+  },
+  {
+    userInput: 'http://localhost:9000/api/v1',
+    expectedBase: 'http://localhost:9000/api/',
+    expectedV1: 'http://localhost:9000/api/v1',
+    expectedRest: 'http://localhost:9000/rest',
+  },
+  {
+    userInput: 'http://alpha:omega@localhost:9000',
+    expectedBase: 'http://alpha:omega@localhost:9000',
+    expectedV1: 'http://alpha:omega@localhost:9000/v1',
+    expectedRest: 'http://alpha:omega@localhost:9000/rest',
+  },
+  {
+    userInput: 'https://app.dev.snyk.io/api/v1',
+    expectedBase: 'https://app.dev.snyk.io/api/',
+    expectedV1: 'https://app.dev.snyk.io/api/v1',
+    expectedRest: 'https://api.dev.snyk.io/rest',
+  },
+];
+
+describe('CLI config - API URL', () => {
+  // TODO: check that console.error was called for error states?
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  describe('getBaseApiUrl', () => {
+    describe('when only default URL is defined', () => {
+      urls.forEach((url) => {
+        it(`returns default API URL ${url.userInput} without the v1 suffix`, () => {
+          expect(getBaseApiUrl(url.userInput)).toEqual(url.expectedBase);
+        });
+      });
+    });
+
+    it('returns envvar API if it is defined and valid', () => {
+      expect(
+        getBaseApiUrl('https://api.snyk.io/', 'http://localhost:9000/'),
+      ).toEqual('http://localhost:9000/');
+      expect(
+        getBaseApiUrl(
+          'https://api.snyk.io/',
+          'http://alpha:omega@localhost:9000/',
+          'https://endpoint-api.snyk.io/',
+        ),
+      ).toEqual('http://alpha:omega@localhost:9000/');
+    });
+
+    it('returns default API if envvar is defined but not valid', () => {
+      expect(getBaseApiUrl('https://api.snyk.io/', 'localhost:10')).toEqual(
+        'https://api.snyk.io/',
+      );
+    });
+
+    it('returns config API if it is defined and valid', () => {
+      expect(
+        getBaseApiUrl(
+          'https://api.snyk.io/',
+          undefined,
+          'http://localhost:9000/',
+        ),
+      ).toEqual('http://localhost:9000/');
+      expect(
+        getBaseApiUrl(
+          'https://api.snyk.io/',
+          undefined,
+          'http://alpha:omega@localhost:9000/',
+        ),
+      ).toEqual('http://alpha:omega@localhost:9000/');
+    });
+
+    it('returns default API if config endpoint is defined but not valid', () => {
+      expect(
+        getBaseApiUrl('https://api.snyk.io/', undefined, 'localhost:10'),
+      ).toEqual('https://api.snyk.io/');
+    });
+  });
+
+  describe('getV1ApiUrl', () => {
+    urls.forEach((url) => {
+      it(`returns V1 API URL ${url.expectedBase} with v1 path`, () => {
+        expect(getV1ApiUrl(url.expectedBase)).toEqual(url.expectedV1);
+      });
+    });
+  });
+
+  describe('getRestApiUrl', () => {
+    urls.forEach((url) => {
+      it(`returns REST API URL ${url.expectedBase}`, () => {
+        expect(getRestApiUrl(url.expectedBase)).toEqual(url.expectedRest);
+      });
+    });
+  });
+});

--- a/test/jest/unit/lib/endpoint-config-test.spec.ts
+++ b/test/jest/unit/lib/endpoint-config-test.spec.ts
@@ -20,6 +20,11 @@ describe('Testing deeproxy URL', () => {
     expect(codeConfig.getCodeClientProxyUrl()).toBe('https://deeproxy.snyk.io');
   });
 
+  test('uses api URL to determine deeproxy URL when provided with app. prefix', () => {
+    config.API = 'https://api.snyk.io/';
+    expect(codeConfig.getCodeClientProxyUrl()).toBe('https://deeproxy.snyk.io');
+  });
+
   test('uses a custom deeproxy endpoint when provided by SNYK_CODE_CLIENT_PROXY_URL environment', () => {
     config.CODE_CLIENT_PROXY_URL = 'https://deeproxy.custom.url.snyk.io';
     expect(codeConfig.getCodeClientProxyUrl()).toBe(

--- a/test/jest/unit/policy-display.spec.ts
+++ b/test/jest/unit/policy-display.spec.ts
@@ -2,11 +2,10 @@ import * as policy from 'snyk-policy';
 import * as fs from 'fs';
 import { display } from '../../../src/lib/display-policy';
 import stripAnsi from 'strip-ansi';
-import { URL } from 'url';
 import { getFixturePath } from '../util/getFixturePath';
+import config from '../../../src/lib/config';
 
-const SNYK_API = process.env.SNYK_API || 'https://snyk.io/api/v1';
-const { hostname } = new URL(SNYK_API);
+const { hostname } = new URL(config.ROOT);
 
 it('test sensibly bails if gets an old .snyk format', async () => {
   const filename = getFixturePath('snyk-config-no-version');

--- a/test/smoke/spec/spec_helper.sh
+++ b/test/smoke/spec/spec_helper.sh
@@ -21,7 +21,7 @@ spec_helper_configure() {
 
   verify_login_url() {
     # https://snyk.io/login?token=uuid-token&utm_medium=cli&utm_source=cli&utm_campaign=cli&os=darwin&docker=false
-    echo "$1" | grep https | grep -E "^https://(dev\.)?(test\.)?snyk\.io/login\?token=[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}\&.*$"
+    echo "$1" | grep https | grep -E "^https://(app\.)?(dev\.)?(test\.)?snyk\.io/login\?token=[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}\&.*$"
   }
 
   # Consume stdout and checks validates whether it's a valid JSON

--- a/test/tap/display-test-results.test.ts
+++ b/test/tap/display-test-results.test.ts
@@ -3,7 +3,6 @@ import * as sinon from 'sinon';
 import * as fs from 'fs';
 
 import config from '../../src/lib/config';
-import * as url from 'url';
 import * as cli from '../../src/cli/commands';
 import * as snyk from '../../src/lib';
 import { chdirWorkspaces } from '../acceptance/workspace-helper';
@@ -12,7 +11,7 @@ import { getWorkspacePath } from '../jest/util/getWorkspacePath';
 
 const { test } = tap;
 (tap as any).runOnly = false; // <- for debug. set to true, and replace a test to only(..)
-const apiUrl = url.parse(config.API);
+const apiUrl = new URL(config.ROOT);
 
 test('`test ruby-app` remediation displayed', async (t) => {
   chdirWorkspaces();


### PR DESCRIPTION
Allright, over 300 lines, but the change is actually not that big.

**Goal is to allow users to set a single configuration option pointing to an API endpoint and let CLI figure out the rest.**

With the REST API being the main (and only) API path used in the near future, I think it make sense to settle on the **default as `https://api.snyk.io/rest/` as per https://apidocs.snyk.io**

For example:

```console
SNYK_API=https://api.custom-domain.dev snyk test
```

Additional benefits introduced in this PR:
- making a hierarchy of envvar vs. config option a bit clearer and communicated to the user
- better error AND debug messages for all options (currently we don't show these!)
- no need to configure any other envvar/option by default. But still offer an override for local development and specific use cases.

There are still a few weakpoints, like manipulating the api to app subdomain strings. But I'd like to sort those out in the CLI v2 configurations and then just update CLI v1 to consume those.

Merging this PR is slightly risky, because it needs to take account specific use cases in the wild. 
I'd like to extend the test coverage if we'll find any other domains/use cases in the wild.