### PR TITLE
refactor: Remove white texts from IaC test output

### DIFF
--- a/src/lib/formatters/iac-output/v2/utils.ts
+++ b/src/lib/formatters/iac-output/v2/utils.ts
@@ -19,12 +19,12 @@ export const colors: IacOutputColors = {
     critical: chalk.magenta,
     high: chalk.red,
     medium: chalk.yellow,
-    low: chalk.white,
+    low: chalk.reset,
   },
   failure: chalk.red,
   success: chalk.green,
-  info: chalk.white,
-  title: chalk.white.bold,
+  info: chalk.reset,
+  title: chalk.reset.bold,
   suggestion: chalk.gray,
 };
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Changes white texts in the new IaC test output to be in the CLI's default text color.


#### Where should the reviewer start?

```
src/lib/formatters/iac-output/v2/utils.ts
```


#### How should this be manually tested?

- Ensure the test output hasn't changed apart from white texts being converted to texts in the default color.
- Using a terminal with a bright bg, ensure all texts are visible.
- Using a terminal with a dark bg, ensure all texts are visible.


#### Any background context you want to provide?

- At the moment, users with a light terminal background will not be able to see most of the headers in our output. 


#### What are the relevant tickets?

- No tickets.

#### Screenshots

Before: 

![image](https://user-images.githubusercontent.com/46415136/176126369-80dc321b-2502-4b36-9929-260c2f6a24c1.png)

![image](https://user-images.githubusercontent.com/46415136/176126411-a534f901-dab9-4d25-b879-45d104056523.png)

After:

![image](https://user-images.githubusercontent.com/46415136/176161558-8fc01b55-b780-46ad-8f46-50cd92fa625e.png)

![image](https://user-images.githubusercontent.com/46415136/176161624-74ba7e2f-7f0a-45f4-8a81-b29380dd73b2.png)


#### Additional information

- [Slack thread on #iac-config-team](https://snyk.slack.com/archives/C02JMMTLUF9/p1656314579867429)
- [Slack thread on #ask-team-hammer](https://snyk.slack.com/archives/C0127HWU0E7/p1656316284434559)