### PR TITLE
chore: Error handling PoC

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -84,6 +84,15 @@ async function runCommand(args: Args) {
 
 async function handleError(args, error) {
   spinner.clearAll();
+
+  if (typeof error === 'object') {
+    error.stack = error.nestedStack || error.stack;
+    error.userMessage = error.nestedUserMessage || error.userMessage;
+    error.code = error.nestedCode || error.code;
+    error.strCode = error.nestedStrCode || error.strCode;
+    error.userMessage = error.nestedUserMessage || error.userMessage;
+  }
+
   let command = 'bad-command';
   let exitCode = EXIT_CODES.ERROR;
 

--- a/src/lib/errors/nested-custom-error.ts
+++ b/src/lib/errors/nested-custom-error.ts
@@ -1,0 +1,67 @@
+import { CustomError } from './custom-error';
+
+export class NestedCustomError extends CustomError {
+  constructor(message: string, innerError?: any) {
+    super(message);
+    this.innerError = innerError;
+  }
+
+  public get nestedName(): string {
+    return this.innerError?.nestedName || this.innerError?.name || this.name;
+  }
+
+  public get nestedStack(): string | undefined {
+    const stackComponents: string[] = [];
+    if (this.stack) {
+      stackComponents.push(this.stack);
+    }
+
+    const nestedStack = this.innerError?.nestedStack || this.innerError?.stack;
+    if (nestedStack) {
+      stackComponents.push(nestedStack);
+    }
+
+    return stackComponents.join('\n' + ' '.repeat(2) + '[cause]: ');
+  }
+
+  public get nestedMessage(): string {
+    let message = this.message;
+
+    const innerErrorMessage =
+      this.innerError?.nestedMessage || this.innerError?.message;
+    if (innerErrorMessage) {
+      message += '\nCaused by: ' + innerErrorMessage;
+    }
+
+    return message;
+  }
+
+  public get nestedUserMessage(): string | undefined {
+    return (
+      this.innerError?.nestedUserMessage ||
+      this.innerError?.userMessage ||
+      this.userMessage
+    );
+  }
+
+  public get nestedCode(): number | undefined {
+    return this.innerError?.nestedCode || this.innerError?.code || this.code;
+  }
+
+  public get nestedStrCode(): string | undefined {
+    return (
+      this.innerError?.nestedStrCode || this.innerError?.strCode || this.strCode
+    );
+  }
+
+  public toString(): string {
+    let errStr = `${this.name}: ${this.message}`;
+
+    const nestedErrStr = this.innerError?.toString();
+    if (nestedErrStr) {
+      errStr += '\nCaused by: ' + nestedErrStr;
+    }
+
+    return errStr;
+  }
+}


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- A PoC for improving error handling for chained errors, including:
    - Chaining error stacks in debug logs.
    - Ensuring the original user message is displayed.

#### Where should the reviewer start?

```
src/lib/errors/nested-custom-error.ts
```
### Notes for the reviewer

- The initial idea was to use the optional `cause` property for the `Error` constructor, but following [this discussion](https://snyk.slack.com/archives/C0127HWU0E7/p1656493212716839), it was agreed that since it was only introduced in the latest `Node.js` versions, we cannot apply it for this implementation. Instead, we made our own implementation to mimic the behavior.
- To prevent any unexpected behaviors with the existing errors, I've introduced a new error class, called `NestedCustomError`.
- The new properties introduces with `NestedCustomError` are:
    - `nestedName`: Gets the original error name from the deepest chained error.
    - `nestedMessage`: Chains the error's message with all the messages of its nested errors.
    - `nestedCode`: Gets the original error code from the deepest chained error.
    - `nestedStrCode`: Gets the original error string code from the deepest chained error.
    - `nestedUserMessage`: Gets the original user message from the deepest chained error.
    - `nestedStack`: Chains the error's stack with all the stacks of its nested errors.
 

#### How should this be manually tested?

- throw a `NestedCustomError` error with a chain of internal errors.
- Ensure the error stacks are chained correctly in the debug logs.
- Ensure the original user message is displayed to the users.

#### What are the relevant threads?

- #ask-team-hammer:
    - https://snyk.slack.com/archives/C0127HWU0E7/p1655816867354399
    - https://snyk.slack.com/archives/C0127HWU0E7/p1656493212716839
-  #team-iac-config:
    - https://snyk.slack.com/archives/C02JMMTLUF9/p1655816525274439

#### Screenshots

![image](https://user-images.githubusercontent.com/46415136/176654305-ef1e8491-bac5-459a-b154-f13aee6ec6c0.png)

![image](https://user-images.githubusercontent.com/46415136/176654345-4a2bd7f0-bb00-4bd1-b55f-c807d7f821b5.png)