### PR TITLE
chore: upgrade snyk-iac-test to v0.3.0

### DIFF
--- a/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/index.ts
+++ b/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/index.ts
@@ -3,7 +3,7 @@ import { formatPolicyEngineFileName } from './utils';
 /**
  * The Policy Engine release version associated with this Snyk CLI version.
  */
-export const policyEngineReleaseVersion = '0.2.0';
+export const policyEngineReleaseVersion = '0.3.0';
 
 /**
  * The Policy Engine executable's file name.

--- a/src/lib/iac/test/v2/setup/local-cache/policy-engine/download.ts
+++ b/src/lib/iac/test/v2/setup/local-cache/policy-engine/download.ts
@@ -81,18 +81,18 @@ function assertValidChecksum(dataBuffer: Buffer): void {
 }
 
 export const policyEngineChecksum = {
-  'snyk-iac-test_0.2.0_Linux_arm64':
-    '24f77f8a190523fb7417f24d56cb251abdc670da0a1e65c063861027e1a3e0be',
-  'snyk-iac-test_0.2.0_Linux_x86_64':
-    '25b65f1eca925ae0e866d1a5a404dbf756b531402d84bf3df2a9415579235004',
-  'snyk-iac-test_0.2.0_Darwin_arm64':
-    '6a8ae91f19124d865d40beafd9764e51c746748c0d851e456e8ff0a56982dca7',
-  'snyk-iac-test_0.2.0_Windows_arm64.exe':
-    'b862f2d9840d112d388a69238421d01e8a229e88401d892a4c865d7420773399',
-  'snyk-iac-test_0.2.0_Windows_x86_64.exe':
-    'e28e9bf0617e60f4259a1ede5aa9b2a820ba070675bb00a0c5925b35a2642ac0',
-  'snyk-iac-test_0.2.0_Darwin_x86_64':
-    'f9fedfc563330ed29667226110cc6652ead5e2afa35da63d19506f09c4956716',
+  'snyk-iac-test_0.3.0_Darwin_x86_64':
+    '02c128be0fa66aac7bc0de57f8c3c35e84ace8dd8a4b5ecb6c28eed7c27b3c7d',
+  'snyk-iac-test_0.3.0_Windows_arm64.exe':
+    '62038ace2d5731721ea28ff4fda81da6602838690ff1ecbc577fd3cfc6fc8cf1',
+  'snyk-iac-test_0.3.0_Linux_x86_64':
+    '73882e94b778f5b7e6bb19b9397ffb3d460d705eef8f1ca59144a37271042804',
+  'snyk-iac-test_0.3.0_Windows_x86_64.exe':
+    '815d4383701ea22e04f29681de9b3c6196f6d5403890775af154ac7b38eb190d',
+  'snyk-iac-test_0.3.0_Darwin_arm64':
+    '9e2350e093167fd001e38168464f1fa3768b999d7777c02d4ddc3afe534e1391',
+  'snyk-iac-test_0.3.0_Linux_arm64':
+    '9e366df185f18a3cd93e92ecc84df68f2d1bddbb61f3c2af0d09911c5161e317',
 }[policyEngineFileName]!;
 
 async function cache(


### PR DESCRIPTION
Upgrade `snyk-iac-test` to v0.3.0.