### PR TITLE
feat: container app vulns by default

### DIFF
--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -93,9 +93,6 @@ export default async function monitor(...args0: MethodArgs): Promise<any> {
   if (options.docker && options['remote-repo-url']) {
     throw new Error('`--remote-repo-url` is not supported for container scans');
   }
-
-  // TODO remove 'app-vulns' options and warning message once
-  // https://github.com/snyk/cli/pull/3433 is merged
   if (options.docker) {
     // order is important here, we want:
     // 1) exclude-app-vulns set -> no app vulns

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -95,8 +95,6 @@ export default async function test(
     throw new MissingArgError();
   }
 
-  // TODO remove 'app-vulns' options and warning message once
-  // https://github.com/snyk/cli/pull/3433 is merged
   if (options.docker) {
     // order is important here, we want:
     // 1) exclude-app-vulns set -> no app vulns

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -10,7 +10,7 @@ const featureFlagDefaults = (): Map<string, boolean> => {
   return new Map([
     ['cliFailFast', false],
     ['iacIntegratedExperience', false],
-    ['containerCliAppVulnsEnabled', false],
+    ['containerCliAppVulnsEnabled', true],
   ]);
 };
 

--- a/test/jest/acceptance/snyk-test/app-vuln-container-project.spec.ts
+++ b/test/jest/acceptance/snyk-test/app-vuln-container-project.spec.ts
@@ -5,16 +5,16 @@ import { runSnykCLI } from '../../util/runSnykCLI';
 describe('container test projects behavior with --app-vulns, --file and --exclude-base-image-vulns flags', () => {
   it('should find nothing when only vulns are in base image', async () => {
     const { code, stdout } = await runSnykCLI(
-      `container test docker-archive:test/fixtures/container-projects/os-app-alpine-and-debug.tar --json --exclude-base-image-vulns`,
+      `container test docker-archive:test/fixtures/container-projects/os-app-alpine-and-debug.tar --exclude-app-vulns --json --exclude-base-image-vulns`,
     );
 
     const jsonOutput = JSON.parse(stdout);
     expect(jsonOutput.ok).toEqual(true);
     expect(code).toEqual(0);
   }, 10000);
-  it('should find all vulns when using --app-vulns', async () => {
+  it('should find all vulns including app vulns', async () => {
     const { code, stdout } = await runSnykCLI(
-      `container test docker-archive:test/fixtures/container-projects/os-packages-and-app-vulns.tar --json --experimental --app-vulns`,
+      `container test docker-archive:test/fixtures/container-projects/os-packages-and-app-vulns.tar --json --experimental`,
     );
     const jsonOutput = JSON.parse(stdout);
 
@@ -48,9 +48,18 @@ describe('container test projects behavior with --app-vulns, --file and --exclud
     expect(jsonOutput.uniqueCount).toBeGreaterThan(0);
     expect(code).toEqual(1);
   }, 10000);
-  it('should find all vulns when using --app-vulns without experimental flag', async () => {
+
+  it('should show app vulns tip when available', async () => {
+    const { stdout } = await runSnykCLI(
+      `container test docker-archive:test/fixtures/container-projects/os-packages-and-app-vulns.tar`,
+    );
+
+    expect(stdout).toContain(`Testing docker-archive:test`);
+  }, 10000);
+
+  it('should find all vulns without experimental flag', async () => {
     const { code, stdout } = await runSnykCLI(
-      `container test docker-archive:test/fixtures/container-projects/os-packages-and-app-vulns.tar --json --app-vulns`,
+      `container test docker-archive:test/fixtures/container-projects/os-packages-and-app-vulns.tar --json`,
     );
     const jsonOutput = JSON.parse(stdout);
 
@@ -68,7 +77,7 @@ describe('container test projects behavior with --app-vulns, --file and --exclud
     );
 
     const { code, stdout } = await runSnykCLI(
-      `container test docker-archive:test/fixtures/container-projects/os-packages-and-app-vulns.tar --json --file=${dockerfilePath} --exclude-base-image-vulns`,
+      `container test docker-archive:test/fixtures/container-projects/os-packages-and-app-vulns.tar --exclude-app-vulns --json --file=${dockerfilePath} --exclude-base-image-vulns`,
     );
     const jsonOutput = JSON.parse(stdout);
 
@@ -77,13 +86,13 @@ describe('container test projects behavior with --app-vulns, --file and --exclud
     expect(code).toEqual(1);
   }, 10000);
 
-  it('finds dockerfile instructions and app vulns when excluding base image vulns and using --app-vulns', async () => {
+  it('finds dockerfile instructions and app vulns when excluding base image vulns', async () => {
     const dockerfilePath = path.normalize(
       'test/fixtures/container-projects/Dockerfile-vulns',
     );
 
     const { code, stdout } = await runSnykCLI(
-      `container test docker-archive:test/fixtures/container-projects/os-packages-and-app-vulns.tar --json --app-vulns --file=${dockerfilePath} --exclude-base-image-vulns`,
+      `container test docker-archive:test/fixtures/container-projects/os-packages-and-app-vulns.tar --json --file=${dockerfilePath} --exclude-base-image-vulns`,
     );
     const jsonOutput = JSON.parse(stdout);
 
@@ -95,7 +104,7 @@ describe('container test projects behavior with --app-vulns, --file and --exclud
   }, 10000);
 });
 
-describe('container test projects behavior with --app-vulns, --json flags', () => {
+describe('container test projects behavior with --json flag', () => {
   let server;
   let env: Record<string, string>;
 
@@ -128,7 +137,7 @@ describe('container test projects behavior with --app-vulns, --json flags', () =
 
   it('returns a json with the --experimental flags', async () => {
     const { code, stdout } = await runSnykCLI(
-      `container test docker-archive:test/fixtures/container-projects/os-app-alpine-and-debug.tar --app-vulns --json --experimental`,
+      `container test docker-archive:test/fixtures/container-projects/os-app-alpine-and-debug.tar --json --experimental`,
       {
         env,
       },

--- a/test/jest/unit/ecosystems-monitor-docker.spec.ts
+++ b/test/jest/unit/ecosystems-monitor-docker.spec.ts
@@ -63,7 +63,6 @@ describe('monitorEcosystem docker/container', () => {
       {
         path: '/srv',
         docker: true,
-        'app-vulns': true,
         org: 'my-org',
         tags: 'keyone=valueone',
       },
@@ -76,7 +75,6 @@ describe('monitorEcosystem docker/container', () => {
       {
         path: '/srv',
         docker: true,
-        'app-vulns': true,
         org: 'my-org',
       } as Options,
     );

--- a/test/jest/unit/lib/formatters/test/__snapshots__/display-result.spec.ts.snap
+++ b/test/jest/unit/lib/formatters/test/__snapshots__/display-result.spec.ts.snap
@@ -130,7 +130,9 @@ Warning: Unable to analyse Dockerfile provided through \`--file\`.
 
 Pro tip: use \`--exclude-base-image-vulns\` to exclude from display Docker base image vulnerabilities.
 
-To remove this message in the future, please run \`snyk config set disableSuggestions=true\`"
+Snyk found some vulnerabilities in your image applications (Snyk searches for these vulnerabilities by default). See [URL]
+
+To remove these messages in the future, please run \`snyk config set disableSuggestions=true\`"
 `;
 
 exports[`displayResult Docker test result with base image non resolvable warning 1`] = `
@@ -163,7 +165,9 @@ Warning: Unable to analyse Dockerfile provided through \`--file\`.
 
 Pro tip: use \`--exclude-base-image-vulns\` to exclude from display Docker base image vulnerabilities.
 
-To remove this message in the future, please run \`snyk config set disableSuggestions=true\`"
+Snyk found some vulnerabilities in your image applications (Snyk searches for these vulnerabilities by default). See [URL]
+
+To remove these messages in the future, please run \`snyk config set disableSuggestions=true\`"
 `;
 
 exports[`displayResult Docker test result with remediation advice 1`] = `

--- a/test/tap/cli-monitor.acceptance.test.ts
+++ b/test/tap/cli-monitor.acceptance.test.ts
@@ -1721,7 +1721,7 @@ if (!isWindows) {
       [
         {
           docker: true,
-          'exclude-app-vulns': true,
+          'exclude-app-vulns': false,
           org: 'explicit-org',
           path: 'foo:latest',
         },
@@ -1790,7 +1790,7 @@ if (!isWindows) {
       [
         {
           docker: true,
-          'exclude-app-vulns': true,
+          'exclude-app-vulns': false,
           file: 'Dockerfile',
           org: 'explicit-org',
           path: 'foo:latest',
@@ -1858,7 +1858,7 @@ if (!isWindows) {
       [
         {
           docker: true,
-          'exclude-app-vulns': true,
+          'exclude-app-vulns': false,
           org: 'explicit-org',
           'policy-path': 'custom-location',
           path: 'foo:latest',
@@ -1873,8 +1873,7 @@ if (!isWindows) {
     const policyString = req.body.scanResult.policy;
     t.deepEqual(policyString, expected, 'sends correct policy');
   });
-
-  test('`monitor foo:latest --docker` with app vulns feature flag enabled', async (t) => {
+  test('`monitor foo:latest --docker` with exlude app vulns flag', async (t) => {
     chdirWorkspaces('npm-package-policy');
     const spyPlugin = stubDockerPluginResponse(
       {
@@ -1894,9 +1893,9 @@ if (!isWindows) {
       t,
     );
 
-    server.setFeatureFlag('containerCliAppVulnsEnabled', true);
     await cli.monitor('foo:latest', {
       docker: true,
+      'exclude-app-vulns': true,
       org: 'explicit-org',
     });
     t.same(
@@ -1904,16 +1903,14 @@ if (!isWindows) {
       [
         {
           docker: true,
-          'exclude-app-vulns': false,
+          'exclude-app-vulns': true,
           org: 'explicit-org',
           path: 'foo:latest',
         },
       ],
       'calls docker plugin with expected arguments',
     );
-    server.setFeatureFlag('containerCliAppVulnsEnabled', false);
   });
-
   test('`monitor foo:latest --docker --platform=linux/arm64`', async (t) => {
     const platform = 'linux/arm64';
     const spyPlugin = stubDockerPluginResponse(
@@ -1962,7 +1959,7 @@ if (!isWindows) {
       [
         {
           docker: true,
-          'exclude-app-vulns': true,
+          'exclude-app-vulns': false,
           path: 'foo:latest',
           platform,
         },

--- a/test/tap/cli-test/cli-test.docker.spec.ts
+++ b/test/tap/cli-test/cli-test.docker.spec.ts
@@ -65,7 +65,7 @@ export const DockerTests: AcceptanceTests = {
         [
           {
             docker: true,
-            'exclude-app-vulns': true,
+            'exclude-app-vulns': false,
             org: 'explicit-org',
             projectName: null,
             packageManager: null,
@@ -142,7 +142,7 @@ export const DockerTests: AcceptanceTests = {
         [
           {
             docker: true,
-            'exclude-app-vulns': true,
+            'exclude-app-vulns': false,
             org: 'explicit-org',
             projectName: null,
             packageManager: null,
@@ -295,7 +295,7 @@ export const DockerTests: AcceptanceTests = {
           {
             file: 'Dockerfile',
             docker: true,
-            'exclude-app-vulns': true,
+            'exclude-app-vulns': false,
             org: 'explicit-org',
             projectName: null,
             packageManager: null,
@@ -410,7 +410,7 @@ export const DockerTests: AcceptanceTests = {
         [
           {
             docker: true,
-            'exclude-app-vulns': true,
+            'exclude-app-vulns': false,
             org: 'explicit-org',
             projectName: null,
             packageManager: null,
@@ -486,7 +486,7 @@ export const DockerTests: AcceptanceTests = {
         [
           {
             docker: true,
-            'exclude-app-vulns': true,
+            'exclude-app-vulns': false,
             org: 'explicit-org',
             projectName: null,
             packageManager: null,
@@ -568,7 +568,7 @@ export const DockerTests: AcceptanceTests = {
         [
           {
             docker: true,
-            'exclude-app-vulns': true,
+            'exclude-app-vulns': false,
             org: 'explicit-org',
             projectName: null,
             packageManager: null,


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Enables container app scan by default. We are introducing a new flag,
`exclude-app-vulns` in case a user would like to disable app scan.


#### How should this be manually tested?
`snyk container test <image_with_app>` should return app scan results without additional parameters.
`snyk container test --exclude-app-vulns <image_with_app>` should return only operating system scan results.

#### Any background context you want to provide?


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/MYC-56


