### PR TITLE
fix: return paths for files that errrored (IaC) [CFG-2026]

### DIFF
--- a/src/cli/commands/test/iac/local-execution/file-loader.ts
+++ b/src/cli/commands/test/iac/local-execution/file-loader.ts
@@ -56,10 +56,12 @@ export class NoFilesToScanError extends CustomError {
 }
 
 export class FailedToLoadFileError extends CustomError {
+  public filename: string;
   constructor(filename: string) {
     super('Failed to load file content');
     this.code = IaCErrorCodes.FailedToLoadFileError;
     this.strCode = getErrorStringCode(this.code);
+    this.filename = filename;
     this.userMessage = `We were unable to read file "${filename}" for scanning. Please ensure that it is readable.`;
   }
 }

--- a/src/cli/commands/test/iac/local-execution/index.ts
+++ b/src/cli/commands/test/iac/local-execution/index.ts
@@ -22,7 +22,6 @@ import {
   trackUsage,
 } from './measurable-methods';
 import { findAndLoadPolicy } from '../../../../../lib/policy';
-import { NoFilesToScanError } from './file-loader';
 import { ResultsProcessor } from './process-results';
 import { generateProjectAttributes, generateTags } from '../../../monitor';
 import {
@@ -31,6 +30,7 @@ import {
 } from './directory-loader';
 import { CustomError } from '../../../../../lib/errors';
 import { getErrorStringCode } from './error-utils';
+import { NoFilesToScanError } from './file-loader';
 
 // this method executes the local processing engine and then formats the results to adapt with the CLI output.
 // this flow is the default GA flow for IAC scanning.
@@ -78,13 +78,12 @@ export async function test(
     allFailedFiles = allFailedFiles.concat(failedFiles);
   }
 
-  // if none of the files were parsed then either we didn't have any IaC files
-  // or there was only one file passed via the CLI and it failed parsing
   if (allParsedFiles.length === 0) {
-    if (allFailedFiles.length === 1) {
-      throw allFailedFiles[0].err;
-    } else {
+    if (allFailedFiles.length === 0) {
       throw new NoFilesToScanError();
+    } else {
+      // we throw an array of errors in order to get the path of the files which generated an error
+      throw allFailedFiles.map((f) => f.err);
     }
   }
 

--- a/src/cli/commands/test/iac/local-execution/parsers/terraform-file-parser.ts
+++ b/src/cli/commands/test/iac/local-execution/parsers/terraform-file-parser.ts
@@ -3,10 +3,12 @@ import { CustomError } from '../../../../../../lib/errors';
 import { getErrorStringCode } from '../error-utils';
 
 export class FailedToParseTerraformFileError extends CustomError {
+  public filename: string;
   constructor(filename: string) {
     super('Failed to parse Terraform file');
     this.code = IaCErrorCodes.FailedToParseTerraformFileError;
     this.strCode = getErrorStringCode(this.code);
+    this.filename = filename;
     this.userMessage = `We were unable to parse the Terraform file "${filename}", please ensure it is valid HCL2. This can be done by running it through the 'terraform validate' command.`;
   }
 }

--- a/src/cli/commands/test/iac/local-execution/yaml-parser.ts
+++ b/src/cli/commands/test/iac/local-execution/yaml-parser.ts
@@ -20,19 +20,23 @@ export function parseYAMLOrJSONFileData(fileData: IacFileData): any[] {
 }
 
 export class InvalidJsonFileError extends CustomError {
+  public filename: string;
   constructor(filename: string) {
     super('Failed to parse JSON file');
     this.code = IaCErrorCodes.InvalidJsonFileError;
     this.strCode = getErrorStringCode(this.code);
+    this.filename = filename;
     this.userMessage = `We were unable to parse the JSON file "${filename}". Please ensure that it contains properly structured JSON`;
   }
 }
 
 export class InvalidYamlFileError extends CustomError {
+  public filename: string;
   constructor(filename: string) {
     super('Failed to parse YAML file');
     this.code = IaCErrorCodes.InvalidYamlFileError;
     this.strCode = getErrorStringCode(this.code);
+    this.filename = filename;
     this.userMessage = `We were unable to parse the YAML file "${filename}". Please ensure that it contains properly structured YAML, without any template directives`;
   }
 }

--- a/test/fixtures/iac/only-invalid/invalid-file1.yml
+++ b/test/fixtures/iac/only-invalid/invalid-file1.yml
@@ -1,0 +1,11 @@
+features:
+  - name: lorem ipsum
+    bullets:
+      - bullet 1
+      - bullet 2
+  - name: lorem ipsum 2
+
+scripts:
+  - BRANCH_LOCAL=${BRANCH/remotes\/origin\//}
+  - echo ${BRANCH_LOCAL}
+  - git checkout -b ${BRANCH_LOCAL} origin/${BRANCH_LOCAL}

--- a/test/fixtures/iac/only-invalid/invalid-file2.yaml
+++ b/test/fixtures/iac/only-invalid/invalid-file2.yaml
@@ -1,0 +1,11 @@
+features:
+  - name: lorem ipsum
+    bullets:
+      - bullet 1
+      - bullet 2
+  - name: lorem ipsum 2
+
+scripts:
+    - BRANCH_LOCAL=${BRANCH/remotes\/origin\//}
+    - echo ${BRANCH_LOCAL}
+    - git checkout -b ${BRANCH_LOCAL} origin/${BRANCH_LOCAL}

--- a/test/jest/acceptance/iac/iac-output.spec.ts
+++ b/test/jest/acceptance/iac/iac-output.spec.ts
@@ -183,6 +183,18 @@ Target file:       ${dirPath}/`);
                 'kubernetes',
                 'helm-config.yaml',
               )}` +
+              EOL +
+              `        ${pathLib.join(
+                'iac',
+                'only-invalid',
+                'invalid-file1.yml',
+              )}` +
+              EOL +
+              `        ${pathLib.join(
+                'iac',
+                'only-invalid',
+                'invalid-file2.yaml',
+              )}` +
               EOL.repeat(2) +
               '  Failed to parse Terraform file' +
               EOL +
@@ -224,7 +236,6 @@ Target file:       ${dirPath}/`);
     describe('with only test failures', () => {
       it('should display the test failures list', async () => {
         const invalidPaths = [
-          pathLib.join('iac', 'only-invalid'),
           pathLib.join('iac', 'cloudformation', 'invalid-cfn.yml'),
           pathLib.join(
             'iac',
@@ -237,13 +248,7 @@ Target file:       ${dirPath}/`);
         const { stdout } = await run(`snyk iac test ${invalidPaths.join(' ')}`);
 
         expect(stdout).toContain(
-          '  Could not find any valid IaC files' +
-            EOL +
-            `  Path: ${pathLib.join('iac', 'only-invalid')}` +
-            EOL +
-            `        ${pathLib.join('does', 'not', 'exist')}` +
-            EOL.repeat(2) +
-            '  Failed to parse YAML file' +
+          '  Failed to parse YAML file' +
             EOL +
             `  Path: ${pathLib.join(
               'iac',
@@ -263,7 +268,11 @@ Target file:       ${dirPath}/`);
               'iac',
               'terraform',
               'sg_open_ssh_invalid_hcl2.tf',
-            )}`,
+            )}` +
+            EOL.repeat(2) +
+            '  Could not find any valid IaC files' +
+            EOL +
+            `  Path: ${pathLib.join('does', 'not', 'exist')}`,
         );
       });
 
@@ -439,7 +448,7 @@ If the issue persists contact support@snyk.io`,
 
     describe('with only test failures', () => {
       it('should display the failure reason for the first failed test', async () => {
-        const dirPath = 'iac/only-invalid';
+        const dirPath = 'iac/no-files';
         const { stdout } = await run(`snyk iac test ${dirPath}`);
 
         expect(stdout).toContain(

--- a/test/jest/acceptance/iac/test-directory.spec.ts
+++ b/test/jest/acceptance/iac/test-directory.spec.ts
@@ -1,7 +1,9 @@
 import { isValidJSONString, startMockServer } from './helpers';
 import { FakeServer } from '../../../acceptance/fake-server';
+import { EOL } from 'os';
+import * as pathLib from 'path';
 
-const IAC_CLI_OUTPUT_FF = 'iacCliOutput';
+const IAC_CLI_OUTPUT_FF = 'iacCliOutputRelease';
 
 jest.setTimeout(50000);
 
@@ -232,6 +234,62 @@ describe('Directory scan', () => {
         expect(stdout).toContain('"ruleId": "SNYK-CC-TF-124",');
         expect(stdout).toContain('"ruleId": "SNYK-CC-AWS-422",');
         expect(exitCode).toBe(1);
+      });
+    });
+
+    describe('directory with files that can not be parsed', () => {
+      beforeEach(() => {
+        server.setFeatureFlag(IAC_CLI_OUTPUT_FF, true);
+      });
+      afterEach(() => {
+        server.restore();
+      });
+      it('prints all invalid paths', async () => {
+        const { stdout, exitCode } = await run(
+          `snyk iac test ./iac/only-invalid`,
+        );
+        expect(stdout).toContain(
+          '  Failed to parse YAML file' +
+            EOL +
+            `  Path: ${pathLib.join(
+              'iac',
+              'only-invalid',
+              'invalid-file1.yml',
+            )}` +
+            EOL +
+            `        ${pathLib.join(
+              'iac',
+              'only-invalid',
+              'invalid-file2.yaml',
+            )}`,
+        );
+        expect(exitCode).toBe(2);
+      });
+      it('prints all errors and paths in --json', async () => {
+        const { stdout, exitCode } = await run(
+          `snyk iac test ./iac/only-invalid --json`,
+        );
+
+        expect(isValidJSONString(stdout)).toBe(true);
+        expect(JSON.parse(stdout).length).toBe(2);
+
+        expect(stdout).toContain('"ok": false');
+        expect(stdout).toContain('"error": "Failed to parse YAML file"');
+        expect(stdout).toContain(
+          `"path": "${pathLib.join(
+            'iac',
+            'only-invalid',
+            'invalid-file1.yml',
+          )}"`,
+        );
+        expect(stdout).toContain(
+          `"path": "${pathLib.join(
+            'iac',
+            'only-invalid',
+            'invalid-file2.yaml',
+          )}"`,
+        );
+        expect(exitCode).toBe(2);
       });
     });
   });


### PR DESCRIPTION
This commit adds a filename attribute to the CustomErrors that need to keep the filename(path) information.

Next, if the scan is complete, and we have 0 parsed files but some failed files (>0),  we will throw these errors in an array.

As a last step we destructure the array of errors and get the filename(path) information in the results.

This is a "quick" fix which might make the code uglier, but as we will get rid of the entire area in the upcoming weeks, we do not think it's worth the effort of refactoring it now to fix it properly.

CFG-2026

### Screenshots

Directory with 1 bad file: Before (left) and After (right)

![image](https://user-images.githubusercontent.com/6989529/177603914-08583ac5-39c2-418d-a5de-d16695ecf000.png)


Directory with 2 bad files: Before (left) and After (right)

![image](https://user-images.githubusercontent.com/6989529/177604088-fd44be48-57d6-454c-aa7a-88be44382123.png)

we also now return all errors when using --json: 

![image](https://user-images.githubusercontent.com/6989529/177604554-05a0d1b6-fafd-462e-a0ea-29d2c93798e9.png)

Multiple paths:

![image](https://user-images.githubusercontent.com/6989529/177606532-20be9fc6-8f13-4d19-a02c-b3b533b2d4a1.png)


Directory without files or with non-iac files (same behaviour for before/after):
![image](https://user-images.githubusercontent.com/6989529/177604292-53879dc8-fb4b-49a2-b8c9-483a11496f12.png)

To test more scenarios you can use this tarball that Craig brought together:
[error-scenario-test-cases.tar.gz](https://github.com/snyk/cli/files/9056772/error-scenario-test-cases.tar.gz)



