### PR TITLE
chore: upgrade snyk-iac-test

### DIFF
--- a/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/index.ts
+++ b/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/index.ts
@@ -3,7 +3,7 @@ import { formatPolicyEngineFileName, getChecksum } from './utils';
 /**
  * The Policy Engine release version associated with this Snyk CLI version.
  */
-export const policyEngineReleaseVersion = '0.4.1';
+export const policyEngineReleaseVersion = '0.4.2';
 
 /**
  * The Policy Engine executable's file name.

--- a/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/utils.ts
@@ -19,12 +19,12 @@ export function formatPolicyEngineFileName(releaseVersion: string) {
 }
 
 // this const is not placed in `index.ts` to avoid circular dependencies
-const policyEngineChecksums = `2613cc16ac1fccae16729d42d45688269a4eccc7732d72071139d2485f0f2292  snyk-iac-test_0.4.1_Linux_arm64
-4960c97b0a33a7d6dc8f6b74708e2ca9533d5da0f442313dd490fe057c55869d  snyk-iac-test_0.4.1_Linux_x86_64
-71837d9a3cba579baaf2bc157e06ce000c2e043f69ab59aec57bf296ac45319c  snyk-iac-test_0.4.1_Windows_arm64.exe
-7818f77ad78ce5b1e372181a173290c57fb15b039f206a681debdba4707f7cda  snyk-iac-test_0.4.1_Darwin_arm64
-aec5181e9af19d16c6f2c0aa23b7d2b765f66c72be152a390daf886bf0128566  snyk-iac-test_0.4.1_Windows_x86_64.exe
-bf0ce9cddec843b392627c000ae83f36e994fae07c8383a49c72aff08351746f  snyk-iac-test_0.4.1_Darwin_x86_64
+const policyEngineChecksums = `17c96fae83c7b7bd287999c3272303045a38051686ac60880c1b3e484773c10d  snyk-iac-test_0.4.2_Linux_x86_64
+1afa95542cfd7c32120b724886fa50d90fc10e186ed10a9cb96242d2dbcb9ace  snyk-iac-test_0.4.2_Windows_x86_64.exe
+1f34e0a099ec4af17b20d7a28f981a0b85902d5f13b315709a66614969d917f0  snyk-iac-test_0.4.2_Linux_arm64
+2340fefd5d389c2d91859aa0251d3dbfa738a1c5de02f6787029f37841c50421  snyk-iac-test_0.4.2_Darwin_arm64
+ec28b5cccd1d9066a5b341c979e465e2a6691339cb1fcc7d5ce3dece0e9fb8f9  snyk-iac-test_0.4.2_Windows_arm64.exe
+f3e54c7e105761851d2de578a6d39a8510af31ed4fbd91cf57162d7b4601f364  snyk-iac-test_0.4.2_Darwin_x86_64
 `;
 
 export function getChecksum(policyEngineFileName: string): string {


### PR DESCRIPTION
Upgrade `snyk-iac-test` to v0.4.2.