### PR TITLE
chore: bump cloud-config-parser [cfg-2016]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "dependencies": {
         "@open-policy-agent/opa-wasm": "^1.6.0",
         "@snyk/cli-interface": "2.11.0",
-        "@snyk/cloud-config-parser": "^1.14.1",
+        "@snyk/cloud-config-parser": "^1.14.3",
         "@snyk/code-client": "^4.12.3",
         "@snyk/dep-graph": "^1.27.1",
         "@snyk/docker-registry-v2-client": "^2.6.1",
@@ -131,6 +131,37 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "../cloud-config-parser": {
+      "name": "@snyk/cloud-config-parser",
+      "version": "0.0.4",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "peggy": "^1.2.0",
+        "tslib": "^1.10.0",
+        "yaml": "^1.10.2",
+        "yaml-js": "^0.3.0"
+      },
+      "devDependencies": {
+        "@types/esprima": "^4.0.2",
+        "@types/jest": "^25.1.1",
+        "@types/node": "^12.12.26",
+        "@typescript-eslint/eslint-plugin": "^2.18.0",
+        "@typescript-eslint/parser": "^2.18.0",
+        "eslint": "^6.8.0",
+        "eslint-config-prettier": "^6.10.0",
+        "jest": "^25.1.0",
+        "prettier": "^1.19.1",
+        "ts-jest": "^25.1.0",
+        "ts-node": "8.6.2",
+        "tsc-watch": "^4.1.0",
+        "typescript": "^3.7.5"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@arcanis/slice-ansi": {
@@ -1917,9 +1948,9 @@
       }
     },
     "node_modules/@snyk/cloud-config-parser": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.14.1.tgz",
-      "integrity": "sha512-TPqhoOejqyDmMXQUZ3W4ih3+cpIRHohncvfjYUfjH6dSUxVUywUEL08MnyIJgHVAdupvh8Mn4ufEsu9RyrVS2g==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.14.3.tgz",
+      "integrity": "sha512-SKfMvZ/YNTKWSAPTUSn/ZsWCcAUNgbUO+0/AdVbMZfoSYSm+VYh3xrQcMy9YsAO0r0G18f+BQxYir37DfY8IAQ==",
       "dependencies": {
         "esprima": "^4.0.1",
         "peggy": "^1.2.0",
@@ -19620,9 +19651,12 @@
       }
     },
     "node_modules/yaml-js": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/yaml-js/-/yaml-js-0.3.0.tgz",
-      "integrity": "sha512-JbTUdsPiCkOyz+JOSqAVc19omTnUBnBQglhuclYov5HpWbEOz8y+ftqWjiMa9Pe/eF/dmCUeNgVs/VWg53GlgQ=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/yaml-js/-/yaml-js-0.3.1.tgz",
+      "integrity": "sha512-LjoIFHCtSfkGzPsmYmfDsW+TShtQBcY7lwH1yLQ5brJHXRhjteUnVE2ThCbz1madq8JUZIAjFiavfnIFeTO8CQ==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/yapool": {
       "version": "1.0.0",
@@ -21283,9 +21317,9 @@
       }
     },
     "@snyk/cloud-config-parser": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.14.1.tgz",
-      "integrity": "sha512-TPqhoOejqyDmMXQUZ3W4ih3+cpIRHohncvfjYUfjH6dSUxVUywUEL08MnyIJgHVAdupvh8Mn4ufEsu9RyrVS2g==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.14.3.tgz",
+      "integrity": "sha512-SKfMvZ/YNTKWSAPTUSn/ZsWCcAUNgbUO+0/AdVbMZfoSYSm+VYh3xrQcMy9YsAO0r0G18f+BQxYir37DfY8IAQ==",
       "requires": {
         "esprima": "^4.0.1",
         "peggy": "^1.2.0",
@@ -35179,9 +35213,9 @@
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yaml-js": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/yaml-js/-/yaml-js-0.3.0.tgz",
-      "integrity": "sha512-JbTUdsPiCkOyz+JOSqAVc19omTnUBnBQglhuclYov5HpWbEOz8y+ftqWjiMa9Pe/eF/dmCUeNgVs/VWg53GlgQ=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/yaml-js/-/yaml-js-0.3.1.tgz",
+      "integrity": "sha512-LjoIFHCtSfkGzPsmYmfDsW+TShtQBcY7lwH1yLQ5brJHXRhjteUnVE2ThCbz1madq8JUZIAjFiavfnIFeTO8CQ=="
     },
     "yapool": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@open-policy-agent/opa-wasm": "^1.6.0",
     "@snyk/cli-interface": "2.11.0",
-    "@snyk/cloud-config-parser": "^1.14.1",
+    "@snyk/cloud-config-parser": "^1.14.3",
     "@snyk/code-client": "^4.12.3",
     "@snyk/dep-graph": "^1.27.1",
     "@snyk/docker-registry-v2-client": "^2.6.1",

--- a/src/cli/commands/test/iac/local-execution/yaml-parser.ts
+++ b/src/cli/commands/test/iac/local-execution/yaml-parser.ts
@@ -1,15 +1,12 @@
 import { CustomError } from '../../../../../lib/errors';
 import { getErrorStringCode } from './error-utils';
 import { IaCErrorCodes, IacFileData } from './types';
-import { ParserFileType, parseFileContent } from '@snyk/cloud-config-parser';
+import { parseFileContent } from '@snyk/cloud-config-parser';
 
 export function parseYAMLOrJSONFileData(fileData: IacFileData): any[] {
   try {
     // this function will always be called with the file types recognised by the parser
-    return parseFileContent(
-      fileData.fileContent,
-      fileData.fileType as ParserFileType,
-    );
+    return parseFileContent(fileData.fileContent);
   } catch (e) {
     if (fileData.fileType === 'json') {
       throw new InvalidJsonFileError(fileData.filePath);

--- a/test/fixtures/iac/only-invalid/invalid-file1.yml
+++ b/test/fixtures/iac/only-invalid/invalid-file1.yml
@@ -1,11 +1,23 @@
-features:
-  - name: lorem ipsum
-    bullets:
-      - bullet 1
-      - bullet 2
-  - name: lorem ipsum 2
-
-scripts:
-  - BRANCH_LOCAL=${BRANCH/remotes\/origin\//}
-  - echo ${BRANCH_LOCAL}
-  - git checkout -b ${BRANCH_LOCAL} origin/${BRANCH_LOCAL}
+---
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: db-controller
+spec:
+  replicas: 2
+  selector:
+    name: db
+  template:
+    spec:
+      containers:
+        - name: db
+          image: dbforweb
+          ports:
+            - containerPort: 3306
+    metadata:
+      labels:
+        name: "db"
+      selectorname: "db"
+  labels:
+    name: "db"
+  script

--- a/test/fixtures/iac/only-invalid/invalid-file2.yaml
+++ b/test/fixtures/iac/only-invalid/invalid-file2.yaml
@@ -1,11 +1,13 @@
-features:
-  - name: lorem ipsum
-    bullets:
-      - bullet 1
-      - bullet 2
-  - name: lorem ipsum 2
-
-scripts:
-    - BRANCH_LOCAL=${BRANCH/remotes\/origin\//}
-    - echo ${BRANCH_LOCAL}
-    - git checkout -b ${BRANCH_LOCAL} origin/${BRANCH_LOCAL}
+---
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: db-controller
+spec:
+  replicas
+  selector:
+    name: db
+  template:
+    labels:
+      name: "db"
+    selectorname: "db"


### PR DESCRIPTION
#### What does this PR do?

Updates the CLI with a new version of our `cloud-config-parser`. This release includes a change in the way we parse YAML documents. 
We used to throw an error when finding escape characters like "\\/", but this is a valid YAML in YAML 1.2 so we removed this error in our parser. https://github.com/snyk/cloud-config-parser/pull/45

#### How should this be manually tested?

- Take the example from the zip file.
- Run `snyk iac test invalid-file1.yml`
- See the error for no valid YAML file
- Build the CLI locally on this branch
- Run ` node ./dist/cli iac test invalid-file1.yml` again, you will now see that the file is parsed (but not valid iac)

Files to test:
- A non-iac file, previously invalid YAML: [invalid-file1.yml.zip](https://github.com/snyk/cli/files/9070795/invalid-file1.yml.zip)
- An iac file, always invalid YAML:  [iac-but-invalid-file.zip](https://github.com/snyk/cli/files/9071211/iac-but-invalid-file.zip)


#### What are the relevant tickets?
CFG-2016

#### Screenshots

Prod build vs local build
![image](https://user-images.githubusercontent.com/6989529/177973202-6bd0a4e7-b190-46ba-95e5-c227322d96da.png)

