### PR TITLE
feat: snyk-iac-test error handling

### DIFF
--- a/src/cli/commands/test/iac/local-execution/types.ts
+++ b/src/cli/commands/test/iac/local-execution/types.ts
@@ -359,6 +359,27 @@ export enum IaCErrorCodes {
 
   // Scan errors
   PolicyEngineScanError = 1150,
+
+  // snyk-iac-test errors
+  NoPaths = 2000,
+  CwdTraversal = 2003,
+  NoBundle = 2004,
+  OpenBundle = 2005,
+  Scan = 2100,
+  UnableToRecognizeInputType = 2101,
+  UnsupportedInputType = 2102,
+  UnableToResolveLocation = 2103,
+  UnrecognizedFileExtension = 2104,
+  FailedToParseInput = 2105,
+  InvalidInput = 2106,
+  UnableToReadFile = 2107,
+  UnableToReadDir = 2108,
+  UnableToReadStdin = 2109,
+  FailedToLoadRegoAPI = 2110,
+  FailedToLoadRules = 2111,
+  FailedToCompile = 2112,
+  UnableToReadPath = 2113,
+  NoLoadableInput = 2114,
 }
 
 export interface TestReturnValue {

--- a/src/lib/iac/test/v2/errors.ts
+++ b/src/lib/iac/test/v2/errors.ts
@@ -1,0 +1,51 @@
+import { getErrorStringCode } from '../../../../cli/commands/test/iac/local-execution/error-utils';
+import { IaCErrorCodes } from '../../../../cli/commands/test/iac/local-execution/types';
+import { CustomError } from '../../../errors';
+import { ScanError } from './scan/results';
+
+const defaultUserMessage =
+  'Your test request could not be completed. Please run the command again with the `-d` flag and contact support@snyk.io with the contents of the output';
+
+const snykIacTestErrorsUserMessages = {
+  NoPaths: 'No valid paths were provided',
+  CwdTraversal:
+    'Running the scan from outside of the current working directory is not supported',
+  NoBundle: 'A rules bundle were not provided',
+  OpenBundle: "The Snyk CLI couldn't open the rules bundle",
+  Scan: defaultUserMessage,
+  UnableToRecognizeInputType: 'Input type was not recognized',
+  UnsupportedInputType: 'Input type is not supported',
+  UnableToResolveLocation: 'Could not resolve location of resource/attribute',
+  UnrecognizedFileExtension: 'Unrecognized file extension',
+  FailedToParseInput: 'Failed to parse input',
+  InvalidInput: 'Invalid input',
+  UnableToReadFile: 'Unable to read file',
+  UnableToReadDir: 'Unable to read directory',
+  UnableToReadStdin: 'Unable to read stdin',
+  FailedToLoadRegoAPI: defaultUserMessage,
+  FailedToLoadRules: defaultUserMessage,
+  FailedToCompile: defaultUserMessage,
+  UnableToReadPath: 'Unable to read path',
+  NoLoadableInput:
+    "The Snyk CLI couldn't find any valid IaC configuration files to scan",
+};
+
+export function getErrorUserMessage(code: number): string {
+  if (code < 2000 || code >= 3000) {
+    return 'INVALID_SNYK_IAC_TEST_ERROR';
+  }
+  const errorName = IaCErrorCodes[code];
+  if (!errorName) {
+    return 'INVALID_IAC_ERROR';
+  }
+  return snykIacTestErrorsUserMessages[errorName];
+}
+
+export class SnykIacTestError extends CustomError {
+  constructor(error: ScanError) {
+    super(error.message);
+    this.code = error.code;
+    this.strCode = getErrorStringCode(this.code);
+    this.userMessage = getErrorUserMessage(this.code);
+  }
+}

--- a/src/lib/iac/test/v2/output.ts
+++ b/src/lib/iac/test/v2/output.ts
@@ -5,12 +5,15 @@ import { SnykIacTestOutput } from './scan/results';
 
 import { TestCommandResult } from '../../../../cli/commands/types';
 import {
+  formatIacTestFailures,
   getIacDisplayedIssues,
+  IaCTestFailure,
   spinnerSuccessMessage,
 } from '../../../formatters/iac-output';
 import { formatSnykIacTestTestData } from '../../../formatters/iac-output';
 import { jsonStringifyLargeObject } from '../../../json';
 import { IacOrgSettings } from '../../../../cli/commands/test/iac/local-execution/types';
+import { SnykIacTestError } from './errors';
 
 export function buildOutput({
   scanResult,
@@ -25,11 +28,31 @@ export function buildOutput({
   orgSettings: IacOrgSettings;
   options: any;
 }): TestCommandResult {
-  testSpinner?.succeed(spinnerSuccessMessage);
+  if (scanResult.results) {
+    testSpinner?.succeed(spinnerSuccessMessage);
+  } else {
+    testSpinner?.stop();
+  }
 
   let response = '';
+
   const testData = formatSnykIacTestTestData(scanResult.results);
   response += EOL + getIacDisplayedIssues(testData.resultsBySeverity);
+
+  if (scanResult.errors) {
+    const testFailures: IaCTestFailure[] = scanResult.errors.map((error) => {
+      const formattedError = new SnykIacTestError(error);
+      // If we received an error without a path it means that the scan failed
+      if (!error?.fields?.path) {
+        throw formattedError;
+      }
+      return {
+        filePath: error.fields!.path!,
+        failureReason: formattedError.userMessage,
+      };
+    });
+    response += EOL.repeat(2) + formatIacTestFailures(testFailures);
+  }
 
   const jsonData = jsonStringifyLargeObject(
     convertEngineToJsonResults({

--- a/test/jest/unit/lib/iac/test/v2/errors.spec.ts
+++ b/test/jest/unit/lib/iac/test/v2/errors.spec.ts
@@ -1,0 +1,40 @@
+import { getErrorUserMessage } from '../../../../../../../src/lib/iac/test/v2/errors';
+
+describe('getErrorUserMessage', () => {
+  it('returns INVALID_SNYK_IAC_TEST_ERROR for an invalid snyk-iac-test error code', () => {
+    expect(getErrorUserMessage(0)).toEqual('INVALID_SNYK_IAC_TEST_ERROR');
+    expect(getErrorUserMessage(3000)).toEqual('INVALID_SNYK_IAC_TEST_ERROR');
+  });
+
+  it('returns INVALID_IAC_ERROR for an invalid error code', () => {
+    expect(getErrorUserMessage(2999)).toEqual('INVALID_IAC_ERROR');
+  });
+
+  it.each`
+    expectedErrorCode
+    ${2000}
+    ${2003}
+    ${2004}
+    ${2005}
+    ${2100}
+    ${2101}
+    ${2102}
+    ${2103}
+    ${2104}
+    ${2105}
+    ${2106}
+    ${2107}
+    ${2108}
+    ${2109}
+    ${2110}
+    ${2111}
+    ${2112}
+    ${2113}
+    ${2114}
+  `(
+    'returns a user message for a valid snyk-iac-test error code - $expectedErrorCode',
+    ({ expectedErrorCode }) => {
+      expect(typeof getErrorUserMessage(expectedErrorCode)).toBe('string');
+    },
+  );
+});


### PR DESCRIPTION
#### What does this PR do?
This PR adds error handling for `snyk-iac-test` errors that were added in https://github.com/snyk/snyk-iac-test/pull/24 and in addition to that it prints the relevant errors.

#### How should this be manually tested?
1. run `snyk-dev iac test .. --experimental`
2. receive a "No valid paths were provided" error
3.  run `snyk-dev iac test {invalid_file} --experimental`
4. receive an invalid file error


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CFG-1997
https://snyksec.atlassian.net/browse/CFG-2025

#### Screenshots
![image](https://user-images.githubusercontent.com/71096571/178445139-3a83917b-2801-4f5e-8341-7740d7106105.png)
![image](https://user-images.githubusercontent.com/71096571/178445314-4af8caf7-af15-41be-a28a-a0074a9faa8b.png)
