### PR TITLE
fix: bump snyk docker plugin version golang fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.20.0",
-        "snyk-docker-plugin": "^4.38.0",
+        "snyk-docker-plugin": "^5.0.1",
         "snyk-go-plugin": "1.19.0",
         "snyk-gradle-plugin": "3.20.2",
         "snyk-module": "3.1.0",
@@ -16347,9 +16347,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "4.38.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.38.0.tgz",
-      "integrity": "sha512-JdDz8Dnb6148k7nrnTOlwM4y1a3qIo+hqUKYB72cj3NFcAuoo2J3tBK/F0MLNlZljrZUGXEyV4utjqeZsVTkEA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.0.1.tgz",
+      "integrity": "sha512-AKjXIafwhb5A1gH+BGHdo9LbuqULk3jzRsQM+8q0tvsPqsw/VpMfegbOP4r7QBsNCEnLXrjzJnE3yRs5b8c2tw==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.3.0",
@@ -16369,7 +16369,8 @@
         "tar-stream": "^2.1.0",
         "tmp": "^0.2.1",
         "tslib": "^1",
-        "uuid": "^8.2.0"
+        "uuid": "^8.2.0",
+        "varint": "^6.0.0"
       },
       "engines": {
         "node": ">=12"
@@ -18916,6 +18917,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "node_modules/varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -32596,9 +32602,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "4.38.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.38.0.tgz",
-      "integrity": "sha512-JdDz8Dnb6148k7nrnTOlwM4y1a3qIo+hqUKYB72cj3NFcAuoo2J3tBK/F0MLNlZljrZUGXEyV4utjqeZsVTkEA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.0.1.tgz",
+      "integrity": "sha512-AKjXIafwhb5A1gH+BGHdo9LbuqULk3jzRsQM+8q0tvsPqsw/VpMfegbOP4r7QBsNCEnLXrjzJnE3yRs5b8c2tw==",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.3.0",
@@ -32618,7 +32624,8 @@
         "tar-stream": "^2.1.0",
         "tmp": "^0.2.1",
         "tslib": "^1",
-        "uuid": "^8.2.0"
+        "uuid": "^8.2.0",
+        "varint": "^6.0.0"
       },
       "dependencies": {
         "@snyk/dep-graph": {
@@ -34661,6 +34668,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.20.0",
-    "snyk-docker-plugin": "^4.38.0",
+    "snyk-docker-plugin": "^5.0.1",
     "snyk-go-plugin": "1.19.0",
     "snyk-gradle-plugin": "3.20.2",
     "snyk-module": "3.1.0",

--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -88,6 +88,11 @@ export default async function monitor(...args0: MethodArgs): Promise<any> {
     throw new Error('`--remote-repo-url` is not supported for container scans');
   }
 
+  // TODO remove once https://github.com/snyk/cli/pull/3433 is merged
+  if (options.docker && !options['app-vulns']) {
+    options['exclude-app-vulns'] = true;
+  }
+
   // Handles no image arg provided to the container command until
   // a validation interface is implemented in the docker plugin.
   if (options.docker && paths.length === 0) {

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -91,6 +91,11 @@ export default async function test(
     throw new MissingArgError();
   }
 
+  // TODO remove once https://github.com/snyk/cli/pull/3433 is merged
+  if (options.docker && !options['app-vulns']) {
+    options['exclude-app-vulns'] = true;
+  }
+
   const ecosystem = getEcosystemForTest(options);
   if (ecosystem) {
     try {

--- a/test/tap/cli-monitor.acceptance.test.ts
+++ b/test/tap/cli-monitor.acceptance.test.ts
@@ -1741,6 +1741,7 @@ if (!isWindows) {
       [
         {
           docker: true,
+          'exclude-app-vulns': true,
           org: 'explicit-org',
           path: 'foo:latest',
         },
@@ -1809,6 +1810,7 @@ if (!isWindows) {
       [
         {
           docker: true,
+          'exclude-app-vulns': true,
           file: 'Dockerfile',
           org: 'explicit-org',
           path: 'foo:latest',
@@ -1876,6 +1878,7 @@ if (!isWindows) {
       [
         {
           docker: true,
+          'exclude-app-vulns': true,
           org: 'explicit-org',
           'policy-path': 'custom-location',
           path: 'foo:latest',
@@ -1939,6 +1942,7 @@ if (!isWindows) {
       [
         {
           docker: true,
+          'exclude-app-vulns': true,
           path: 'foo:latest',
           platform,
         },

--- a/test/tap/cli-test/cli-test.docker.spec.ts
+++ b/test/tap/cli-test/cli-test.docker.spec.ts
@@ -65,6 +65,7 @@ export const DockerTests: AcceptanceTests = {
         [
           {
             docker: true,
+            'exclude-app-vulns': true,
             org: 'explicit-org',
             projectName: null,
             packageManager: null,
@@ -141,6 +142,7 @@ export const DockerTests: AcceptanceTests = {
         [
           {
             docker: true,
+            'exclude-app-vulns': true,
             org: 'explicit-org',
             projectName: null,
             packageManager: null,
@@ -293,6 +295,7 @@ export const DockerTests: AcceptanceTests = {
           {
             file: 'Dockerfile',
             docker: true,
+            'exclude-app-vulns': true,
             org: 'explicit-org',
             projectName: null,
             packageManager: null,
@@ -407,6 +410,7 @@ export const DockerTests: AcceptanceTests = {
         [
           {
             docker: true,
+            'exclude-app-vulns': true,
             org: 'explicit-org',
             projectName: null,
             packageManager: null,
@@ -482,6 +486,7 @@ export const DockerTests: AcceptanceTests = {
         [
           {
             docker: true,
+            'exclude-app-vulns': true,
             org: 'explicit-org',
             projectName: null,
             packageManager: null,
@@ -563,6 +568,7 @@ export const DockerTests: AcceptanceTests = {
         [
           {
             docker: true,
+            'exclude-app-vulns': true,
             org: 'explicit-org',
             projectName: null,
             packageManager: null,


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
We had issues with Go modules not being detected. Version 5.0.1 of
`snyk-docker-plugin` should fix those issues.
This commit includes a workaround since we have a blocked PR (#3433) for
making app vulns the default using the lates version of
`snyk-docker-plugin`. Until we are able to make scanning app vulns the
default, we need to make sure that we set `exclude-app-vulns` option
when a user doesn't set the `app-vulns` option.



#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/MYC-131

