### PR TITLE
chore: Add line numbers to test output [CFG-2055]

### DIFF
--- a/src/lib/formatters/iac-output/v2/formatters.ts
+++ b/src/lib/formatters/iac-output/v2/formatters.ts
@@ -144,6 +144,7 @@ function formatSnykIacTestScanVulnerability(
     severity: vulnerability.severity,
     title: vulnerability.rule.title,
     isIgnored: vulnerability.ignored,
+    lineNumber: vulnerability.resource.line,
     cloudConfigPath: vulnerability.resource.id
       .split('.')
       .concat(vulnerability.resource.path as string[]),

--- a/src/lib/formatters/iac-output/v2/issues-list/index.ts
+++ b/src/lib/formatters/iac-output/v2/issues-list/index.ts
@@ -10,9 +10,11 @@ import {
   FormattedOutputResult,
   FormattedOutputResultsBySeverity,
 } from '../types';
+import { Options } from './types';
 
 export function getIacDisplayedIssues(
   resultsBySeverity: FormattedOutputResultsBySeverity,
+  options?: Options,
 ): string {
   const titleOutput = colors.title('Issues');
 
@@ -43,7 +45,7 @@ export function getIacDisplayedIssues(
             ) ||
             severityResult1.issue.id.localeCompare(severityResult2.issue.id),
         )
-        .map(formatIssue)
+        .map((result) => formatIssue(result, options))
         .join(EOL.repeat(2));
 
       debug(

--- a/src/lib/formatters/iac-output/v2/issues-list/types.ts
+++ b/src/lib/formatters/iac-output/v2/issues-list/types.ts
@@ -1,0 +1,3 @@
+export interface Options {
+  shouldShowLineNumbers?: boolean;
+}

--- a/src/lib/iac/test/v2/output.ts
+++ b/src/lib/iac/test/v2/output.ts
@@ -29,7 +29,11 @@ export function buildOutput({
 
   let response = '';
   const testData = formatSnykIacTestTestData(scanResult.results);
-  response += EOL + getIacDisplayedIssues(testData.resultsBySeverity);
+  response +=
+    EOL +
+    getIacDisplayedIssues(testData.resultsBySeverity, {
+      shouldShowLineNumbers: true,
+    });
 
   const jsonData = jsonStringifyLargeObject(
     convertEngineToJsonResults({

--- a/test/jest/unit/iac/process-results/fixtures/new-output-formatted-results.json
+++ b/test/jest/unit/iac/process-results/fixtures/new-output-formatted-results.json
@@ -30,7 +30,7 @@
                                         "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
                                         "resolve": "Set `disable_api_termination` attribute  with value `true`"
                                 },
-                                "lineNumber": -1,
+                                "lineNumber": 21,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
                         },
                         "targetFile": "aws_ec2_metadata_secrets.tf",
@@ -66,7 +66,6 @@
                                         "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
                                         "resolve": "Set `disable_api_termination` attribute  with value `true`"
                                 },
-                                "lineNumber": -1,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
                         },
                         "targetFile": "aws_ec2_metadata_secrets.tf",
@@ -102,7 +101,7 @@
                                         "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
                                         "resolve": "Set `disable_api_termination` attribute  with value `true`"
                                 },
-                                "lineNumber": -1,
+                                "lineNumber": 1,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
                         },
                         "targetFile": "aws_ec2_metadata_secrets.tf",
@@ -138,7 +137,7 @@
                                         "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
                                         "resolve": "Set `disable_api_termination` attribute  with value `true`"
                                 },
-                                "lineNumber": -1,
+                                "lineNumber": 2,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
                         },
                         "targetFile": "aws_ec2_metadata_secrets.tf",
@@ -174,7 +173,7 @@
                                         "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
                                         "resolve": "Set `disable_api_termination` attribute  with value `true`"
                                 },
-                                "lineNumber": -1,
+                                "lineNumber": 3,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
                         },
                         "targetFile": "aws_ec2_metadata_secrets.tf",
@@ -210,7 +209,7 @@
                                         "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
                                         "resolve": "Set `disable_api_termination` attribute  with value `true`"
                                 },
-                                "lineNumber": -1,
+                                "lineNumber": 4,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
                         },
                         "targetFile": "aws_ec2_metadata_secrets.tf",
@@ -247,7 +246,7 @@
                                         "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
                                         "resolve": "Set `DisableApiTermination` attribute with value `true`"
                                 },
-                                "lineNumber": -1,
+                                "lineNumber": 5,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
                         },
                         "targetFile": "bastion.yml",
@@ -285,7 +284,7 @@
                                         "impact": "Scope of use of the key cannot be controlled via KMS/IAM policies",
                                         "resolve": "Set `Properties.KmsKeyId` attribute with customer managed key id"
                                 },
-                                "lineNumber": -1,
+                                "lineNumber": 6,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-415"
                         },
                         "targetFile": "bastion.yml",
@@ -323,7 +322,7 @@
                                         "impact": "The container may run with outdated or unauthorized image",
                                         "resolve": "Set `imagePullPolicy` attribute to `Always`"
                                 },
-                                "lineNumber": -1,
+                                "lineNumber": 7,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42"
                         },
                         "targetFile": "k8s.yaml",
@@ -363,7 +362,7 @@
                                         "impact": "Compromised process could abuse writable root filesystem to elevate privileges",
                                         "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
                                 },
-                                "lineNumber": -1,
+                                "lineNumber": 8,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8"
                         },
                         "targetFile": "k8s.yaml",
@@ -398,7 +397,7 @@
                                         "impact": "AppArmor will not enforce mandatory access control, which can increase the attack vectors.",
                                         "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
                                 },
-                                "lineNumber": -1,
+                                "lineNumber": 9,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32"
                         },
                         "targetFile": "k8s.yaml",
@@ -439,7 +438,7 @@
                                         "impact": "Containers without memory limits are more likely to be terminated when the node runs out of memory",
                                         "resolve": "Set `resources.limits.memory` value"
                                 },
-                                "lineNumber": -1,
+                                "lineNumber": 10,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4"
                         },
                         "targetFile": "k8s.yaml",
@@ -481,7 +480,7 @@
                                         "impact": "Containers without limits can exceed the capacity of the node, and affect availability/performance of the host and other containers.",
                                         "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
                                 },
-                                "lineNumber": -1,
+                                "lineNumber": 11,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5"
                         },
                         "targetFile": "k8s.yaml",
@@ -555,7 +554,7 @@
                                         "impact": "Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
                                         "resolve": "Remove secret value from `user_data` attribute"
                                 },
-                                "lineNumber": -1,
+                                "lineNumber": 13,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-123"
                         },
                         "targetFile": "aws_ec2_metadata_secrets.tf",
@@ -591,7 +590,7 @@
                                         "impact": "Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
                                         "resolve": "Remove secret value from `user_data` attribute"
                                 },
-                                "lineNumber": -1,
+                                "lineNumber": 14,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-123"
                         },
                         "targetFile": "aws_ec2_metadata_secrets.tf",
@@ -627,7 +626,7 @@
                                         "impact": "Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
                                         "resolve": "Remove secret value from `user_data` attribute"
                                 },
-                                "lineNumber": -1,
+                                "lineNumber": 15,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-123"
                         },
                         "targetFile": "aws_ec2_metadata_secrets.tf",
@@ -667,7 +666,7 @@
                                         "impact": "Compromised container could potentially modify the underlying host’s kernel by loading unauthorized modules (i.e. drivers).",
                                         "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
                                 },
-                                "lineNumber": -1,
+                                "lineNumber": 16,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1"
                         },
                         "targetFile": "k8s.yaml",
@@ -710,7 +709,7 @@
                                         "impact": "That should someone gain unauthorized access to the data they would be able to read the contents.",
                                         "resolve": "Set `BlockDeviceMappings.Encrypted` attribute of root device to `true`"
                                 },
-                                "lineNumber": -1,
+                                "lineNumber": 17,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53"
                         },
                         "targetFile": "bastion.yml",
@@ -750,7 +749,7 @@
                                         "impact": "Container could be running with full administrative privileges",
                                         "resolve": "Set `securityContext.runAsNonRoot` to `true`"
                                 },
-                                "lineNumber": -1,
+                                "lineNumber": 18,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10"
                         },
                         "targetFile": "k8s.yaml",
@@ -790,7 +789,7 @@
                                         "impact": "Containers are running with potentially unnecessary privileges",
                                         "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
                                 },
-                                "lineNumber": -1,
+                                "lineNumber": 19,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6"
                         },
                         "targetFile": "k8s.yaml",
@@ -830,7 +829,7 @@
                                         "impact": "Processes could elevate current privileges via known vectors, for example SUID binaries",
                                         "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
                                 },
-                                "lineNumber": -1,
+                                "lineNumber": 20,
                                 "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9"
                         },
                         "targetFile": "k8s.yaml",

--- a/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-test-data.json
+++ b/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-test-data.json
@@ -20,7 +20,8 @@
               "issue":"",
               "impact":"",
               "resolve":""
-            }
+            },
+            "lineNumber": 12
           },
           "targetFile":"/Users/yairzohar/snyk/upe-test/default_vpc_security_group.tf",
           "projectType":"aws_default_security_group"
@@ -43,7 +44,8 @@
               "issue":"",
               "impact":"",
               "resolve":""
-            }
+            },
+            "lineNumber": 8
           },
           "targetFile":"/Users/yairzohar/snyk/upe-test/s3_cis.tf",
           "projectType":"aws_s3_bucket"
@@ -64,7 +66,8 @@
               "issue":"",
               "impact":"",
               "resolve":""
-            }
+            },
+            "lineNumber": 3
           },
           "targetFile":"/Users/yairzohar/snyk/upe-test/s3_cis.tf",
           "projectType":"aws_s3_bucket"

--- a/test/jest/unit/lib/formatters/iac-output/v2/issues-list/index.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/issues-list/index.spec.ts
@@ -177,4 +177,59 @@ describe('getIacDisplayedIssues', () => {
       );
     });
   });
+
+  describe('with the `shouldShowLineNumbers` option', () => {
+    it('should display line numbers', () => {
+      // Act
+      const result = getIacDisplayedIssues(resultFixtures, {
+        shouldShowLineNumbers: true,
+      });
+
+      // Assert
+      expect(result).toContain('aws_ec2_metadata_secrets.tf:21');
+    });
+
+    describe('when an issue does not have a line number', () => {
+      it('should not display the line number', () => {
+        // Act
+        const result = getIacDisplayedIssues(resultFixtures, {
+          shouldShowLineNumbers: true,
+        });
+
+        // Assert
+        expect(result).toContain(
+          `  ${colors.severities.low(
+            `[Low] ${chalk.bold(
+              'EC2 API termination protection is not enabled',
+            )}`,
+          )}
+  Info:    To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance. Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type
+  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-AWS-426')}
+  Path:    resource > aws_instance[denied_3] > disable_api_termination
+  File:    aws_ec2_metadata_secrets.tf
+  Resolve: Set \`disable_api_termination\` attribute  with value \`true\``,
+        );
+      });
+    });
+    describe('when an issue line number is a non-positive number', () => {
+      it('should not display the line number', () => {
+        // Act
+        const result = getIacDisplayedIssues(resultFixtures, {
+          shouldShowLineNumbers: true,
+        });
+
+        // Assert
+        expect(result).toContain(
+          `${colors.severities.high(
+            `[High] ${chalk.bold('Hard coded secrets in EC2 metadata')}`,
+          )}
+  Info:    Secret keys have been hardcoded in user_data script. Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources
+  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-TF-123')}
+  Path:    resource > aws_instance[denied_2] > user_data_base64[aws_access_key_id]
+  File:    aws_ec2_metadata_secrets.tf
+  Resolve: Remove secret value from \`user_data\` attribute`,
+        );
+      });
+    });
+  });
 });


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Adds line numbers to the human-readable test output format **only** for `snyk-iac-test`, based on [this design](https://www.figma.com/file/buNFZqr1Uhf4SaifHw4WXE/Snyk-IaC-CLI).

#### Where should the reviewer start?

```
src/lib/formatters/iac-output/v2/issues-list/issue.ts
```
#### How should this be manually tested?

- Run `snyk-dev iac test`
- Ensure results **do not have** line numbers.
- Activate the `iacCliUnifiedEngine` feature flag.
- Run `snyk-dev iac test --experimental`
- Ensure results **have** line numbers.

#### Any background context you want to provide?

- For the local-execution test flow, it’s been decided that since the current line number calculation is not accurate enough, we will not include it in this flow’s test output.

- For the `snyk-iac-test` test flow, we receive accurate line numbers from `snyk-iac-test`, which we can include in the test output.

- The design for the test output with line numbers can be viewed in.

#### Notes for the reviewer

- The line numbers validation check includes checking values to be positive integers. This means numeric strings will not pass this validation.

#### What are the relevant tickets?

- [CFG-2055](https://snyksec.atlassian.net/browse/CFG-2055)

#### Screenshots

- local-execution test flow
    <img width="1027" alt="image" src="https://user-images.githubusercontent.com/46415136/178148273-66c1caac-8cc2-4f84-8c3a-2a6d9574b695.png">

- `snyk-iac-test` test flow
    <img width="626" alt="image" src="https://user-images.githubusercontent.com/46415136/178148237-748a73b2-60d6-4ccd-8a54-ca228b49ee6b.png">
