### PR TITLE
Feat/update vuln urls to point to security.snyk.io

### DIFF
--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -25,6 +25,7 @@ interface Config {
   IAC_BUNDLE_PATH?: string;
   IAC_POLICY_ENGINE_PATH?: string;
   IAC_OUTPUT_V2?: boolean;
+  PUBLIC_VULN_DB_URL: string;
 }
 
 // TODO: fix the types!
@@ -75,5 +76,7 @@ if (!config.ROOT) {
   apiUrl.host = apiUrl.host.replace(/^ap[pi]\./, '');
   config.ROOT = apiUrl.protocol + '//' + apiUrl.host;
 }
+
+config.PUBLIC_VULN_DB_URL = "https://security.snyk.io"
 
 export default config;

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -77,6 +77,6 @@ if (!config.ROOT) {
   config.ROOT = apiUrl.protocol + '//' + apiUrl.host;
 }
 
-config.PUBLIC_VULN_DB_URL = "https://security.snyk.io"
+config.PUBLIC_VULN_DB_URL = 'https://security.snyk.io';
 
 export default config;

--- a/src/lib/display-policy.ts
+++ b/src/lib/display-policy.ts
@@ -3,7 +3,7 @@ import { demunge } from 'snyk-policy';
 import config from './config';
 
 export async function display(policy) {
-  const p = demunge(policy, config.ROOT);
+  const p = demunge(policy, config.PUBLIC_VULN_DB_URL);
   const delimiter = '\n\n------------------------\n';
 
   let res =

--- a/src/lib/formatters/legacy-format-issue.ts
+++ b/src/lib/formatters/legacy-format-issue.ts
@@ -46,7 +46,7 @@ export function formatIssues(
     }),
     introducedThrough: '  Introduced through: ' + uniquePackages,
     description: '  Description: ' + vuln.title,
-    info: '  Info: ' + chalk.underline(config.ROOT + '/vuln/' + vulnID),
+    info: '  Info: ' + chalk.underline(config.PUBLIC_VULN_DB_URL + '/vuln/' + vulnID),
     fromPaths: createTruncatedVulnsPathsText(vuln.list, options.showVulnPaths),
     extraInfo: vuln.note ? chalk.bold('\n  Note: ' + vuln.note) : '',
     remediationInfo:

--- a/src/lib/formatters/legacy-format-issue.ts
+++ b/src/lib/formatters/legacy-format-issue.ts
@@ -46,7 +46,9 @@ export function formatIssues(
     }),
     introducedThrough: '  Introduced through: ' + uniquePackages,
     description: '  Description: ' + vuln.title,
-    info: '  Info: ' + chalk.underline(config.PUBLIC_VULN_DB_URL + '/vuln/' + vulnID),
+    info:
+      '  Info: ' +
+      chalk.underline(config.PUBLIC_VULN_DB_URL + '/vuln/' + vulnID),
     fromPaths: createTruncatedVulnsPathsText(vuln.list, options.showVulnPaths),
     extraInfo: vuln.note ? chalk.bold('\n  Note: ' + vuln.note) : '',
     remediationInfo:

--- a/src/lib/formatters/remediation-based-format-issues.ts
+++ b/src/lib/formatters/remediation-based-format-issues.ts
@@ -494,7 +494,7 @@ export function formatIssue(
       )} Severity${originalSeverityStr}]`,
     ) +
     reachabilityText +
-    `[${config.ROOT}/vuln/${id}]` +
+    `[${config.PUBLIC_VULN_DB_URL}/vuln/${id}]` +
     name +
     reachableVia +
     introducedBy +

--- a/src/lib/spotlight-vuln-notification.ts
+++ b/src/lib/spotlight-vuln-notification.ts
@@ -41,7 +41,7 @@ export function notificationForSpotlightVulns(
           );
 
           for (const vulnId of foundSpotlightVulnsIds) {
-            message += `  - ${vulnId} (See https://snyk.io/vuln/${vulnId})`;
+            message += `  - ${vulnId} (See https://security.snyk.io/vuln/${vulnId})`;
           }
 
           message += EOL + EOL;

--- a/src/lib/spotlight-vuln-notification.ts
+++ b/src/lib/spotlight-vuln-notification.ts
@@ -1,6 +1,7 @@
 import * as theme from './theme';
 import * as createDebug from 'debug';
 import { EOL } from 'os';
+import config from './config';
 
 const debug = createDebug('snyk-spotlight-vuln-notification');
 
@@ -41,7 +42,7 @@ export function notificationForSpotlightVulns(
           );
 
           for (const vulnId of foundSpotlightVulnsIds) {
-            message += `  - ${vulnId} (See https://security.snyk.io/vuln/${vulnId})`;
+            message += `  - ${vulnId} (See ${config.PUBLIC_VULN_DB_URL}/vuln/${vulnId})`;
           }
 
           message += EOL + EOL;
@@ -50,9 +51,9 @@ export function notificationForSpotlightVulns(
               `We highly recommend fixing this vulnerability. If it cannot be fixed by upgrading, see mitigation information here:`,
             ) +
             EOL +
-            '  - https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHELOGGINGLOG4J-2314720' +
+            `  - ${config.PUBLIC_VULN_DB_URL}/vuln/SNYK-JAVA-ORGAPACHELOGGINGLOG4J-2314720` +
             EOL +
-            '  - https://snyk.io/blog/log4shell-remediation-cheat-sheet/' +
+            `  - https://snyk.io/blog/log4shell-remediation-cheat-sheet/` +
             EOL;
         }
       }

--- a/test/acceptance/workspaces/pip-app-transitive-vuln/cli-output-actionable-remediation.txt
+++ b/test/acceptance/workspaces/pip-app-transitive-vuln/cli-output-actionable-remediation.txt
@@ -7,17 +7,17 @@ Tested 6 dependencies for known vulnerabilities, found 4 vulnerabilities, 4 vuln
 Issues to fix by upgrading dependencies:
 
   Upgrade flask to 1.0 to fix
-  ✗ Improper Input Validation [High Severity][http://localhost:12345/vuln/SNYK-PYTHON-FLASK-42185] in flask@0.12.2
+  ✗ Improper Input Validation [High Severity][https://security.snyk.io/vuln/SNYK-PYTHON-FLASK-42185] in flask@0.12.2
     introduced by flask@0.12.2
-  ✗ Denial of Service (DOS) [High Severity][http://localhost:12345/vuln/SNYK-PYTHON-FLASK-451637] in flask@0.12.2
+  ✗ Denial of Service (DOS) [High Severity][https://security.snyk.io/vuln/SNYK-PYTHON-FLASK-451637] in flask@0.12.2
     introduced by flask@0.12.2
 
   Pin Jinja2 to 2.10.1 to fix
-  ✗ Sandbox Escape [Medium Severity][http://localhost:12345/vuln/SNYK-PYTHON-JINJA2-174126] in Jinja2@2.9.6
+  ✗ Sandbox Escape [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-174126] in Jinja2@2.9.6
     introduced by flask@0.12.2 > Jinja2@2.9.6
 
   Pin Werkzeug to 0.15.3 to fix
-  ✗ Insufficient Randomness [High Severity][http://localhost:12345/vuln/SNYK-PYTHON-WERKZEUG-458931] in Werkzeug@0.12.2
+  ✗ Insufficient Randomness [High Severity][https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-458931] in Werkzeug@0.12.2
     introduced by flask@0.12.2 > Werkzeug@0.12.2
 
 

--- a/test/acceptance/workspaces/pip-app-transitive-vuln/cli-output.txt
+++ b/test/acceptance/workspaces/pip-app-transitive-vuln/cli-output.txt
@@ -3,7 +3,7 @@ Testing pip-app-transitive-vuln...
 
 ✗ Medium severity vulnerability found in Jinja2
   Description: Sandbox Escape
-  Info: http://localhost:12345/vuln/SNYK-PYTHON-JINJA2-174126
+  Info: https://security.snyk.io/vuln/SNYK-PYTHON-JINJA2-174126
   Introduced through: flask@0.12.2
   From: flask@0.12.2 > Jinja2@2.9.6
   Remediation:
@@ -11,7 +11,7 @@ Testing pip-app-transitive-vuln...
 
 ✗ High severity vulnerability found in flask
   Description: Improper Input Validation
-  Info: http://localhost:12345/vuln/SNYK-PYTHON-FLASK-42185
+  Info: https://security.snyk.io/vuln/SNYK-PYTHON-FLASK-42185
   Introduced through: flask@0.12.2
   From: flask@0.12.2
   Remediation:
@@ -19,7 +19,7 @@ Testing pip-app-transitive-vuln...
 
 ✗ High severity vulnerability found in flask
   Description: Denial of Service (DOS)
-  Info: http://localhost:12345/vuln/SNYK-PYTHON-FLASK-451637
+  Info: https://security.snyk.io/vuln/SNYK-PYTHON-FLASK-451637
   Introduced through: flask@0.12.2
   From: flask@0.12.2
   Remediation:
@@ -27,7 +27,7 @@ Testing pip-app-transitive-vuln...
 
 ✗ High severity vulnerability found in Werkzeug
   Description: Insufficient Randomness
-  Info: http://localhost:12345/vuln/SNYK-PYTHON-WERKZEUG-458931
+  Info: https://security.snyk.io/vuln/SNYK-PYTHON-WERKZEUG-458931
   Introduced through: flask@0.12.2
   From: flask@0.12.2 > Werkzeug@0.12.2
   Remediation:

--- a/test/fixtures/snyk-config-no-version/expected
+++ b/test/fixtures/snyk-config-no-version/expected
@@ -2,7 +2,7 @@ Current Snyk policy, read from .snyk file
 Modified: Fri Nov 20 2015 17:32:48 GMT+0000 (GMT)
 Created:  Fri Nov 20 2015 16:04:35 GMT+0000 (GMT)
 
-#1 Patch vulnerability https://snyk.io/vuln/npm:ms:20151024 in the following paths:
+#1 Patch vulnerability https://security.snyk.io/vuln/npm:ms:20151024 in the following paths:
 socket.io@1.3.7 > debug@2.1.0 > ms@0.6.2
 spm-client@0.4.3 > debug@2.1.3 > ms@0.7.0
 socket.io@1.3.7 > engine.io@1.5.4 > debug@1.0.3 > ms@0.6.2
@@ -11,16 +11,16 @@ socket.io-client@1.3.7 > engine.io-client@1.5.4 > debug@1.0.4 > ms@0.6.2
 spm-client@0.4.3 > father@0.10.6 > debug@1.0.4 > ms@0.6.2
 wascally@0.2.7 > whistlepunk@0.2.0 > debug@2.1.1 > ms@0.6.2
 
-#2 Patch vulnerability https://snyk.io/vuln/npm:semver:20150403 in the following paths:
+#2 Patch vulnerability https://security.snyk.io/vuln/npm:semver:20150403 in the following paths:
 spm-client@0.4.3 > semver@4.2.2
 spm-client@0.4.3 > father@0.10.6 > semver@2.3.2
 
-#3 Patch vulnerability https://snyk.io/vuln/npm:uglify-js:20151024 in the following paths:
+#3 Patch vulnerability https://security.snyk.io/vuln/npm:uglify-js:20151024 in the following paths:
 handlebars@4.0.3 > uglify-js@2.4.24
 
 ------------------------
 
-#1 Ignore https://snyk.io/vuln/npm:tar:20151103 in the following paths:
+#1 Ignore https://security.snyk.io/vuln/npm:tar:20151103 in the following paths:
 spm-client@0.4.3 > tar@1.0.3
 Reason: Something better than a turnip
 Expires: Sun, 20 Dec 2015 16:37:39 GMT
@@ -33,12 +33,12 @@ babel@5.8.29 > chokidar@1.2.0 > fsevents@1.0.2 > node-pre-gyp@0.6.12 > tar-pack@
 Reason: Oranges
 Expires: Sun, 20 Dec 2015 16:37:39 GMT
 
-#2 Ignore https://snyk.io/vuln/npm:uglify-js:20150824 in the following paths:
+#2 Ignore https://security.snyk.io/vuln/npm:uglify-js:20150824 in the following paths:
 tap@0.7.1 > runforcover@0.0.2 > bunker@0.1.2 > burrito@0.2.12 > uglify-js@1.1.1
 Reason: Fruits
 Expires: Sun, 20 Dec 2015 16:37:39 GMT
 
-#3 Ignore https://snyk.io/vuln/npm:uglify-js:20151024 in the following paths:
+#3 Ignore https://security.snyk.io/vuln/npm:uglify-js:20151024 in the following paths:
 tap@0.7.1 > runforcover@0.0.2 > bunker@0.1.2 > burrito@0.2.12 > uglify-js@1.1.1
 Reason: Stuff
 Expires: Sun, 20 Dec 2015 16:37:39 GMT

--- a/test/jest/unit/policy-display.spec.ts
+++ b/test/jest/unit/policy-display.spec.ts
@@ -3,9 +3,6 @@ import * as fs from 'fs';
 import { display } from '../../../src/lib/display-policy';
 import stripAnsi from 'strip-ansi';
 import { getFixturePath } from '../util/getFixturePath';
-import config from '../../../src/lib/config';
-
-const { hostname } = new URL(config.ROOT);
 
 it('test sensibly bails if gets an old .snyk format', async () => {
   const filename = getFixturePath('snyk-config-no-version');
@@ -21,12 +18,12 @@ it('test sensibly bails if gets an old .snyk format', async () => {
     .split('\n')
     .slice(3)
     .join('\n');
+
   const expected = expectedFileString
     .trim()
-    // replace hostname in policy if using env var SNYK_API
-    .replace(/snyk\.io/g, hostname)
     .split('\n')
     .slice(3)
     .join('\n');
+
   expect(result).toEqual(expected);
 });

--- a/test/smoke/spec/snyk_test_spec.sh
+++ b/test/smoke/spec/snyk_test_spec.sh
@@ -58,7 +58,7 @@ Describe "Snyk test command"
     It "finds vulns in a project in the same folder"
       When run run_test_in_subfolder
       The status should equal 1
-      The output should include "https://snyk.io/vuln/npm:minimatch:20160620"
+      The output should include "https://security.snyk.io/vuln/npm:minimatch:20160620"
       if should_have_deprecation_warnings; then 
         The stderr should not equal ""
       else
@@ -69,7 +69,7 @@ Describe "Snyk test command"
     It "finds vulns in a project when pointing to a folder"
       When run snyk test ../fixtures/basic-npm
       The status should be failure # issues found
-      The output should include "https://snyk.io/vuln/npm:minimatch:20160620"
+      The output should include "https://security.snyk.io/vuln/npm:minimatch:20160620"
       if should_have_deprecation_warnings; then 
         The stderr should not equal ""
       else
@@ -80,7 +80,7 @@ Describe "Snyk test command"
     It "finds vulns in a project when pointing to a file"
       When run snyk test --file=../fixtures/basic-npm/package.json
       The status should be failure # issues found
-      The output should include "https://snyk.io/vuln/npm:minimatch:20160620"
+      The output should include "https://security.snyk.io/vuln/npm:minimatch:20160620"
       if should_have_deprecation_warnings; then 
         The stderr should not equal ""
       else

--- a/test/tap/cli-test/cli-test.docker.spec.ts
+++ b/test/tap/cli-test/cli-test.docker.spec.ts
@@ -632,7 +632,7 @@ export const DockerTests: AcceptanceTests = {
         );
         t.match(
           msg,
-          'Info: http://localhost:12345/vuln/SNYK-UPSTREAM-NODE-72359',
+          'Info: https://security.snyk.io/vuln/SNYK-UPSTREAM-NODE-72359',
         );
         t.false(
           msg.includes('vulnerable paths'),

--- a/test/tap/display-test-results.test.ts
+++ b/test/tap/display-test-results.test.ts
@@ -11,7 +11,6 @@ import { getWorkspacePath } from '../jest/util/getWorkspacePath';
 
 const { test } = tap;
 (tap as any).runOnly = false; // <- for debug. set to true, and replace a test to only(..)
-const apiUrl = new URL(config.ROOT);
 
 test('`test ruby-app` remediation displayed', async (t) => {
   chdirWorkspaces();

--- a/test/tap/display-test-results.test.ts
+++ b/test/tap/display-test-results.test.ts
@@ -173,7 +173,7 @@ test('`test npm-package-with-severity-override` show original severity upgrade',
     const { message } = error;
     t.match(
       message,
-      `[Low Severity (originally Medium)][${apiUrl.protocol}//${apiUrl.host}/vuln/npm:node-uuid:20160328]`,
+      `[Low Severity (originally Medium)][${config.PUBLIC_VULN_DB_URL}/vuln/npm:node-uuid:20160328]`,
     );
   }
 
@@ -200,7 +200,7 @@ test('`test npm-package-with-severity-override` show original severity patches',
     t.match(message, 'Patch available for node-uuid@1.4.0');
     t.match(
       message,
-      `[Low Severity (originally Medium)][${apiUrl.protocol}//${apiUrl.host}/vuln/npm:node-uuid:20160328]`,
+      `[Low Severity (originally Medium)][${config.PUBLIC_VULN_DB_URL}/vuln/npm:node-uuid:20160328]`,
     );
   }
 
@@ -252,7 +252,7 @@ test('`test npm-package-with-severity-override` show original severity unresolve
     const { message } = error;
     t.match(
       message,
-      `Malicious Package [Low Severity (originally Medium)][${apiUrl.protocol}//${apiUrl.host}/vuln/npm:node-uuid:20160328`,
+      `Malicious Package [Low Severity (originally Medium)][${config.PUBLIC_VULN_DB_URL}/vuln/npm:node-uuid:20160328`,
     );
   }
 
@@ -278,7 +278,7 @@ test('`test npm-package-with-severity-override` dont show original severity if i
     const { message } = error;
     t.match(
       message,
-      `[Low Severity][${apiUrl.protocol}//${apiUrl.host}/vuln/npm:node-uuid:20160328]`,
+      `[Low Severity][${config.PUBLIC_VULN_DB_URL}/vuln/npm:node-uuid:20160328]`,
     );
   }
 


### PR DESCRIPTION
#### What does this PR do?
Updates URL links for vulns in the CLI output to point to security.snyk.io, the new snyk vulnerability db which generally has better UX and more info than the legacy site the links are currently pointing to.
