### PR TITLE
chore: Add project name to test summary [CFG-2013]

### DIFF
--- a/src/lib/formatters/iac-output/v2/test-summary.ts
+++ b/src/lib/formatters/iac-output/v2/test-summary.ts
@@ -28,6 +28,10 @@ function formatTestMetaSection(iacMeta: IacOutputMeta): string {
     metaSectionProperties.push(['Organization', iacMeta.orgName]);
   }
 
+  if (iacMeta.projectName) {
+    metaSectionProperties.push(['Project name', iacMeta.projectName]);
+  }
+
   const metaSection = metaSectionProperties
     .map(([key, value]) =>
       rightPadWithSpaces(`${INDENT}${key}: ${value}`, PAD_LENGTH),

--- a/test/jest/acceptance/iac/iac-output.spec.ts
+++ b/test/jest/acceptance/iac/iac-output.spec.ts
@@ -93,6 +93,8 @@ describe('iac test output', () => {
         'Test Summary' +
           EOL.repeat(2) +
           '  Organization: test-org' +
+          EOL +
+          '  Project name: fixtures' +
           EOL.repeat(2) +
           '✔ Files without issues: 0' +
           EOL +

--- a/test/jest/unit/lib/formatters/iac-output/v2/test-summary.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/test-summary.spec.ts
@@ -47,7 +47,8 @@ describe('formatIacTestSummary', () => {
     const result = formatIacTestSummary(testTestData);
 
     // Assert
-    expect(result).toContain(`Organization: Shmulik.Kipod`);
+    expect(result).toContain(`Organization: Shmulik.Kipod
+  Project name: project-name`);
   });
 
   it('should include the counts section with the correct values', () => {


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Adds the project name property to the test summary section of the test output.

#### Where should the reviewer start?

```
src/lib/formatters/iac-output/v2/test-summary.ts
```

#### How should this be manually tested?

- Run `snyk-dev iac test`.
- Ensure the correct project name is displayed in the test summary section of the output.
- Ensure the project name is aligned with [the design](https://www.figma.com/file/buNFZqr1Uhf4SaifHw4WXE/Snyk-IaC-CLI?node-id=2626%3A1145).

#### Any background context you want to provide?

Following the recent changes introduced by [CFG-1973: Switch to the new scanning and project grouping behavior](https://snyksec.atlassian.net/browse/CFG-1973), which activates the new project grouping behavior, any IaC test will result in a single project name.

We would like to include this project’s name in the output.

#### What are the relevant tickets?

- [CFG-2013](https://snyksec.atlassian.net/browse/CFG-2013)

#### Screenshots

<img width="609" alt="image" src="https://user-images.githubusercontent.com/46415136/178444789-6cdf4061-0788-4093-91a3-3eed207ad618.png">