### PR TITLE
fix: handle errors from /share-results [CFG-2028]

### DIFF
--- a/src/cli/commands/test/iac/local-execution/process-results/cli-share-results.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/cli-share-results.ts
@@ -68,15 +68,15 @@ export async function shareResults({
     },
   });
 
-  switch (res.statusCode) {
-    case 401:
-      throw AuthFailedError();
-    case 422:
-      throw new ValidationError(
-        res.body.error ?? 'An error occurred, please contact Snyk support',
-      );
-    case 429:
-      throw new TestLimitReachedError();
+  if (res.statusCode === 401) {
+    throw AuthFailedError();
+  } else if (res.statusCode === 429) {
+    throw new TestLimitReachedError();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  } else if (res.statusCode! < 200 || res.statusCode! > 299) {
+    throw new ValidationError(
+      res.body.error ?? 'An error occurred, please contact Snyk support',
+    );
   }
 
   return { projectPublicIds: body, gitRemoteUrl: gitTarget?.remoteUrl };

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -470,6 +470,10 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
     res.status(200).send({});
   });
 
+  app.post(basePath + '/iac-cli-share-results', (req, res) => {
+    res.status(200).send({});
+  });
+
   app.post(basePath + '/analytics/cli', (req, res) => {
     res.status(200).send({});
   });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

While investigating https://snyk.zendesk.com/agent/tickets/26894, we noticed that client errors (e.g. HTTP 422) from the IaC share-results endpoint are not communicated to the CLI caller at all.

Example error returned in prod-registry that is not surfaced to users (example with non english chars in tag, but this can be caused by any non Az09 characters):

`snyk iac test test/fixtures/iac/terraform/var_deref/nested_var_deref/ --project-tags=client=nαδαδσδαomnom,Team=Cloud --report`

```
InvalidUserInputError: invalid tag value: contains invalid characters
    at assertValidValue (/srv/app/dist/lib/tags/validation.js:36:15)
    at assertValidFields (/srv/app/dist/lib/tags/validation.js:50:34)
    at parse (/srv/app/dist/web/routes/project/tags/parse.js:17:38)
    at /srv/app/dist/web/routes/api/v1/iac-cli-share-results.js:36:39
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

Users should see the error in the CLI’s output so that they know they need to do something in order to record project results, otherwise the problem might go un-noticed for some time. The silence can also lead users to believe that it is a backend error, and not an input error.

We will not print the specific validation error as part of this PR - this code is to be refactored in the next weeks so we will re-write this again.

This PR updates the call to share-results to handle all 500 errors (that's what we wrap them with in Registry). 

before - the error was silent for the invalid tag:
![image](https://user-images.githubusercontent.com/6989529/178479454-194d174a-a5c0-4228-b951-efbad809cf7d.png)

after

![image](https://user-images.githubusercontent.com/6989529/178479308-c8c6b092-bc91-4190-85b9-18363709b848.png)

