### PR TITLE
test: kerberos/jest setup

### DIFF
--- a/cliv2/Makefile
+++ b/cliv2/Makefile
@@ -169,8 +169,12 @@ whiteboxtest:
 	@echo "$(LOG_PREFIX) Running $@"
 	@$(GOCMD) test -cover ./...
 
+.PHONY: acceptancetest 
+acceptancetest: build
+	TEST_SNYK_COMMAND="$(BUILD_DIR)/$(V2_EXECUTABLE_NAME)" npx jest
+
 .PHONY: test
-test: whiteboxtest blackboxtest
+test: whiteboxtest blackboxtest acceptancetest
 
 .PHONY: lint
 lint:

--- a/cliv2/jest.config.ts
+++ b/cliv2/jest.config.ts
@@ -1,0 +1,3 @@
+import { createJestConfig } from '../test/createJestConfig';
+
+export default createJestConfig({ displayName: 'cliv2' });

--- a/cliv2/test/acceptance/proxy_authentication.spec.ts
+++ b/cliv2/test/acceptance/proxy_authentication.spec.ts
@@ -1,0 +1,203 @@
+import * as path from 'path';
+import { fakeServer, FakeServer } from '../../../test/acceptance/fake-server';
+import {
+  createProjectFromWorkspace,
+  TestProject,
+} from '../../../test/jest/util/createProject';
+import {
+  startCommand,
+  TestCLI,
+  startSnykCLI,
+} from '../../../test/jest/util/startSnykCLI';
+import { isCLIV2 } from '../../../test/jest/util/isCLIV2';
+import { unlink } from 'fs';
+
+jest.setTimeout(1000 * 60);
+
+// Global test configuration
+const dockerComposeFile = path.resolve(
+  path.join(__dirname, '..', 'fixtures', 'kerberos', 'docker-compose.yml'),
+);
+const scriptsPath = path.resolve(
+  path.join(__dirname, '..', 'fixtures', 'kerberos', 'scripts'),
+);
+const containerName = 'proxy_authentication_container';
+const hostnameFakeServer = 'host.docker.internal';
+const hostnameProxy = 'proxy.snyk.local';
+const proxyPort = '3128';
+const port = process.env.PORT || process.env.SNYK_PORT || '12345';
+const baseApi = '/api/v1';
+const SNYK_API = 'http://' + hostnameFakeServer + ':' + port + baseApi;
+const HTTP_PROXY = 'http://localhost:' + proxyPort;
+const KRB5_CACHE_FILE = 'krb5_cache';
+const KRB5_CONFIG_FILE = 'krb5.conf';
+
+function getDockerOptions() {
+  const dockerOptions = {
+    env: {
+      ...process.env,
+      HTTP_PROXY_PORT: proxyPort,
+      PROXY_HOSTNAME: hostnameProxy,
+      SNYK_API: SNYK_API,
+      CONTAINER_NAME: containerName,
+      SCRIPTS_PATH: scriptsPath,
+    },
+  };
+  return dockerOptions;
+}
+
+async function isDockerAvailable(): Promise<boolean> {
+  let result = false;
+
+  try {
+    const process = await startCommand('docker', ['--version']);
+    const errorCode = process.wait({ timeout: 30_000 });
+    if ((await errorCode).valueOf() == 0) {
+      result = true;
+    }
+  } catch {
+    result = false;
+  }
+
+  return result;
+}
+
+async function startProxyEnvironment(): Promise<void> {
+  // Stop any orphaned containers from previous runs.
+  await stopProxyEnvironment();
+
+  const dockerUp = await startCommand(
+    'docker-compose',
+    ['--file', dockerComposeFile, 'up', '--build'],
+    getDockerOptions(),
+  );
+  await expect(dockerUp).toDisplay('Kerberos setup complete.', {
+    timeout: 60_000,
+  });
+}
+
+async function stopProxyEnvironment(): Promise<void> {
+  const dockerDown = await startCommand(
+    'docker-compose',
+    ['--file', dockerComposeFile, 'down'],
+    getDockerOptions(),
+  );
+  await expect(dockerDown).toExitWith(0, { timeout: 30_000 });
+}
+
+async function getProxyAccessLog(): Promise<string> {
+  const check = await startCommand('docker', [
+    'exec',
+    containerName,
+    'cat',
+    '/var/log/squid/access.log',
+  ]);
+  await expect(check).toExitWith(0);
+  return check.stdout.get();
+}
+
+async function runCliWithProxy(
+  env: Record<string, string>,
+  args: string[] = [],
+  cmd = 'test',
+): Promise<TestCLI> {
+  let temp: string[] = [cmd, '--debug'];
+  temp = temp.concat(args);
+  const cli = await startSnykCLI(temp.join(' '), {
+    env: {
+      ...env,
+      SNYK_HTTP_PROTOCOL_UPGRADE: '0',
+      KRB5CCNAME: 'FILE:' + path.join(scriptsPath, KRB5_CACHE_FILE),
+      KRB5_CONFIG: path.join(scriptsPath, KRB5_CONFIG_FILE),
+    },
+  });
+  return cli;
+}
+
+describe('Proxy Authentication', () => {
+  if (!isCLIV2() || !process.env.TEST_SNYK_COMMAND?.includes('linux')) {
+    // eslint-disable-next-line jest/no-focused-tests
+    it.only('These tests are currently limited to cover linux builds of CLIv2.', () => {
+      console.warn(
+        'Skipping test. These tests covering CLIv2 only features on linux and mac.',
+      );
+    });
+  } else {
+    let server: FakeServer;
+    let env: Record<string, string>;
+    let project: TestProject;
+    let hasDockerInstalled: boolean;
+
+    beforeAll(async () => {
+      hasDockerInstalled = (await isDockerAvailable()).valueOf();
+      if (false == hasDockerInstalled) {
+        console.warn('These tests require Docker to be installed!');
+      }
+      expect(hasDockerInstalled).toBe(true);
+
+      project = await createProjectFromWorkspace('npm-package');
+      await startProxyEnvironment();
+
+      env = {
+        ...process.env,
+        SNYK_API: SNYK_API,
+        SNYK_TOKEN: '123456789',
+        HTTP_PROXY: HTTP_PROXY,
+        HTTPS_PROXY: HTTP_PROXY,
+      };
+      server = fakeServer(baseApi, env.SNYK_TOKEN);
+      await server.listenPromise(port);
+    });
+
+    afterEach(() => {
+      if (hasDockerInstalled) {
+        server.restore();
+      }
+    });
+
+    afterAll(async () => {
+      if (hasDockerInstalled) {
+        await server.closePromise();
+        await stopProxyEnvironment();
+        unlink(path.join(scriptsPath, KRB5_CACHE_FILE), () => {});
+        unlink(path.join(scriptsPath, KRB5_CONFIG_FILE), () => {});
+      }
+    });
+
+    it('fails to run snyk test due to missing --proxy-negotiate', async () => {
+      const logOnEntry = await getProxyAccessLog();
+
+      // run snyk test
+      const args: string[] = [project.path()];
+      const cli = await runCliWithProxy(env, args);
+      await expect(cli).toExitWith(2);
+
+      const logOnExit = await getProxyAccessLog();
+      const additionalLogEntries = logOnExit.substring(logOnEntry.length);
+      expect(additionalLogEntries.includes('TCP_DENIED/407')).toBeTruthy();
+      expect(
+        additionalLogEntries.includes(
+          'CONNECT ' + hostnameFakeServer + ':' + port,
+        ),
+      ).toBeFalsy();
+    });
+
+    it('successfully runs snyk test', async () => {
+      const logOnEntry = await getProxyAccessLog();
+
+      // run snyk test
+      const args: string[] = ['--proxy-negotiate', project.path()];
+      const cli = await runCliWithProxy(env, args);
+      await expect(cli).toExitWith(0);
+
+      const logOnExit = await getProxyAccessLog();
+      const additionalLogEntries = logOnExit.substring(logOnEntry.length);
+      expect(additionalLogEntries.includes('TCP_TUNNEL/200')).toBeTruthy();
+      expect(
+        additionalLogEntries.includes(
+          'CONNECT ' + hostnameFakeServer + ':' + port,
+        ),
+      ).toBeTruthy();
+    });
+  }
+});

--- a/cliv2/test/fixtures/kerberos/Dockerfile
+++ b/cliv2/test/fixtures/kerberos/Dockerfile
@@ -1,0 +1,11 @@
+FROM debian:bullseye-slim
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    build-essential \
+    krb5-user krb5-kdc krb5-admin-server krb5-multidev libkrb5-dev \
+    curl openssl ca-certificates \
+    squid \
+    && mkdir -p /etc/cliv2/bin && touch /etc/cliv2/bin/snyk
+
+ENTRYPOINT [ "/etc/cliv2/scripts/setup_kerberos.sh" ]

--- a/cliv2/test/fixtures/kerberos/docker-compose.yml
+++ b/cliv2/test/fixtures/kerberos/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  cliv2_kerberos:
+    container_name: ${CONTAINER_NAME}
+    build: .
+    environment:
+      - KERBEROS_USERNAME=administrator
+      - KERBEROS_PASSWORD=password123
+      - HTTP_PROXY_PORT=${HTTP_PROXY_PORT}
+    ports:
+      - "${HTTP_PROXY_PORT}:${HTTP_PROXY_PORT}"
+      - "88:88"
+    expose:
+      - "${HTTP_PROXY_PORT}"
+      - "88/udp"
+    hostname: "${PROXY_HOSTNAME}"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ${SCRIPTS_PATH}:/etc/cliv2/scripts

--- a/cliv2/test/fixtures/kerberos/scripts/setup_kerberos.sh
+++ b/cliv2/test/fixtures/kerberos/scripts/setup_kerberos.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -exuo pipefail
+# Inspired by: https://github.com/requests/requests-kerberos/blob/cf45bbac9df696c5dd2d1a2360b6fbee7096207c/ci/setup-kerb.sh
+# ${VAR^^} uppercases all characters.
+
+export KERBEROS_HOSTNAME="$(cat /etc/hostname)"
+export KERBEROS_REALM="$(echo ${KERBEROS_HOSTNAME} | cut -d'.' -f2,3)"
+export KRB5_KTNAME='/etc/krb5.keytab'
+
+echo "Setting up Kerberos config file at /etc/krb5.conf"
+cat > /etc/krb5.conf << EOL
+[libdefaults]
+    default_realm = ${KERBEROS_REALM^^}
+    dns_lookup_realm = false
+    dns_lookup_kdc = false
+[realms]
+    ${KERBEROS_REALM^^} = {
+        kdc = localhost
+        admin_server = localhost
+    }
+[domain_realm]
+    .${KERBEROS_REALM} = ${KERBEROS_REALM^^}
+[logging]
+    kdc = FILE:/var/log/krb5kdc.log
+    admin_server = FILE:/var/log/kadmin.log
+    default = FILE:/var/log/krb5lib.log
+EOL
+cat /etc/krb5.conf
+
+echo "Setting up kerberos ACL configuration at /etc/krb5kdc/kadm5.acl"
+echo -e "*/*@${KERBEROS_REALM^^}\t*" > /etc/krb5kdc/kadm5.acl
+
+echo "Creating KDC database"
+printf "${KERBEROS_PASSWORD}\n${KERBEROS_PASSWORD}" | krb5_newrealm
+
+echo "Creating principals for tests"
+kadmin.local -q "addprinc -pw ${KERBEROS_PASSWORD} ${KERBEROS_USERNAME}"
+
+echo "Adding HTTP principal for Kerberos and create keytab"
+kadmin.local -q "addprinc -randkey HTTP/localhost"
+kadmin.local -q "addprinc -randkey HTTP/${KERBEROS_HOSTNAME}"
+kadmin.local -q "ktadd -k ${KRB5_KTNAME} HTTP/localhost"
+kadmin.local -q "ktadd -k ${KRB5_KTNAME} HTTP/${KERBEROS_HOSTNAME}"
+chmod 777 "${KRB5_KTNAME}"
+
+echo "Restarting Kerberos KDS service"
+service krb5-kdc restart
+
+echo "Configuring Squid HTTP proxy"
+cat > /etc/squid/squid.conf << EOL
+auth_param negotiate program /usr/lib/squid/negotiate_wrapper_auth --kerberos /usr/lib/squid/negotiate_kerberos_auth -d -s HTTP/localhost --ntlm /usr/lib/squid/ntlm_fake_auth
+auth_param negotiate children 10
+auth_param negotiate keep_alive on
+acl auth proxy_auth REQUIRED
+http_port 0.0.0.0:${HTTP_PROXY_PORT}
+http_access deny !auth
+http_access allow auth
+http_access deny all
+EOL
+cat /etc/squid/squid.conf
+service squid restart
+
+sleep 1
+
+echo "Getting ticket for Kerberos user"
+echo -n "${KERBEROS_PASSWORD}" | kinit "${KERBEROS_USERNAME}@${KERBEROS_REALM^^}"
+
+echo "Checking HTTP proxy"
+curl --verbose --head --retry 5 \
+    --proxy "http://localhost:${HTTP_PROXY_PORT}" --proxy-negotiate -u ":" \
+    "https://snyk.io"
+
+cp /tmp/krb5cc_0 /etc/cliv2/scripts/krb5_cache
+cp /etc/krb5.conf /etc/cliv2/scripts/krb5.conf
+chmod a+r /etc/cliv2/scripts/krb5_cache
+chmod a+r /etc/cliv2/scripts/krb5.conf
+
+echo "Kerberos setup complete."
+echo "Keeping container running... Press CTRL+C to stop."
+tail -F /var/log/squid/access.log

--- a/test/jest/util/createProject.ts
+++ b/test/jest/util/createProject.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { getFixturePath } from './getFixturePath';
 
-type TestProject = {
+export type TestProject = {
   path: (filePath?: string) => string;
   read: (filePath: string) => Promise<string>;
   readJSON: (filePath: string) => Promise<any>;


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
In this PR we introduce acceptance tests for proxy authentication implemented in CLIv2. The proxy authentication currently supports [SPNEGO based authentication](https://www.ietf.org/rfc/rfc4559.txt) and thereby mainly kerberos (all platforms) and NTLM (on Windows machines). 
The PR introduces a Docker based test environment spinning up a linux container hosting a Squid Proxy and a Kerberos KDC, with which the executable under test interacts.

Unfortunately due to limitations on our CircleCi Runners, the tests currently only run for linux builds.

#### Where should the reviewer start?
The test suite can be found here cliv2/test/acceptance/proxy_authentication.spec.ts
