### PR TITLE
fix: container app vulns json with experimental flag

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,6 +69,7 @@ src/cli/commands/log4shell-hashes.ts @snyk/tundra
 src/cli/commands/log4shell.ts @snyk/tundra
 test/fixtures/unmanaged-log4j-fixture @snyk/tundra
 test/jest/acceptance/snyk-log4shell/log4shell-detection.spec.ts @snyk/tundra
+test/jest/acceptance/snyk-test/app-vuln-container-project.spec.ts @snyk/mycelium
 /.github @snyk/hammer
 
 # tap tests ownership

--- a/src/lib/formatters/test/format-test-results.ts
+++ b/src/lib/formatters/test/format-test-results.ts
@@ -102,7 +102,7 @@ export function extractDataToSendFromResults(
   let jsonData = jsonResults.length === 1 ? jsonResults[0] : jsonResults;
 
   // for container projects, we want the app vulns data to be a part of the result object
-  if (options.docker && jsonResults.length > 1) {
+  if (options.docker && jsonResults.length > 1 && !options.experimental) {
     const appVulnsData = jsonData.splice(1);
     jsonData = jsonData[0];
     if (jsonData.vulnerabilities.length === 0) {

--- a/test/jest/acceptance/snyk-test/app-vuln-container-project.spec.ts
+++ b/test/jest/acceptance/snyk-test/app-vuln-container-project.spec.ts
@@ -18,12 +18,10 @@ describe('container test projects behavior with --app-vulns, --file and --exclud
     );
     const jsonOutput = JSON.parse(stdout);
 
-    expect(jsonOutput.ok).toEqual(false);
-    expect(jsonOutput.uniqueCount).toBeGreaterThan(0);
-    const applications = jsonOutput.applications;
-    expect(applications.length).toEqual(1);
-    expect(applications[0].uniqueCount).toBeGreaterThan(0);
-    expect(applications[0].ok).toEqual(false);
+    expect(jsonOutput[0].ok).toEqual(false);
+    expect(jsonOutput[0].uniqueCount).toBeGreaterThan(0);
+    expect(jsonOutput[1].ok).toEqual(false);
+    expect(jsonOutput[1].uniqueCount).toBeGreaterThan(0);
     expect(code).toEqual(1);
   }, 10000);
   it('should find all vulns when using --app-vulns without experimental flag', async () => {
@@ -113,7 +111,8 @@ describe('container test projects behavior with --app-vulns, --json flags', () =
     );
 
     const jsonOutput = JSON.parse(stdout);
-    expect(jsonOutput.applications).toHaveLength(1);
+    expect(Array.isArray(jsonOutput)).toBeTruthy();
+    expect(jsonOutput).toHaveLength(2);
     expect(code).toEqual(0);
   });
 });


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
In a recent [PR](https://github.com/snyk/cli/pull/3417) we released a new JSON structure for container tests with app vulns, eliminating the need for the `experimental` flag when doing so. Since some customers are still using the `experimental` flag and expect the output in the older format, we are reverting the JSON output for container app vulns to how it was when using the experimental flag.


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/MYC-139

