### PR TITLE
feat: add test summary section to the experimental output

### DIFF
--- a/src/lib/formatters/iac-output/v2/formatters.ts
+++ b/src/lib/formatters/iac-output/v2/formatters.ts
@@ -86,6 +86,8 @@ function formatScanResultsNewOutput(
 
 export function formatSnykIacTestTestData(
   snykIacTestScanResult: Results | undefined,
+  projectName: string,
+  orgName: string,
 ): IacTestData {
   const resultsBySeverity = formatSnykIacTestScanResultNewOutput(
     snykIacTestScanResult,
@@ -99,19 +101,53 @@ export function formatSnykIacTestTestData(
     totalIssues += issuesCountBySeverity[severity];
   });
 
+  const allFilesCount = countFiles(snykIacTestScanResult);
+  const filesWithIssuesCount = countFilesWithIssues(snykIacTestScanResult);
+  const filesWithoutIssuesCount = allFilesCount - filesWithIssuesCount;
+
   return {
     resultsBySeverity,
-    // TODO: Add metadata when working on the Share Results feat
-    metadata: { projectName: 'TBD', orgName: 'TBD' },
-    // TODO: Add missing preoprties when adding support for the test summary
+    metadata: { projectName, orgName },
     counts: {
       ignores: 0,
-      filesWithIssues: 0,
-      filesWithoutIssues: 0,
+      filesWithIssues: filesWithIssuesCount,
+      filesWithoutIssues: filesWithoutIssuesCount,
       issues: totalIssues,
       issuesBySeverity: issuesCountBySeverity,
     },
   };
+}
+
+function countFilesWithIssues(results?: Results): number {
+  if (results && results.vulnerabilities) {
+    const files = new Set<string>();
+
+    for (const vulnerability of results.vulnerabilities) {
+      if (vulnerability.resource.file) {
+        files.add(vulnerability.resource.file);
+      }
+    }
+
+    return files.size;
+  }
+
+  return 0;
+}
+
+function countFiles(results?: Results): number {
+  if (results && results?.resources) {
+    const files = new Set<string>();
+
+    for (const resource of results.resources) {
+      if (resource.file) {
+        files.add(resource.file);
+      }
+    }
+
+    return files.size;
+  }
+
+  return 0;
 }
 
 function formatSnykIacTestScanResultNewOutput(

--- a/test/jest/unit/cli/commands/test/iac/v2/index.spec.ts
+++ b/test/jest/unit/cli/commands/test/iac/v2/index.spec.ts
@@ -1,53 +1,88 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import chalk from 'chalk';
 
 import * as scanLib from '../../../../../../../../src/lib/iac/test/v2/scan';
 import * as downloadPolicyEngineLib from '../../../../../../../../src/lib/iac/test/v2/setup/local-cache/policy-engine/download';
 import * as downloadRulesBundleLib from '../../../../../../../../src/lib/iac/test/v2/setup/local-cache/rules-bundle/download';
+import * as orgSettingsLib from '../../../../../../../../src/cli/commands/test/iac/local-execution/org-settings/get-iac-org-settings';
 import { test } from '../../../../../../../../src/cli/commands/test/iac/v2/index';
 import { Options, TestOptions } from '../../../../../../../../src/lib/types';
 import { isValidJSONString } from '../../../../../../acceptance/iac/helpers';
+import { IacOrgSettings } from '../../../../../../../../src/cli/commands/test/iac/local-execution/types';
 
 jest.setTimeout(1000 * 10);
 
+const projectRoot = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+  '..',
+);
+
+const scanFixturePath = path.join(
+  projectRoot,
+  'test',
+  'jest',
+  'unit',
+  'iac',
+  'process-results',
+  'fixtures',
+  'snyk-iac-test-results.json',
+);
+
 describe('test', () => {
+  chalk.enabled = false;
+
   const defaultOptions: Options & TestOptions = {
     iac: true,
     path: 'path/to/test',
     showVulnPaths: 'all',
   };
-  const snykIacTestfixtureContent = fs.readFileSync(
-    path.join(
-      __dirname,
-      '..',
-      '..',
-      '..',
-      '..',
-      '..',
-      'iac',
-      'process-results',
-      'fixtures',
-      'snyk-iac-test-results.json',
-    ),
-    'utf-8',
-  );
-  const snykIacTestfixture = JSON.parse(snykIacTestfixtureContent);
-  jest.spyOn(scanLib, 'scan').mockReturnValue(snykIacTestfixture);
+
+  const orgSettings: IacOrgSettings = {
+    customPolicies: {},
+    meta: {
+      org: 'my-org-name',
+      isLicensesEnabled: false,
+      isPrivate: false,
+    },
+  };
+
+  const scanFixture = JSON.parse(fs.readFileSync(scanFixturePath, 'utf-8'));
+
+  jest.spyOn(scanLib, 'scan').mockReturnValue(scanFixture);
+
   jest
     .spyOn(downloadPolicyEngineLib, 'downloadPolicyEngine')
     .mockResolvedValue('');
+
   jest
     .spyOn(downloadRulesBundleLib, 'downloadRulesBundle')
     .mockResolvedValue('');
 
-  it('without any flags outputs the test results', async () => {
-    const result = (
-      await test(['path/to/test'], defaultOptions)
-    ).getDisplayResults();
+  jest
+    .spyOn(orgSettingsLib, 'getIacOrgSettings')
+    .mockResolvedValue(orgSettings);
 
-    expect(result).toContain('Issues');
-    expect(result).toContain('Medium Severity Issues: ');
-    expect(result).toContain('High Severity Issues: ');
+  it('without any flags outputs the test results', async () => {
+    const result = await test(['path/to/test'], defaultOptions);
+    const output = result.getDisplayResults();
+
+    expect(output).toContain('Issues');
+    expect(output).toContain('Medium Severity Issues: ');
+    expect(output).toContain('High Severity Issues: ');
+    expect(output).toContain(`Organization: ${orgSettings.meta.org}`);
+    expect(output).toContain(`Project name: ${path.basename(projectRoot)}`);
+    expect(output).toContain('Files without issues: 1');
+    expect(output).toContain('Files with issues: 2');
+    expect(output).toContain('Total issues: 3');
+    expect(output).toContain('[ 0 critical, 2 high, 1 medium, 0 low ]');
   });
 
   it('with `--json` flag', async () => {

--- a/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-test-data.json
+++ b/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-test-data.json
@@ -1,93 +1,93 @@
 {
-    "resultsBySeverity":{
-      "medium":[
-        {
-          "issue":{
-            "id":"SNYK-CC-00024",
-            "severity":"medium",
-            "title":"VPC default security group allows unrestricted ingress traffic",
-            "isIgnored":false,
-            "cloudConfigPath":[
-              "aws_default_security_group",
-              "default",
-              "ingress",
-              0,
-              "cidr_blocks",
-              0
-            ],
-            "subType":"",
-            "iacDescription":{
-              "issue":"",
-              "impact":"",
-              "resolve":""
-            },
-            "lineNumber": 12
+  "resultsBySeverity": {
+    "medium": [
+      {
+        "issue": {
+          "id": "SNYK-CC-00024",
+          "severity": "medium",
+          "title": "VPC default security group allows unrestricted ingress traffic",
+          "isIgnored": false,
+          "cloudConfigPath": [
+            "aws_default_security_group",
+            "default",
+            "ingress",
+            0,
+            "cidr_blocks",
+            0
+          ],
+          "subType": "",
+          "iacDescription": {
+            "issue": "",
+            "impact": "",
+            "resolve": ""
           },
-          "targetFile":"/Users/yairzohar/snyk/upe-test/default_vpc_security_group.tf",
-          "projectType":"aws_default_security_group"
-        }
-      ],
-      "high":[
-        {
-          "issue":{
-            "id":"SNYK-CC-00107",
-            "severity":"high",
-            "title":"S3 bucket is publicly readable",
-            "isIgnored":false,
-            "cloudConfigPath":[
-              "aws_s3_bucket",
-              "readable",
-              "acl"
-            ],
-            "subType":"",
-            "iacDescription":{
-              "issue":"",
-              "impact":"",
-              "resolve":""
-            },
-            "lineNumber": 8
-          },
-          "targetFile":"/Users/yairzohar/snyk/upe-test/s3_cis.tf",
-          "projectType":"aws_s3_bucket"
+          "lineNumber": 12
         },
-        {
-          "issue":{
-            "id":"SNYK-CC-00107",
-            "severity":"high",
-            "title":"S3 bucket is publicly readable",
-            "isIgnored":false,
-            "cloudConfigPath":[
-              "aws_s3_bucket",
-              "writable",
-              "acl"
-            ],
-            "subType":"",
-            "iacDescription":{
-              "issue":"",
-              "impact":"",
-              "resolve":""
-            },
-            "lineNumber": 3
-          },
-          "targetFile":"/Users/yairzohar/snyk/upe-test/s3_cis.tf",
-          "projectType":"aws_s3_bucket"
-        }
-      ]
-    },
-    "metadata":{
-      "projectName":"TBD",
-      "orgName":"TBD"
-    },
-      "counts": {
-        "filesWithIssues": 0,
-        "filesWithoutIssues": 0,
-        "ignores": 0,
-        "issues": 3,
-        "issuesBySeverity": {
-          "critical": 0,
-          "high": 2,
-          "low": 0,
-          "medium": 1
-        }
+        "targetFile": "/Users/yairzohar/snyk/upe-test/default_vpc_security_group.tf",
+        "projectType": "aws_default_security_group"
       }
+    ],
+    "high": [
+      {
+        "issue": {
+          "id": "SNYK-CC-00107",
+          "severity": "high",
+          "title": "S3 bucket is publicly readable",
+          "isIgnored": false,
+          "cloudConfigPath": [
+            "aws_s3_bucket",
+            "readable",
+            "acl"
+          ],
+          "subType": "",
+          "iacDescription": {
+            "issue": "",
+            "impact": "",
+            "resolve": ""
+          },
+          "lineNumber": 8
+        },
+        "targetFile": "/Users/yairzohar/snyk/upe-test/s3_cis.tf",
+        "projectType": "aws_s3_bucket"
+      },
+      {
+        "issue": {
+          "id": "SNYK-CC-00107",
+          "severity": "high",
+          "title": "S3 bucket is publicly readable",
+          "isIgnored": false,
+          "cloudConfigPath": [
+            "aws_s3_bucket",
+            "writable",
+            "acl"
+          ],
+          "subType": "",
+          "iacDescription": {
+            "issue": "",
+            "impact": "",
+            "resolve": ""
+          },
+          "lineNumber": 3
+        },
+        "targetFile": "/Users/yairzohar/snyk/upe-test/s3_cis.tf",
+        "projectType": "aws_s3_bucket"
+      }
+    ]
+  },
+  "metadata": {
+    "projectName": "project-name",
+    "orgName": "org-name"
+  },
+  "counts": {
+    "filesWithIssues": 2,
+    "filesWithoutIssues": 1,
+    "ignores": 0,
+    "issues": 3,
+    "issuesBySeverity": {
+      "critical": 0,
+      "high": 2,
+      "low": 0,
+      "medium": 1
+    }
   }
+}

--- a/test/jest/unit/lib/formatters/iac-output/v2/formatters.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/formatters.spec.ts
@@ -99,8 +99,12 @@ describe('formatSnykIacTestTestData', () => {
   );
 
   it('formats the test data correctly', () => {
-    expect(formatSnykIacTestTestData(snykIacTestOutputFixture.results)).toEqual(
-      testDataFixture,
-    );
+    expect(
+      formatSnykIacTestTestData(
+        snykIacTestOutputFixture.results,
+        'project-name',
+        'org-name',
+      ),
+    ).toEqual(testDataFixture);
   });
 });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR adds the test summary section to the `iac test` command when run with the `--experimental` flag.

#### Where should the reviewer start?

The bulk of the implementation is in `src/lib/formatters/iac-output/v2/formatters.ts`.

#### How should this be manually tested?

Run a scan using a command similar to this:

```
snyk iac test test/fixtures/iac --experimental
```

You should see a test summary similar to the following at the end of the output:

```
Test Summary

  Organization: francescomari
  Project name: cli

✔ Files without issues: 10
✗ Files with issues: 1
  Ignored issues: 0
  Total issues: 1 [ 0 critical, 1 high, 0 medium, 0 low ]
```

#### What are the relevant tickets?

[CFG-2024](https://snyksec.atlassian.net/browse/CFG-2024)
