### PR TITLE
chore: upgrade snyk-iac-test to v0.7.4

### DIFF
--- a/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/index.ts
+++ b/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/index.ts
@@ -3,7 +3,7 @@ import { formatPolicyEngineFileName, getChecksum } from './utils';
 /**
  * The Policy Engine release version associated with this Snyk CLI version.
  */
-export const policyEngineReleaseVersion = '0.4.2';
+export const policyEngineReleaseVersion = '0.7.4';
 
 /**
  * The Policy Engine executable's file name.

--- a/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/utils.ts
@@ -19,12 +19,12 @@ export function formatPolicyEngineFileName(releaseVersion: string) {
 }
 
 // this const is not placed in `index.ts` to avoid circular dependencies
-const policyEngineChecksums = `17c96fae83c7b7bd287999c3272303045a38051686ac60880c1b3e484773c10d  snyk-iac-test_0.4.2_Linux_x86_64
-1afa95542cfd7c32120b724886fa50d90fc10e186ed10a9cb96242d2dbcb9ace  snyk-iac-test_0.4.2_Windows_x86_64.exe
-1f34e0a099ec4af17b20d7a28f981a0b85902d5f13b315709a66614969d917f0  snyk-iac-test_0.4.2_Linux_arm64
-2340fefd5d389c2d91859aa0251d3dbfa738a1c5de02f6787029f37841c50421  snyk-iac-test_0.4.2_Darwin_arm64
-ec28b5cccd1d9066a5b341c979e465e2a6691339cb1fcc7d5ce3dece0e9fb8f9  snyk-iac-test_0.4.2_Windows_arm64.exe
-f3e54c7e105761851d2de578a6d39a8510af31ed4fbd91cf57162d7b4601f364  snyk-iac-test_0.4.2_Darwin_x86_64
+const policyEngineChecksums = `149794ee99d273cd461eb51dd0df6cac2d3b0eddc6f2c612af669bd1aa1b5ada  snyk-iac-test_0.7.4_Darwin_x86_64
+3263270469e144061e86caedea33c5df2917b036be0f78727880c802e1e5dbaa  snyk-iac-test_0.7.4_Windows_arm64.exe
+61fb24c4f70e0d6039d563d72bbaee3e7cb998b6f1486ad97fd43fddfeedcb42  snyk-iac-test_0.7.4_Darwin_arm64
+a466c326389c6f7e004b24ad2f5761e28b739832a48c9efcbf812a639280481b  snyk-iac-test_0.7.4_Windows_x86_64.exe
+f36a16eaf98bb4681c8dc60ae7301d56c6bd8b3595de0fe2baf2561a3cd3071a  snyk-iac-test_0.7.4_Linux_arm64
+fc0cdeb5c358c21a163e00c117cf6ae526d289fb04523e7e0ee91f2da7c52e66  snyk-iac-test_0.7.4_Linux_x86_64
 `;
 
 export function getChecksum(policyEngineFileName: string): string {


### PR DESCRIPTION
Upgrade snyk-iac-test to v0.7.4