### PR TITLE
chore: Applied explicit assignment for issue mapping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "lodash.merge": "^4.6.2",
         "lodash.omit": "^4.5.0",
         "lodash.orderby": "^4.6.0",
+        "lodash.pick": "^4.4.0",
         "lodash.sortby": "^4.7.0",
         "lodash.uniq": "^4.5.0",
         "lodash.upperfirst": "^4.3.1",
@@ -12309,7 +12310,7 @@
     "node_modules/lodash.pick": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+      "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q=="
     },
     "node_modules/lodash.reduce": {
       "version": "4.6.0",
@@ -29516,7 +29517,7 @@
     "lodash.pick": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+      "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q=="
     },
     "lodash.reduce": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "lodash.merge": "^4.6.2",
     "lodash.omit": "^4.5.0",
     "lodash.orderby": "^4.6.0",
+    "lodash.pick": "^4.4.0",
     "lodash.sortby": "^4.7.0",
     "lodash.uniq": "^4.5.0",
     "lodash.upperfirst": "^4.3.1",

--- a/src/lib/formatters/iac-output/v2/formatters.ts
+++ b/src/lib/formatters/iac-output/v2/formatters.ts
@@ -177,6 +177,7 @@ function formatSnykIacTestScanVulnerability(
 ): AnnotatedIacIssue {
   return {
     id: vulnerability.rule.id,
+    publicId: vulnerability.rule.id,
     severity: vulnerability.severity,
     title: vulnerability.rule.title,
     isIgnored: vulnerability.ignored,
@@ -190,5 +191,9 @@ function formatSnykIacTestScanVulnerability(
       impact: '',
       resolve: '',
     },
+    issue: '',
+    impact: '',
+    resolve: '',
+    msg: '',
   };
 }

--- a/src/lib/snyk-test/iac-test-result.ts
+++ b/src/lib/snyk-test/iac-test-result.ts
@@ -1,7 +1,9 @@
+import pick = require('lodash.pick');
 import { BasicResultData, SEVERITY, TestDepGraphMeta } from './legacy';
 
 export interface AnnotatedIacIssue {
   id: string;
+  publicId: string;
   title: string;
   description?: string;
   severity: SEVERITY | 'none';
@@ -11,9 +13,14 @@ export interface AnnotatedIacIssue {
   path?: string[];
   documentation?: string;
   isGeneratedByCustomRule?: boolean;
+  issue: string;
+  impact: string;
+  resolve: string;
   remediation?: Partial<
     Record<'terraform' | 'cloudformation' | 'arm' | 'kubernetes', string>
   >;
+  msg: string;
+  compliance?: string[][];
 
   // Legacy fields from Registry, unused.
   name?: string;
@@ -94,7 +101,27 @@ export function mapIacIssue(
   iacIssue: AnnotatedIacIssue,
 ): MappedAnnotatedIacIssue {
   // filters out & renames properties we're getting from registry and don't need for the JSON output.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { cloudConfigPath: path, name, from, ...mappedIacIssue } = iacIssue;
-  return { ...mappedIacIssue, path };
+  return {
+    ...pick(
+      iacIssue,
+      'id',
+      'title',
+      'severity',
+      'isIgnored',
+      'subType',
+      'documentation',
+      'isGeneratedByCustomRule',
+      'issue',
+      'impact',
+      'resolve',
+      'remediation',
+      'lineNumber',
+      'iacDescription',
+      'publicId',
+      'msg',
+      'description',
+      'compliance',
+    ),
+    path: iacIssue.cloudConfigPath,
+  };
 }

--- a/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-test-data.json
+++ b/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-test-data.json
@@ -4,6 +4,7 @@
       {
         "issue": {
           "id": "SNYK-CC-00024",
+          "publicId": "SNYK-CC-00024",
           "severity": "medium",
           "title": "VPC default security group allows unrestricted ingress traffic",
           "isIgnored": false,
@@ -21,7 +22,11 @@
             "impact": "",
             "resolve": ""
           },
-          "lineNumber": 12
+          "issue": "",
+          "impact": "",
+          "resolve": "",
+          "lineNumber": 12,
+          "msg": ""
         },
         "targetFile": "/Users/yairzohar/snyk/upe-test/default_vpc_security_group.tf",
         "projectType": "aws_default_security_group"
@@ -31,6 +36,7 @@
       {
         "issue": {
           "id": "SNYK-CC-00107",
+          "publicId": "SNYK-CC-00107",
           "severity": "high",
           "title": "S3 bucket is publicly readable",
           "isIgnored": false,
@@ -45,7 +51,11 @@
             "impact": "",
             "resolve": ""
           },
-          "lineNumber": 8
+          "issue": "",
+          "impact": "",
+          "resolve": "",
+          "lineNumber": 8,
+          "msg": ""
         },
         "targetFile": "/Users/yairzohar/snyk/upe-test/s3_cis.tf",
         "projectType": "aws_s3_bucket"
@@ -53,6 +63,7 @@
       {
         "issue": {
           "id": "SNYK-CC-00107",
+          "publicId": "SNYK-CC-00107",
           "severity": "high",
           "title": "S3 bucket is publicly readable",
           "isIgnored": false,
@@ -67,7 +78,11 @@
             "impact": "",
             "resolve": ""
           },
-          "lineNumber": 3
+          "issue": "",
+          "impact": "",
+          "resolve": "",
+          "lineNumber": 3,
+          "msg": ""
         },
         "targetFile": "/Users/yairzohar/snyk/upe-test/s3_cis.tf",
         "projectType": "aws_s3_bucket"

--- a/test/jest/unit/lib/formatters/iac-output/v1/index.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v1/index.spec.ts
@@ -21,6 +21,7 @@ describe('createSarifOutputForIac', () => {
   ): IacTestResponse {
     const issue: AnnotatedIacIssue = {
       id: 'ID',
+      publicId: 'ID',
       title: 'TITLE',
       severity,
       isIgnored: false,
@@ -33,6 +34,10 @@ describe('createSarifOutputForIac', () => {
         impact: 'Description of Impact',
         resolve: 'Description of Remediation',
       },
+      issue: 'Description of Issue',
+      impact: 'Description of Impact',
+      resolve: 'Description of Remediation',
+      msg: 'MSG',
       ...issueOverrides,
     };
 


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Updates the IaC issues mapping for the JSON and SARIF formats to explicitly assign properties, instead of using the spread operator, to gain better control over which properties should be user-facing.

#### Where should the reviewer start?

```
src/lib/snyk-test/iac-test-result.ts
```

#### How should this be manually tested?

- Ensure the JSON output for the `snyk iac test` command did not change.

#### Any background context you want to provide?

- Following [this Slack discussion](https://snyk.slack.com/archives/C036BK48B4H/p1658310737256919?thread_ts=1658223730.805649&cid=C036BK48B4H), it's been decided that rather than implicitly piping all of the properties to for a security policy associated with an IaC issue, we should explicitly assign the user-facing properties, to gain better control over which properties would be available in the JSON and SARIF outputs.

#### What are the relevant tickets?

- [CFG-2033](https://snyksec.atlassian.net/browse/CFG-2033)

#### Additional information

- [Slack thread](https://snyk.slack.com/archives/C036BK48B4H/p1658310737256919?thread_ts=1658223730.805649&cid=C036BK48B4H)