### PR TITLE
fix: handle gradle strict lock mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "snyk-cpp-plugin": "2.20.0",
         "snyk-docker-plugin": "^5.0.1",
         "snyk-go-plugin": "1.19.0",
-        "snyk-gradle-plugin": "3.21.0",
+        "snyk-gradle-plugin": "3.21.1",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.29.7",
         "snyk-nodejs-lockfile-parser": "1.38.0",
@@ -16614,9 +16614,9 @@
       }
     },
     "node_modules/snyk-gradle-plugin": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.21.0.tgz",
-      "integrity": "sha512-g48fceLhf4LZcRQQ7BObEBnKE6fuNuLG3vXoE+wpfLTSrU40rapSMdXTrPXl2JVCXE8zCKdJzaNushbBM/12gw==",
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.21.1.tgz",
+      "integrity": "sha512-ZL2GXi76owUi5Y4SvasBtpxvMi/6thxBNDXjghbzBmnMAZUanc2vwZldE7aRa7vvyVv60Jao9ommH2IMye7s7Q==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",
@@ -32817,9 +32817,9 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.21.0.tgz",
-      "integrity": "sha512-g48fceLhf4LZcRQQ7BObEBnKE6fuNuLG3vXoE+wpfLTSrU40rapSMdXTrPXl2JVCXE8zCKdJzaNushbBM/12gw==",
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.21.1.tgz",
+      "integrity": "sha512-ZL2GXi76owUi5Y4SvasBtpxvMi/6thxBNDXjghbzBmnMAZUanc2vwZldE7aRa7vvyVv60Jao9ommH2IMye7s7Q==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "snyk-cpp-plugin": "2.20.0",
     "snyk-docker-plugin": "^5.0.1",
     "snyk-go-plugin": "1.19.0",
-    "snyk-gradle-plugin": "3.21.0",
+    "snyk-gradle-plugin": "3.21.1",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.29.7",
     "snyk-nodejs-lockfile-parser": "1.38.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This change bumps the snyk-gradle-plugin version to include a change that allows us to properly handle scanning Gradle projects using strict lock-mode.

[related snyk-gradle-plugin PR](https://github.com/snyk/snyk-gradle-plugin/pull/217)