### PR TITLE
chore: Set hardcoded compliance value for JSON output

### DIFF
--- a/src/lib/iac/test/v2/json.ts
+++ b/src/lib/iac/test/v2/json.ts
@@ -272,7 +272,7 @@ function vulnerabilitiesToIacIssues(
       documentation: `https://snyk.io/security-rules/${v.rule.id}`, // only works for rules available on snyk.io
       isGeneratedByCustomRule: false,
       path: v.resource.path || [], // needs to be fixed, currently doesn't show the full path
-      compliance: [['TBD']], // missing in `snyk-iac-test` v0.3.0 will be added in a future release
+      compliance: [],
       description: v.rule.description,
     };
   });

--- a/src/lib/snyk-test/iac-test-result.ts
+++ b/src/lib/snyk-test/iac-test-result.ts
@@ -120,8 +120,8 @@ export function mapIacIssue(
       'publicId',
       'msg',
       'description',
-      'compliance',
     ),
     path: iacIssue.cloudConfigPath,
+    compliance: [],
   };
 }

--- a/test/jest/unit/iac/process-results/fixtures/experimental-json-output.json
+++ b/test/jest/unit/iac/process-results/fixtures/experimental-json-output.json
@@ -101,7 +101,7 @@
           0
         ],
         "description":"Configuring all VPC default security groups to restrict all traffic encourages least privilege security\ngroup development and mindful placement of AWS resources into security groups which in turn reduces the exposure of those resources.\n",
-        "compliance": [["TBD"]]
+        "compliance": []
       }
     ]
   },
@@ -167,7 +167,7 @@
           "acl"
         ],
         "description":"A bucket with a public ACL or bucket policy is exposed to the entire internet if all\nblock public access settings are disabled at the resource and account level. This\nposes a security vulnerability, as any AWS user or anonymous user can access the\ndata in the bucket.\n",
-        "compliance": [["TBD"]]
+        "compliance": []
       },
       {
         "severity":"high",
@@ -197,7 +197,7 @@
           "acl"
         ],
         "description":"A bucket with a public ACL or bucket policy is exposed to the entire internet if all\nblock public access settings are disabled at the resource and account level. This\nposes a security vulnerability, as any AWS user or anonymous user can access the\ndata in the bucket.\n",
-        "compliance": [["TBD"]]
+        "compliance": []
       }
     ]
   }


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Omits `compliance` from issue data in the JSON format, by setting a hardcoded empty array instead.

#### How should this be manually tested?

- Run `snyk-dev iac test --json`
- Ensure the JSON output is valid, and that `compliance` is set to be an empty array.
- Activate the `iacCliUnifiedEngine` FF.
- Run `snyk-dev iac test --experimental --json`
- Ensure the JSON output is valid, and that `compliance` is set to be an empty array.

#### Any background context you want to provide?

We started adding compliance information to rules as part of H1 plans to surface compliance information in the product. 

We started by adding the info to the metadata but have not yet decided how to present it best to the user. 
The CLI exposes raw rule metadata to the customer via the --json flag in the CLI.

This means partial and incomplete metadata is surfaced via the --json flag which has not been considered (e..g we may want a different data structure or output entirely). As this is not the final format nor complete information we want to remove the data from the CLI output for now.

#### What are the relevant tickets?

- [CFG-2036](https://snyksec.atlassian.net/browse/CFG-2036)

#### More information

- [Slack thread](https://snyk.slack.com/archives/C02JMMTLUF9/p1658413498487039)