### PR TITLE
chore: Add errors to results for JSON output [CFG-2036]

### DIFF
--- a/src/lib/iac/test/v2/json.ts
+++ b/src/lib/iac/test/v2/json.ts
@@ -3,7 +3,12 @@
 // to keep backwards compatibility.
 
 import { IacOrgSettings } from '../../../../cli/commands/test/iac/local-execution/types';
-import { Resource, SnykIacTestOutput, Vulnerability } from './scan/results';
+import {
+  Resource,
+  ScanError,
+  SnykIacTestOutput,
+  Vulnerability,
+} from './scan/results';
 import * as path from 'path';
 import { createErrorMappedResultsForJsonOutput } from '../../../formatters/test/format-test-results';
 
@@ -93,7 +98,7 @@ export function convertEngineToJsonResults({
   results: SnykIacTestOutput;
   projectName: string;
   orgSettings: IacOrgSettings;
-}): Result[] {
+}): Array<Result | ScanError> {
   const vulnerabilityGroups = groupVulnerabilitiesByFile(results); // all vulns groups by file
   const resourceGroups = groupResourcesByFile(results); // all resources grouped by file
   const filesWithoutIssues = findFilesWithoutIssues(
@@ -101,11 +106,10 @@ export function convertEngineToJsonResults({
     vulnerabilityGroups,
   ); // all resources without issues grouped by file
 
-  const output: Result[] = [];
+  const output: Array<Result | ScanError> = [];
 
-  // TODO: add support for multiple errors, currently we output only the first one
   if (results.errors) {
-    return createErrorMappedResultsForJsonOutput(results.errors);
+    output.push(...createErrorMappedResultsForJsonOutput(results.errors));
   }
 
   for (const [file, resources] of Object.entries(filesWithoutIssues)) {

--- a/test/jest/unit/iac/process-results/fixtures/experimental-json-output.json
+++ b/test/jest/unit/iac/process-results/fixtures/experimental-json-output.json
@@ -1,5 +1,10 @@
 [
   {
+    "message": "invalid input for input type: /Users/yairzohar/snyk/upe-test/README.txt",
+    "code": 2106,
+    "fields": { "path": "/Users/yairzohar/snyk/upe-test/README.txt" }
+  },
+  {
     "meta":{
       "isPrivate":false,
       "isLicensesEnabled":false,

--- a/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results.json
+++ b/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results.json
@@ -169,6 +169,15 @@
       }
     ]
   },
+  "errors": [
+    {
+      "message": "invalid input for input type: /Users/yairzohar/snyk/upe-test/README.txt",
+      "code": 2106,
+      "fields": {
+        "path": "/Users/yairzohar/snyk/upe-test/README.txt"
+      }
+    }
+  ],
   "rawResults": {
     "format": "results",
     "format_version": "1.0.0",

--- a/test/jest/unit/lib/iac/test/v2/json.spec.ts
+++ b/test/jest/unit/lib/iac/test/v2/json.spec.ts
@@ -5,7 +5,10 @@ import {
   convertEngineToJsonResults,
   Result,
 } from '../../../../../../../src/lib/iac/test/v2/json';
-import { SnykIacTestOutput } from '../../../../../../../src/lib/iac/test/v2/scan/results';
+import {
+  ScanError,
+  SnykIacTestOutput,
+} from '../../../../../../../src/lib/iac/test/v2/scan/results';
 
 describe('convertEngineToJsonResults', () => {
   const snykIacTestFixtureContent = fs.readFileSync(
@@ -40,13 +43,13 @@ describe('convertEngineToJsonResults', () => {
     ),
     'utf-8',
   );
-  let experimentalJsonOutputFixture: Result[] = JSON.parse(
+  let experimentalJsonOutputFixture: Array<Result | ScanError> = JSON.parse(
     experimentalJsonOutputFixtureContent,
   );
 
-  experimentalJsonOutputFixture = experimentalJsonOutputFixture.map((item) => {
-    return { ...item, path: process.cwd() };
-  });
+  experimentalJsonOutputFixture = experimentalJsonOutputFixture.map((item) =>
+    'path' in item ? { ...item, path: process.cwd() } : item,
+  );
 
   const orgSettings: IacOrgSettings = {
     meta: {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Adding error objects to the JSON output of the new test flow, when a test produces both results and errors.

#### Where should the reviewer start?

```
src/lib/iac/test/v2/json.ts
```

#### How should this be manually tested?

- Activate the `iacCliUnifiedEngine` FF for your org.
- Run `snyk-dev iac test --experimental --json <dir>`, where `<dir>` is a directory with both valid and invalid IaC files.
- Ensure the JSON output includes both test results for the valid files, and error objects for invalid files.
- Run `snyk-dev iac test --json <dir>, where `<dir`> is a directory with both valid and invalid IaC files.
- Ensure the JSON output still only includes test results for the valid files, without including error objects for invalid files.

#### Any background context you want to provide?

- When running a scan that produces results (or in other words, when scanning valid IaC files) we will not output any of the errors we received during the scan, this means that the user won’t know if we faced any invalid IaC files for example.
We would like to add to the JSON output an errors array.

<details>
  <summary><h4>Output example</h4></summary>

```json
[
  {
    "message": "failed to parse input: test/fixtures/iac/only-invalid/invalid-file1.yml",
    "code": 2105,
    "fields": {
      "path": "test/fixtures/iac/only-invalid/invalid-file1.yml"
    }
  },
  {
    "message": "failed to parse input: test/fixtures/iac/only-invalid/invalid-file2.yaml",
    "code": 2105,
    "fields": {
      "path": "test/fixtures/iac/only-invalid/invalid-file2.yaml"
    }
  },
  {
    "meta": {
      "isPrivate": true,
      "isLicensesEnabled": false,
      "org": "ofek.atar",
      "policy": "",
      "ignoreSettings": {
        "adminOnly": false,
        "reasonRequired": false,
        "disregardFilesystemIgnores": false
      }
    },
    "filesystemPolicy": false,
    "vulnerabilities": [],
    "dependencyCount": 0,
    "licensesPolicy": null,
    "ignoreSettings": {
      "adminOnly": false,
      "reasonRequired": false,
      "disregardFilesystemIgnores": false
    },
    "targetFile": "test/fixtures/iac/only-valid/sg_open_ssh.tf",
    "projectName": "cli",
    "org": "ofek.atar",
    "policy": "",
    "isPrivate": true,
    "targetFilePath": "/Users/ofek/Documents/Snykcraft/repos/snyk/cli/test/fixtures/iac/only-valid/sg_open_ssh.tf",
    "packageManager": "terraformconfig",
    "path": "/Users/ofek/Documents/Snykcraft/repos/snyk/cli",
    "projectType": "terraformconfig",
    "ok": true,
    "infrastructureAsCodeIssues": []
  }
]
```
</details>

#### What are the relevant tickets?

- [CFG-2036](https://snyksec.atlassian.net/browse/CFG-2036)