### PR TITLE
fix: Add missing IaC issue props in JSON output

### DIFF
--- a/src/lib/formatters/iac-output/v2/formatters.ts
+++ b/src/lib/formatters/iac-output/v2/formatters.ts
@@ -195,5 +195,6 @@ function formatSnykIacTestScanVulnerability(
     impact: '',
     resolve: '',
     msg: '',
+    references: [],
   };
 }

--- a/src/lib/snyk-test/iac-test-result.ts
+++ b/src/lib/snyk-test/iac-test-result.ts
@@ -9,7 +9,10 @@ export interface AnnotatedIacIssue {
   severity: SEVERITY | 'none';
   isIgnored: boolean;
   cloudConfigPath: string[];
+  type?: string;
   subType: string;
+  policyEngineType?: string;
+  references: string[];
   path?: string[];
   documentation?: string;
   isGeneratedByCustomRule?: boolean;
@@ -108,7 +111,9 @@ export function mapIacIssue(
       'title',
       'severity',
       'isIgnored',
+      'type',
       'subType',
+      'policyEngineType',
       'documentation',
       'isGeneratedByCustomRule',
       'issue',
@@ -120,6 +125,7 @@ export function mapIacIssue(
       'publicId',
       'msg',
       'description',
+      'references',
     ),
     path: iacIssue.cloudConfigPath,
     compliance: [],

--- a/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-test-data.json
+++ b/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-test-data.json
@@ -26,7 +26,8 @@
           "impact": "",
           "resolve": "",
           "lineNumber": 12,
-          "msg": ""
+          "msg": "",
+          "references": []
         },
         "targetFile": "/Users/yairzohar/snyk/upe-test/default_vpc_security_group.tf",
         "projectType": "aws_default_security_group"
@@ -55,7 +56,8 @@
           "impact": "",
           "resolve": "",
           "lineNumber": 8,
-          "msg": ""
+          "msg": "",
+          "references": []
         },
         "targetFile": "/Users/yairzohar/snyk/upe-test/s3_cis.tf",
         "projectType": "aws_s3_bucket"
@@ -82,7 +84,8 @@
           "impact": "",
           "resolve": "",
           "lineNumber": 3,
-          "msg": ""
+          "msg": "",
+          "references": []
         },
         "targetFile": "/Users/yairzohar/snyk/upe-test/s3_cis.tf",
         "projectType": "aws_s3_bucket"

--- a/test/jest/unit/lib/formatters/iac-output/v1/index.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v1/index.spec.ts
@@ -38,6 +38,7 @@ describe('createSarifOutputForIac', () => {
       impact: 'Description of Impact',
       resolve: 'Description of Remediation',
       msg: 'MSG',
+      references: [],
       ...issueOverrides,
     };
 


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Adds the missing IaC issue properties to the JSON output:
    - `references`
    - `type`
    - `policyEngineType`

#### Where should the reviewer start?

```
src/lib/snyk-test/iac-test-result.ts
```

#### Any background context you want to provide?

- Fixes the changes made in #3479
- [Relevant thread](https://snyk.slack.com/archives/CRV0PMFDH/p1658759532036059)