### PR TITLE
chore: Added CWD path to out of CWD error message

### DIFF
--- a/src/cli/commands/test/iac/scan.ts
+++ b/src/cli/commands/test/iac/scan.ts
@@ -82,7 +82,7 @@ export async function scan(
         assertIaCOptionsFlags(process.argv);
 
         if (pathLib.relative(projectRoot, path).includes('..')) {
-          throw new CurrentWorkingDirectoryTraversalError(path);
+          throw new CurrentWorkingDirectoryTraversalError(path, projectRoot);
         }
 
         const resultsProcessor = new SingleGroupResultsProcessor(
@@ -168,13 +168,15 @@ function formatTestError(error) {
 
 class CurrentWorkingDirectoryTraversalError extends CustomError {
   public filename: string;
+  public projectRoot: string;
 
-  constructor(path: string) {
+  constructor(path: string, projectRoot: string) {
     super('Path is outside the current working directory');
     this.code = IaCErrorCodes.CurrentWorkingDirectoryTraversalError;
     this.strCode = getErrorStringCode(this.code);
     this.userMessage = `Path is outside the current working directory`;
     this.filename = path;
+    this.projectRoot = projectRoot;
   }
 }
 


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Adds a `projectRoot` property with the CWD path to the `CurrentWorkingDirectoryTraversalError` error.

#### Any background context you want to provide?

- This PR was opened following this [#ask post](https://snyk.slack.com/archives/CRV0PMFDH/p1658920411524319) in which the error occurred during scans made by an IDE plugin.