### PR TITLE
feat: OS CLI output part IV - actionable focus on upgrade

### DIFF
--- a/src/lib/formatters/remediation-based-format-issues.ts
+++ b/src/lib/formatters/remediation-based-format-issues.ts
@@ -115,9 +115,6 @@ export function formatIssuesWithRemediation(
       options,
     );
   }
-  if (upgradeTextArray.length > 0) {
-    results.push(upgradeTextArray.join('\n'));
-  }
 
   const patchedTextArray = constructPatchesText(
     remediationInfo.patch,
@@ -125,13 +122,14 @@ export function formatIssuesWithRemediation(
     options,
   );
 
-  if (patchedTextArray.length > 0) {
-    results.push(patchedTextArray.join('\n'));
-  }
-
   const unfixableIssuesTextArray = constructUnfixableText(
     remediationInfo.unresolved,
     basicVulnInfo,
+    options,
+  );
+
+  const licenseIssuesTextArray = constructLicenseText(
+    basicLicenseInfo,
     options,
   );
 
@@ -139,13 +137,16 @@ export function formatIssuesWithRemediation(
     results.push(unfixableIssuesTextArray.join('\n'));
   }
 
-  const licenseIssuesTextArray = constructLicenseText(
-    basicLicenseInfo,
-    options,
-  );
-
   if (licenseIssuesTextArray.length > 0) {
     results.push(licenseIssuesTextArray.join('\n'));
+  }
+
+  if (patchedTextArray.length > 0) {
+    results.push(patchedTextArray.join('\n'));
+  }
+
+  if (upgradeTextArray.length > 0) {
+    results.push(upgradeTextArray.join('\n'));
   }
 
   return results;

--- a/test/jest/unit/lib/formatters/__snapshots__/remediation-based-format-issues.spec.ts.snap
+++ b/test/jest/unit/lib/formatters/__snapshots__/remediation-based-format-issues.spec.ts.snap
@@ -3,6 +3,14 @@
 exports[`with license issues 1`] = `
 "
 
+License issues:
+
+  ✗ Unknown license [High Severity][URL] in rack-cache@1.1
+    introduced by:
+    rack-cache@1.1
+    Legal instructions:
+    ○ for LGPL-3.0 license: I am legal license instruction
+
 Issues to fix by upgrading:
 
   Upgrade rack@1.6.5 to rack@1.6.11 to fix
@@ -36,32 +44,24 @@ Issues to fix by upgrading:
     introduced by:
     rack@1.6.5
     rack-cache@1.1 > rack@1.6.5
-    rack-protection@1.5.3 > rack@1.6.5
-
-License issues:
-
-  ✗ Unknown license [High Severity][URL] in rack-cache@1.1
-    introduced by:
-    rack-cache@1.1
-    Legal instructions:
-    ○ for LGPL-3.0 license: I am legal license instruction"
+    rack-protection@1.5.3 > rack@1.6.5"
 `;
 
 exports[`with pins & unfixable & showVulnsPaths = all 1`] = `
 "
+
+Issues with no direct upgrade or patch:
+  ✗ Directory Traversal [Low Severity][URL] in django@1.6.1
+    introduced by:
+    django@1.6.1
+  This issue was fixed in versions: 2.2.18, 3.0.12, 3.1.6
 
 Issues to fix by upgrading dependencies:
 
   Upgrade django@1.6.1 to django@2.2.18 to fix
   ✗ Content Spoofing [Medium Severity][URL] in django@1.6.1
     introduced by:
-    django@1.6.1
-
-Issues with no direct upgrade or patch:
-  ✗ Directory Traversal [Low Severity][URL] in django@1.6.1
-    introduced by:
-    django@1.6.1
-  This issue was fixed in versions: 2.2.18, 3.0.12, 3.1.6"
+    django@1.6.1"
 `;
 
 exports[`with reachable info 1`] = `
@@ -78,20 +78,27 @@ Issues to fix by upgrading:
 exports[`with showVulnPaths = some 1`] = `
 "
 
+Issues with no direct upgrade or patch:
+  ✗ Directory Traversal [Low Severity][URL] in django@1.6.1
+    introduced by django@1.6.1
+  This issue was fixed in versions: 2.2.18, 3.0.12, 3.1.6
+
 Issues to fix by upgrading dependencies:
 
   Upgrade django@1.6.1 to django@2.2.18 to fix
   ✗ Content Spoofing [Medium Severity][URL] in django@1.6.1
-    introduced by django@1.6.1
-
-Issues with no direct upgrade or patch:
-  ✗ Directory Traversal [Low Severity][URL] in django@1.6.1
-    introduced by django@1.6.1
-  This issue was fixed in versions: 2.2.18, 3.0.12, 3.1.6"
+    introduced by django@1.6.1"
 `;
 
 exports[`with upgrades & patches 1`] = `
 "
+
+Patchable issues:
+
+  Patch available for node-uuid@1.4.0
+  ✗ Insecure Randomness [Low Severity (originally Medium)][URL] in node-uuid@1.4.0
+    introduced by:
+    node-uuid@1.4.0
 
 Issues to fix by upgrading:
 
@@ -104,12 +111,5 @@ Issues to fix by upgrading:
     qs@0.0.6
   ✗ Denial of Service (DoS) [Low Severity (originally Medium)][URL] in qs@0.0.6
     introduced by:
-    qs@0.0.6
-
-Patchable issues:
-
-  Patch available for node-uuid@1.4.0
-  ✗ Insecure Randomness [Low Severity (originally Medium)][URL] in node-uuid@1.4.0
-    introduced by:
-    node-uuid@1.4.0"
+    qs@0.0.6"
 `;

--- a/test/jest/unit/lib/formatters/test/__snapshots__/display-result.spec.ts.snap
+++ b/test/jest/unit/lib/formatters/test/__snapshots__/display-result.spec.ts.snap
@@ -233,19 +233,19 @@ Testing src...
 Tested 2 dependencies for known issues, found 32 issues, 2 vulnerable paths.
 
 
+Issues with no direct upgrade or patch:
+  ✗ Directory Traversal [Low Severity][URL] in django@1.6.1
+    introduced by:
+    django@1.6.1
+  This issue was fixed in versions: 2.2.18, 3.0.12, 3.1.6
+
+
 Issues to fix by upgrading dependencies:
 
   Upgrade django@1.6.1 to django@2.2.18 to fix
   ✗ Content Spoofing [Medium Severity][URL] in django@1.6.1
     introduced by:
     django@1.6.1
-
-
-Issues with no direct upgrade or patch:
-  ✗ Directory Traversal [Low Severity][URL] in django@1.6.1
-    introduced by:
-    django@1.6.1
-  This issue was fixed in versions: 2.2.18, 3.0.12, 3.1.6
 
 
 
@@ -270,6 +270,14 @@ Testing src...
 Tested 2 dependencies for known vulnerabilities, found 4 vulnerabilities, 4 vulnerable paths.
 
 
+Patchable issues:
+
+  Patch available for node-uuid@1.4.0
+  ✗ Insecure Randomness [Low Severity (originally Medium)][URL] in node-uuid@1.4.0
+    introduced by:
+    node-uuid@1.4.0
+
+
 Issues to fix by upgrading:
 
   Upgrade qs@0.0.6 to qs@6.0.4 to fix
@@ -282,14 +290,6 @@ Issues to fix by upgrading:
   ✗ Denial of Service (DoS) [Low Severity (originally Medium)][URL] in qs@0.0.6
     introduced by:
     qs@0.0.6
-
-
-Patchable issues:
-
-  Patch available for node-uuid@1.4.0
-  ✗ Insecure Randomness [Low Severity (originally Medium)][URL] in node-uuid@1.4.0
-    introduced by:
-    node-uuid@1.4.0
 
 
 
@@ -308,6 +308,15 @@ exports[`displayResult with license issues 1`] = `
 Testing src...
 
 Tested 3 dependencies for known issues, found 6 issues, 8 vulnerable paths.
+
+
+License issues:
+
+  ✗ Unknown license [High Severity][URL] in rack-cache@1.1
+    introduced by:
+    rack-cache@1.1
+    Legal instructions:
+    ○ for LGPL-3.0 license: I am legal license instruction
 
 
 Issues to fix by upgrading:
@@ -344,15 +353,6 @@ Issues to fix by upgrading:
     rack@1.6.5
     rack-cache@1.1 > rack@1.6.5
     rack-protection@1.5.3 > rack@1.6.5
-
-
-License issues:
-
-  ✗ Unknown license [High Severity][URL] in rack-cache@1.1
-    introduced by:
-    rack-cache@1.1
-    Legal instructions:
-    ○ for LGPL-3.0 license: I am legal license instruction
 
 
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Improve snyk-open-source CLI output as follows:
- Moving actionable content closer to the users’ visual focus
(moving issues to fix by upgrading lower in the output)

#### Where should the reviewer start?
`src/lib/formatters/remediation-based-format-issues.ts
`
#### How should this be manually tested?
Run 'snyk test' command on a local project and compare output formatting with the attached screenshot

#### Any background context you want to provide?


#### What are the relevant tickets?
[TUN-269](https://snyksec.atlassian.net/browse/TUN-269)

#### Screenshots
![Screenshot 2022-07-27 at 16 14 51](https://user-images.githubusercontent.com/10830729/181256015-db6475b2-dd13-408b-9312-600c00ef5e5d.png)
...
![Screenshot 2022-07-27 at 16 15 37](https://user-images.githubusercontent.com/10830729/181256170-94622dd3-3962-49b5-b592-15e70f9b2383.png)
...
![Screenshot 2022-07-27 at 16 16 21](https://user-images.githubusercontent.com/10830729/181256332-0b645eec-562c-449c-9255-efe3e12a3e7b.png)

#### Additional questions
