### PR TITLE
feat: pass projectTags arg to snyk-iac-test [CFG-2051]

### DIFF
--- a/src/cli/commands/test/iac/local-execution/index.ts
+++ b/src/cli/commands/test/iac/local-execution/index.ts
@@ -153,7 +153,7 @@ export function removeFileContent({
   };
 }
 
-function parseTags(options: IaCTestFlags) {
+export function parseTags(options: IaCTestFlags) {
   if (options.report) {
     return generateTags(options);
   }

--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -10,6 +10,7 @@ import { buildOutput } from '../../../../../lib/iac/test/v2/output';
 import { getIacOrgSettings } from '../local-execution/org-settings/get-iac-org-settings';
 import { Options, TestOptions } from '../../../../../lib/types';
 import { generateProjectAttributes } from '../../../monitor';
+import { parseTags } from '../local-execution';
 
 export async function test(
   paths: string[],
@@ -51,6 +52,7 @@ async function prepareTestConfig(
 
   const org = (options.org as string) || config.org;
   const orgSettings = await getIacOrgSettings(org);
+  const projectTags = parseTags(options);
 
   const attributes = parseAttributes(options);
 
@@ -62,8 +64,9 @@ async function prepareTestConfig(
     userRulesBundlePath: config.IAC_BUNDLE_PATH,
     userPolicyEnginePath: config.IAC_POLICY_ENGINE_PATH,
     severityThreshold: options.severityThreshold,
-    attributes,
     report: !!options.report,
+    attributes,
+    projectTags,
   };
 }
 

--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -98,6 +98,15 @@ function processFlags(
     flags.push('-project-lifecycle', options.attributes.lifecycle.join(','));
   }
 
+  if (options.projectTags) {
+    const stringifiedTags = options.projectTags
+      .map((tag) => {
+        return `${tag.key}=${tag.value}`;
+      })
+      .join(',');
+    flags.push('-project-tags', stringifiedTags);
+  }
+
   if (options.report) {
     flags.push('-report');
   }

--- a/src/lib/iac/test/v2/types.ts
+++ b/src/lib/iac/test/v2/types.ts
@@ -1,6 +1,7 @@
 import { IacOrgSettings } from '../../../../cli/commands/test/iac/local-execution/types';
 import { SEVERITY } from '../../../snyk-test/legacy';
 import { ProjectAttributes } from '../../../types';
+import { Tag } from '../../../types';
 
 export interface TestConfig {
   paths: string[];
@@ -12,4 +13,5 @@ export interface TestConfig {
   report: boolean;
   severityThreshold?: SEVERITY;
   attributes?: ProjectAttributes;
+  projectTags?: Tag[];
 }


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR passes the values of the `--project-tags` flag to the snyk-iac-test binary. You can check it in combination with this branch: https://github.com/snyk/snyk-iac-test/pull/54 where the command accepts the new argument.

I used the existing `parseTags` function in the CLI which handles the validation and errors of the `--project-tags`.  There is a second check on the snyk-iac-test side as well, TBC if we need both.

#### How should this be manually tested?

- Go to this branch: https://github.com/snyk/snyk-iac-test/tree/feat/get-project-tags-arg
- Run locally `go build -o snyk-iac-test .`
- Now on the CLI side, point to the binary you just built (and a bundle) and try it out: 

```
SNYK_IAC_POLICY_ENGINE_PATH=/Users/iliannapapastefanou/snyk-repos/snyk-iac-test/snyk-iac-test \
SNYK_IAC_BUNDLE_PATH=/Users/iliannapapastefanou/snyk-repos/opa-rules/dist.tar.gz \
snyk-dev iac test test/fixtures/iac/terraform/sg_open_ssh.tf --experimental --report --project-tags=key1=value1,key2=value2

```

TODO: update the snyk-iac-test version when the branch is merged.

#### Any background context you want to provide?
Handling the values of this command such as formatting them and adding them to the endpoint will be handled in a new PR.

#### What are the relevant tickets?
CFG-2051
