### PR TITLE
Chore/Send results to API [CFG-2046]

### DIFF
--- a/src/cli/commands/test/iac/local-execution/types.ts
+++ b/src/cli/commands/test/iac/local-execution/types.ts
@@ -386,6 +386,7 @@ export enum IaCErrorCodes {
   FailedToCompile = 2112,
   UnableToReadPath = 2113,
   NoLoadableInput = 2114,
+  FailedToShareResults = 2200,
 }
 
 export interface TestReturnValue {

--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -63,6 +63,7 @@ async function prepareTestConfig(
     userPolicyEnginePath: config.IAC_POLICY_ENGINE_PATH,
     severityThreshold: options.severityThreshold,
     attributes,
+    report: !!options.report,
   };
 }
 

--- a/src/lib/iac/test/v2/errors.ts
+++ b/src/lib/iac/test/v2/errors.ts
@@ -30,6 +30,7 @@ const snykIacTestErrorsUserMessages = {
   UnableToReadPath: 'Unable to read path',
   NoLoadableInput:
     "The Snyk CLI couldn't find any valid IaC configuration files to scan",
+  FailedToShareResults: 'Failed to upload the test results with the platform',
 };
 
 export function getErrorUserMessage(code: number): string {

--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -98,6 +98,10 @@ function processFlags(
     flags.push('-project-lifecycle', options.attributes.lifecycle.join(','));
   }
 
+  if (options.report) {
+    flags.push('-report');
+  }
+
   return flags;
 }
 

--- a/src/lib/iac/test/v2/types.ts
+++ b/src/lib/iac/test/v2/types.ts
@@ -9,6 +9,7 @@ export interface TestConfig {
   userPolicyEnginePath?: string;
   projectName: string;
   orgSettings: IacOrgSettings;
+  report: boolean;
   severityThreshold?: SEVERITY;
   attributes?: ProjectAttributes;
 }


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Adds support for the `report` flag, which enables sharing test results in `snyk-iac-test` in [this PR](https://github.com/snyk/snyk-iac-test/pull/57).

#### Any background context you want to provide?

At this point, you should have the Share Results API client defined by [CFG-2043](https://snyksec.atlassian.net/browse/CFG-2043), all the necessary configuration and authentication information from CFG-[2044](https://snyksec.atlassian.net/browse/CFG-2044), and a way to convert between scan results and API payload with [CFG-2045](https://snyksec.atlassian.net/browse/CFG-2045).

The only missing piece of information is to detect whether the user activated the `--report` flag on the Snyk CLI. For this, you should create a corresponding flag or equivalent mechanism to pass this information to `snyk-iac-test`. The work at [CFG-2044](https://snyksec.atlassian.net/browse/CFG-2044) should already have defined such a mechanism. Use the same mechanism.

If the user activated the `--report` flag, tie all the parts together (client, configuration, and conversion) to post the results to the Share Results API.

#### What are the relevant tickets?

- [Jira ticket CFG-2046](https://snyksec.atlassian.net/browse/CFG-2046)