### PR TITLE
feat: add project attributes support in --experimental

### DIFF
--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -9,6 +9,7 @@ import { spinnerMessage } from '../../../../../lib/formatters/iac-output';
 import { buildOutput } from '../../../../../lib/iac/test/v2/output';
 import { getIacOrgSettings } from '../local-execution/org-settings/get-iac-org-settings';
 import { Options, TestOptions } from '../../../../../lib/types';
+import { generateProjectAttributes } from '../../../monitor';
 
 export async function test(
   paths: string[],
@@ -42,7 +43,7 @@ export async function test(
 
 async function prepareTestConfig(
   paths: string[],
-  options: any,
+  options: Options & TestOptions,
 ): Promise<TestConfig> {
   const systemCachePath = config.CACHE_PATH ?? envPaths('snyk').cache;
   const iacCachePath = pathLib.join(systemCachePath, 'iac');
@@ -50,6 +51,8 @@ async function prepareTestConfig(
 
   const org = (options.org as string) || config.org;
   const orgSettings = await getIacOrgSettings(org);
+
+  const attributes = parseAttributes(options);
 
   return {
     paths,
@@ -59,5 +62,12 @@ async function prepareTestConfig(
     userRulesBundlePath: config.IAC_BUNDLE_PATH,
     userPolicyEnginePath: config.IAC_POLICY_ENGINE_PATH,
     severityThreshold: options.severityThreshold,
+    attributes,
   };
+}
+
+function parseAttributes(options: Options & TestOptions) {
+  if (options.report) {
+    return generateProjectAttributes(options);
+  }
 }

--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -39,11 +39,7 @@ function scanWithConfig(
   rulesBundlePath: string,
   configPath: string,
 ): SnykIacTestOutput {
-  const args = ['-bundle', rulesBundlePath, '-config', configPath];
-
-  if (options.severityThreshold) {
-    args.push('-severity-threshold', options.severityThreshold);
-  }
+  const args = processFlags(options, rulesBundlePath, configPath);
 
   args.push(...options.paths);
 
@@ -71,6 +67,38 @@ function scanWithConfig(
   }
 
   return output;
+}
+
+function processFlags(
+  options: TestConfig,
+  rulesBundlePath: string,
+  configPath: string,
+) {
+  const flags = ['-bundle', rulesBundlePath, '-config', configPath];
+
+  if (options.severityThreshold) {
+    flags.push('-severity-threshold', options.severityThreshold);
+  }
+
+  if (options.attributes?.criticality) {
+    flags.push(
+      '-project-business-criticality',
+      options.attributes.criticality.join(','),
+    );
+  }
+
+  if (options.attributes?.environment) {
+    flags.push(
+      '-project-environment',
+      options.attributes.environment.join(','),
+    );
+  }
+
+  if (options.attributes?.lifecycle) {
+    flags.push('-project-lifecycle', options.attributes.lifecycle.join(','));
+  }
+
+  return flags;
 }
 
 function createConfig(options: TestConfig): string {

--- a/src/lib/iac/test/v2/types.ts
+++ b/src/lib/iac/test/v2/types.ts
@@ -1,5 +1,6 @@
 import { IacOrgSettings } from '../../../../cli/commands/test/iac/local-execution/types';
 import { SEVERITY } from '../../../snyk-test/legacy';
+import { ProjectAttributes } from '../../../types';
 
 export interface TestConfig {
   paths: string[];
@@ -9,4 +10,5 @@ export interface TestConfig {
   projectName: string;
   orgSettings: IacOrgSettings;
   severityThreshold?: SEVERITY;
+  attributes?: ProjectAttributes;
 }


### PR DESCRIPTION
#### What does this PR do?
This PR adds support for project attributes in the new PE testing flow by sending the values the user provides to the `snyk-iac-test` exe.

### Notes for the reviewer

`snyk-iac-test` PR - https://github.com/snyk/snyk-iac-test/pull/58

#### What are the relevant tickets?
https://snyksec.atlassian.net/jira/software/c/projects/CFG/boards/301?modal=detail&selectedIssue=CFG-2049