### PR TITLE
chore: remove deprecated type

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -25,8 +25,6 @@ export interface TestOptions {
   command?: string; // python interpreter to use for python tests
   testDepGraphDockerEndpoint?: string | null;
   isDockerUser?: boolean;
-  /** @deprecated Only used by the legacy `iac test` flow remove once local exec path is GA */
-  iacDirFiles?: IacFileInDirectory[];
 }
 
 export interface Contributor {


### PR DESCRIPTION
#### What does this PR do?

This PR removes a type which we forgot to delete when deprecating the legacy IaC test flow.