### PR TITLE
[CTX-190] feat: share cache path with IaC plugin

### DIFF
--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -1,4 +1,3 @@
-import envPaths from 'env-paths';
 import * as pathLib from 'path';
 import * as testLib from '../../../../../lib/iac/test/v2';
 import { TestConfig } from '../../../../../lib/iac/test/v2';
@@ -11,6 +10,7 @@ import { getIacOrgSettings } from '../local-execution/org-settings/get-iac-org-s
 import { Options, TestOptions } from '../../../../../lib/types';
 import { generateProjectAttributes } from '../../../monitor';
 import { parseTags } from '../local-execution';
+import { systemCachePath } from '../../../../../lib/iac/test/v2/scan';
 
 export async function test(
   paths: string[],
@@ -46,7 +46,6 @@ async function prepareTestConfig(
   paths: string[],
   options: Options & TestOptions,
 ): Promise<TestConfig> {
-  const systemCachePath = config.CACHE_PATH ?? envPaths('snyk').cache;
   const iacCachePath = pathLib.join(systemCachePath, 'iac');
   const projectName = pathLib.basename(process.cwd());
 

--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -16,8 +16,11 @@ import * as rimraf from 'rimraf';
 import config from '../../../../config';
 import { getAuthHeader } from '../../../../api-token';
 import { allowAnalytics } from '../../../../analytics';
+import envPaths from 'env-paths';
 
 const debug = newDebug('snyk-iac');
+
+export const systemCachePath = config.CACHE_PATH ?? envPaths('snyk').cache;
 
 export function scan(
   options: TestConfig,
@@ -80,7 +83,14 @@ function processFlags(
   rulesBundlePath: string,
   configPath: string,
 ) {
-  const flags = ['-bundle', rulesBundlePath, '-config', configPath];
+  const flags = [
+    '-cache-dir',
+    systemCachePath,
+    '-bundle',
+    rulesBundlePath,
+    '-config',
+    configPath,
+  ];
 
   if (options.severityThreshold) {
     flags.push('-severity-threshold', options.severityThreshold);

--- a/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/index.ts
+++ b/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/index.ts
@@ -3,7 +3,7 @@ import { formatPolicyEngineFileName, getChecksum } from './utils';
 /**
  * The Policy Engine release version associated with this Snyk CLI version.
  */
-export const policyEngineReleaseVersion = '0.15.0';
+export const policyEngineReleaseVersion = '0.17.3';
 
 /**
  * The Policy Engine executable's file name.

--- a/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/utils.ts
@@ -19,12 +19,12 @@ export function formatPolicyEngineFileName(releaseVersion: string) {
 }
 
 // this const is not placed in `index.ts` to avoid circular dependencies
-const policyEngineChecksums = `0a2566f393a963c4a863e774fb4fa055ecc5fd018407f4c92213085592693eb9  snyk-iac-test_0.15.0_Linux_x86_64
-5d46d756f849704cd811707e552dd9a9e047b01ea6ea43ce424ddd41936b295f  snyk-iac-test_0.15.0_Linux_arm64
-7c2e881766c26711cd51f5027ff0f84ffae02d419a6489fd219092e5a2b3253d  snyk-iac-test_0.15.0_Windows_x86_64.exe
-8e1f0c5ba1e0c4b3344218e1373b81a48c25f7d58e755e3032b7f995e4f0a6f8  snyk-iac-test_0.15.0_Windows_arm64.exe
-c456b9e7b0eb9c73e406cb955e5dfb6b0adc3cee92b3a17c23ec5f23f37f9eb4  snyk-iac-test_0.15.0_Darwin_x86_64
-d6d6e9b0f722b125e7be5e21a03104babad6949bb7ca6f7e2b19cc044fda9169  snyk-iac-test_0.15.0_Darwin_arm64
+const policyEngineChecksums = `269ba8671e12b0a0b103d7f77cdfc587b5543270cbda116defb9cdb00d9d6cf0  snyk-iac-test_0.17.3_Darwin_x86_64
+2768d899c9e44d515d4ec9c88ececaeee588817fa1a0502c0034c412e79f39a0  snyk-iac-test_0.17.3_Windows_arm64.exe
+29aa2f407d7792cf9abfda3b9ee73721a3f32d1d18d14cf07f8edd32e88e98ee  snyk-iac-test_0.17.3_Linux_arm64
+7285a310ab4d6b341d78ac94ec4cd8b58c72672e151874de7c7a64bcbddbbed3  snyk-iac-test_0.17.3_Darwin_arm64
+85ed199a2fb2f94f3969f04e476161b451066af5b6a75818cb9e5b447c20814f  snyk-iac-test_0.17.3_Linux_x86_64
+91ce1ea3acbcb03b3e6f39ef0aedce43e10bb592f22df2a88a7e506b687d123d  snyk-iac-test_0.17.3_Windows_x86_64.exe
 `;
 
 export function getChecksum(policyEngineFileName: string): string {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?



Pass the IaC cache path to snyk-iac-test so that all subcomponents can
share cached resources.



#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?

Companion to https://github.com/snyk/snyk-iac-test/pull/64. **Do not merge** until that is released.


#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/CTX-190

#### Screenshots


#### Additional questions
