### PR TITLE
Introduce --about command for printing Open Source attributions

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -150,6 +150,11 @@ export function args(rawArgv: string[]): Args {
     command = 'version';
   }
 
+  // alias `--about` to `snyk about`
+  if (argv.about) {
+    command = 'about';
+  }
+
   if (!command || argv.help || command === 'help') {
     // bit of a song and dance to support `snyk -h` and `snyk help`
     if (argv.help === true || command === 'help') {

--- a/src/cli/commands/about.ts
+++ b/src/cli/commands/about.ts
@@ -1,0 +1,21 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export default function about(): void {
+  console.log(`Snyk CLI Open Source Attributions\n\n`);
+  const licenseNoticesArray = JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, 'thirdPartyNotice.json'), 'utf8'),
+  );
+  for (const licenseNotice of licenseNoticesArray) {
+    console.log(
+      `${licenseNotice.name} \u00B7 ${licenseNotice.version} \u00B7 ${licenseNotice.license}`,
+    );
+    console.log(
+      `Author(s): ${licenseNotice.author ||
+        'Not filled'} \u00B7 Package: ${licenseNotice.source || ''}`,
+    );
+    console.log(`${licenseNotice.licenseText || ''}`); // WTFPL is not required the embed its license text
+    console.log('\n+-+-+-+-+-+-+');
+    console.log('\n');
+  }
+}

--- a/src/cli/commands/index.js
+++ b/src/cli/commands/index.js
@@ -20,6 +20,7 @@ const commands = {
   protect: async (...args) => callModule(import('./protect'), args),
   test: async (...args) => callModule(import('./test'), args),
   version: async (...args) => callModule(import('./version'), args),
+  about: async (...args) => callModule(import('./about'), args),
   wizard: async (...args) => callModule(import('./protect/wizard'), args),
   woof: async (...args) => callModule(import('./woof'), args),
   log4shell: async (...args) => callModule(import('./log4shell'), args),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -235,6 +235,7 @@ export type SupportedUserReachableFacingCliArgs =
 
 export enum SupportedCliCommands {
   version = 'version',
+  about = 'about',
   help = 'help',
   // config = 'config', // TODO: cleanup `$ snyk config` parsing logic before adding it here
   // auth = 'auth', // TODO: auth does not support argv._ at the moment

--- a/test/jest/acceptance/about.spec.ts
+++ b/test/jest/acceptance/about.spec.ts
@@ -1,0 +1,12 @@
+import { runSnykCLI } from '../util/runSnykCLI';
+
+describe('--about', () => {
+  it('prints open source attribution information', async () => {
+    const { code, stdout } = await runSnykCLI(`--about`);
+
+    expect(code).toBe(0);
+    expect(stdout).toContain('Snyk CLI Open Source Attributions');
+    expect(stdout).toContain('MIT');
+    expect(stdout).toContain('John-David Dalton'); // lodash author
+  });
+});

--- a/test/smoke/spec/snyk_basic_spec.sh
+++ b/test/smoke/spec/snyk_basic_spec.sh
@@ -150,4 +150,13 @@ Describe "Snyk CLI basics"
       The stderr should equal ""
     End
   End
+
+  Describe "snyk --about"
+    It "prints license attributions"
+      When run snyk --about
+      The output should include "Snyk CLI Open Source Attributions" # Version should start with a (major) 1
+      The status should be success
+      The stderr should equal ""
+    End
+  End
 End

--- a/webpack.common.ts
+++ b/webpack.common.ts
@@ -1,5 +1,6 @@
 const path = require('path');
 const CopyPlugin = require('copy-webpack-plugin');
+const LicensePlugin = require('webpack-license-plugin');
 
 export default {
   entry: './src/cli/index.ts',
@@ -53,6 +54,36 @@ export default {
           to: '../',
         },
       ],
+    }),
+    new LicensePlugin({
+      outputFilename: 'thirdPartyNotice.json',
+      excludedPackageTest: (packageName) => {
+        return (
+          packageName.startsWith('@snyk/') ||
+          packageName === '@arcanis/slice-ansi' // this MIT package comes with license in the README
+        );
+      },
+      additionalFiles: {
+        'thirdPartyNotice.json': (packages) =>
+          JSON.stringify(
+            [
+              {
+                name: '@arcanis/slice-ansi',
+                version: '1.0.2',
+                repository: null,
+                source:
+                  'https://registry.npmjs.org/@arcanis/slice-ansi/-/slice-ansi-1.0.2.tgz',
+                license: 'MIT',
+                // taken from npm page README https://www.npmjs.com/package/@arcanis/slice-ansi/v/1.0.2
+                licenseText:
+                  'Copyright © 2020 Mael Nison\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.',
+              },
+              ...packages,
+            ],
+            null,
+            2,
+          ),
+      },
     }),
   ],
   module: {

--- a/webpack.prod.ts
+++ b/webpack.prod.ts
@@ -1,7 +1,6 @@
 import { merge } from 'webpack-merge';
 import common from './webpack.common';
 import { Configuration } from 'webpack';
-const LicensePlugin = require('webpack-license-plugin');
 
 export default merge(common as Configuration, {
   mode: 'production',
@@ -9,15 +8,4 @@ export default merge(common as Configuration, {
   optimization: {
     minimize: false,
   },
-  plugins: [
-    new LicensePlugin({
-      outputFilename: 'thirdPartyNotice.json',
-      licenseOverrides: {
-        '@arcanis/slice-ansi@1.0.2': 'MIT',
-      },
-      excludedPackageTest: (packageName) => {
-        return packageName.startsWith('@snyk/');
-      },
-    }),
-  ],
 });


### PR DESCRIPTION
Ever since Snyk CLI started [bundling its npm packages](https://github.com/snyk/cli/blob/8331c5518f45a6f9caa222acb5d097f4e1e7f4f3/help/_about-this-project/why-we-are-bundling-dependencies.md), we [generated an attributions file](https://github.com/snyk/cli/blob/8331c5518f45a6f9caa222acb5d097f4e1e7f4f3/webpack.prod.ts#L14) that was part of the npm package we distributed.

However, since we also distribute single executables, we should expose the attribution information from the CLI interface itself. This PR introduces an `--about` option, with a same importance as `--version`. This option will print out the license information if libraries bundled into the Snyk CLI. I chose `about` as a command name following an [SO thread](https://opensource.stackexchange.com/questions/6886/single-executable-cli-program-does-this-comply-with-the-mit-license).

<img width="1146" alt="Screen Shot 2022-08-05 at 14 32 59" src="https://user-images.githubusercontent.com/1788727/183077953-3f15c14c-4898-4750-8904-0da32dc0a9c9.png">

Since `thirdPartyNotice.json` is now a runtime dependency, this PR also moves the file generation step to the main webpack config file.

