### PR TITLE
chore: Moved snyk-iac-test error mapping to be after scanning

### DIFF
--- a/src/lib/iac/test/v2/errors.ts
+++ b/src/lib/iac/test/v2/errors.ts
@@ -45,10 +45,26 @@ export function getErrorUserMessage(code: number): string {
 }
 
 export class SnykIacTestError extends CustomError {
-  constructor(error: ScanError) {
-    super(error.message);
-    this.code = error.code;
+  public fields: { path: string; [key: string]: string };
+
+  constructor(scanError: ScanError) {
+    super(scanError.message);
+    this.code = scanError.code;
     this.strCode = getErrorStringCode(this.code);
     this.userMessage = getErrorUserMessage(this.code);
+    this.fields = Object.assign(
+      {
+        path: '',
+      },
+      scanError.fields,
+    );
+  }
+
+  public get path(): string {
+    return this.fields?.path;
+  }
+
+  public set path(path1: string) {
+    this.fields.path = path1;
   }
 }

--- a/src/lib/iac/test/v2/index.ts
+++ b/src/lib/iac/test/v2/index.ts
@@ -1,11 +1,11 @@
 import { TestConfig } from './types';
 import { setup } from './setup';
 import { scan } from './scan';
-import { SnykIacTestOutput } from '../../../../lib/iac/test/v2/scan/results';
+import { TestOutput } from '../../../../lib/iac/test/v2/scan/results';
 
 export { TestConfig } from './types';
 
-export async function test(testConfig: TestConfig): Promise<SnykIacTestOutput> {
+export async function test(testConfig: TestConfig): Promise<TestOutput> {
   const { policyEnginePath, rulesBundlePath } = await setup(testConfig);
 
   return scan(testConfig, policyEnginePath, rulesBundlePath);

--- a/src/lib/iac/test/v2/json.ts
+++ b/src/lib/iac/test/v2/json.ts
@@ -3,12 +3,7 @@
 // to keep backwards compatibility.
 
 import { IacOrgSettings } from '../../../../cli/commands/test/iac/local-execution/types';
-import {
-  Resource,
-  ScanError,
-  SnykIacTestOutput,
-  Vulnerability,
-} from './scan/results';
+import { Resource, ScanError, TestOutput, Vulnerability } from './scan/results';
 import * as path from 'path';
 import { createErrorMappedResultsForJsonOutput } from '../../../formatters/test/format-test-results';
 
@@ -95,7 +90,7 @@ export function convertEngineToJsonResults({
   projectName,
   orgSettings,
 }: {
-  results: SnykIacTestOutput;
+  results: TestOutput;
   projectName: string;
   orgSettings: IacOrgSettings;
 }): Array<Result | ScanError> {
@@ -125,7 +120,7 @@ export function convertEngineToJsonResults({
   return output;
 }
 
-function groupResourcesByFile(results: SnykIacTestOutput) {
+function groupResourcesByFile(results: TestOutput) {
   const groups: Record<string, Resource[]> = {};
 
   if (results.results?.resources) {
@@ -141,7 +136,7 @@ function groupResourcesByFile(results: SnykIacTestOutput) {
   return groups;
 }
 
-function groupVulnerabilitiesByFile(results: SnykIacTestOutput) {
+function groupVulnerabilitiesByFile(results: TestOutput) {
   const groups: Record<string, Vulnerability[]> = {};
 
   if (results.results?.vulnerabilities) {

--- a/src/lib/iac/test/v2/sarif.ts
+++ b/src/lib/iac/test/v2/sarif.ts
@@ -6,16 +6,14 @@ import * as upperFirst from 'lodash.upperfirst';
 import * as camelCase from 'lodash.camelcase';
 
 import { getVersion } from '../../../version';
-import { Results, SnykIacTestOutput } from './scan/results';
+import { Results, TestOutput } from './scan/results';
 import { getIssueLevel } from '../../../formatters/sarif-output';
 import { getRepositoryRoot } from '../../git';
 
 // Used to reference the base path in results.
 const PROJECT_ROOT_KEY = 'PROJECTROOT';
 
-export function convertEngineToSarifResults(
-  scanResult: SnykIacTestOutput,
-): sarif.Log {
+export function convertEngineToSarifResults(scanResult: TestOutput): sarif.Log {
   let repoRoot;
   try {
     repoRoot = getRepositoryRoot() + '/';

--- a/src/lib/iac/test/v2/scan/results.ts
+++ b/src/lib/iac/test/v2/scan/results.ts
@@ -1,5 +1,27 @@
 import { SEVERITY } from '../../../../snyk-test/common';
+import { SnykIacTestError } from '../errors';
 import * as PolicyEngineTypes from './policy-engine';
+
+export function mapSnykIacTestOutputToTestOutput(
+  snykIacOutput: SnykIacTestOutput,
+): TestOutput {
+  const errors = snykIacOutput.errors?.map((err) => new SnykIacTestError(err));
+
+  const errWithoutPath = errors?.find((err) => !err.fields?.path);
+  if (errWithoutPath) {
+    throw errWithoutPath;
+  }
+
+  return {
+    results: snykIacOutput.results,
+    errors,
+  };
+}
+
+export interface TestOutput {
+  results?: Results;
+  errors?: SnykIacTestError[];
+}
 
 export interface SnykIacTestOutput {
   results?: Results;

--- a/test/jest/unit/cli/commands/test/iac/v2/index.spec.ts
+++ b/test/jest/unit/cli/commands/test/iac/v2/index.spec.ts
@@ -11,6 +11,7 @@ import { Options, TestOptions } from '../../../../../../../../src/lib/types';
 import { isValidJSONString } from '../../../../../../acceptance/iac/helpers';
 import { IacOrgSettings } from '../../../../../../../../src/cli/commands/test/iac/local-execution/types';
 import { FoundIssuesError } from '../../../../../../../../src/lib/iac/test/v2/output';
+import { SnykIacTestError } from '../../../../../../../../src/lib/iac/test/v2/errors';
 
 jest.setTimeout(1000 * 10);
 
@@ -56,6 +57,9 @@ describe('test', () => {
   };
 
   const scanFixture = JSON.parse(fs.readFileSync(scanFixturePath, 'utf-8'));
+  scanFixture.errors = scanFixture.errors.map(
+    (scanError) => new SnykIacTestError(scanError),
+  );
 
   jest.spyOn(scanLib, 'scan').mockReturnValue(scanFixture);
 

--- a/test/jest/unit/iac/process-results/fixtures/experimental-json-output.json
+++ b/test/jest/unit/iac/process-results/fixtures/experimental-json-output.json
@@ -1,8 +1,8 @@
 [
   {
-    "message": "invalid input for input type: /Users/yairzohar/snyk/upe-test/README.txt",
-    "code": 2106,
-    "fields": { "path": "/Users/yairzohar/snyk/upe-test/README.txt" }
+    "error": "invalid input for input type: /Users/yairzohar/snyk/upe-test/README.txt",
+    "ok": false,
+    "path": "/Users/yairzohar/snyk/upe-test/README.txt"
   },
   {
     "meta":{

--- a/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results.json
+++ b/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results.json
@@ -196,8 +196,11 @@
   },
   "errors": [
     {
+      "name": "SnykIacTestError",
       "message": "invalid input for input type: /Users/yairzohar/snyk/upe-test/README.txt",
+      "userMessage": "invalid input for input type",
       "code": 2106,
+      "strCode": "INVALID_INPUT",
       "fields": {
         "path": "/Users/yairzohar/snyk/upe-test/README.txt"
       }

--- a/test/jest/unit/lib/iac/test/v2/sarif.spec.ts
+++ b/test/jest/unit/lib/iac/test/v2/sarif.spec.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as sarif from 'sarif';
 import { pathToFileURL } from 'url';
 
-import { SnykIacTestOutput } from '../../../../../../../src/lib/iac/test/v2/scan/results';
+import { TestOutput } from '../../../../../../../src/lib/iac/test/v2/scan/results';
 import { convertEngineToSarifResults } from '../../../../../../../src/lib/iac/test/v2/sarif';
 describe('convertEngineToSarifResults', () => {
   const snykIacTestFixtureContent = fs.readFileSync(
@@ -20,9 +20,7 @@ describe('convertEngineToSarifResults', () => {
     ),
     'utf-8',
   );
-  const snykIacTestFixture: SnykIacTestOutput = JSON.parse(
-    snykIacTestFixtureContent,
-  );
+  const snykIacTestFixture: TestOutput = JSON.parse(snykIacTestFixtureContent);
 
   const experimentalSarifOutputFixtureContent = fs.readFileSync(
     path.join(


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Adds mapping for the `snyk-iac-test` output (`SnykIacTestOutput`) to the internal test output model (`TestOutput`). This includes:
    - Mapping `snyk-iac-test` scan errors to Snyk CLI errors.
    - Omitting `snyk-iac-test`'s raw results property, as we currently do not use it in the test flow. 
    - Adds the `path` and `fields` properties to `SnykIacTestError`.

#### Background context

- We currently do the mapping of `snyk-iac-test` errors to Snyk CLI errors only for the text output, when this mapping is relevant for all test output formats in the CLI.
- We currently do not use the `rawResults` property received from `snyk-iac-test`.
- We currently don't hold a top-level `path` property in test errors, but the JSON output formatted expects it when adding errors.
- We currently don't add the `fields` property from `snyk-iac-test` errors to the `SnykIacTestError` instances we create.