### PR TITLE
chore: Add missing text output properties

### DIFF
--- a/src/lib/formatters/iac-output/v2/formatters.ts
+++ b/src/lib/formatters/iac-output/v2/formatters.ts
@@ -181,9 +181,10 @@ function formatSnykIacTestScanVulnerability(
     title: vulnerability.rule.title,
     lineNumber: vulnerability.resource.line,
     cloudConfigPath: formatCloudConfigPath(vulnerability),
-    issue: '',
-    impact: '',
+    issue: vulnerability.rule.title,
+    impact: vulnerability.rule.description,
     resolve: '',
+    documentation: formatDocumentation(vulnerability),
   };
 }
 
@@ -195,4 +196,8 @@ function formatCloudConfigPath(vulnerability: Vulnerability): string[] {
   }
 
   return cloudConfigPath;
+}
+
+function formatDocumentation(vulnerability: Vulnerability) {
+  return `https://snyk.io/security-rules/${vulnerability.rule.id}`;
 }

--- a/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-test-data.json
+++ b/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-test-data.json
@@ -14,10 +14,11 @@
             "cidr_blocks",
             0
           ],
-          "issue": "",
-          "impact": "",
+          "issue": "VPC default security group allows unrestricted ingress traffic",
+          "impact": "Configuring all VPC default security groups to restrict all traffic encourages least privilege security\ngroup development and mindful placement of AWS resources into security groups which in turn reduces the exposure of those resources.\n",
           "resolve": "",
-          "lineNumber": 12
+          "lineNumber": 12,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-00024"
         },
         "targetFile": "/Users/yairzohar/snyk/upe-test/default_vpc_security_group.tf",
         "projectType": "aws_default_security_group"
@@ -34,10 +35,11 @@
             "readable",
             "acl"
           ],
-          "issue": "",
-          "impact": "",
+          "issue": "S3 bucket is publicly readable",
+          "impact": "A bucket with a public ACL or bucket policy is exposed to the entire internet if all\nblock public access settings are disabled at the resource and account level. This\nposes a security vulnerability, as any AWS user or anonymous user can access the\ndata in the bucket.\n",
           "resolve": "",
-          "lineNumber": 8
+          "lineNumber": 8,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-00107"
         },
         "targetFile": "/Users/yairzohar/snyk/upe-test/s3_cis.tf",
         "projectType": "aws_s3_bucket"
@@ -52,10 +54,11 @@
             "writable",
             "acl"
           ],
-          "issue": "",
-          "impact": "",
+          "issue": "S3 bucket is publicly readable",
+          "impact": "A bucket with a public ACL or bucket policy is exposed to the entire internet if all\nblock public access settings are disabled at the resource and account level. This\nposes a security vulnerability, as any AWS user or anonymous user can access the\ndata in the bucket.\n",
           "resolve": "",
-          "lineNumber": 3
+          "lineNumber": 3,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-00107"
         },
         "targetFile": "/Users/yairzohar/snyk/upe-test/s3_cis.tf",
         "projectType": "aws_s3_bucket"
@@ -69,10 +72,11 @@
             "aws_s3_bucket",
             "writable"
           ],
-          "issue": "",
-          "impact": "",
+          "issue": "S3 bucket is publicly readable",
+          "impact": "A bucket with a public ACL or bucket policy is exposed to the entire internet if all\nblock public access settings are disabled at the resource and account level. This\nposes a security vulnerability, as any AWS user or anonymous user can access the\ndata in the bucket.\n",
           "resolve": "",
-          "lineNumber": 12
+          "lineNumber": 12,
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-00107"
         },
         "targetFile": "/Users/yairzohar/snyk/upe-test/s3_cis.tf",
         "projectType": "aws_s3_bucket"


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Adds the `Info` issue property in the text output by:
    - Mapping the `results[].vulnerabilities[].rule.title` to the `issue.issue` and `issue.iacDescription.issue` properties.
    - Mapping the `results[].vulnerabilities[].rule.description` to the `issue.impact` and `issue.iacDescription.impact` properties.
- Adds the `Docs` issue property in the text output by generating it with `results[].vulnerabilities[].rule.id`.