### PR TITLE
refactor: Create Issue interface for text output

### DIFF
--- a/src/lib/formatters/iac-output/v2/formatters.ts
+++ b/src/lib/formatters/iac-output/v2/formatters.ts
@@ -1,12 +1,12 @@
 import { FormattedResult } from '../../../../cli/commands/test/iac/local-execution/types';
 import { Results, Vulnerability } from '../../../iac/test/v2/scan/results';
-import { AnnotatedIacIssue } from '../../../snyk-test/iac-test-result';
 import { SEVERITY } from '../../../snyk-test/legacy';
 import { IacOutputMeta } from '../../../types';
 import {
   FormattedOutputResultsBySeverity,
   IacTestCounts,
   IacTestData,
+  Issue,
 } from './types';
 
 interface FormatTestDataParams {
@@ -174,26 +174,16 @@ function formatSnykIacTestScanResultNewOutput(
 
 function formatSnykIacTestScanVulnerability(
   vulnerability: Vulnerability,
-): AnnotatedIacIssue {
+): Issue {
   return {
     id: vulnerability.rule.id,
-    publicId: vulnerability.rule.id,
     severity: vulnerability.severity,
     title: vulnerability.rule.title,
-    isIgnored: vulnerability.ignored,
     lineNumber: vulnerability.resource.line,
     cloudConfigPath: formatCloudConfigPath(vulnerability),
-    subType: '',
-    iacDescription: {
-      issue: '',
-      impact: '',
-      resolve: '',
-    },
     issue: '',
     impact: '',
     resolve: '',
-    msg: '',
-    references: [],
   };
 }
 

--- a/src/lib/formatters/iac-output/v2/issues-list/issue.ts
+++ b/src/lib/formatters/iac-output/v2/issues-list/issue.ts
@@ -4,8 +4,7 @@ import { EOL } from 'os';
 import { iacRemediationTypes } from '../../../../iac/constants';
 import { printPath } from '../../../remediation-based-format-issues';
 import { colors, contentPadding } from '../utils';
-import { FormattedOutputResult } from '../types';
-import { AnnotatedIacIssue } from '../../../../snyk-test/iac-test-result';
+import { FormattedOutputResult, Issue } from '../types';
 import { Options } from './types';
 
 export function formatIssue(
@@ -24,7 +23,7 @@ export function formatIssue(
   );
 }
 
-function formatTitle(issue: AnnotatedIacIssue): string {
+function formatTitle(issue: Issue): string {
   const severity = issue.severity;
   const titleOutput = colors.severities[severity](
     `[${capitalize([issue.severity])}] ${chalk.bold(issue.title)}`,
@@ -33,9 +32,9 @@ function formatTitle(issue: AnnotatedIacIssue): string {
   return titleOutput;
 }
 
-function formatInfo(issue: AnnotatedIacIssue): string | undefined {
-  const issueDesc = issue.iacDescription.issue;
-  const issueImpact = issue.iacDescription.impact;
+function formatInfo(issue: Issue): string | undefined {
+  const issueDesc = issue.issue;
+  const issueImpact = issue.impact;
 
   if (!issueDesc) {
     return issueImpact;
@@ -76,7 +75,7 @@ function formatProperties(
       'Resolve',
       remediationKey && result.issue.remediation?.[remediationKey]
         ? result.issue.remediation[remediationKey]
-        : result.issue.iacDescription.resolve,
+        : result.issue.resolve,
     ],
   ].filter(([, val]) => !!val) as [string, string][];
 

--- a/src/lib/formatters/iac-output/v2/types.ts
+++ b/src/lib/formatters/iac-output/v2/types.ts
@@ -15,7 +15,7 @@ export type FormattedOutputResultsBySeverity = {
 };
 
 export type FormattedOutputResult = {
-  issue: AnnotatedIacIssue;
+  issue: Issue;
   targetFile: string;
   projectType: IacProjectType | State.InputTypeEnum;
 };
@@ -32,3 +32,18 @@ export type IaCTestFailure = {
   filePath: string;
   failureReason: string | undefined;
 };
+
+export type Issue = Pick<
+  AnnotatedIacIssue,
+  | 'id'
+  | 'title'
+  | 'severity'
+  | 'issue'
+  | 'impact'
+  | 'resolve'
+  | 'remediation'
+  | 'lineNumber'
+  | 'isGeneratedByCustomRule'
+  | 'documentation'
+  | 'cloudConfigPath'
+>;

--- a/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-test-data.json
+++ b/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-test-data.json
@@ -4,10 +4,8 @@
       {
         "issue": {
           "id": "SNYK-CC-00024",
-          "publicId": "SNYK-CC-00024",
           "severity": "medium",
           "title": "VPC default security group allows unrestricted ingress traffic",
-          "isIgnored": false,
           "cloudConfigPath": [
             "aws_default_security_group",
             "default",
@@ -16,18 +14,10 @@
             "cidr_blocks",
             0
           ],
-          "subType": "",
-          "iacDescription": {
-            "issue": "",
-            "impact": "",
-            "resolve": ""
-          },
           "issue": "",
           "impact": "",
           "resolve": "",
-          "lineNumber": 12,
-          "msg": "",
-          "references": []
+          "lineNumber": 12
         },
         "targetFile": "/Users/yairzohar/snyk/upe-test/default_vpc_security_group.tf",
         "projectType": "aws_default_security_group"
@@ -37,27 +27,17 @@
       {
         "issue": {
           "id": "SNYK-CC-00107",
-          "publicId": "SNYK-CC-00107",
           "severity": "high",
           "title": "S3 bucket is publicly readable",
-          "isIgnored": false,
           "cloudConfigPath": [
             "aws_s3_bucket",
             "readable",
             "acl"
           ],
-          "subType": "",
-          "iacDescription": {
-            "issue": "",
-            "impact": "",
-            "resolve": ""
-          },
           "issue": "",
           "impact": "",
           "resolve": "",
-          "lineNumber": 8,
-          "msg": "",
-          "references": []
+          "lineNumber": 8
         },
         "targetFile": "/Users/yairzohar/snyk/upe-test/s3_cis.tf",
         "projectType": "aws_s3_bucket"
@@ -65,27 +45,17 @@
       {
         "issue": {
           "id": "SNYK-CC-00107",
-          "publicId": "SNYK-CC-00107",
           "severity": "high",
           "title": "S3 bucket is publicly readable",
-          "isIgnored": false,
           "cloudConfigPath": [
             "aws_s3_bucket",
             "writable",
             "acl"
           ],
-          "subType": "",
-          "iacDescription": {
-            "issue": "",
-            "impact": "",
-            "resolve": ""
-          },
           "issue": "",
           "impact": "",
           "resolve": "",
-          "lineNumber": 3,
-          "msg": "",
-          "references": []
+          "lineNumber": 3
         },
         "targetFile": "/Users/yairzohar/snyk/upe-test/s3_cis.tf",
         "projectType": "aws_s3_bucket"
@@ -93,26 +63,16 @@
       {
         "issue": {
           "id": "SNYK-CC-00107",
-          "publicId": "SNYK-CC-00107",
           "severity": "high",
           "title": "S3 bucket is publicly readable",
-          "isIgnored": false,
           "cloudConfigPath": [
             "aws_s3_bucket",
             "writable"
           ],
-          "subType": "",
-          "iacDescription": {
-            "issue": "",
-            "impact": "",
-            "resolve": ""
-          },
           "issue": "",
           "impact": "",
           "resolve": "",
-          "lineNumber": 12,
-          "msg": "",
-          "references": []
+          "lineNumber": 12
         },
         "targetFile": "/Users/yairzohar/snyk/upe-test/s3_cis.tf",
         "projectType": "aws_s3_bucket"


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Creates an `Issue` interface for the text output, to define which properties are relevant for the output. This also makes the mapping of `snyk-iac-test` results to issues used by the text output formatter easier, as it highlights which properties should be mapped and populated.