### PR TITLE
fix: Ensure the test spinner stops

### DIFF
--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -31,15 +31,19 @@ export async function test(
 
   testSpinner?.start(spinnerMessage);
 
-  const scanResult = await testLib.test(testConfig);
+  try {
+    const scanResult = await testLib.test(testConfig);
 
-  return buildOutput({
-    scanResult,
-    testSpinner,
-    projectName,
-    orgSettings,
-    options,
-  });
+    return buildOutput({
+      scanResult,
+      testSpinner,
+      projectName,
+      orgSettings,
+      options,
+    });
+  } finally {
+    testSpinner?.stop();
+  }
 }
 
 async function prepareTestConfig(


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Ensures the spinner for the experimental test flow stops, no matter if the flow fails or ends successfully.

#### Where should the reviewer start?

```
src/cli/commands/test/iac/v2/index.ts
```

#### How should this be manually tested?

- Run the experimental test flow in a way that should make it fail, e.g., provide a custom ruleset bundle path to a non-existing ruleset.
- Ensure the spinner disappears as expected.

#### Screenshots

- Before: 
    <img width="1038" alt="image" src="https://user-images.githubusercontent.com/46415136/183922815-570fefa1-88b4-41eb-a6f0-51dbb8e94a48.png">
- After:
    <img width="1036" alt="image" src="https://user-images.githubusercontent.com/46415136/183923179-85a1db93-6381-4d9a-90d8-c2198af49acc.png">
