### PR TITLE
Fix: iac double counts in multi-yaml documents with --report [CFG-2085]

### DIFF
--- a/src/cli/commands/test/iac/local-execution/measurable-methods.ts
+++ b/src/cli/commands/test/iac/local-execution/measurable-methods.ts
@@ -109,7 +109,7 @@ export {
   measurableScanFiles as scanFiles,
   measurableGetIacOrgSettings as getIacOrgSettings,
   measurableApplyCustomSeverities as applyCustomSeverities,
-  measurableFormatScanResults as formatScanResultsV2,
+  measurableFormatScanResults as formatScanResults,
   measurableTrackUsage as trackUsage,
   measurableCleanLocalCache as cleanLocalCache,
   measurableLocalTest as localTest,

--- a/src/cli/commands/test/iac/local-execution/process-results/process-results.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/process-results.ts
@@ -1,6 +1,7 @@
 import { filterIgnoredIssues } from './policy';
 import { formatAndShareResults } from './share-results';
-import { formatScanResultsV2 } from '../measurable-methods';
+import { formatScanResults } from '../measurable-methods';
+import * as cloneDeep from 'lodash.clonedeep';
 import { Policy } from '../../../../../../lib/policy/find-and-load-policy';
 import {
   IacOutputMeta,
@@ -33,7 +34,11 @@ export async function processResults(
 
   if (options.report) {
     ({ projectPublicIds, gitRemoteUrl } = await formatAndShareResults({
-      results: resultsWithCustomSeverities,
+      // this is to fix a bug where we mutated the "results" in the formatAndShareResults
+      // and these were used again in the formatScanResults below
+      // resulting in double count of issues
+      // note: this happened only in multi-YAML documents
+      results: cloneDeep(resultsWithCustomSeverities),
       options,
       orgPublicId,
       policy,
@@ -44,7 +49,7 @@ export async function processResults(
     }));
   }
 
-  const formattedResults = formatScanResultsV2(
+  const formattedResults = formatScanResults(
     resultsWithCustomSeverities,
     options,
     iacOrgSettings.meta,

--- a/src/cli/commands/test/iac/local-execution/process-results/results-formatter.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/results-formatter.ts
@@ -27,12 +27,12 @@ export function formatScanResults(
   options: IaCTestFlags,
   meta: TestMeta,
   projectPublicIds: Record<string, string>,
-  porjectRoot: string,
+  projectRoot: string,
   gitRemoteUrl?: string,
 ): FormattedResult[] {
   try {
     const groupedByFile = scanResults.reduce((memo, scanResult) => {
-      const res = formatScanResult(scanResult, meta, options, porjectRoot);
+      const res = formatScanResult(scanResult, meta, options, projectRoot);
 
       if (memo[scanResult.filePath]) {
         memo[scanResult.filePath].result.cloudConfigResults.push(


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

this is to fix a bug where we mutated the "results" in the formatAndShareResults and these were used again in the formatScanResults below, resulting in double count of issues.

note: this happened only in multi-YAML documents - Tested with other filetypes and none had issue with it.
This is not an issue in --experimental format as the code in go is functionally correct.

how to test:
- Run `snyk iac test output.yml`
- Run `snyk iac test output.yml --report` and see the difference in issues, counts, and docIds.
![image](https://user-images.githubusercontent.com/6989529/183977184-abacac40-be06-4b94-92f3-85273e2643ac.png)


run with this branch again to see the issue fixed.

TODO: It's not yet clear why it only happened to the multi-doc files, but this code is to be deprecated soon.
