### PR TITLE
feat: scan maven aggregate projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "snyk-go-plugin": "1.19.0",
         "snyk-gradle-plugin": "3.21.1",
         "snyk-module": "3.1.0",
-        "snyk-mvn-plugin": "2.30.0",
+        "snyk-mvn-plugin": "^2.31.0",
         "snyk-nodejs-lockfile-parser": "1.38.0",
         "snyk-nuget-plugin": "1.23.5",
         "snyk-php-plugin": "1.9.2",
@@ -16894,9 +16894,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-mvn-plugin": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.30.0.tgz",
-      "integrity": "sha512-zQe4S+G1Ih0qMGzW5Wlj4omeYBcPpRyN8J7hoWgv8Uy7JYbjG8uANqNvL+Awy/mRoAKihbgCZgBqod96kupI3w==",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.31.0.tgz",
+      "integrity": "sha512-b1H8F0t5zHDygMQytebBn+oCY3Vt8XTTh/qvMxdv0xQaHHs3kq3O4R/kXCn/rCMjBhVGkObcMWwb32rNrrK89g==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.23.1",
@@ -33173,9 +33173,9 @@
       }
     },
     "snyk-mvn-plugin": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.30.0.tgz",
-      "integrity": "sha512-zQe4S+G1Ih0qMGzW5Wlj4omeYBcPpRyN8J7hoWgv8Uy7JYbjG8uANqNvL+Awy/mRoAKihbgCZgBqod96kupI3w==",
+      "version": "2.31.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.31.0.tgz",
+      "integrity": "sha512-b1H8F0t5zHDygMQytebBn+oCY3Vt8XTTh/qvMxdv0xQaHHs3kq3O4R/kXCn/rCMjBhVGkObcMWwb32rNrrK89g==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.23.1",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "snyk-go-plugin": "1.19.0",
     "snyk-gradle-plugin": "3.21.1",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "2.30.0",
+    "snyk-mvn-plugin": "2.31.0",
     "snyk-nodejs-lockfile-parser": "1.38.0",
     "snyk-nuget-plugin": "1.23.5",
     "snyk-php-plugin": "1.9.2",

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -219,6 +219,7 @@ export function args(rawArgv: string[]): Args {
     'fail-on',
     'all-projects',
     'yarn-workspaces',
+    'maven-aggregate-project',
     'detection-depth',
     'reachable',
     'reachable-vulns',

--- a/src/lib/formatters/show-multi-scan-tip.ts
+++ b/src/lib/formatters/show-multi-scan-tip.ts
@@ -17,6 +17,19 @@ export function showMultiScanTip(
   if (gradleSubProjectsTip) {
     return gradleSubProjectsTip;
   }
+  if (
+    projectType === 'maven' &&
+    foundProjectCount &&
+    foundProjectCount > 1 &&
+    !options.allProjects &&
+    !options.mavenAggregateProject
+  ) {
+    return (
+      'Tip: Detected Maven project, are you using modules? ' +
+      'Use --maven-aggregate-project to scan each project. ' +
+      'Alternatively use --all-projects to scan Maven and other types of projects.'
+    );
+  }
   const allProjectsTip = showAllProjectsTip(
     projectType,
     options,

--- a/src/lib/plugins/get-multi-plugin-result.ts
+++ b/src/lib/plugins/get-multi-plugin-result.ts
@@ -51,6 +51,7 @@ export async function getMultiPluginResult(
   } = await processYarnWorkspacesProjects(root, options, targetFiles);
   allResults.push(...scannedProjects);
   debug(`Not part of a workspace: ${unprocessedFiles.join(', ')}}`);
+
   // process the rest 1 by 1 sent to relevant plugins
   for (const targetFile of unprocessedFiles) {
     const optionsClone = cloneDeep(options);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -54,6 +54,7 @@ export interface Options {
   insecure?: boolean;
   'dry-run'?: boolean;
   allSubProjects?: boolean;
+  mavenAggregateProject?: boolean;
   'project-name'?: string;
   'show-vulnerable-paths'?: string;
   packageManager?: SupportedPackageManagers;
@@ -231,7 +232,8 @@ export type SupportedUserReachableFacingCliArgs =
   | 'strict-out-of-sync'
   | 'sub-project'
   | 'trust-policies'
-  | 'yarn-workspaces';
+  | 'yarn-workspaces'
+  | 'maven-aggregate-project';
 
 export enum SupportedCliCommands {
   version = 'version',

--- a/test/jest/unit/lib/formatters/show-multi-scan-tip.spec.ts
+++ b/test/jest/unit/lib/formatters/show-multi-scan-tip.spec.ts
@@ -44,4 +44,10 @@ describe('showMultiScanTip', () => {
       ),
     ).toEqual('');
   });
+
+  it('maven without options and more than 1 file detected shows tip', () => {
+    expect(
+      showMultiScanTip('maven', { path: 'src', showVulnPaths: 'none' }, 2),
+    ).toMatch('Tip: Detected Maven project, are you using modules?');
+  });
 });


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
See https://github.com/snyk/snyk-mvn-plugin/pull/136

Introduces `--maven-aggregate-project` so that we can support Maven module scanning better. Until now if modules depend on each other we would error out when using `--all-projects`. This new flag uses the Maven reactor and a `compile` phase to correctly scan the entire project using one Maven command, passing back a multi scan result to the CLI.

Added a Maven tip if we detect a Maven project with multiple manifests and no relevant options being used.
