### PR TITLE
refactor: derive the Policy Engine version from the checksums

### DIFF
--- a/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/index.ts
+++ b/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/index.ts
@@ -1,9 +1,13 @@
-import { formatPolicyEngineFileName, getChecksum } from './utils';
+import {
+  formatPolicyEngineFileName,
+  getChecksum,
+  policyEngineVersion,
+} from './utils';
 
 /**
  * The Policy Engine release version associated with this Snyk CLI version.
  */
-export const policyEngineReleaseVersion = '0.17.3';
+export const policyEngineReleaseVersion = policyEngineVersion;
 
 /**
  * The Policy Engine executable's file name.

--- a/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/utils.ts
@@ -1,5 +1,16 @@
 import * as os from 'os';
 
+const policyEngineChecksums = `
+269ba8671e12b0a0b103d7f77cdfc587b5543270cbda116defb9cdb00d9d6cf0  snyk-iac-test_0.17.3_Darwin_x86_64
+2768d899c9e44d515d4ec9c88ececaeee588817fa1a0502c0034c412e79f39a0  snyk-iac-test_0.17.3_Windows_arm64.exe
+29aa2f407d7792cf9abfda3b9ee73721a3f32d1d18d14cf07f8edd32e88e98ee  snyk-iac-test_0.17.3_Linux_arm64
+7285a310ab4d6b341d78ac94ec4cd8b58c72672e151874de7c7a64bcbddbbed3  snyk-iac-test_0.17.3_Darwin_arm64
+85ed199a2fb2f94f3969f04e476161b451066af5b6a75818cb9e5b447c20814f  snyk-iac-test_0.17.3_Linux_x86_64
+91ce1ea3acbcb03b3e6f39ef0aedce43e10bb592f22df2a88a7e506b687d123d  snyk-iac-test_0.17.3_Windows_x86_64.exe
+`;
+
+export const policyEngineVersion = getPolicyEngineVersion();
+
 export function formatPolicyEngineFileName(releaseVersion: string) {
   let platform = 'Linux';
   switch (os.platform()) {
@@ -17,15 +28,6 @@ export function formatPolicyEngineFileName(releaseVersion: string) {
 
   return `snyk-iac-test_${releaseVersion}_${platform}_${arch}${execExt}`;
 }
-
-// this const is not placed in `index.ts` to avoid circular dependencies
-const policyEngineChecksums = `269ba8671e12b0a0b103d7f77cdfc587b5543270cbda116defb9cdb00d9d6cf0  snyk-iac-test_0.17.3_Darwin_x86_64
-2768d899c9e44d515d4ec9c88ececaeee588817fa1a0502c0034c412e79f39a0  snyk-iac-test_0.17.3_Windows_arm64.exe
-29aa2f407d7792cf9abfda3b9ee73721a3f32d1d18d14cf07f8edd32e88e98ee  snyk-iac-test_0.17.3_Linux_arm64
-7285a310ab4d6b341d78ac94ec4cd8b58c72672e151874de7c7a64bcbddbbed3  snyk-iac-test_0.17.3_Darwin_arm64
-85ed199a2fb2f94f3969f04e476161b451066af5b6a75818cb9e5b447c20814f  snyk-iac-test_0.17.3_Linux_x86_64
-91ce1ea3acbcb03b3e6f39ef0aedce43e10bb592f22df2a88a7e506b687d123d  snyk-iac-test_0.17.3_Windows_x86_64.exe
-`;
 
 export function getChecksum(policyEngineFileName: string): string {
   const lines = policyEngineChecksums.split(/\r?\n/);
@@ -47,4 +49,32 @@ export function getChecksum(policyEngineFileName: string): string {
   }
 
   return policyEngineChecksum;
+}
+
+function getPolicyEngineVersion(): string {
+  const lines = policyEngineChecksums.split(/\r?\n/);
+
+  if (lines.length == 0) {
+    throw new Error('empty checksum');
+  }
+
+  const line = lines.find((line) => line.length > 0);
+
+  if (line === undefined) {
+    throw new Error('empty checksum lines');
+  }
+
+  const parts = line.split(/\s+/);
+
+  if (parts.length < 2) {
+    throw new Error('invalid checksum line');
+  }
+
+  const components = parts[1].split('_');
+
+  if (components.length < 2) {
+    throw new Error('invalid checksum file name');
+  }
+
+  return components[1];
 }


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Implements a function to derive the version of the `snyk-iac-test`from the checksum. This allows a developer to upgrade the dependency to `snyk-iac-test` by just pasting a new checksum, which is a change that must be done in one place only.
