### PR TITLE
chore: change project name source

### DIFF
--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -17,7 +17,7 @@ export async function test(
   options: Options & TestOptions,
 ): Promise<TestCommandResult> {
   const testConfig = await prepareTestConfig(paths, options);
-  const { projectName, orgSettings } = testConfig;
+  const { orgSettings } = testConfig;
 
   const testSpinner = buildSpinner({
     options,
@@ -37,7 +37,6 @@ export async function test(
     return buildOutput({
       scanResult,
       testSpinner,
-      projectName,
       orgSettings,
       options,
     });
@@ -51,7 +50,6 @@ async function prepareTestConfig(
   options: Options & TestOptions,
 ): Promise<TestConfig> {
   const iacCachePath = pathLib.join(systemCachePath, 'iac');
-  const projectName = pathLib.basename(process.cwd());
 
   const org = (options.org as string) || config.org;
   const orgSettings = await getIacOrgSettings(org);
@@ -62,7 +60,6 @@ async function prepareTestConfig(
   return {
     paths,
     iacCachePath,
-    projectName,
     orgSettings,
     userRulesBundlePath: config.IAC_BUNDLE_PATH,
     userPolicyEnginePath: config.IAC_POLICY_ENGINE_PATH,

--- a/src/lib/iac/test/v2/output.ts
+++ b/src/lib/iac/test/v2/output.ts
@@ -18,17 +18,16 @@ import { convertEngineToSarifResults } from './sarif';
 import { CustomError, FormattedCustomError } from '../../../errors';
 import { SnykIacTestError } from './errors';
 import stripAnsi from 'strip-ansi';
+import * as path from 'path';
 
 export function buildOutput({
   scanResult,
   testSpinner,
-  projectName,
   orgSettings,
   options,
 }: {
   scanResult: TestOutput;
   testSpinner?: Ora;
-  projectName: string;
   orgSettings: IacOrgSettings;
   options: any;
 }): TestCommandResult {
@@ -40,7 +39,6 @@ export function buildOutput({
 
   const { responseData, jsonData, sarifData } = buildTestCommandResultData({
     scanResult,
-    projectName,
     orgSettings,
     options,
   });
@@ -62,15 +60,16 @@ export function buildOutput({
 
 function buildTestCommandResultData({
   scanResult,
-  projectName,
   orgSettings,
   options,
 }: {
   scanResult: TestOutput;
-  projectName: string;
   orgSettings: IacOrgSettings;
   options: any;
 }) {
+  const projectName =
+    scanResult.results?.metadata?.projectName ?? path.basename(process.cwd());
+
   const jsonData = jsonStringifyLargeObject(
     convertEngineToJsonResults({
       results: scanResult,

--- a/src/lib/iac/test/v2/scan/results.ts
+++ b/src/lib/iac/test/v2/scan/results.ts
@@ -32,6 +32,11 @@ export interface SnykIacTestOutput {
 export interface Results {
   resources?: Resource[];
   vulnerabilities?: Vulnerability[];
+  metadata?: Metadata;
+}
+
+export interface Metadata {
+  projectName: string;
 }
 
 export interface Vulnerability {

--- a/src/lib/iac/test/v2/types.ts
+++ b/src/lib/iac/test/v2/types.ts
@@ -8,7 +8,6 @@ export interface TestConfig {
   iacCachePath: string;
   userRulesBundlePath?: string;
   userPolicyEnginePath?: string;
-  projectName: string;
   orgSettings: IacOrgSettings;
   report: boolean;
   severityThreshold?: SEVERITY;


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Removes the project name calculation that we are doing in the CLI and instead starts using the project name that we are returning from `snyk-iac-test`
