### PR TITLE
fix: return exit code 3 when no resources can be found

### DIFF
--- a/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/utils.ts
@@ -1,11 +1,11 @@
 import * as os from 'os';
 
-const policyEngineChecksums = `0f27f5068f0984000cccffb6826d338cd65f1b5ec3229aad0ba59e9c97babf72  snyk-iac-test_0.18.1_Windows_arm64.exe
-122274110bce6bba12f04091672b0269a12824c17361765b76d3020c88209524  snyk-iac-test_0.18.1_Linux_arm64
-92d9e69445f67005a8828f83b6235fa7d7276042c832ac92cff0c5189712fa97  snyk-iac-test_0.18.1_Windows_x86_64.exe
-d683f8e3030d60115cadd33d11b851de0d0794e7b3e061bdace6d6cea6877b56  snyk-iac-test_0.18.1_Linux_x86_64
-fa17535d946e75031e30b655672fcb232ea2272871cdd9b9f7a14313ee3a7225  snyk-iac-test_0.18.1_Darwin_arm64
-fbef8749657fbe93818fa98504bbf66225bbbd153837d8a4dc7fb5f77fc04975  snyk-iac-test_0.18.1_Darwin_x86_64
+const policyEngineChecksums = `528fb9634e8eba009a07afba446648541dd664f8d1eaf4b3025b773dda62dd97  snyk-iac-test_0.19.1_Darwin_arm64
+90a85040d859a82331c9de283f1c4c674e4856a5ca98a3a36640eec9a732e101  snyk-iac-test_0.19.1_Windows_x86_64.exe
+b1dd144e8a921a9312b667425d6afdc45dc70d485ce7473f415465eee93cb69f  snyk-iac-test_0.19.1_Windows_arm64.exe
+c74d3d5fd4ad35769ae0b8d5637c684f58a69ef5640a2a863bf120faa9b2c1a2  snyk-iac-test_0.19.1_Darwin_x86_64
+d25fa0aac5ac399f2d06b6bb553a602ba99f83131543c0e5246bf50a3e584b18  snyk-iac-test_0.19.1_Linux_arm64
+e5377a7e761949f78b532dc2daa5ea4d4da43e43c6393a5bbfd0d960953bdb6c  snyk-iac-test_0.19.1_Linux_x86_64
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();

--- a/test/jest/unit/iac/process-results/fixtures/experimental-json-output.json
+++ b/test/jest/unit/iac/process-results/fixtures/experimental-json-output.json
@@ -1,8 +1,8 @@
 [
   {
-    "error": "invalid input for input type: /Users/yairzohar/snyk/upe-test/README.txt",
+    "error": "failed to parse input: /Users/yairzohar/snyk/upe-test/invalid-cfn.yml",
     "ok": false,
-    "path": "/Users/yairzohar/snyk/upe-test/README.txt"
+    "path": "/Users/yairzohar/snyk/upe-test/invalid-cfn.yml"
   },
   {
     "meta":{

--- a/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results.json
+++ b/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results.json
@@ -197,12 +197,12 @@
   "errors": [
     {
       "name": "SnykIacTestError",
-      "message": "invalid input for input type: /Users/yairzohar/snyk/upe-test/README.txt",
-      "userMessage": "invalid input for input type",
-      "code": 2106,
-      "strCode": "INVALID_INPUT",
+      "message": "failed to parse input: /Users/yairzohar/snyk/upe-test/invalid-cfn.yml",
+      "userMessage": "failed to parse input",
+      "code": 2105,
+      "strCode": "FAILED_TO_PARSE_INPUT",
       "fields": {
-        "path": "/Users/yairzohar/snyk/upe-test/README.txt"
+        "path": "/Users/yairzohar/snyk/upe-test/invalid-cfn.yml"
       }
     }
   ],


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Adds support for exit code 3 when no resources can be found.

#### Where should the reviewer start?

```
src/lib/iac/test/v2/output.ts
```

#### How should this be manually tested?

- Scan a directory with no supported IaC files and ensure the exit code is `3`.
- Scan a directory with some supported IaC files and ensure the exit code is `3`.
- Scan an unsupported file and ensure the exit code is `3`.
- Scan a supported IaC file and ensure the exit code is not `3`.

#### Any background context you want to provide?

- At the moment, we return an exit code value of 0 when no supported IaC files were found.
- According to the [Snyk CLI docs](https://docs.snyk.io/snyk-cli/cli-reference#subcommands-of-cli-commands), these cases should return an exit code value of 3 for all output formats.
- This is aligned with the exit code return in the local-execution flow, where we also return an exit code of 3.
- [A recent PR](https://github.com/snyk/snyk-iac-test/pull/84) in `snyk-iac-test` introduced a change that aggregated all the relevant errors for unsupported IaC files under a single error, `NoLoadableInputs`, which was used in this PR.

#### What are the relevant tickets?

- [CFG-2077](https://snyksec.atlassian.net/browse/CFG-2077)