### PR TITLE
feat: stop using cached rules bundle

### DIFF
--- a/src/lib/iac/test/v2/setup/local-cache/rules-bundle/index.ts
+++ b/src/lib/iac/test/v2/setup/local-cache/rules-bundle/index.ts
@@ -2,20 +2,18 @@ import * as createDebugLogger from 'debug';
 
 import { TestConfig } from '../../../types';
 import { downloadRulesBundle } from './download';
-import { lookupLocalRulesBundle } from './lookup-local';
 
 const debugLogger = createDebugLogger('snyk-iac');
 
 export async function initRulesBundle(testConfig: TestConfig): Promise<string> {
-  debugLogger('Looking for rules bundle locally');
-  let rulesBundlePath = await lookupLocalRulesBundle(testConfig);
+  // We are currently using the legacy rules bundle and we need to redownload it each time to use the latest one available.
+  // debugLogger('Looking for rules bundle locally');
+  // let rulesBundlePath = await lookupLocalRulesBundle(testConfig);
 
-  if (!rulesBundlePath) {
-    debugLogger(
-      `Downloading the rules bundle and saving it at ${testConfig.iacCachePath}`,
-    );
-    rulesBundlePath = await downloadRulesBundle(testConfig);
-  }
+  debugLogger(
+    `Downloading the rules bundle and saving it at ${testConfig.iacCachePath}`,
+  );
+  const rulesBundlePath = await downloadRulesBundle(testConfig);
 
   return rulesBundlePath;
 }


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This PR removes the ability to use the cached rules bundle and instead it will redownload the bundle each time.
The reason behind this is the switch to the legacy rules bundle which is not using versioning so the latest "version" is being uploaded to the same S3 bucket each time.