### PR TITLE
fix: increase buffer size

### DIFF
--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -53,6 +53,7 @@ function scanWithConfig(
   const process = childProcess.spawnSync(policyEnginePath, args, {
     encoding: 'utf-8',
     stdio: 'pipe',
+    maxBuffer: 1024 * 1024 * 10, // The default value is 1024 * 1024, if we see in the future that multiplying it by 10 is not enough we can increase it further.
   });
 
   debug('policy engine standard error:\n%s', '\n' + process.stderr);


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
The PR fixes the problem where in some cases when scanning a directory with a high number of files, the scan failed due to an [ENOBUFS](https://www.encyclo.co.uk/meaning-of-ENOBUFS) error.
The fix is rather simple, it simply increases the max buffer.

