### PR TITLE
refactor: use IacTestFlags type instead of generic Options

### DIFF
--- a/src/cli/commands/test/iac/index.ts
+++ b/src/cli/commands/test/iac/index.ts
@@ -13,8 +13,8 @@ import config from '../../../../lib/config';
 import { UnsupportedEntitlementError } from '../../../../lib/errors/unsupported-entitlement-error';
 import { scan } from './scan';
 import { buildOutput, buildSpinner, printHeader } from './output';
-import { Options, TestOptions } from '../../../../lib/types';
 import { InvalidArgumentError } from './local-execution/assert-iac-options-flag';
+import { IaCTestFlags } from './local-execution/types';
 
 export default async function(...args: MethodArgs): Promise<TestCommandResult> {
   const { options: originalOptions, paths } = processCommandArgs(...args);
@@ -92,7 +92,7 @@ export default async function(...args: MethodArgs): Promise<TestCommandResult> {
 }
 
 export function getFlag(
-  options: Options & TestOptions,
+  options: IaCTestFlags,
   flag: string,
 ): string | undefined {
   const flagValue = options[flag];

--- a/src/cli/commands/test/iac/local-execution/index.ts
+++ b/src/cli/commands/test/iac/local-execution/index.ts
@@ -31,6 +31,7 @@ import {
 import { CustomError } from '../../../../../lib/errors';
 import { getErrorStringCode } from './error-utils';
 import { NoFilesToScanError } from './file-loader';
+import { Tag } from '../../../../../lib/types';
 
 // this method executes the local processing engine and then formats the results to adapt with the CLI output.
 // this flow is the default GA flow for IAC scanning.
@@ -153,7 +154,7 @@ export function removeFileContent({
   };
 }
 
-export function parseTags(options: IaCTestFlags) {
+export function parseTags(options: IaCTestFlags): Tag[] | undefined {
   if (options.report) {
     return generateTags(options);
   }

--- a/src/cli/commands/test/iac/output.ts
+++ b/src/cli/commands/test/iac/output.ts
@@ -51,7 +51,7 @@ export function buildSpinner({
   options,
   isNewIacOutputSupported,
 }: {
-  options: Options & TestOptions;
+  options: IaCTestFlags;
   isNewIacOutputSupported?: boolean;
 }) {
   if (shouldLogUserMessages(options, isNewIacOutputSupported)) {
@@ -63,7 +63,7 @@ export function printHeader({
   options,
   isNewIacOutputSupported,
 }: {
-  options: Options & TestOptions;
+  options: IaCTestFlags;
   isNewIacOutputSupported?: boolean;
 }) {
   if (shouldLogUserMessages(options, isNewIacOutputSupported)) {

--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -7,15 +7,15 @@ import { buildSpinner, printHeader } from '../output';
 import { spinnerMessage } from '../../../../../lib/formatters/iac-output';
 import { buildOutput } from '../../../../../lib/iac/test/v2/output';
 import { getIacOrgSettings } from '../local-execution/org-settings/get-iac-org-settings';
-import { Options, TestOptions } from '../../../../../lib/types';
 import { generateProjectAttributes } from '../../../monitor';
 import { parseTags } from '../local-execution';
 import { systemCachePath } from '../../../../../lib/iac/test/v2/scan';
 import { getFlag } from '../index';
+import { IaCTestFlags } from '../local-execution/types';
 
 export async function test(
   paths: string[],
-  options: Options & TestOptions,
+  options: IaCTestFlags,
 ): Promise<TestCommandResult> {
   const testConfig = await prepareTestConfig(paths, options);
   const { orgSettings } = testConfig;
@@ -48,7 +48,7 @@ export async function test(
 
 async function prepareTestConfig(
   paths: string[],
-  options: Options & TestOptions,
+  options: IaCTestFlags,
 ): Promise<TestConfig> {
   const iacCachePath = pathLib.join(systemCachePath, 'iac');
 
@@ -57,7 +57,6 @@ async function prepareTestConfig(
   const projectTags = parseTags(options);
   const targetName = getFlag(options, 'target-name');
   const remoteRepoUrl = getFlag(options, 'remote-repo-url');
-
   const attributes = parseAttributes(options);
 
   return {
@@ -76,7 +75,7 @@ async function prepareTestConfig(
   };
 }
 
-function parseAttributes(options: Options & TestOptions) {
+function parseAttributes(options: IaCTestFlags) {
   if (options.report) {
     return generateProjectAttributes(options);
   }


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

I'm suggesting this change for using only the subset of types we actually need. this will also help the next PR which needs the Policy Options to be used at a later point in code. https://github.com/snyk/cli/pull/3602