### PR TITLE
Feat: pass ignores to snyk iac test [cfg-2088]

### DIFF
--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -12,6 +12,7 @@ import { parseTags } from '../local-execution';
 import { systemCachePath } from '../../../../../lib/iac/test/v2/scan';
 import { getFlag } from '../index';
 import { IaCTestFlags } from '../local-execution/types';
+import { findAndLoadPolicy } from '../../../../../lib/policy';
 
 export async function test(
   paths: string[],
@@ -58,6 +59,7 @@ async function prepareTestConfig(
   const targetName = getFlag(options, 'target-name');
   const remoteRepoUrl = getFlag(options, 'remote-repo-url');
   const attributes = parseAttributes(options);
+  const policy = await findAndLoadPolicy(process.cwd(), 'iac', options);
 
   return {
     paths,
@@ -72,6 +74,7 @@ async function prepareTestConfig(
     targetReference: options['target-reference'],
     targetName,
     remoteRepoUrl,
+    policy: policy?.toString(),
   };
 }
 

--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -151,6 +151,7 @@ function createConfig(options: TestConfig): string {
       apiUrl: config.API,
       apiAuth: getAuthHeader(),
       allowAnalytics: allowAnalytics(),
+      policy: options.policy,
     });
 
     fs.writeFileSync(tempConfig, configData);

--- a/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/setup/local-cache/policy-engine/constants/utils.ts
@@ -1,16 +1,16 @@
 import * as os from 'os';
 
-const policyEngineChecksums = `4f86b8133caa3e27410c853a910a41551a92de3c6402891fc22d8306185a170a  snyk-iac-test_0.21.1_Windows_arm64.exe
-58b617385dcb1f7da100c1c04e50260d98dbee6811eda9575fc0a41367f9222e  snyk-iac-test_0.21.1_Windows_x86_64.exe
-6fdd0b0d944bc4986a061d1eec404c6ef5cc7cc5ce4d9a3755b3dd24aa89af57  snyk-iac-test_0.21.1_Darwin_x86_64
-80dc9ab2b4b51df29d4a3edd994a394c1c62d6c1f2d364ce98e1b5365a05f855  snyk-iac-test_0.21.1_Linux_arm64
-b06f169fc03f6e6c3c7047c9270c6b7b20496070122ed3babeedd7e568c98009  snyk-iac-test_0.21.1_Linux_x86_64
-c98a06db1bafa683cc479ecf77e7191eb94ece82dfdf9c229ac7258e73094f10  snyk-iac-test_0.21.1_Darwin_arm64
+const policyEngineChecksums = `0313de2afa00ed6301e8cadbe344e448085c6e94cb0e87a06264b908c3c5e2de  snyk-iac-test_0.22.0_Windows_x86_64.exe
+031416e2714ba2bfe85bb294f588eebc20b028dae2222b1929df2072fd01028d  snyk-iac-test_0.22.0_Windows_arm64.exe
+03dcc3b16f1d84f80346aaf05fe7f8a5f8099af765c9979e8f36ee4b9cee4fb3  snyk-iac-test_0.22.0_Darwin_x86_64
+54d0a20a209c45f948f147e4280650b366b4f8252b042fe4a30bec832fe3f915  snyk-iac-test_0.22.0_Darwin_arm64
+cb0d714746310cda42914163572e39c4e4f044342d54695ac901d80e03c9ecf8  snyk-iac-test_0.22.0_Linux_x86_64
+f95568949342bf7f33285500022a9ee0f3d64fc6dd601f16ce9b654e43cb6de6  snyk-iac-test_0.22.0_Linux_arm64
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();
 
-export function formatPolicyEngineFileName(releaseVersion: string) {
+export function formatPolicyEngineFileName(releaseVersion: string): string {
   let platform = 'Linux';
   switch (os.platform()) {
     case 'darwin':

--- a/src/lib/iac/test/v2/types.ts
+++ b/src/lib/iac/test/v2/types.ts
@@ -1,7 +1,6 @@
 import { IacOrgSettings } from '../../../../cli/commands/test/iac/local-execution/types';
 import { SEVERITY } from '../../../snyk-test/legacy';
-import { ProjectAttributes } from '../../../types';
-import { Tag } from '../../../types';
+import { ProjectAttributes, Tag } from '../../../types';
 
 export interface TestConfig {
   paths: string[];
@@ -16,4 +15,5 @@ export interface TestConfig {
   targetReference?: string;
   targetName?: string;
   remoteRepoUrl?: string;
+  policy?: string;
 }


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This commit adds the policy file to the config file. We use the existing "policy" library to find and load the policy file.
We have decided that we can only have one .snyk file per repo, so even if we scan multiple paths, we will use the current working directory to load the .snyk file from the root of the project.

#### Where should the reviewer start?


#### How should this be manually tested?
- Make sure you have a .snyk file in the project root, or create one.
- Try with one path
`snyk-dev iac test test/fixtures/iac/terraform/sg_open_ssh.tf --experimental`

Then try with multiple paths and multiple .snyk files, it should only load the one from the project root. 
`snyk-dev iac test test/fixtures/iac/terraform/sg_open_ssh.tf test/fixtures/iac/terraform/var_deref/nested_var_deref/variables.tf --experimental`

example output of the config file:
```
{
  "org": "my.org",
  "apiUrl": "https://api.snyk.io/v1",
  "apiAuth": "token basdasdasdasd23423423432",
  "allowAnalytics": true,
  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.0\n# ignores vulnerabilities until expiry date; change duration by modifying expiry date\nignore:\n  SNYK-JS-ANSIREGEX-1583908:\n    - '*':\n        reason: Not affecting Snyk CLI. No upgrade path currently available\n        expires: 2022-02-01T00:00:00.000Z\n        created: 2021-11-29T17:25:19.200Z\n  SNYK-CC-K8S-4:\n    - test/fixtures/kubernetes/pod-privileged.yaml:\n        reason: None Given\n        expires: 2022-09-16T16:45:04.439Z\n        created: 2022-08-17T16:45:04.445Z\npatch: {}\n"
}
```

After https://github.com/snyk/snyk-iac-test/pull/93 is merged, update the checksums in this PR to include the snyk-iac-test version.