### PR TITLE
feat: add scan flag support

### DIFF
--- a/src/cli/commands/test/iac/local-execution/assert-iac-options-flag.ts
+++ b/src/cli/commands/test/iac/local-execution/assert-iac-options-flag.ts
@@ -146,7 +146,7 @@ const SUPPORTED_TF_PLAN_SCAN_MODES = [
   TerraformPlanScanMode.FullScan,
 ];
 
-function assertTerraformPlanModes(scanModeArgValue: string) {
+export function assertTerraformPlanModes(scanModeArgValue: string) {
   if (
     !SUPPORTED_TF_PLAN_SCAN_MODES.includes(
       scanModeArgValue as TerraformPlanScanMode,

--- a/src/cli/commands/test/iac/v2/assert-iac-options.ts
+++ b/src/cli/commands/test/iac/v2/assert-iac-options.ts
@@ -1,0 +1,45 @@
+import {
+  assertTerraformPlanModes,
+  FlagError,
+} from '../local-execution/assert-iac-options-flag';
+import { IaCTestFlags } from '../local-execution/types';
+
+const keys: (keyof IaCTestFlags)[] = [
+  'debug',
+  'v',
+  'version',
+  'h',
+  'help',
+  'q',
+  'quiet',
+  'org',
+  'insecure',
+  'severityThreshold',
+  'json',
+  'sarif',
+  'json-file-output',
+  'sarif-file-output',
+  'scan',
+  'experimental',
+  'var-file',
+  // PolicyOptions
+  'ignore-policy',
+  'policy-path',
+];
+const allowed = new Set<string>(keys);
+
+export function assertIacV2Options(options: IaCTestFlags): void {
+  // We process the process.argv so we don't get default values.
+  for (const key of Object.keys(options)) {
+    // The _ property is a special case that contains non
+    // flag strings passed to the command line (usually files)
+    // and `iac` is the command provided.
+    if (key !== '_' && key !== 'iac' && !allowed.has(key)) {
+      throw new FlagError(key);
+    }
+  }
+
+  if (options.scan) {
+    assertTerraformPlanModes(options.scan as string);
+  }
+}

--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -13,11 +13,13 @@ import { systemCachePath } from '../../../../../lib/iac/test/v2/scan';
 import { getFlag } from '../index';
 import { IaCTestFlags } from '../local-execution/types';
 import { findAndLoadPolicy } from '../../../../../lib/policy';
+import { assertIacV2Options } from './assert-iac-options';
 
 export async function test(
   paths: string[],
   options: IaCTestFlags,
 ): Promise<TestCommandResult> {
+  assertIacV2Options(options);
   const testConfig = await prepareTestConfig(paths, options);
   const { orgSettings } = testConfig;
 
@@ -54,6 +56,7 @@ async function prepareTestConfig(
   const remoteRepoUrl = getFlag(options, 'remote-repo-url');
   const attributes = parseAttributes(options);
   const policy = await findAndLoadPolicy(process.cwd(), 'iac', options);
+  const scan = options.scan ?? 'resource-changes';
 
   return {
     paths,
@@ -69,6 +72,7 @@ async function prepareTestConfig(
     targetName,
     remoteRepoUrl,
     policy: policy?.toString(),
+    scan,
   };
 }
 

--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -1,11 +1,11 @@
 import * as os from 'os';
 
-const policyEngineChecksums = `0313de2afa00ed6301e8cadbe344e448085c6e94cb0e87a06264b908c3c5e2de  snyk-iac-test_0.22.0_Windows_x86_64.exe
-031416e2714ba2bfe85bb294f588eebc20b028dae2222b1929df2072fd01028d  snyk-iac-test_0.22.0_Windows_arm64.exe
-03dcc3b16f1d84f80346aaf05fe7f8a5f8099af765c9979e8f36ee4b9cee4fb3  snyk-iac-test_0.22.0_Darwin_x86_64
-54d0a20a209c45f948f147e4280650b366b4f8252b042fe4a30bec832fe3f915  snyk-iac-test_0.22.0_Darwin_arm64
-cb0d714746310cda42914163572e39c4e4f044342d54695ac901d80e03c9ecf8  snyk-iac-test_0.22.0_Linux_x86_64
-f95568949342bf7f33285500022a9ee0f3d64fc6dd601f16ce9b654e43cb6de6  snyk-iac-test_0.22.0_Linux_arm64
+const policyEngineChecksums = `20c1531abe769c623106d72158c7008904abbf5e9434c3e13ad1bbd0142c485b  snyk-iac-test_0.24.0_Windows_x86_64.exe
+3bc449f592a51e0cb3e1d7c8c4eeae8f65a6ffca3cbe1466ecb58e89138bf075  snyk-iac-test_0.24.0_Linux_x86_64
+9efe44502e92a7b6011ab133349a1d59575773c78c5154642cb4b687aad5fa7e  snyk-iac-test_0.24.0_Darwin_x86_64
+a0f577d1169532fa1056f5502e7481522520fc6259ce12f9d2877b87b4269bb0  snyk-iac-test_0.24.0_Windows_arm64.exe
+f519daf0bd505865a94ba37079f1109dd0177d645bf07c0bd5ceb1288da18b0c  snyk-iac-test_0.24.0_Linux_arm64
+f6039356de00a6075714f8d703b4120fb41f8f6ada836f32fdb40d22a89230f2  snyk-iac-test_0.24.0_Darwin_arm64
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();

--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -134,6 +134,10 @@ function processFlags(
     flags.push('-target-name', options.targetName);
   }
 
+  if (options.scan) {
+    flags.push('-scan', options.scan);
+  }
+
   if (options.remoteRepoUrl) {
     flags.push('-remote-repo-url', options.remoteRepoUrl);
   }

--- a/src/lib/iac/test/v2/types.ts
+++ b/src/lib/iac/test/v2/types.ts
@@ -16,4 +16,5 @@ export interface TestConfig {
   targetName?: string;
   remoteRepoUrl?: string;
   policy?: string;
+  scan: string;
 }

--- a/test/jest/unit/cli/commands/test/iac/v2/index.spec.ts
+++ b/test/jest/unit/cli/commands/test/iac/v2/index.spec.ts
@@ -7,7 +7,6 @@ import * as downloadPolicyEngineLib from '../../../../../../../../src/lib/iac/te
 import * as downloadRulesBundleLib from '../../../../../../../../src/lib/iac/test/v2/local-cache/rules-bundle/download';
 import * as orgSettingsLib from '../../../../../../../../src/cli/commands/test/iac/local-execution/org-settings/get-iac-org-settings';
 import { test } from '../../../../../../../../src/cli/commands/test/iac/v2/index';
-import { Options, TestOptions } from '../../../../../../../../src/lib/types';
 import { isValidJSONString } from '../../../../../../acceptance/iac/helpers';
 import { IacOrgSettings } from '../../../../../../../../src/cli/commands/test/iac/local-execution/types';
 import { SnykIacTestError } from '../../../../../../../../src/lib/iac/test/v2/errors';
@@ -45,12 +44,6 @@ const scanFixturePath = path.join(
 
 describe('test', () => {
   chalk.enabled = false;
-
-  const defaultOptions: Options & TestOptions = {
-    iac: true,
-    path: 'path/to/test',
-    showVulnPaths: 'all',
-  };
 
   const orgSettings: IacOrgSettings = {
     customPolicies: {},
@@ -108,7 +101,7 @@ describe('test', () => {
 
     // Act
     try {
-      await test(['path/to/test'], defaultOptions);
+      await test(['path/to/test'], {});
     } catch (error) {
       output = error.message;
     }
@@ -133,7 +126,7 @@ describe('test', () => {
 
       // Act
       try {
-        await test(['path/to/test'], defaultOptions);
+        await test(['path/to/test'], {});
       } catch (err) {
         error = err;
       }
@@ -175,7 +168,7 @@ describe('test', () => {
 
         // Act
         try {
-          await test(['path/to/test'], defaultOptions);
+          await test(['path/to/test'], {});
         } catch (err) {
           error = err;
         }
@@ -212,7 +205,7 @@ describe('test', () => {
   describe('with issues', () => {
     it('throws the expected error', async () => {
       // Act + Assert
-      await expect(test(['path/to/test'], defaultOptions)).rejects.toThrowError(
+      await expect(test(['path/to/test'], {})).rejects.toThrowError(
         FoundIssuesError,
       );
     });
@@ -226,7 +219,6 @@ describe('test', () => {
       // Act
       try {
         await test(['path/to/test'], {
-          ...defaultOptions,
           json: true,
         });
       } catch (error) {
@@ -249,7 +241,7 @@ describe('test', () => {
 
         // Act
         try {
-          await test(['path/to/test'], { ...defaultOptions, json: true });
+          await test(['path/to/test'], { json: true });
         } catch (err) {
           error = err;
         }
@@ -292,7 +284,6 @@ describe('test', () => {
           // Act
           try {
             await test(['path/to/test'], {
-              ...defaultOptions,
               json: true,
             });
           } catch (err) {
@@ -338,7 +329,6 @@ describe('test', () => {
       // Act
       try {
         await test(['path/to/test'], {
-          ...defaultOptions,
           sarif: true,
         });
       } catch (error) {
@@ -363,7 +353,7 @@ describe('test', () => {
 
         // Act
         try {
-          await test(['path/to/test'], { ...defaultOptions, sarif: true });
+          await test(['path/to/test'], { sarif: true });
         } catch (err) {
           error = err;
         }
@@ -409,7 +399,6 @@ describe('test', () => {
           // Act
           try {
             await test(['path/to/test'], {
-              ...defaultOptions,
               sarif: true,
             });
           } catch (err) {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds support for the `--scan` flag in the v2 testing flow and in addition to that adds assertion for the flags that the user provided.

#### How should this be manually tested?
1. switch to the [following](https://github.com/snyk/snyk-iac-test/pull/91) `snyk-iac-test` branch and run `make build`
2. Using the file [tf-plan-no-op.json](https://github.com/snyk/cli/blob/master/test/fixtures/iac/terraform-plan/tf-plan-no-op.json) run the commands below:
3. `SNYK_IAC_POLICY_ENGINE_PATH={local_snyk-iac-test_exe_path} snyk-dev iac test tf-plan-no-op.json --scan=resource-changes --experimental` and check for no issues found
4. `SNYK_IAC_POLICY_ENGINE_PATH={local_snyk-iac-test_exe_path} snyk-dev iac test tf-plan-no-op.json --scan=planned-values --experimental` and check for issues found
5. `SNYK_IAC_POLICY_ENGINE_PATH={local_snyk-iac-test_exe_path} snyk-dev iac test tf-plan-no-op.json --experimental` and check for no issues found

#### What are the relevant tickets?
https://snyksec.atlassian.net/jira/software/c/projects/CFG/boards/301?modal=detail&selectedIssue=CFG-2108
