### PR TITLE
fix: none custom policies severity issues should be filtered out before sending them to registry

### DIFF
--- a/src/cli/commands/test/iac/local-execution/process-results/share-results-formatter.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/share-results-formatter.ts
@@ -22,7 +22,9 @@ export function formatShareResults(
       filePath: result.filePath,
       fileType: result.fileType,
       projectType: result.projectType,
-      violatedPolicies: result.violatedPolicies,
+      violatedPolicies: result.violatedPolicies.filter(
+        (violatedPolicy) => violatedPolicy.severity !== 'none',
+      ),
     };
   });
 }

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -410,6 +410,15 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
       });
     }
 
+    if (req.query.org === 'custom-policies') {
+      return res.status(200).send({
+        ...baseResponse,
+        customPolicies: {
+          'SNYK-CC-AZURE-543': { severity: 'none' },
+        },
+      });
+    }
+
     res.status(200).send(baseResponse);
   });
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Related to this [Tier 3 Zendesk ticket](https://snyk.zendesk.com/agent/tickets/30091) where if you tried to send to `/iac-share-results` endpoint issues with custom policies set to `NONE` in the Snyk UI, you were getting an error using the `--report` in the CLI. Whereas, without the `--report` flag, everything works fine.

Behind the user experience, the problem is that we got a weird bug where registry send back to the CLI a 400 introduced in [this PR](https://github.com/snyk/registry/pull/27508) and we're now throwing an error back to the client due to a change of errors handling introduced [here](https://github.com/snyk/cli/pull/3454).

This PR is simply filtering `NONE` custom policies severity issues prior to sending them through the `/iac-share-results` endpoint.

#### How should this be manually tested?

Create a simple terraform file like this one:

```
resource "aws_s3_bucket" "this" {
  force_destroy = true
}
```

And then run this first command to check that it works fine without any custom policies:

```
$ snyk iac test <YOUR_TERRAFORM_FILE>
```

Go into Snyk UI and change one policies to NONE:

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/8110579/185469309-afaa0b17-c5bc-4373-8a08-4e9d191b052f.png">

And rerun the above command, it should send only the other issues and not the one you changed in the UI.

#### What are the relevant tickets?

[Zendesk ticket](https://snyk.zendesk.com/agent/tickets/30091)
