### PR TITLE
Upgrade-docker-registry-v2-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@snyk/cloud-config-parser": "^1.14.3",
         "@snyk/code-client": "^4.12.3",
         "@snyk/dep-graph": "^1.27.1",
-        "@snyk/docker-registry-v2-client": "^2.7.2",
+        "@snyk/docker-registry-v2-client": "^2.7.3",
         "@snyk/fix": "file:packages/snyk-fix",
         "@snyk/gemfile": "1.2.0",
         "@snyk/snyk-cocoapods-plugin": "2.5.2",
@@ -2080,48 +2080,13 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@snyk/docker-registry-v2-client": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.7.2.tgz",
-      "integrity": "sha512-RCqoXVCgbaSJhD4NSSXDSrHppuzvw1dqcBw9BHuWmgrMZ0UYQt0fYbmFVCR5L+qGpyKH9JUwtWpaXewVMYZSRw==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.7.3.tgz",
+      "integrity": "sha512-5OY8z8RObmHpydKui+bbOmlEbzE2hSS8GAkJmPy+Zl19ZOUJ02L3K816qws9Kg1qDzJi3Cl2T6hmLSF2HHVfyw==",
       "dependencies": {
-        "needle": "^3.1.0",
+        "needle": "^2.6.0",
         "parse-link-header": "^2.0.0",
         "tslib": "^1.10.0"
-      }
-    },
-    "node_modules/@snyk/docker-registry-v2-client/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/@snyk/docker-registry-v2-client/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@snyk/docker-registry-v2-client/node_modules/needle": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-3.1.0.tgz",
-      "integrity": "sha512-gCE9weDhjVGCRqS8dwDR/D3GTAeyXLXuqp7I8EzH6DllZGXSUyxuqqLh+YX9rMAWaaTFyVAg6rHGL25dqvczKw==",
-      "dependencies": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.6.3",
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "needle": "bin/needle"
-      },
-      "engines": {
-        "node": ">= 4.4.x"
       }
     },
     "node_modules/@snyk/docker-registry-v2-client/node_modules/parse-link-header": {
@@ -21585,41 +21550,15 @@
       }
     },
     "@snyk/docker-registry-v2-client": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.7.2.tgz",
-      "integrity": "sha512-RCqoXVCgbaSJhD4NSSXDSrHppuzvw1dqcBw9BHuWmgrMZ0UYQt0fYbmFVCR5L+qGpyKH9JUwtWpaXewVMYZSRw==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.7.3.tgz",
+      "integrity": "sha512-5OY8z8RObmHpydKui+bbOmlEbzE2hSS8GAkJmPy+Zl19ZOUJ02L3K816qws9Kg1qDzJi3Cl2T6hmLSF2HHVfyw==",
       "requires": {
-        "needle": "^3.1.0",
+        "needle": "^2.6.0",
         "parse-link-header": "^2.0.0",
         "tslib": "^1.10.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        },
-        "needle": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-3.1.0.tgz",
-          "integrity": "sha512-gCE9weDhjVGCRqS8dwDR/D3GTAeyXLXuqp7I8EzH6DllZGXSUyxuqqLh+YX9rMAWaaTFyVAg6rHGL25dqvczKw==",
-          "requires": {
-            "debug": "^3.2.6",
-            "iconv-lite": "^0.6.3",
-            "sax": "^1.2.4"
-          }
-        },
         "parse-link-header": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@snyk/cloud-config-parser": "^1.14.3",
     "@snyk/code-client": "^4.12.3",
     "@snyk/dep-graph": "^1.27.1",
-    "@snyk/docker-registry-v2-client": "^2.7.2",
+    "@snyk/docker-registry-v2-client": "^2.7.3",
     "@snyk/fix": "file:packages/snyk-fix",
     "@snyk/gemfile": "1.2.0",
     "@snyk/snyk-cocoapods-plugin": "2.5.2",


### PR DESCRIPTION
To revert proxy behavior for calling docker registries before the no_proxy behavior change can go live.