### PR TITLE
chore: fix no_proxy behavior in cliv2 and add a test for it

### DIFF
--- a/cliv2/internal/httpauth/proxy_authenticator.go
+++ b/cliv2/internal/httpauth/proxy_authenticator.go
@@ -42,6 +42,7 @@ func (p *ProxyAuthenticator) DialContext(ctx context.Context, network, addr stri
 	if p.upstreamProxy != nil {
 		fakeRequest := &http.Request{URL: &url.URL{}}
 		fakeRequest.URL.Scheme = LookupSchemeFromCannonicalAddress(addr, "https")
+		fakeRequest.URL.Host = addr
 		proxyUrl, err = p.upstreamProxy(fakeRequest)
 		if err != nil {
 			return nil, err

--- a/test/jest/acceptance/proxy-behavior.spec.ts
+++ b/test/jest/acceptance/proxy-behavior.spec.ts
@@ -6,6 +6,24 @@ const SNYK_API_HTTPS = 'https://snyk.io/api/v1';
 const SNYK_API_HTTP = 'http://snyk.io/api/v1';
 const FAKE_HTTP_PROXY = `http://localhost:${fakeServerPort}`;
 
+function getConnectionRefusedRegExp(): string | RegExp {
+  // When running this test against a v2 artifact, we need to look for a message like:
+  //   - locally (darwin_amd64): `Cannot read TLS response from mitm'd server proxyconnect tcp: dial tcp 127.0.0.1:12345: connect: connection refused`
+  //   - on Windows in CirclCI: `Cannot read TLS response from mitm'd server proxyconnect tcp: dial tcp [::1]:12345: connectex: No connection could be made because the target machine actively refused it`
+  //   - on some other systems in CirclCI: `Cannot read TLS response from mitm'd server proxyconnect tcp: dial tcp [::1]:12345: connect: connection refused`
+  // Here is a regex that matches any of these scenarios:
+  const cliv2MessageRegex = new RegExp(
+    `connectex: No connection could be made|connection.*refused`,
+  );
+  // When running this for v1, the message is more predictable:
+  // `Error: connect ECONNREFUSED 127.0.0.1:${fakeServerPort}`
+  const expectedMessageRegex = isCLIV2()
+    ? cliv2MessageRegex
+    : `Error: connect ECONNREFUSED 127.0.0.1:${fakeServerPort}`;
+
+  return expectedMessageRegex;
+}
+
 jest.setTimeout(1000 * 60 * 1);
 describe('Proxy configuration behavior', () => {
   describe('*_PROXY against HTTPS host', () => {
@@ -21,21 +39,24 @@ describe('Proxy configuration behavior', () => {
       expect(code).toBe(0);
 
       // It will *attempt* to connect to a FAKE_HTTP_PROXY (and fails, because it's not a real proxy server)
-
-      // When running this test against a v2 artifact, we need to look for a message like:
-      //   - locally (darwin_amd64): `Cannot read TLS response from mitm'd server proxyconnect tcp: dial tcp 127.0.0.1:12345: connect: connection refused`
-      //   - on Windows in CirclCI: `Cannot read TLS response from mitm'd server proxyconnect tcp: dial tcp [::1]:12345: connectex: No connection could be made because the target machine actively refused it`
-      //   - on some other systems in CirclCI: `Cannot read TLS response from mitm'd server proxyconnect tcp: dial tcp [::1]:12345: connect: connection refused`
-      // Here is a regex that matches any of these scenarios:
-      const cliv2MessageRegex = new RegExp(
-        `Cannot read TLS response from mitm'd server dial tcp (127\\.0\\.0\\.1|\\[::1\\]):${fakeServerPort}: (connectex: No connection could be made|connect: connection refused)`,
-      );
-      // When running this for v1, the message is more predictable:
-      // `Error: connect ECONNREFUSED 127.0.0.1:${fakeServerPort}`
-      const expectedMessageRegex = isCLIV2()
-        ? cliv2MessageRegex
-        : `Error: connect ECONNREFUSED 127.0.0.1:${fakeServerPort}`;
+      const expectedMessageRegex = getConnectionRefusedRegExp();
       expect(stderr).toMatch(expectedMessageRegex);
+    });
+
+    it('uses NO_PROXY to avoid connecting to the HTTPS_PROXY that is set', async () => {
+      const { code, stderr } = await runSnykCLI(`woof --debug`, {
+        env: {
+          ...process.env,
+          NO_PROXY: 'snyk.io',
+          HTTPS_PROXY: FAKE_HTTP_PROXY,
+          SNYK_API: SNYK_API_HTTPS,
+        },
+      });
+
+      expect(code).toBe(0);
+
+      const expectedMessageRegex = getConnectionRefusedRegExp();
+      expect(stderr).not.toMatch(expectedMessageRegex);
     });
 
     it('does not try to connect to the HTTP_PROXY when it is set', async () => {
@@ -55,25 +76,24 @@ describe('Proxy configuration behavior', () => {
   });
 
   describe('*_PROXY against HTTP host', () => {
-    if (!isCLIV2()) {
-      it('tries to connect to the HTTP_PROXY when HTTP_PROXY is set', async () => {
-        const { code, stderr } = await runSnykCLI(`woof -d`, {
-          env: {
-            ...process.env,
-            HTTP_PROXY: FAKE_HTTP_PROXY,
-            SNYK_API: SNYK_API_HTTP,
-            SNYK_HTTP_PROTOCOL_UPGRADE: '0',
-          },
-        });
-
-        expect(code).toBe(0);
-
-        // It will *attempt* to connect to a FAKE_HTTP_PROXY (and fails, because it's not a real proxy server)
-        expect(stderr).toContain(
-          `Error: connect ECONNREFUSED 127.0.0.1:${fakeServerPort}`,
-        );
+    it('tries to connect to the HTTP_PROXY when HTTP_PROXY is set', async () => {
+      const { code, stderr } = await runSnykCLI(`woof -d`, {
+        env: {
+          ...process.env,
+          HTTP_PROXY: FAKE_HTTP_PROXY,
+          SNYK_API: SNYK_API_HTTP,
+          SNYK_HTTP_PROTOCOL_UPGRADE: '0',
+        },
       });
 
+      expect(code).toBe(0);
+
+      // It will *attempt* to connect to a FAKE_HTTP_PROXY (and fails, because it's not a real proxy server)
+      const expectedMessageRegex = getConnectionRefusedRegExp();
+      expect(stderr).toMatch(expectedMessageRegex);
+    });
+
+    if (!isCLIV2()) {
       it('does not try to connect to the HTTPS_PROXY when it is set', async () => {
         const { code, stderr } = await runSnykCLI(`woof -d`, {
           env: {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
It fixes an issue with the NO_PROXY environment configuration for the Extensible CLI.
In addition a test is added.

