### PR TITLE
fix: downgrade snyk-go-plugin to 1.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.20.0",
         "snyk-docker-plugin": "^5.1.2",
-        "snyk-go-plugin": "1.19.1",
+        "snyk-go-plugin": "^1.19.0",
         "snyk-gradle-plugin": "3.21.1",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.31.0",
@@ -16664,9 +16664,9 @@
       }
     },
     "node_modules/snyk-go-plugin": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.19.1.tgz",
-      "integrity": "sha512-bitFBTZwvFkDegS/rA4P7YcvTHJGIOZXlPn7fWvbFXx5KmJcRlZo9koWE6HtDTJiyaQKaBST+YnpOL/uoonZBA==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.19.0.tgz",
+      "integrity": "sha512-KC8kBXBx3Qd2ro9ZQv+AGqMrElRLogmmLac/uuSt5rfV3o2wVHnuxPN+YUfr0PgH5lOdMeIeqaYCpWEsc4GhJQ==",
       "dependencies": {
         "@snyk/dep-graph": "^1.23.1",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -32959,9 +32959,9 @@
       }
     },
     "snyk-go-plugin": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.19.1.tgz",
-      "integrity": "sha512-bitFBTZwvFkDegS/rA4P7YcvTHJGIOZXlPn7fWvbFXx5KmJcRlZo9koWE6HtDTJiyaQKaBST+YnpOL/uoonZBA==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.19.0.tgz",
+      "integrity": "sha512-KC8kBXBx3Qd2ro9ZQv+AGqMrElRLogmmLac/uuSt5rfV3o2wVHnuxPN+YUfr0PgH5lOdMeIeqaYCpWEsc4GhJQ==",
       "requires": {
         "@snyk/dep-graph": "^1.23.1",
         "@snyk/graphlib": "2.1.9-patch.3",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.20.0",
     "snyk-docker-plugin": "^5.1.2",
-    "snyk-go-plugin": "1.19.1",
+    "snyk-go-plugin": "^1.19.0",
     "snyk-gradle-plugin": "3.21.1",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.31.0",


### PR DESCRIPTION
since it broke regression tests and wasn’t actually release
