### PR TITLE
feat: add report summary

### DIFF
--- a/src/cli/commands/test/iac/output.ts
+++ b/src/cli/commands/test/iac/output.ts
@@ -88,7 +88,7 @@ export function buildOutput({
   isNewIacOutputSupported: boolean;
   isIacShareCliResultsCustomRulesSupported: boolean;
   isIacCustomRulesEntitlementEnabled: boolean;
-  iacOutputMeta?: IacOutputMeta;
+  iacOutputMeta: IacOutputMeta;
   resultOptions: (Options & TestOptions)[];
   iacScanFailures: IacFileInDirectory[];
   iacIgnoredIssuesCount: number;
@@ -281,7 +281,8 @@ export function buildOutput({
     if (isNewIacOutputSupported) {
       response += buildShareResultsSummary({
         options,
-        iacOutputMeta,
+        projectName: iacOutputMeta.projectName,
+        orgName: iacOutputMeta.orgName,
         isIacCustomRulesEntitlementEnabled,
         isIacShareCliResultsCustomRulesSupported,
         isNewIacOutputSupported,
@@ -316,14 +317,16 @@ export function buildOutput({
   );
 }
 
-function buildShareResultsSummary({
-  iacOutputMeta,
+export function buildShareResultsSummary({
+  orgName,
+  projectName,
   options,
   isIacCustomRulesEntitlementEnabled,
   isNewIacOutputSupported,
   isIacShareCliResultsCustomRulesSupported,
 }: {
-  iacOutputMeta?: IacOutputMeta;
+  orgName: string;
+  projectName: string;
   options: IaCTestFlags;
   isIacCustomRulesEntitlementEnabled: boolean;
   isNewIacOutputSupported: boolean;
@@ -331,7 +334,7 @@ function buildShareResultsSummary({
 }): string {
   let response = '';
 
-  response += SEPARATOR + EOL + formatShareResultsOutput(iacOutputMeta!);
+  response += SEPARATOR + EOL + formatShareResultsOutput(orgName, projectName);
 
   if (
     shouldPrintShareCustomRulesDisclaimer(
@@ -347,7 +350,7 @@ function buildShareResultsSummary({
   return response;
 }
 
-function shouldPrintShareResultsTip(
+export function shouldPrintShareResultsTip(
   options: IaCTestFlags,
   isNewOutput: boolean,
 ): boolean {

--- a/src/cli/commands/test/iac/scan.ts
+++ b/src/cli/commands/test/iac/scan.ts
@@ -38,7 +38,7 @@ export async function scan(
   remoteRepoUrl?: string,
   targetName?: string,
 ): Promise<{
-  iacOutputMeta: IacOutputMeta | undefined;
+  iacOutputMeta: IacOutputMeta;
   iacScanFailures: IacFileInDirectory[];
   iacIgnoredIssuesCount: number;
   results: any[];

--- a/src/lib/formatters/iac-output/v2/share-results.ts
+++ b/src/lib/formatters/iac-output/v2/share-results.ts
@@ -1,20 +1,19 @@
-import { IacOutputMeta } from '../../../types';
 import config from '../../../config';
 import { EOL } from 'os';
 import { colors, contentPadding } from './utils';
 
-export function formatShareResultsOutput(iacOutputMeta: IacOutputMeta) {
+export function formatShareResultsOutput(orgName: string, projectName: string) {
   return (
     colors.title('Report Complete') +
     EOL +
     EOL +
     contentPadding +
     'Your test results are available at: ' +
-    colors.title(`${config.ROOT}/org/${iacOutputMeta.orgName}/projects`) +
+    colors.title(`${config.ROOT}/org/${orgName}/projects`) +
     EOL +
     contentPadding +
     'under the name: ' +
-    colors.title(iacOutputMeta.projectName)
+    colors.title(projectName)
   );
 }
 

--- a/test/jest/unit/lib/formatters/iac-output/v2/share-results.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/v2/share-results.spec.ts
@@ -13,10 +13,7 @@ describe('formatShareResultsOutput', () => {
     const testOrgName = 'test-org';
 
     // Act
-    const output = formatShareResultsOutput({
-      projectName: testProjectName,
-      orgName: testOrgName,
-    });
+    const output = formatShareResultsOutput(testOrgName, testProjectName);
 
     // Assert
     expect(output).toEqual(


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds to the text output 2 new sections:
1. When using `--report` it adds a short summary of the generated projects and where to find them
2. When not using `--report` it adds a tip to let users know about the `--report` flag

#### How should this be manually tested?
1. Run `snyk-dev iac test --experimental --report` inside a dir that is a root of a repo and inside a dir which is not and see the correct project name with a link to the relevant projects page.
2. Run `snyk-dev iac test --experimental` and check for the correct tip at the bottom of the text output.

#### What are the relevant tickets?
https://snyksec.atlassian.net/jira/software/c/projects/CFG/boards/301?modal=detail&selectedIssue=CFG-2102

#### Screenshots
Report summary
<img width="606" alt="image" src="https://user-images.githubusercontent.com/71096571/185796160-33556496-8873-48bb-b9a2-88a22ceb7039.png">

Report tip
<img width="574" alt="image" src="https://user-images.githubusercontent.com/71096571/185796174-85ab100b-284e-436e-b446-f11c7494bb75.png">

