### PR TITLE
fix: `--target-name` bug

### DIFF
--- a/src/cli/commands/test/iac/local-execution/process-results/cli-share-results.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/cli-share-results.ts
@@ -34,7 +34,7 @@ export async function shareResults({
   policy: Policy | undefined;
   tags?: Tag[];
   attributes?: ProjectAttributes;
-  options?: IaCTestFlags;
+  options: IaCTestFlags;
   meta: IacOutputMeta;
 }): Promise<ShareResultsOutput> {
   const scanResults = results.map((result) =>

--- a/src/lib/ecosystems/types.ts
+++ b/src/lib/ecosystems/types.ts
@@ -20,7 +20,7 @@ export interface ContainerTarget {
   image: string;
 }
 
-export interface UnknownTarget {
+export interface NamedTarget extends GitTarget {
   name: string; // Should be equal to the project name
 }
 
@@ -30,7 +30,7 @@ export interface ScanResult {
   findings?: Finding[];
   name?: string;
   policy?: string;
-  target?: GitTarget | ContainerTarget | UnknownTarget;
+  target?: GitTarget | ContainerTarget | NamedTarget;
   analytics?: Analytics[];
   targetReference?: string;
 }

--- a/src/lib/iac/envelope-formatters.ts
+++ b/src/lib/iac/envelope-formatters.ts
@@ -3,7 +3,7 @@ import {
   IaCTestFlags,
   PolicyMetadata,
 } from '../../cli/commands/test/iac/local-execution/types';
-import { ScanResult } from '../ecosystems/types';
+import { GitTarget, NamedTarget, ScanResult } from '../ecosystems/types';
 import { Policy } from '../policy/find-and-load-policy';
 import { IacOutputMeta } from '../types';
 
@@ -11,7 +11,7 @@ export function convertIacResultToScanResult(
   iacResult: IacShareResultsFormat,
   policy: Policy | undefined,
   meta: IacOutputMeta,
-  options?: IaCTestFlags,
+  options: IaCTestFlags,
 ): ScanResult {
   return {
     identity: {
@@ -26,15 +26,18 @@ export function convertIacResultToScanResult(
       };
     }),
     name: iacResult.projectName,
-    target: buildTarget(meta),
+    target: buildTarget(meta, options),
     policy: policy?.toString() ?? '',
     targetReference: options?.['target-reference'],
   };
 }
 
-function buildTarget(meta: IacOutputMeta) {
+function buildTarget(
+  meta: IacOutputMeta,
+  options: IaCTestFlags,
+): NamedTarget | GitTarget {
   if (meta.gitRemoteUrl) {
-    return { remoteUrl: meta.gitRemoteUrl };
+    return { remoteUrl: meta.gitRemoteUrl, name: options['target-name'] };
   }
   return { name: meta.projectName };
 }

--- a/src/lib/polling/types.ts
+++ b/src/lib/polling/types.ts
@@ -6,7 +6,7 @@ import {
 import {
   GitTarget,
   ContainerTarget,
-  UnknownTarget,
+  NamedTarget,
   MonitorDependenciesResponse,
 } from '../ecosystems/types';
 
@@ -49,7 +49,7 @@ export interface ResolutionMeta {
   identity: {
     type: string;
   };
-  target?: GitTarget | ContainerTarget | UnknownTarget;
+  target?: GitTarget | ContainerTarget | NamedTarget;
   policy?: string;
   targetReference?: string;
 }

--- a/test/jest/unit/iac/cli-share-results.spec.ts
+++ b/test/jest/unit/iac/cli-share-results.spec.ts
@@ -43,6 +43,7 @@ describe('CLI Share Results', () => {
         orgName: 'org-name',
         gitRemoteUrl: 'http://github.com/snyk/cli.git',
       },
+      options: {},
     });
 
     expect(envelopeFormattersSpy.mock.calls.length).toBe(2);
@@ -69,6 +70,7 @@ describe('CLI Share Results', () => {
         orgName: 'org-name',
         gitRemoteUrl: 'http://github.com/snyk/cli.git',
       },
+      options: {},
     });
 
     expect(envelopeFormattersSpy.mock.calls.length).toBe(2);
@@ -139,6 +141,7 @@ describe('CLI Share Results', () => {
         orgName: 'org-name',
         gitRemoteUrl: 'http://github.com/snyk/cli.git',
       },
+      options: {},
     });
 
     expect(requestSpy.mock.calls.length).toBe(1);


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
IaC has recently introduced a new flag in the CLI called `--target-name` that as the name suggest allows the user to overwrite the target name in the platform.
We currently have a bug where when scanning a directory that is a root of a repo the target name is not getting overridden with the one that the user set by using the flag.
This PR adds the ability to add the name field to the target together with git information, in registry we can use the `name` to overwrite the `target` name.

#### How should this be manually tested?
1. Run registry using the fix PR linked below
2. cd to a directory that is the root of a repo
3. Run `snyk-dev iac test --report --target-name=test`
4. Open the UI and check for the correct target name

#### Any background context you want to provide?
The fix in this PR is dependent on the fix in https://github.com/snyk/registry/pull/28707.

#### What are the relevant tickets?
https://snyksec.atlassian.net/jira/software/c/projects/CFG/boards/301?modal=detail&selectedIssue=CFG-2101
