### PR TITLE
fix: Spacing for issue descriptions with custom rules

### DIFF
--- a/src/lib/formatters/iac-output/v2/issues-list/issue.ts
+++ b/src/lib/formatters/iac-output/v2/issues-list/issue.ts
@@ -77,16 +77,18 @@ function formatProperties(
         ? result.issue.remediation[remediationKey]
         : result.issue.resolve,
     ],
-  ].filter(([, val]) => !!val) as [string, string][];
+  ];
 
   const maxPropertyNameLength = Math.max(
     ...properties.map(([key]) => key.length),
   );
 
-  return properties.map(
-    ([key, value]) =>
-      `${key}: ${' '.repeat(maxPropertyNameLength - key.length)}${value}`,
-  );
+  return properties
+    .filter(([, val]) => !!val)
+    .map(
+      ([key, value]) =>
+        `${key}: ${' '.repeat(maxPropertyNameLength - key.length)}${value}`,
+    );
 }
 
 function isValidLineNumber(lineNumber: number | undefined): boolean {

--- a/test/jest/acceptance/iac/output-formats/text.spec.ts
+++ b/test/jest/acceptance/iac/output-formats/text.spec.ts
@@ -275,7 +275,7 @@ Target file:       ${dirPath}/`);
           `snyk iac test ${filePath} --rules=./iac/custom-rules/custom.tar.gz`,
         );
 
-        expect(stdout).toContain(`Rule: custom rule CUSTOM-1`);
+        expect(stdout).toContain(`Rule:    custom rule CUSTOM-1`);
       });
     });
   });


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Sets the spacing in the issue description between property name and values to be consistent, no matter which of the issue properties are available.

#### Background context

Before, the spacing was set based on the longest *available* issue property. With this PR, the space will be determined based on the longest possible property name, regardless of whether it is available or not for a particular issue.

#### Screenshots

- Before:

    <img width="1117" alt="image" src="https://user-images.githubusercontent.com/46415136/186377859-03b708d2-eff1-4c3f-a52a-39e35cd3787e.png">

- After:
   <img width="1129" alt="image" src="https://user-images.githubusercontent.com/46415136/186377638-a7b5ccf1-be88-4f0d-81e8-fdbda061eeed.png">
