### PR TITLE
chore: handle GOOS alpine in Makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,9 @@ parameters:
     default: '7.0.4'
 
 executors:
+  alpine:
+    docker:
+      - image: alpine:3.16.2
   docker-node:
     parameters:
       node_version:
@@ -369,6 +372,31 @@ jobs:
           command: npm run test:acceptance -- --selectProjects snyk
           environment:
             TEST_SNYK_COMMAND: << parameters.test_snyk_command >>
+  test-alpine:
+    parameters:
+      test_snyk_command:
+        type: string
+    executor: alpine
+    working_directory: /home/circleci/snyk
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Installing Node.js + other test dependencies
+          command: |
+            apk add --update nodejs npm bash maven
+      - setup_npm:
+          npm_cache_directory: /home/circleci/.npm
+          npm_global_sudo: false
+      - run:
+          name: Configuring artifact
+          command: << parameters.test_snyk_command >> config set "api=${SNYK_API_KEY}"
+      - run:
+          name: Testing artifact
+          command: npm run test:acceptance -- --selectProjects snyk
+          environment:
+            TEST_SNYK_COMMAND: << parameters.test_snyk_command >>
   test-linux:
     parameters:
       test_snyk_command:
@@ -605,6 +633,9 @@ jobs:
         type: string
       go_arch:
         type: string
+      c_compiler:
+        type: string
+        default: ''
     executor: linux
     working_directory: /home/circleci/snyk
     steps:
@@ -615,10 +646,12 @@ jobs:
           version: << pipeline.parameters.go_version >>
       - restore_cache:
           key: go-build-{{ arch }}-{{ checksum "cliv2/go.sum" }}
+      - run: sudo apt-get install musl-tools
       - run:
           name: Build << parameters.go_os >>/<< parameters.go_arch >>
           working_directory: ./cliv2
           environment:
+            CC: << parameters.c_compiler >>
             GOOS: << parameters.go_os >>
             GOARCH: << parameters.go_arch >>
             CLI_V1_LOCATION: ../binary-releases
@@ -975,6 +1008,18 @@ workflows:
               only:
                 - /^.*cliv2.*$/
                 - master
+      - v2-build-artifact:
+          name: v2 / Build (alpine/amd64)
+          requires:
+            - Build (snyk-alpine)
+          go_os: alpine
+          go_arch: amd64
+          c_compiler: /usr/bin/musl-gcc
+          filters:
+            branches:
+              only:
+                - /^.*cliv2.*$/
+                - master
       - v2-test-linux-amd64:
           name: v2 / Integration Tests (linux/amd64)
           requires:
@@ -1000,6 +1045,12 @@ workflows:
           requires:
             - v2 / Build (windows/amd64)
       # Tests for backwards compatibility with CLIv1
+      - test-alpine:
+          name: v2 / Jest Acceptance Tests (alpine/amd64)
+          context: nodejs-install
+          requires:
+            - v2 / Build (alpine/amd64)
+          test_snyk_command: /home/circleci/snyk/cliv2/bin/snyk_alpine_amd64
       - test-linux:
           name: v2 / Jest Acceptance Tests (linux/amd64)
           context: nodejs-install
@@ -1043,6 +1094,7 @@ workflows:
       - v2-prepare-release:
           name: v2 / Prepare Release
           requires:
+            - v2 / Build (alpine/amd64)
             - v2 / Build (linux/amd64)
             - v2 / Build (linux/arm64)
             - v2 / Sign (darwin/amd64)

--- a/cliv2/Makefile
+++ b/cliv2/Makefile
@@ -24,6 +24,7 @@ SRCS = $(shell find $(WORKING_DIR) -type f -name '*.go')
 -include $(CACHE_DIR)/version.mk
 
 # the platform string used by the deployed binaries is not excatly OS-ARCH so we need to translate a bit
+_GO_OS = $(GOOS)
 _V1_OS = $(GOOS)
 _V1_ARCH = $(GOARCH)
 _EMPTY =
@@ -58,6 +59,9 @@ ifneq ($(CLI_V1_LOCATION), $(_EMPTY))
 	_V1_DOWNLOAD = false
 endif
 
+ifeq ($(_GO_OS), alpine)
+	_GO_OS = linux
+endif
 
 # some globally assembled variables
 APPLICATION_NAME = snyk
@@ -73,8 +77,8 @@ V1_EMBEDDED_FILE_OUTPUT = embedded$(_SEPARATOR)$(V2_PLATFORM_STRING).go
 HASH_STRING = $(HASH)$(HASH_ALGORITHM)
 TEST_SNYK_EXECUTABLE_PATH=$(BUILD_DIR)/$(V2_EXECUTABLE_NAME)
 TEST_EXECUTABLE_NAME = $(TEST_NAME)$(_SEPARATOR)$(V2_PLATFORM_STRING)$(_EXE_POSTFIX)
-SIGN_SCRIPT = sign_$(GOOS).sh
-ISSIGNED_SCRIPT = issigned_$(GOOS).sh
+SIGN_SCRIPT = sign_$(_GO_OS).sh
+ISSIGNED_SCRIPT = issigned_$(_GO_OS).sh
 
 # some make file variables
 LOG_PREFIX = --
@@ -140,7 +144,7 @@ configure: $(V2_DIRECTORY)/cliv2.version $(CACHE_DIR) $(CACHE_DIR)/version.mk $(
 
 $(BUILD_DIR)/$(V2_EXECUTABLE_NAME): $(BUILD_DIR) $(SRCS)
 	@echo "$(LOG_PREFIX) Building ( $(BUILD_DIR)/$(V2_EXECUTABLE_NAME) )"
-	@GOOS=$(GOOS) GOARCH=$(GOARCH) $(GOCMD) build -o $(BUILD_DIR)/$(V2_EXECUTABLE_NAME) $(WORKING_DIR)/cmd/cliv2/main.go
+	@GOOS=$(_GO_OS) GOARCH=$(GOARCH) $(GOCMD) build -o $(BUILD_DIR)/$(V2_EXECUTABLE_NAME) $(WORKING_DIR)/cmd/cliv2/main.go
 
 $(BUILD_DIR)/$(V2_EXECUTABLE_NAME).$(HASH_STRING): 
 	@echo "$(LOG_PREFIX) Generating checksum ( $(BUILD_DIR)/$(V2_EXECUTABLE_NAME).$(HASH_STRING) )"
@@ -148,7 +152,7 @@ $(BUILD_DIR)/$(V2_EXECUTABLE_NAME).$(HASH_STRING):
 
 $(BUILD_DIR)/$(TEST_EXECUTABLE_NAME):
 	@echo "$(LOG_PREFIX) Building test executable ( $(BUILD_DIR)/$(TEST_EXECUTABLE_NAME) )"
-	@GOOS=$(GOOS) GOARCH=$(GOARCH) $(GOCMD) test -c -o $(BUILD_DIR)/$(TEST_EXECUTABLE_NAME) main_integration_test.go
+	@GOOS=$(_GO_OS) GOARCH=$(GOARCH) $(GOCMD) test -c -o $(BUILD_DIR)/$(TEST_EXECUTABLE_NAME) main_integration_test.go
 
 .PHONY: build
 build: configure $(BUILD_DIR)/$(V2_EXECUTABLE_NAME) $(BUILD_DIR)/$(V2_EXECUTABLE_NAME).$(HASH_STRING)


### PR DESCRIPTION
#### What does this PR do?
Add handling of alpine builds to the Makefile. It introduces the possibility to run

`make build GOOS=alpine GOARCH=amd64`

#### How does it work?
While for the golang cli this will actually result in a linux build, the bundled TS cli will have to be build explicitly for alpine.

