### PR TITLE
chore: fix docs link in modified-help warning

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -105,7 +105,7 @@ if (danger.github && danger.github.pr) {
 
   if (modifiedHelp || createdHelp) {
     warn(
-      'Please make changes to `snyk help` text in [Gitbook](https://docs.snyk.io/features/snyk-cli/commands). Changes will be automatically synchronised to Snyk CLI as a [scheduled PR](https://github.com/snyk/snyk/actions/workflows/sync-cli-help-to-user-docs.yml).\nFor more information, see: [`help/README.md`](https://github.com/snyk/snyk/tree/master/help/README.md).',
+      'Please make changes to `snyk help` text in [Gitbook](https://docs.snyk.io/snyk-cli/commands). Changes will be automatically synchronised to Snyk CLI as a [scheduled PR](https://github.com/snyk/snyk/actions/workflows/sync-cli-help-to-user-docs.yml).\nFor more information, see: [`help/README.md`](https://github.com/snyk/snyk/tree/master/help/README.md).',
     );
   }
 }


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
 This PR fixes the link to snyk docs which is displayed in the warning when updating the CLI help text.

![image](https://user-images.githubusercontent.com/11232557/186655314-aa8f2832-21c7-4d34-9b02-3bf4c85e8341.png)
