### PR TITLE
Feat/pass org settings to iac test [CFG-2109]

### DIFF
--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -1,11 +1,11 @@
 import * as os from 'os';
 
-const policyEngineChecksums = `005afd663b57bc2981943496c2abb15f592df0c8a1022340c03c36c728d42366  snyk-iac-test_0.24.2_Darwin_x86_64
-2ac72979d98ef2eaa8cc6a9fabe5b871bc87f1778c79ed3fffb704d3e6d41248  snyk-iac-test_0.24.2_Windows_arm64.exe
-539d34c1b6af5b18d266e881a5612e6030ac6deae8a9172f6b198c5e27d57004  snyk-iac-test_0.24.2_Darwin_arm64
-c91c105e2269fd1bf76eee5221f3046972febc6f803a70a52454b8d181760a96  snyk-iac-test_0.24.2_Linux_arm64
-fbe724a3285d8dee7a70a8aedb539e998e368c6accafc9c3ce952b5ae0dca84d  snyk-iac-test_0.24.2_Windows_x86_64.exe
-ff9fee0711c0556cf0f58469ef5c6db164825e855c29dfb404dfcd6cb338faed  snyk-iac-test_0.24.2_Linux_x86_64
+const policyEngineChecksums = `2b96e44012ab42e6a181a954c83af374e1bbdcb0f39782504421730615dd8b0d  snyk-iac-test_0.25.0_Windows_arm64.exe
+6ed11a2f3fed1a382a69e5ad47eed37951490688dc0d0ea31c15b81e6022a98c  snyk-iac-test_0.25.0_Linux_arm64
+94cf0ffdb75108f826f2df2495f579c48e016f1fc5b63f25205f79a72523930d  snyk-iac-test_0.25.0_Windows_x86_64.exe
+af7c9d6334cb6bc2af981a950035eeca755c26a366a7142e5b3774341104a80c  snyk-iac-test_0.25.0_Darwin_x86_64
+e6f8838f419d8639b2358d84b134d0abd2cc6c855730db5ab27464f32911d8c2  snyk-iac-test_0.25.0_Darwin_arm64
+e89838a2d41ebc90e4575558c09074044b3e2966494590fa13b31efe9ed3efc6  snyk-iac-test_0.25.0_Linux_x86_64
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();

--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -156,6 +156,7 @@ function createConfig(options: TestConfig): string {
       apiAuth: getAuthHeader(),
       allowAnalytics: allowAnalytics(),
       policy: options.policy,
+      customSeverities: options.orgSettings.customPolicies,
     });
 
     fs.writeFileSync(tempConfig, configData);


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Adds custom severities as part of the config we send to the snyk-iac-test. 

This is now an object containing the custom severities set on the IaC Settings on Snyk Platform.
We fetch these from the registry `/iac-org-settings endpoint` and then pass them over to snyk-iac-test through the config.

To test it out:

- Run this branch locally `npm run build-cli:dev`
- Build the `snyk-iac-test` exec from this branch: https://github.com/snyk/snyk-iac-test/pull/103 by running
` go build -o snyk-iac-test . `
- Run an experimental scan `SNYK_IAC_POLICY_ENGINE_PATH=~/snyk-iac-test/snyk-iac-test snyk-dev iac test test/fixtures/iac/depth_detection/root.tf --experimental`
- See that the issue shows SNYK-CC-TF-4 with severity of medium.
![image](https://user-images.githubusercontent.com/6989529/187407482-e6dd7681-3124-4480-9f10-75f612cd4051.png)

- Set up a new severity in your org in snyk platform, eg set `SNYK-CC-TF-4` to low.  https://app.snyk.io/org/my-test-org/manage/cloud-config
![image](https://user-images.githubusercontent.com/6989529/187407234-674d9b56-3711-48e0-947d-11378f46bd58.png)

- Run the scan again and see the issue flagged as low
![image](https://user-images.githubusercontent.com/6989529/187407385-f5a523ae-3896-44b6-aa62-e3abf4bd8bab.png)


Now, setup the rule with a custom severity of 'none'. this should get ignored from the results.
![image](https://user-images.githubusercontent.com/6989529/187407706-a19b1407-4ebf-4085-9815-69d29b0673c2.png)

Notice that before it was:
Total issues: `15` [ 0 critical, 6 high, `3` medium, 6 low ]

If you run a scan again: 
Total issues: `14` [ 0 critical, 6 high, `2` medium, 6 low ]