### PR TITLE
chore: Added line breaking for IaC issue description

### DIFF
--- a/src/lib/formatters/iac-output/text/issues-list/index.ts
+++ b/src/lib/formatters/iac-output/text/issues-list/index.ts
@@ -30,8 +30,9 @@ export function getIacDisplayedIssues(
   const severitySectionsOutput = Object.values(SEVERITY)
     .filter((severity) => !!resultsBySeverity[severity])
     .map((severity) => {
-      const severityResults: FormattedOutputResult[] =
-        resultsBySeverity[severity];
+      const severityResults: FormattedOutputResult[] = resultsBySeverity[
+        severity
+      ]!;
 
       const titleOutput = colors.title(
         `${capitalize(severity)} Severity Issues: ${severityResults.length}`,

--- a/src/lib/formatters/iac-output/text/issues-list/issue.ts
+++ b/src/lib/formatters/iac-output/text/issues-list/issue.ts
@@ -1,9 +1,10 @@
 import * as capitalize from 'lodash.capitalize';
 import chalk from 'chalk';
 import { EOL } from 'os';
+import * as wrapAnsi from 'wrap-ansi';
 import { iacRemediationTypes } from '../../../../iac/constants';
 import { printPath } from '../../../remediation-based-format-issues';
-import { colors, contentPadding } from '../utils';
+import { colors, contentPadding, maxLineWidth } from '../utils';
 import { FormattedOutputResult, Issue } from '../types';
 import { Options } from './types';
 
@@ -79,15 +80,22 @@ function formatProperties(
     ],
   ];
 
-  const maxPropertyNameLength = Math.max(
-    ...properties.map(([key]) => key.length),
-  );
+  const propKeyColWidth = Math.max(...properties.map(([key]) => key.length));
+  const propValColWidth =
+    maxLineWidth - contentPadding.length - propKeyColWidth - 2;
+  const indentLength = propKeyColWidth + 2;
 
   return properties
     .filter(([, val]) => !!val)
+    .map(([key, value]) => [
+      key,
+      wrapAnsi(value, propValColWidth, {
+        hard: true,
+      }).replace(/\r?\n|\r/g, EOL + contentPadding + ' '.repeat(indentLength)),
+    ])
     .map(
       ([key, value]) =>
-        `${key}: ${' '.repeat(maxPropertyNameLength - key.length)}${value}`,
+        `${key}: ${' '.repeat(propKeyColWidth - key.length)}${value}`,
     );
 }
 

--- a/src/lib/formatters/iac-output/text/types.ts
+++ b/src/lib/formatters/iac-output/text/types.ts
@@ -11,7 +11,7 @@ export interface IacTestData {
 }
 
 export type FormattedOutputResultsBySeverity = {
-  [severity in keyof SEVERITY]?: FormattedOutputResult[];
+  [severity in SEVERITY]?: FormattedOutputResult[];
 };
 
 export type FormattedOutputResult = {

--- a/src/lib/formatters/iac-output/text/utils.ts
+++ b/src/lib/formatters/iac-output/text/utils.ts
@@ -29,3 +29,5 @@ export const colors: IacOutputColors = {
 };
 
 export const contentPadding = ' '.repeat(2);
+
+export const maxLineWidth = 80;

--- a/src/lib/iac/test/v2/json.ts
+++ b/src/lib/iac/test/v2/json.ts
@@ -6,6 +6,8 @@ import { IacOrgSettings } from '../../../../cli/commands/test/iac/local-executio
 import { Resource, ScanError, TestOutput, Vulnerability } from './scan/results';
 import * as path from 'path';
 import { createErrorMappedResultsForJsonOutput } from '../../../formatters/test/format-test-results';
+import { IacProjectType } from '../../constants';
+import { State } from './scan/policy-engine';
 
 export interface Result {
   meta: Meta;
@@ -54,7 +56,7 @@ export interface IacIssue {
   impact: string;
   msg: string;
   remediation?: Remediation;
-  subType: string;
+  subType: IacProjectType | State.InputTypeEnum;
   issue: string;
   publicId: string;
   title: string;

--- a/src/lib/iac/test/v2/scan/results.ts
+++ b/src/lib/iac/test/v2/scan/results.ts
@@ -1,4 +1,5 @@
 import { SEVERITY } from '../../../../snyk-test/common';
+import { IacProjectType } from '../../../constants';
 import { SnykIacTestError } from '../errors';
 import * as PolicyEngineTypes from './policy-engine';
 
@@ -60,10 +61,10 @@ export interface Rule {
 
 export interface Resource {
   id: string;
-  type: string;
+  type: IacProjectType | PolicyEngineTypes.State.InputTypeEnum;
   path?: any[];
   formattedPath: string;
-  file?: string;
+  file: string;
   kind: string;
   line?: number;
   column?: number;

--- a/test/jest/acceptance/iac/output-formats/text.spec.ts
+++ b/test/jest/acceptance/iac/output-formats/text.spec.ts
@@ -55,15 +55,25 @@ describe('iac test text output', () => {
     expect(stdout).toContain(
       '  [Medium] Azure Firewall Network Rule Collection allows public access' +
         EOL +
-        '  Info:    That inbound traffic is allowed to a resource from any source instead of a restricted range. That potentially everyone can access your resource' +
+        '  Info:    That inbound traffic is allowed to a resource from any source instead' +
+        EOL +
+        '           of a restricted range. That potentially everyone can access your' +
+        EOL +
+        '           resource' +
         EOL +
         '  Rule:    https://snyk.io/security-rules/SNYK-CC-TF-20' +
         EOL +
-        '  Path:    resources[1] > properties > networkRuleCollections[0] > properties > rules[0] > sourceAddresses' +
+        '  Path:    resources[1] > properties > networkRuleCollections[0] > properties >' +
+        EOL +
+        '           rules[0] > sourceAddresses' +
         EOL +
         '  File:    ./iac/arm/rule_test.json' +
         EOL +
-        '  Resolve: Set `properties.networkRuleCollections.properties.rules.sourceAddresses` attribute to specific IP range only, e.g. `192.168.1.0/24`',
+        '  Resolve: Set' +
+        EOL +
+        '           `properties.networkRuleCollections.properties.rules.sourceAddresses`' +
+        EOL +
+        '           attribute to specific IP range only, e.g. `192.168.1.0/24`',
     );
   });
 

--- a/test/jest/acceptance/iac/test-arm.spec.ts
+++ b/test/jest/acceptance/iac/test-arm.spec.ts
@@ -1,6 +1,5 @@
 import { EOL } from 'os';
 import { startMockServer, isValidJSONString } from './helpers';
-
 jest.setTimeout(50000);
 
 describe('ARM single file scan', () => {
@@ -25,7 +24,9 @@ describe('ARM single file scan', () => {
       'Azure Firewall Network Rule Collection allows public access',
     );
     expect(stdout).toContain(
-      'Path:    resources[1] > properties > networkRuleCollections[0] > properties > rules[0] > sourceAddresses',
+      '  Path:    resources[1] > properties > networkRuleCollections[0] > properties >' +
+        EOL +
+        '           rules[0] > sourceAddresses',
     );
     expect(stdout).toContain('File:    ./iac/arm/rule_test.json');
     expect(exitCode).toBe(1);

--- a/test/jest/acceptance/iac/test-cloudformation.spec.ts
+++ b/test/jest/acceptance/iac/test-cloudformation.spec.ts
@@ -26,7 +26,9 @@ describe('CloudFormation single file scan', () => {
       'SNS topic is not encrypted with customer managed key',
     );
     expect(stdout).toContain(
-      '[DocId: 0] > Resources[DatabaseAlarmTopic] > Properties > KmsMasterKeyId',
+      '  Path:    [DocId: 0] > Resources[DatabaseAlarmTopic] > Properties >' +
+        EOL +
+        '           KmsMasterKeyId',
     );
     expect(exitCode).toBe(1);
   });
@@ -40,7 +42,9 @@ describe('CloudFormation single file scan', () => {
     );
     expect(stdout).toContain('S3 restrict public bucket control is disabled');
     expect(stdout).toContain(
-      'Resources[CodePipelineArtifactBucket] > Properties > PublicAccessBlockConfiguration > RestrictPublicBuckets',
+      '  Path:    Resources[CodePipelineArtifactBucket] > Properties >' +
+        EOL +
+        '           PublicAccessBlockConfiguration > RestrictPublicBuckets',
     );
     expect(exitCode).toBe(1);
   });

--- a/test/jest/acceptance/iac/test-kubernetes.spec.ts
+++ b/test/jest/acceptance/iac/test-kubernetes.spec.ts
@@ -25,7 +25,9 @@ describe('Kubernetes single file scan', () => {
     expect(stdout).toContain(`File:    ./iac/kubernetes/pod-privileged.yaml`);
     expect(stdout).toContain('Privileged container');
     expect(stdout).toContain(
-      '[DocId: 0] > input > spec > containers[example] > securityContext > privileged',
+      '  Path:    [DocId: 0] > input > spec > containers[example] > securityContext >' +
+        EOL +
+        '           privileged',
     );
     expect(exitCode).toBe(1);
   });

--- a/test/jest/acceptance/iac/test-terraform.spec.ts
+++ b/test/jest/acceptance/iac/test-terraform.spec.ts
@@ -167,7 +167,9 @@ describe('Terraform', () => {
         `snyk iac test ./iac/terraform/var_deref/nested_var_deref --var-file=./iac/terraform/vars.tf`,
       );
       expect(stdout).toContain(
-        'Path:    input > resource > aws_security_group[allow_ssh_external_var_file] > ingress',
+        '  Path:    input > resource > aws_security_group[allow_ssh_external_var_file] >' +
+          EOL +
+          '           ingress',
       );
       expect(stdout).toContain(
         'Files without issues: 2' + EOL + '✗ Files with issues: 1',

--- a/test/jest/unit/lib/formatters/iac-output/text/issues-list/index.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/text/issues-list/index.spec.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import { getIacDisplayedIssues } from '../../../../../../../../src/lib/formatters/iac-output/text';
 import { colors } from '../../../../../../../../src/lib/formatters/iac-output/text/utils';
 import { FormattedOutputResultsBySeverity } from '../../../../../../../../src/lib/formatters/iac-output/text/types';
+import { SEVERITY } from '../../../../../../../../src/lib/snyk-test/legacy';
 
 describe('getIacDisplayedIssues', () => {
   let resultFixtures: FormattedOutputResultsBySeverity;
@@ -49,96 +50,81 @@ describe('getIacDisplayedIssues', () => {
     // Assert
     expect(result).toContain(
       `  ${colors.severities.low(
-        `[Low] ${chalk.bold('Container is running without AppArmor profile')}`,
+        `[Low] ${chalk.bold('EC2 API termination protection is not enabled')}`,
       )}
-  Info:    The AppArmor profile is not set correctly. AppArmor will not enforce mandatory access control, which can increase the attack vectors.
-  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-K8S-32')}
-  Path:    [DocId: 0] > metadata > annotations['container.apparmor.security.beta.kubernetes.io/web']
-  File:    k8s.yaml
-  Resolve: Add \`container.apparmor.security.beta.kubernetes.io/<container-name>\` annotation with value \`runtime/default\` or \`localhost/<name-of-profile\`
-
-  ${colors.severities.low(
-    `[Low] ${chalk.bold('Container is running without memory limit')}`,
-  )}
-  Info:    Memory limit is not defined. Containers without memory limits are more likely to be terminated when the node runs out of memory
-  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-K8S-4')}
-  Path:    [DocId: 0] > input > spec > template > spec > containers[web] > resources > limits > memory
-  File:    k8s.yaml
-  Resolve: Set \`resources.limits.memory\` value
-
-  ${colors.severities.low(
-    `[Low] ${chalk.bold('Container could be running with outdated image')}`,
-  )}
-  Info:    The image policy does not prevent image reuse. The container may run with outdated or unauthorized image
-  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-K8S-42')}
-  Path:    [DocId: 0] > spec > template > spec > containers[web] > imagePullPolicy
-  File:    k8s.yaml
-  Resolve: Set \`imagePullPolicy\` attribute to \`Always\`
-
-  ${colors.severities.low(
-    `[Low] ${chalk.bold('Container is running without cpu limit')}`,
-  )}
-  Info:    CPU limit is not defined. Containers without limits can exceed the capacity of the node, and affect availability/performance of the host and other containers.
-  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-K8S-5')}
-  Path:    [DocId: 0] > input > spec > template > spec > containers[web] > resources > limits > cpu
-  File:    k8s.yaml
-  Resolve: Add \`resources.limits.cpu\` field with required CPU limit value
-
-  ${colors.severities.low(
-    `[Low] ${chalk.bold('Container is running with writable root filesystem')}`,
-  )}
-  Info:    \`readOnlyRootFilesystem\` attribute is not set to \`true\`. Compromised process could abuse writable root filesystem to elevate privileges
-  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-K8S-8')}
-  Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > readOnlyRootFilesystem
-  File:    k8s.yaml
-  Resolve: Set \`securityContext.readOnlyRootFilesystem\` to \`true\``,
+  Info:    To prevent instance from being accidentally terminated using Amazon
+           EC2, you can enable termination protection for the instance. Without
+           this setting enabled the instances can be terminated by accident.
+           This setting should only be used for instances with high availability
+           requirements. Enabling this may prevent IaC workflows from updating
+           the instance, for example terraform will not be able to terminate the
+           instance to update instance type
+  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-AWS-426')}
+  Path:    resource > aws_instance[denied] > disable_api_termination
+  File:    aws_ec2_metadata_secrets.tf
+  Resolve: Set \`disable_api_termination\` attribute  with value \`true\``,
     );
 
     expect(result).toContain(
       `  ${colors.severities.medium(
-        `[Medium] ${chalk.bold(
-          'Container is running without root user control',
-        )}`,
+        `[Medium] ${chalk.bold('Non-Encrypted root block device')}`,
       )}
-  Info:    Container is running without root user control. Container could be running with full administrative privileges
-  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-K8S-10')}
-  Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > runAsNonRoot
-  File:    k8s.yaml
-  Resolve: Set \`securityContext.runAsNonRoot\` to \`true\`
-
-  ${colors.severities.medium(
-    `[Medium] ${chalk.bold(
-      'Container does not drop all default capabilities',
-    )}`,
-  )}
-  Info:    All default capabilities are not explicitly dropped. Containers are running with potentially unnecessary privileges
-  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-K8S-6')}
-  Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > capabilities > drop
-  File:    k8s.yaml
-  Resolve: Add \`ALL\` to \`securityContext.capabilities.drop\` list, and add only required capabilities in \`securityContext.capabilities.add\`
-
-  ${colors.severities.medium(
-    `[Medium] ${chalk.bold(
-      'Container is running without privilege escalation control',
-    )}`,
-  )}
-  Info:    \`allowPrivilegeEscalation\` attribute is not set to \`false\`. Processes could elevate current privileges via known vectors, for example SUID binaries
-  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-K8S-9')}
-  Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > allowPrivilegeEscalation
-  File:    k8s.yaml
-  Resolve: Set \`securityContext.allowPrivilegeEscalation\` to \`false\``,
+  Info:    The root block device for ec2 instance is not encrypted. That should
+           someone gain unauthorized access to the data they would be able to
+           read the contents.
+  Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-TF-53')}
+  Path:    [DocId: 0] > Resources > BastionHost > Properties >
+           BlockDeviceMappings
+  File:    bastion.yml
+  Resolve: Set \`BlockDeviceMappings.Encrypted\` attribute of root device to
+           \`true\``,
     );
 
     expect(result).toContain(
       `  ${colors.severities.high(
         `[High] ${chalk.bold('Container is running in privileged mode')}`,
       )}
-  Info:    Container is running in privileged mode. Compromised container could potentially modify the underlying host’s kernel by loading unauthorized modules (i.e. drivers).
+  Info:    Container is running in privileged mode. Compromised container could
+           potentially modify the underlying host’s kernel by loading
+           unauthorized modules (i.e. drivers).
   Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-K8S-1')}
-  Path:    [DocId: 0] > input > spec > template > spec > containers[web] > securityContext > privileged
+  Path:    [DocId: 0] > input > spec > template > spec > containers[web] >
+           securityContext > privileged
   File:    k8s.yaml
-  Resolve: Remove \`securityContext.privileged\` attribute, or set value to \`false\``,
+  Resolve: Remove \`securityContext.privileged\` attribute, or set value to
+           \`false\``,
     );
+  });
+
+  it('should break issue details lines', async () => {
+    // Arrange
+    const lowIssue = resultFixtures[SEVERITY.LOW]![0];
+    const testResults: FormattedOutputResultsBySeverity = {
+      low: [
+        {
+          ...lowIssue,
+          issue: {
+            ...lowIssue.issue,
+            issue:
+              'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cumque doloribus molestiae atque eveniet, minus, obcaecati possimus libero id porro alias nihil sit vero necessitatibus quos labore provident.',
+            impact:
+              'Lorem ipsum dolor sit amet consectetur adipisicing elit. Cumque doloribus molestiae atque eveniet, minus, obcaecati possimus libero id porro alias nihil sit vero necessitatibus quos labore provident.',
+          },
+        },
+      ],
+    };
+
+    // Act
+    const result = getIacDisplayedIssues(testResults);
+
+    // Assert
+    expect(result)
+      .toContain(`Info:    Lorem ipsum dolor sit amet consectetur adipisicing elit. Cumque
+           doloribus molestiae atque eveniet, minus, obcaecati possimus libero
+           id porro alias nihil sit vero necessitatibus quos labore provident.
+           Lorem ipsum dolor sit amet consectetur adipisicing elit. Cumque
+           doloribus molestiae atque eveniet, minus, obcaecati possimus libero
+           id porro alias nihil sit vero necessitatibus quos labore provident.`);
   });
 
   describe('with no issues', () => {
@@ -203,7 +189,13 @@ describe('getIacDisplayedIssues', () => {
               'EC2 API termination protection is not enabled',
             )}`,
           )}
-  Info:    To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance. Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type
+  Info:    To prevent instance from being accidentally terminated using Amazon
+           EC2, you can enable termination protection for the instance. Without
+           this setting enabled the instances can be terminated by accident.
+           This setting should only be used for instances with high availability
+           requirements. Enabling this may prevent IaC workflows from updating
+           the instance, for example terraform will not be able to terminate the
+           instance to update instance type
   Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-AWS-426')}
   Path:    resource > aws_instance[denied_3] > disable_api_termination
   File:    aws_ec2_metadata_secrets.tf
@@ -223,9 +215,12 @@ describe('getIacDisplayedIssues', () => {
           `${colors.severities.high(
             `[High] ${chalk.bold('Hard coded secrets in EC2 metadata')}`,
           )}
-  Info:    Secret keys have been hardcoded in user_data script. Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources
+  Info:    Secret keys have been hardcoded in user_data script. Anyone with
+           access to VCS will be able to obtain the secret keys, and access the
+           unauthorized resources
   Rule:    ${chalk.underline('https://snyk.io/security-rules/SNYK-CC-TF-123')}
-  Path:    resource > aws_instance[denied_2] > user_data_base64[aws_access_key_id]
+  Path:    resource > aws_instance[denied_2] >
+           user_data_base64[aws_access_key_id]
   File:    aws_ec2_metadata_secrets.tf
   Resolve: Remove secret value from \`user_data\` attribute`,
         );


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Fixes the lack of indentation for issue properties that exceed the line width of the CLI.

#### Where should the reviewer start?

```
src/lib/formatters/iac-output/text/issues-list/issue.ts
```

#### How should this be manually tested?

- Run `snyk-dev iac test`
- For the issues list in the test output, ensure the issue properties are broken into new indented lines as needed, rather than start at the beginning of the line beneath the property name.

#### Screenshots

- Before:
    <img width="1098" alt="image" src="https://user-images.githubusercontent.com/46415136/187216810-51c0e32f-ac59-4269-b6a3-aafcf8b05fcf.png">

- After:
    <img width="1096" alt="image" src="https://user-images.githubusercontent.com/46415136/187216913-b9f1fc9c-c205-4be0-b9e2-5d9931aaad83.png">
