### PR TITLE
feat: add ignore count in the experimental version of iac test

### DIFF
--- a/src/lib/formatters/iac-output/text/formatters.ts
+++ b/src/lib/formatters/iac-output/text/formatters.ts
@@ -104,12 +104,15 @@ export function formatSnykIacTestTestData(
   const allFilesCount = countFiles(snykIacTestScanResult);
   const filesWithIssuesCount = countFilesWithIssues(snykIacTestScanResult);
   const filesWithoutIssuesCount = allFilesCount - filesWithIssuesCount;
+  const ignores = snykIacTestScanResult
+    ? snykIacTestScanResult.metadata.ignoredCount
+    : 0;
 
   return {
     resultsBySeverity,
     metadata: { projectName, orgName },
     counts: {
-      ignores: 0,
+      ignores,
       filesWithIssues: filesWithIssuesCount,
       filesWithoutIssues: filesWithoutIssuesCount,
       issues: totalIssues,

--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -1,11 +1,11 @@
 import * as os from 'os';
 
-const policyEngineChecksums = `56b32bea2a67c546d7d86d7ea7128664499956f5ae7f1db7f9f66b26069c3d7b  snyk-iac-test_0.24.1_Darwin_x86_64
-6d83a25074a3cb3ca5b715e853d06fe0504bd185fecd80fde2bbdc838835f378  snyk-iac-test_0.24.1_Darwin_arm64
-6e54515b5f7d84f90cc893cd81868a927cb413ed71303939c7f62e2f5414e18f  snyk-iac-test_0.24.1_Windows_x86_64.exe
-87c224f936a4e6a969eb2b62767d793ec93dea494b12e508b9d69890fd4b2e22  snyk-iac-test_0.24.1_Linux_x86_64
-df043f48385f4c6e5bd529125d5b9673adc36197fffd47655f19f5c790fbefb5  snyk-iac-test_0.24.1_Windows_arm64.exe
-dfef8e2e83a4d967e3e2897b8795f22aa2fc9f0565c02ad80fa157085dfd61f8  snyk-iac-test_0.24.1_Linux_arm64
+const policyEngineChecksums = `005afd663b57bc2981943496c2abb15f592df0c8a1022340c03c36c728d42366  snyk-iac-test_0.24.2_Darwin_x86_64
+2ac72979d98ef2eaa8cc6a9fabe5b871bc87f1778c79ed3fffb704d3e6d41248  snyk-iac-test_0.24.2_Windows_arm64.exe
+539d34c1b6af5b18d266e881a5612e6030ac6deae8a9172f6b198c5e27d57004  snyk-iac-test_0.24.2_Darwin_arm64
+c91c105e2269fd1bf76eee5221f3046972febc6f803a70a52454b8d181760a96  snyk-iac-test_0.24.2_Linux_arm64
+fbe724a3285d8dee7a70a8aedb539e998e368c6accafc9c3ce952b5ae0dca84d  snyk-iac-test_0.24.2_Windows_x86_64.exe
+ff9fee0711c0556cf0f58469ef5c6db164825e855c29dfb404dfcd6cb338faed  snyk-iac-test_0.24.2_Linux_x86_64
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();

--- a/src/lib/iac/test/v2/scan/results.ts
+++ b/src/lib/iac/test/v2/scan/results.ts
@@ -32,11 +32,12 @@ export interface SnykIacTestOutput {
 export interface Results {
   resources?: Resource[];
   vulnerabilities?: Vulnerability[];
-  metadata?: Metadata;
+  metadata: Metadata;
 }
 
 export interface Metadata {
   projectName: string;
+  ignoredCount: number;
 }
 
 export interface Vulnerability {

--- a/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results.json
+++ b/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results.json
@@ -147,7 +147,8 @@
       }
     ],
     "metadata": {
-      "projectName": "input-files-for-json-v2"
+      "projectName": "input-files-for-json-v2",
+      "ignoredCount": 3
     }
   },
   "errors": [

--- a/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-text-output-data.json
+++ b/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-text-output-data.json
@@ -88,7 +88,7 @@
     "orgName": "org-name"
   },
   "counts": {
-    "ignores": 0,
+    "ignores": 3,
     "filesWithIssues": 2,
     "filesWithoutIssues": 0,
     "issues": 4,


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Add support for displaying the amount of ignored vulnerabilities in the summary section of the text output.

#### How should this be manually tested?

Run a scan with the `--experimental` flag.

```
$ snyk iac test --experimental test/fixtures/iac
```

The text output should present this summary:

```
✔ Files without issues: 12
✗ Files with issues: 3
  Ignored issues: 0
  Total issues: 59 [ 0 critical, 22 high, 10 medium, 27 low ]
```

Add an ignore using the `snyk` command.

```
$ snyk ignore --id=SNYK-CC-TF-98 --path='*'
```

Re-run the same scan as before. The text output should account for the number of vulnerabilities that were ignored:

```
✔ Files without issues: 12
✗ Files with issues: 3
  Ignored issues: 5
  Total issues: 54 [ 0 critical, 17 high, 10 medium, 27 low ]
```

#### What are the relevant tickets?

[CFG-2092](https://snyksec.atlassian.net/browse/CFG-2092)
