### PR TITLE
chore: remove —proxy cmd argument

### DIFF
--- a/cliv2/cmd/cliv2/main.go
+++ b/cliv2/cmd/cliv2/main.go
@@ -16,7 +16,6 @@ type EnvironmentVariables struct {
 	CacheDirectory               string
 	Insecure                     bool
 	ProxyAuthenticationMechanism httpauth.AuthenticationMechanism
-	ProxyAddr                    string
 }
 
 func getDebugLogger(args []string) *log.Logger {
@@ -35,8 +34,6 @@ func getDebugLogger(args []string) *log.Logger {
 }
 
 func GetConfiguration(args []string) (EnvironmentVariables, []string) {
-	argsAsMap := utils.ToKeyValueMap(args, "=")
-
 	envVariables := EnvironmentVariables{
 		CacheDirectory:               os.Getenv("SNYK_CACHE_PATH"),
 		ProxyAuthenticationMechanism: httpauth.AnyAuth,
@@ -49,10 +46,8 @@ func GetConfiguration(args []string) (EnvironmentVariables, []string) {
 
 	envVariables.Insecure = utils.Contains(args, "--insecure")
 
-	envVariables.ProxyAddr, _ = argsAsMap["--proxy"]
-
 	// filter args not meant to be forwarded to CLIv1 or an Extensions
-	elementsToFilter := []string{"--proxy=", "--proxy-noauth"}
+	elementsToFilter := []string{"--proxy-noauth"}
 	filteredArgs := args
 	for _, element := range elementsToFilter {
 		filteredArgs = utils.RemoveSimilar(filteredArgs, element)
@@ -99,7 +94,6 @@ func MainWithErrorCode(envVariables EnvironmentVariables, args []string) int {
 		return cliv2.SNYK_EXIT_CODE_ERROR
 	}
 
-	wrapperProxy.SetUpstreamProxyFromUrl(envVariables.ProxyAddr)
 	wrapperProxy.SetUpstreamProxyAuthentication(envVariables.ProxyAuthenticationMechanism)
 
 	port, err := wrapperProxy.Start()

--- a/cliv2/cmd/cliv2/main_test.go
+++ b/cliv2/cmd/cliv2/main_test.go
@@ -36,13 +36,12 @@ func Test_MainWithErrorCode_no_cache(t *testing.T) {
 }
 
 func Test_GetConfiguration(t *testing.T) {
-	cmd := "_bin/snyk_darwin_arm64 --debug --proxy=http://host.example.com:3128 --insecure test"
+	cmd := "_bin/snyk_darwin_arm64 --debug --insecure test"
 	args := strings.Split(cmd, " ")
 
 	expectedConfig := main.EnvironmentVariables{
 		Insecure:                     true,
 		ProxyAuthenticationMechanism: httpauth.AnyAuth,
-		ProxyAddr:                    "http://host.example.com:3128",
 	}
 	expectedArgs := []string{"_bin/snyk_darwin_arm64", "--debug", "--insecure", "test"}
 
@@ -53,13 +52,12 @@ func Test_GetConfiguration(t *testing.T) {
 }
 
 func Test_GetConfiguration02(t *testing.T) {
-	cmd := "_bin/snyk_darwin_arm64 --debug --proxy-noauth --proxy=http://host.example.com:3128 --insecure test"
+	cmd := "_bin/snyk_darwin_arm64 --debug --proxy-noauth --insecure test"
 	args := strings.Split(cmd, " ")
 
 	expectedConfig := main.EnvironmentVariables{
 		Insecure:                     true,
 		ProxyAuthenticationMechanism: httpauth.NoAuth,
-		ProxyAddr:                    "http://host.example.com:3128",
 	}
 	expectedArgs := []string{"_bin/snyk_darwin_arm64", "--debug", "--insecure", "test"}
 


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Remove the command line argument `--proxy`, to only support Proxy configuration via environment variables HTTP_PROXY, HTTPS_PROXY, NO_PROXY.
