### PR TITLE
feat: Added support for depth-detection [CFG-2110]

### DIFF
--- a/src/cli/commands/test/iac/v2/assert-iac-options.ts
+++ b/src/cli/commands/test/iac/v2/assert-iac-options.ts
@@ -22,6 +22,7 @@ const keys: (keyof IaCTestFlags)[] = [
   'scan',
   'experimental',
   'var-file',
+  'detectionDepth',
   // PolicyOptions
   'ignore-policy',
   'policy-path',

--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -54,6 +54,8 @@ async function prepareTestConfig(
   const projectTags = parseTags(options);
   const targetName = getFlag(options, 'target-name');
   const remoteRepoUrl = getFlag(options, 'remote-repo-url');
+  const depthDetection =
+    parseInt(getFlag(options, 'depth-detection') as string) || undefined;
   const attributes = parseAttributes(options);
   const policy = await findAndLoadPolicy(process.cwd(), 'iac', options);
   const scan = options.scan ?? 'resource-changes';
@@ -73,6 +75,7 @@ async function prepareTestConfig(
     remoteRepoUrl,
     policy: policy?.toString(),
     scan,
+    depthDetection,
   };
 }
 

--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -1,11 +1,11 @@
 import * as os from 'os';
 
-const policyEngineChecksums = `2b96e44012ab42e6a181a954c83af374e1bbdcb0f39782504421730615dd8b0d  snyk-iac-test_0.25.0_Windows_arm64.exe
-6ed11a2f3fed1a382a69e5ad47eed37951490688dc0d0ea31c15b81e6022a98c  snyk-iac-test_0.25.0_Linux_arm64
-94cf0ffdb75108f826f2df2495f579c48e016f1fc5b63f25205f79a72523930d  snyk-iac-test_0.25.0_Windows_x86_64.exe
-af7c9d6334cb6bc2af981a950035eeca755c26a366a7142e5b3774341104a80c  snyk-iac-test_0.25.0_Darwin_x86_64
-e6f8838f419d8639b2358d84b134d0abd2cc6c855730db5ab27464f32911d8c2  snyk-iac-test_0.25.0_Darwin_arm64
-e89838a2d41ebc90e4575558c09074044b3e2966494590fa13b31efe9ed3efc6  snyk-iac-test_0.25.0_Linux_x86_64
+const policyEngineChecksums = `104f3a8d8d1835f9621007fb7976a837ee8946510f41f7fc50323f728cebb21c  snyk-iac-test_0.26.0_Darwin_arm64
+61bfc743d4392952eb7de3f3c4cdb6e0dfb4a491d0ca24d67c929fc3656d6c5f  snyk-iac-test_0.26.0_Linux_x86_64
+73847b5bcc0f42cc8acd918f0dff97ee917a64ce84991785a8e6c46a6c4bc6f2  snyk-iac-test_0.26.0_Linux_arm64
+ac9100c8a1314a22fe7db7df8faa7d6be0aa6ba986f2db172f727fe004a0853d  snyk-iac-test_0.26.0_Windows_x86_64.exe
+ad2983ff583989608e259441de12b6871d9e9dcb994eb81214e9dbb14d3b3dd4  snyk-iac-test_0.26.0_Darwin_x86_64
+c7de20ee54fd66c885e2bbe37b8c1d533464a525a5abdbc1d86a6a5c8a76b2b8  snyk-iac-test_0.26.0_Windows_arm64.exe
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();

--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -113,6 +113,10 @@ function processFlags(
     flags.push('-project-lifecycle', options.attributes.lifecycle.join(','));
   }
 
+  if (options.depthDetection) {
+    flags.push('-depth-detection', `${options.depthDetection}`);
+  }
+
   if (options.projectTags) {
     const stringifiedTags = options.projectTags
       .map((tag) => {

--- a/src/lib/iac/test/v2/types.ts
+++ b/src/lib/iac/test/v2/types.ts
@@ -17,4 +17,5 @@ export interface TestConfig {
   remoteRepoUrl?: string;
   policy?: string;
   scan: string;
+  depthDetection?: number;
 }


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Updates the checksum values for `snyk-iac-test`.
- Adds support for the `--depth-detection` flag from the CLI, to pass to `snyk-iac-test`.

#### Notes for the reviewer

- The definition of depth in `policy-engine` was different than the definition in the Snyk CLI. In `snyk-iac-test`, files inside a directory are defined as another depth level, whereas in the CLI the definitions are only defined by the directories. Example, for `zero/one/main.tf`, `snyk-iac-test` would define the file to be in depth level `2`, whereas in the CLI, the depth level would be `1`.
- The `depth-detection` flag accepts positive integers (d > 0).

#### How should this be manually tested?

- Build a local `snyk-iac-test` binary with https://github.com/snyk/snyk-iac-test/pull/104
- Build a local Snyk CLI
- Run the following:
```
SNYK_IAC_POLICY_ENGINE_PATH=<path-to-snyk-iac-test> snyk-dev iac test --experimental --detection-depth=0 <path-to-dir>
```
- Ensure the command fails with the expected error message.
- Run the following:
```
SNYK_IAC_POLICY_ENGINE_PATH=<path-to-snyk-iac-test> snyk-dev iac test --experimental --detection-depth=<positive-int> <path-to-dir>
```

- Ensure the expected files were scanned, and files on deeper levels were not scanned.
- Repeat the process on any other invalid values and ensure they are result in the expected error message.

#### Any background context you want to provide?

- A user can specify a --detection-depth to limit depth of traversal when scanning files and directories. Support for this attribute must be implemented in snyk-iac-test.
- When scanning a directory, the Policy Engine already [passes the traversal depth to the input.WalkFunc](https://github.com/snyk/snyk-iac-test/blob/9208e8179910667ade57fce6f065a0c8d16e9249/pkg/engine/scanner.go#L83-L90). If a traversal depth is specified by the user, we can compare that to the traversal depth of the scanned path and stop scanning as soon as we exceed the desired depth.

#### What are the relevant tickets?

- [CFG-2110](https://snyksec.atlassian.net/browse/CFG-2110)