### PR TITLE
chore: increase timeout to 60sec to reduce test flakiness

### DIFF
--- a/test/jest/acceptance/snyk-test/spotlight-vuln-notification.spec.ts
+++ b/test/jest/acceptance/snyk-test/spotlight-vuln-notification.spec.ts
@@ -2,7 +2,7 @@ import { fakeServer } from '../../../acceptance/fake-server';
 import { createProjectFromFixture } from '../../util/createProject';
 import { runSnykCLI } from '../../util/runSnykCLI';
 
-jest.setTimeout(1000 * 30);
+jest.setTimeout(1000 * 60);
 
 describe('spotlight vuln notification', () => {
   let server;


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Since the test `test/jest/acceptance/snyk-test/spotlight-vuln-notification.spec.ts` often fails with a timeout, I increased the timeout for this specific test from 30s to 60s.
