### PR TITLE
feat: create temp filepath for iac engine to write results [CFG-2114]

### DIFF
--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -1,11 +1,11 @@
 import * as os from 'os';
 
-const policyEngineChecksums = `283cb07a894f8252733e6634bef84fbc4fe98eac338239493753e20477150abb  snyk-iac-test_0.27.0_Darwin_arm64
-55c6cae0b4805047d0f0d8f3eea74f12a4233211499cc2f006cee633f1f2e7b8  snyk-iac-test_0.27.0_Windows_x86_64.exe
-7a845e2108c309a7bde435342b69d3ed172a36971779dbc2e1a9a96582f1c4fb  snyk-iac-test_0.27.0_Windows_arm64.exe
-a06de762874686612d9d42b2eb165979f334413f6460a675f0559e8e56a264dc  snyk-iac-test_0.27.0_Linux_x86_64
-ac3ece2e1d59927330c996d968dc5bf84faaa766f85402b56b3ae15fe2fae313  snyk-iac-test_0.27.0_Linux_arm64
-d96eda3334548db4dc17ea9892b94f48a3a4187af13090118e04cdbd23c821b7  snyk-iac-test_0.27.0_Darwin_x86_64
+const policyEngineChecksums = `0cbcdc8f4a7652835355f010d5cb97597055577e624799428c62819d74773b7e  snyk-iac-test_0.28.0_Windows_arm64.exe
+28637249844c060dc950c6d3fdb31e1ff2d96bfe76291fb383d5c94ee2db7b26  snyk-iac-test_0.28.0_Linux_x86_64
+45629e08ff8c3bfc601773d38705c19ea3abc2b8c33ee7174c97eb5669aa73f9  snyk-iac-test_0.28.0_Linux_arm64
+5a5066edc9dc8daf61fe57f57e844cff59c91c0fdb70f3efda3fe8260f06e801  snyk-iac-test_0.28.0_Windows_x86_64.exe
+db669ad313d222184e07c02f3540b06c62de283ef2e57a75ee1df4116f1831a3  snyk-iac-test_0.28.0_Darwin_x86_64
+eb0b99c469eb31f930852466bb1e8b9e576a0bf22ea17dc951762f824009c18a  snyk-iac-test_0.28.0_Darwin_arm64
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();


### PR DESCRIPTION
#### What does this PR do?

This commit creates a temporary filepath and passes it through the `-output` flag to the snyk-iac-test executable.
The snyk-iac-test will then write all the results to this file, which the CLI will have to read and present to the user.

Notes: 
- the flag is not visible to the user, this will all happen in the background.
- the file is created with empty content on the CLI side, and then gets overwritten by the snyk-iac-test with the results. This comment explains also reasoning about runnings scans in parallel: https://snyksec.atlassian.net/browse/CFG-2114?focusedCommentId=509517
- the file is deleted when the results are read on the CLI side.
- if errors happen during the file creation they will get caught on the CLI side too.
- if errors happen during the file writing we will handle them on the snyk-iac-test side and return with exit code 1 to the CLI.

Use this in combination with https://github.com/snyk/snyk-iac-test/pull/106 to test.

#### How should this be manually tested?

- Go to the branch of snyk-iac-test above and build locally: `go build -o snyk-iac-test .`
- Create a bundle in `opa-rules` repository if you don't have one: `make dist`
- Then run a scan as usual to see results:
`SNYK_IAC_POLICY_ENGINE_PATH=~/snyk-iac-test/snyk-iac-test SNYK_IAC_BUNDLE_PATH=~/opa-rules/dist.tar.gz snyk-dev iac test test/fixtures/iac/terraform/sg_open_ssh.tf --experimental`

﻿﻿
![image](https://user-images.githubusercontent.com/6989529/187501153-27bae1d2-51ae-4808-b4d9-af540b8965d7.png)
