### PR TITLE
fix: matching configurations error on gradle version catalog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "snyk-cpp-plugin": "2.20.0",
         "snyk-docker-plugin": "^5.1.2",
         "snyk-go-plugin": "^1.19.0",
-        "snyk-gradle-plugin": "3.21.1",
+        "snyk-gradle-plugin": "^3.22.1",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.31.0",
         "snyk-nodejs-lockfile-parser": "1.38.0",
@@ -16702,9 +16702,9 @@
       }
     },
     "node_modules/snyk-gradle-plugin": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.21.1.tgz",
-      "integrity": "sha512-ZL2GXi76owUi5Y4SvasBtpxvMi/6thxBNDXjghbzBmnMAZUanc2vwZldE7aRa7vvyVv60Jao9ommH2IMye7s7Q==",
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.22.1.tgz",
+      "integrity": "sha512-MXLo1aGoE95d2rKNajwFZ4GcpYj/ap0WkyQXnVMfFM0NeYHOeZU/cQqIbY49/14vtu/Gtqlc5phHjDhERYx3Rg==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",
@@ -32990,9 +32990,9 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.21.1.tgz",
-      "integrity": "sha512-ZL2GXi76owUi5Y4SvasBtpxvMi/6thxBNDXjghbzBmnMAZUanc2vwZldE7aRa7vvyVv60Jao9ommH2IMye7s7Q==",
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.22.1.tgz",
+      "integrity": "sha512-MXLo1aGoE95d2rKNajwFZ4GcpYj/ap0WkyQXnVMfFM0NeYHOeZU/cQqIbY49/14vtu/Gtqlc5phHjDhERYx3Rg==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "snyk-cpp-plugin": "2.20.0",
     "snyk-docker-plugin": "^5.1.2",
     "snyk-go-plugin": "^1.19.0",
-    "snyk-gradle-plugin": "3.21.1",
+    "snyk-gradle-plugin": "^3.22.1",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.31.0",
     "snyk-nodejs-lockfile-parser": "1.38.0",


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

The new version of the Gradle plugin introduces a fix for projects that would get a "matching configuration" error when there were no resolvable configurations. These projects will instead return an empty dep graph.   

See this [PR](https://github.com/snyk/snyk-gradle-plugin/pull/221)
