### PR TITLE
chore: Add issue remediation to test output [CFG-2124]

### DIFF
--- a/src/lib/formatters/iac-output/text/formatters.ts
+++ b/src/lib/formatters/iac-output/text/formatters.ts
@@ -1,4 +1,5 @@
 import { FormattedResult } from '../../../../cli/commands/test/iac/local-execution/types';
+import { iacRemediationTypes } from '../../../iac/constants';
 import { Results, Vulnerability } from '../../../iac/test/v2/scan/results';
 import { SEVERITY } from '../../../snyk-test/legacy';
 import { IacOutputMeta } from '../../../types';
@@ -167,7 +168,7 @@ function formatSnykIacTestScanResultNewOutput(
       resultsBySeverity[vulnerability.severity]!.push({
         issue: formatSnykIacTestScanVulnerability(vulnerability),
         targetFile: vulnerability.resource.file,
-        projectType: vulnerability.resource.type,
+        projectType: vulnerability.resource.kind,
       });
     });
   }
@@ -178,6 +179,8 @@ function formatSnykIacTestScanResultNewOutput(
 function formatSnykIacTestScanVulnerability(
   vulnerability: Vulnerability,
 ): Issue {
+  const resolve = extractResolve(vulnerability);
+
   return {
     id: vulnerability.rule.id,
     severity: vulnerability.severity,
@@ -186,9 +189,18 @@ function formatSnykIacTestScanVulnerability(
     cloudConfigPath: formatCloudConfigPath(vulnerability),
     issue: vulnerability.rule.title,
     impact: vulnerability.rule.description,
-    resolve: '',
+    resolve,
     documentation: vulnerability.rule.documentation,
+    remediation: {
+      [iacRemediationTypes[vulnerability.resource.kind]]: resolve,
+    },
   };
+}
+function extractResolve(vulnerability: Vulnerability): string {
+  const newLineIdx = vulnerability.remediation.search(/\r?\n|\r/g);
+  return newLineIdx < 0
+    ? vulnerability.remediation
+    : vulnerability.remediation.substring(0, newLineIdx);
 }
 
 function formatCloudConfigPath(vulnerability: Vulnerability): string[] {

--- a/src/lib/iac/test/v2/sarif.ts
+++ b/src/lib/iac/test/v2/sarif.ts
@@ -6,7 +6,7 @@ import * as upperFirst from 'lodash.upperfirst';
 import * as camelCase from 'lodash.camelcase';
 
 import { getVersion } from '../../../version';
-import { Results, TestOutput } from './scan/results';
+import { Results, TestOutput, Vulnerability } from './scan/results';
 import { getIssueLevel } from '../../../formatters/sarif-output';
 import { getRepositoryRoot } from '../../git';
 
@@ -73,6 +73,8 @@ function extractReportingDescriptor(
 
     const tags = ['security']; // switch to rules.labels once `snyk-iac-test` includes this info
 
+    const remediation = extractRemediation(vulnerability);
+
     rules[vulnerability.rule.id] = {
       id: vulnerability.rule.id,
       name: upperFirst(camelCase(vulnerability.rule.title)).replace(/ /g, ''),
@@ -85,8 +87,8 @@ function extractReportingDescriptor(
         text: vulnerability.rule.description,
       },
       help: {
-        text: renderMarkdown(vulnerability.remediation),
-        markdown: vulnerability.remediation,
+        text: renderMarkdown(remediation),
+        markdown: remediation,
       },
       defaultConfiguration: {
         level: getIssueLevel(vulnerability.severity),
@@ -175,4 +177,11 @@ function mapSnykIacTestResultsToSarifResults(
   });
 
   return result;
+}
+
+function extractRemediation(vulnerability: Vulnerability): string {
+  const newLineIdx = vulnerability.remediation.search(/\r?\n|\r/g);
+  return newLineIdx < 0
+    ? vulnerability.remediation
+    : vulnerability.remediation.substring(0, newLineIdx);
 }

--- a/src/lib/iac/test/v2/scan/results.ts
+++ b/src/lib/iac/test/v2/scan/results.ts
@@ -62,11 +62,11 @@ export interface Rule {
 
 export interface Resource {
   id: string;
-  type: IacProjectType | PolicyEngineTypes.State.InputTypeEnum;
+  type: string;
   path?: any[];
   formattedPath: string;
   file: string;
-  kind: string;
+  kind: IacProjectType | PolicyEngineTypes.State.InputTypeEnum;
   line?: number;
   column?: number;
 }

--- a/test/jest/unit/iac/process-results/fixtures/experimental-json-output.json
+++ b/test/jest/unit/iac/process-results/fixtures/experimental-json-output.json
@@ -38,11 +38,11 @@
     "infrastructureAsCodeIssues": [
       {
         "severity": "medium",
-        "resolve": "# Remediation Steps\n\n* Ensure that the [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) is referenced in an [aws_flog_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) `vpc_id` field.\n\n#### Example Configuration\n\n```hcl\nresource \"aws_vpc\" \"valid_vpc\" {\n  # other required fields here\n}\n\nresource \"aws_flow_log\" \"test_flow_log\" {\n  vpc_id         = \"${aws_vpc.valid_vpc.id}\"\n  # other required fields here\n}\n```\n",
+        "resolve": "Reference the `aws_vpc` in an `aws_flog_log` `vpc_id` field.",
         "impact": "VPC flow logging should be enabled. AWS VPC Flow Logs provide visibility into network traffic that traverses the AWS VPC.\nUsers can use the flow logs to detect anomalous traffic or insight during security workflows.\n",
         "msg": "resource.aws_vpc[mainvpc]",
         "remediation": {
-          "terraform": "# Remediation Steps\n\n* Ensure that the [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) is referenced in an [aws_flog_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) `vpc_id` field.\n\n#### Example Configuration\n\n```hcl\nresource \"aws_vpc\" \"valid_vpc\" {\n  # other required fields here\n}\n\nresource \"aws_flow_log\" \"test_flow_log\" {\n  vpc_id         = \"${aws_vpc.valid_vpc.id}\"\n  # other required fields here\n}\n```\n"
+          "terraform": "Reference the `aws_vpc` in an `aws_flog_log` `vpc_id` field."
         },
         "type": "terraformconfig",
         "subType": "aws_vpc",
@@ -57,7 +57,7 @@
         "iacDescription": {
           "issue": "VPC flow logging should be enabled",
           "impact": "VPC flow logging should be enabled. AWS VPC Flow Logs provide visibility into network traffic that traverses the AWS VPC.\nUsers can use the flow logs to detect anomalous traffic or insight during security workflows.\n",
-          "resolve": "# Remediation Steps\n\n* Ensure that the [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) is referenced in an [aws_flog_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) `vpc_id` field.\n\n#### Example Configuration\n\n```hcl\nresource \"aws_vpc\" \"valid_vpc\" {\n  # other required fields here\n}\n\nresource \"aws_flow_log\" \"test_flow_log\" {\n  vpc_id         = \"${aws_vpc.valid_vpc.id}\"\n  # other required fields here\n}\n```\n"
+          "resolve": "Reference the `aws_vpc` in an `aws_flog_log` `vpc_id` field."
         },
         "lineNumber": -1,
         "documentation": "https://snyk.io/security-rules/SNYK-CC-00151",
@@ -68,11 +68,11 @@
       },
       {
         "severity": "medium",
-        "resolve": "# Remediation Steps\nEnsure that an [aws_default_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group) or [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) `ingress` block does NOT contain the value `0.0.0.0/0` in the `cidr_blocks` (`ipv6_cidr_blocks` for ipv6) field.\n\n# Example configuration\n```hcl\nresource \"aws_security_group\" \"example\" {\n  ingress {\n    cidr_blocks = [10.0.0.0/16]\n    from_port   = 5900\n    to_port     = 5900\n    # other required fields here\n  }\n}\n```\n",
+        "resolve": "Remove any invalid `ingress` block from the `aws_security_group` or `aws_default_security_group`.",
         "impact": "Configuring all VPC default security groups to restrict all traffic encourages least privilege security\ngroup development and mindful placement of AWS resources into security groups which in turn reduces the exposure of those resources.\n",
         "msg": "input.resource.aws_default_security_group[default].ingress[0].cidr_blocks[0]",
         "remediation": {
-          "terraform": "# Remediation Steps\nEnsure that an [aws_default_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group) or [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) `ingress` block does NOT contain the value `0.0.0.0/0` in the `cidr_blocks` (`ipv6_cidr_blocks` for ipv6) field.\n\n# Example configuration\n```hcl\nresource \"aws_security_group\" \"example\" {\n  ingress {\n    cidr_blocks = [10.0.0.0/16]\n    from_port   = 5900\n    to_port     = 5900\n    # other required fields here\n  }\n}\n```\n"
+          "terraform": "Remove any invalid `ingress` block from the `aws_security_group` or `aws_default_security_group`."
         },
         "type": "terraformconfig",
         "subType": "aws_default_security_group",
@@ -87,7 +87,7 @@
         "iacDescription": {
           "issue": "VPC default security group allows unrestricted ingress traffic",
           "impact": "Configuring all VPC default security groups to restrict all traffic encourages least privilege security\ngroup development and mindful placement of AWS resources into security groups which in turn reduces the exposure of those resources.\n",
-          "resolve": "# Remediation Steps\nEnsure that an [aws_default_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group) or [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) `ingress` block does NOT contain the value `0.0.0.0/0` in the `cidr_blocks` (`ipv6_cidr_blocks` for ipv6) field.\n\n# Example configuration\n```hcl\nresource \"aws_security_group\" \"example\" {\n  ingress {\n    cidr_blocks = [10.0.0.0/16]\n    from_port   = 5900\n    to_port     = 5900\n    # other required fields here\n  }\n}\n```\n"
+          "resolve": "Remove any invalid `ingress` block from the `aws_security_group` or `aws_default_security_group`."
         },
         "lineNumber": -1,
         "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-5",
@@ -137,11 +137,11 @@
     "infrastructureAsCodeIssues": [
       {
         "severity": "medium",
-        "resolve": "# Remediation Steps\n\n* Ensure that the [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) is referenced in an [aws_flog_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) `vpc_id` field.\n\n#### Example Configuration\n\n```hcl\nresource \"aws_vpc\" \"valid_vpc\" {\n  # other required fields here\n}\n\nresource \"aws_flow_log\" \"test_flow_log\" {\n  vpc_id         = \"${aws_vpc.valid_vpc.id}\"\n  # other required fields here\n}\n```\n",
+        "resolve": "Reference the `aws_vpc` in an `aws_flog_log` `vpc_id` field.",
         "impact": "VPC flow logging should be enabled. AWS VPC Flow Logs provide visibility into network traffic that traverses the AWS VPC.\nUsers can use the flow logs to detect anomalous traffic or insight during security workflows.\n",
         "msg": "resource.aws_vpc[mainvpc]",
         "remediation": {
-          "terraform": "# Remediation Steps\n\n* Ensure that the [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) is referenced in an [aws_flog_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) `vpc_id` field.\n\n#### Example Configuration\n\n```hcl\nresource \"aws_vpc\" \"valid_vpc\" {\n  # other required fields here\n}\n\nresource \"aws_flow_log\" \"test_flow_log\" {\n  vpc_id         = \"${aws_vpc.valid_vpc.id}\"\n  # other required fields here\n}\n```\n"
+          "terraform": "Reference the `aws_vpc` in an `aws_flog_log` `vpc_id` field."
         },
         "type": "terraformconfig",
         "subType": "aws_vpc",
@@ -156,7 +156,7 @@
         "iacDescription": {
           "issue": "VPC flow logging should be enabled",
           "impact": "VPC flow logging should be enabled. AWS VPC Flow Logs provide visibility into network traffic that traverses the AWS VPC.\nUsers can use the flow logs to detect anomalous traffic or insight during security workflows.\n",
-          "resolve": "# Remediation Steps\n\n* Ensure that the [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) is referenced in an [aws_flog_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) `vpc_id` field.\n\n#### Example Configuration\n\n```hcl\nresource \"aws_vpc\" \"valid_vpc\" {\n  # other required fields here\n}\n\nresource \"aws_flow_log\" \"test_flow_log\" {\n  vpc_id         = \"${aws_vpc.valid_vpc.id}\"\n  # other required fields here\n}\n```\n"
+          "resolve": "Reference the `aws_vpc` in an `aws_flog_log` `vpc_id` field."
         },
         "lineNumber": 5,
         "documentation": "https://snyk.io/security-rules/SNYK-CC-00151",
@@ -167,11 +167,11 @@
       },
       {
         "severity": "medium",
-        "resolve": "# Remediation Steps\nEnsure that an [aws_default_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group) or [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) `ingress` block does NOT contain the value `0.0.0.0/0` in the `cidr_blocks` (`ipv6_cidr_blocks` for ipv6) field.\n\n# Example configuration\n```hcl\nresource \"aws_security_group\" \"example\" {\n  ingress {\n    cidr_blocks = [10.0.0.0/16]\n    from_port   = 5900\n    to_port     = 5900\n    # other required fields here\n  }\n}\n```\n",
+        "resolve": "Remove any invalid `ingress` block from the `aws_security_group` or `aws_default_security_group`.",
         "impact": "Configuring all VPC default security groups to restrict all traffic encourages least privilege security\ngroup development and mindful placement of AWS resources into security groups which in turn reduces the exposure of those resources.\n",
         "msg": "input.resource.aws_default_security_group[default].ingress[0].cidr_blocks[0]",
         "remediation": {
-          "terraform": "# Remediation Steps\nEnsure that an [aws_default_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group) or [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) `ingress` block does NOT contain the value `0.0.0.0/0` in the `cidr_blocks` (`ipv6_cidr_blocks` for ipv6) field.\n\n# Example configuration\n```hcl\nresource \"aws_security_group\" \"example\" {\n  ingress {\n    cidr_blocks = [10.0.0.0/16]\n    from_port   = 5900\n    to_port     = 5900\n    # other required fields here\n  }\n}\n```\n"
+          "terraform": "Remove any invalid `ingress` block from the `aws_security_group` or `aws_default_security_group`."
         },
         "type": "terraformconfig",
         "subType": "aws_default_security_group",
@@ -186,7 +186,7 @@
         "iacDescription": {
           "issue": "VPC default security group allows unrestricted ingress traffic",
           "impact": "Configuring all VPC default security groups to restrict all traffic encourages least privilege security\ngroup development and mindful placement of AWS resources into security groups which in turn reduces the exposure of those resources.\n",
-          "resolve": "# Remediation Steps\nEnsure that an [aws_default_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group) or [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) `ingress` block does NOT contain the value `0.0.0.0/0` in the `cidr_blocks` (`ipv6_cidr_blocks` for ipv6) field.\n\n# Example configuration\n```hcl\nresource \"aws_security_group\" \"example\" {\n  ingress {\n    cidr_blocks = [10.0.0.0/16]\n    from_port   = 5900\n    to_port     = 5900\n    # other required fields here\n  }\n}\n```\n"
+          "resolve": "Remove any invalid `ingress` block from the `aws_security_group` or `aws_default_security_group`."
         },
         "lineNumber": 16,
         "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-5",

--- a/test/jest/unit/iac/process-results/fixtures/experimental-sarif-output.json
+++ b/test/jest/unit/iac/process-results/fixtures/experimental-sarif-output.json
@@ -28,8 +28,8 @@
                 "text": "VPC flow logging should be enabled. AWS VPC Flow Logs provide visibility into network traffic that traverses the AWS VPC.\nUsers can use the flow logs to detect anomalous traffic or insight during security workflows.\n"
               },
               "help": {
-                "text": "Remediation Steps\nEnsure that the https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc is referenced in an https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log vpc_id field.Example Configuration\nresource \"aws_vpc\" \"valid_vpc\" {\n  # other required fields here\n}\n\nresource \"aws_flow_log\" \"test_flow_log\" {\n  vpc_id         = \"${aws_vpc.valid_vpc.id}\"\n  # other required fields here\n}",
-                "markdown": "# Remediation Steps\n\n* Ensure that the [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) is referenced in an [aws_flog_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) `vpc_id` field.\n\n#### Example Configuration\n\n```hcl\nresource \"aws_vpc\" \"valid_vpc\" {\n  # other required fields here\n}\n\nresource \"aws_flow_log\" \"test_flow_log\" {\n  vpc_id         = \"${aws_vpc.valid_vpc.id}\"\n  # other required fields here\n}\n```\n"
+                "text": "Reference the aws_vpc in an aws_flog_log vpc_id field.",
+                "markdown": "Reference the `aws_vpc` in an `aws_flog_log` `vpc_id` field."
               },
               "defaultConfiguration": {
                 "level": "warning"
@@ -54,8 +54,8 @@
                 "text": "Configuring all VPC default security groups to restrict all traffic encourages least privilege security\ngroup development and mindful placement of AWS resources into security groups which in turn reduces the exposure of those resources.\n"
               },
               "help": {
-                "text": "Remediation Steps\nEnsure that an https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group or https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group ingress block does NOT contain the value 0.0.0.0/0 in the cidr_blocks (ipv6_cidr_blocks for ipv6) field.Example configuration\nresource \"aws_security_group\" \"example\" {\n  ingress {\n    cidr_blocks = [10.0.0.0/16]\n    from_port   = 5900\n    to_port     = 5900\n    # other required fields here\n  }\n}",
-                "markdown": "# Remediation Steps\nEnsure that an [aws_default_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group) or [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) `ingress` block does NOT contain the value `0.0.0.0/0` in the `cidr_blocks` (`ipv6_cidr_blocks` for ipv6) field.\n\n# Example configuration\n```hcl\nresource \"aws_security_group\" \"example\" {\n  ingress {\n    cidr_blocks = [10.0.0.0/16]\n    from_port   = 5900\n    to_port     = 5900\n    # other required fields here\n  }\n}\n```\n"
+                "text": "Remove any invalid ingress block from the aws_security_group or aws_default_security_group.",
+                "markdown": "Remove any invalid `ingress` block from the `aws_security_group` or `aws_default_security_group`."
               },
               "defaultConfiguration": {
                 "level": "warning"

--- a/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results.json
+++ b/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results.json
@@ -44,7 +44,7 @@
           "documentation": "https://snyk.io/security-rules/SNYK-CC-00151"
         },
         "message": "VPC flow logging should be enabled",
-        "remediation": "# Remediation Steps\n\n* Ensure that the [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) is referenced in an [aws_flog_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) `vpc_id` field.\n\n#### Example Configuration\n\n```hcl\nresource \"aws_vpc\" \"valid_vpc\" {\n  # other required fields here\n}\n\nresource \"aws_flow_log\" \"test_flow_log\" {\n  vpc_id         = \"${aws_vpc.valid_vpc.id}\"\n  # other required fields here\n}\n```\n",
+        "remediation": "Reference the `aws_vpc` in an `aws_flog_log` `vpc_id` field.",
         "severity": "medium",
         "ignored": false,
         "resource": {
@@ -69,7 +69,7 @@
           "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-5"
         },
         "message": "Inbound traffic to VPC should be more restrictive",
-        "remediation": "# Remediation Steps\nEnsure that an [aws_default_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group) or [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) `ingress` block does NOT contain the value `0.0.0.0/0` in the `cidr_blocks` (`ipv6_cidr_blocks` for ipv6) field.\n\n# Example configuration\n```hcl\nresource \"aws_security_group\" \"example\" {\n  ingress {\n    cidr_blocks = [10.0.0.0/16]\n    from_port   = 5900\n    to_port     = 5900\n    # other required fields here\n  }\n}\n```\n",
+        "remediation": "Remove any invalid `ingress` block from the `aws_security_group` or `aws_default_security_group`.\n\nEnsure that an [aws_default_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group) or [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) `ingress` block does NOT contain the value `0.0.0.0/0` in the `cidr_blocks` (`ipv6_cidr_blocks` for ipv6) field.\n\n# Example configuration\n```hcl\nresource \"aws_security_group\" \"example\" {\n  ingress {\n    cidr_blocks = [10.0.0.0/16]\n    from_port   = 5900\n    to_port     = 5900\n    # other required fields here\n  }\n}\n```\n",
         "severity": "medium",
         "ignored": false,
         "resource": {
@@ -99,7 +99,7 @@
           "documentation": "https://snyk.io/security-rules/SNYK-CC-00151"
         },
         "message": "VPC flow logging should be enabled",
-        "remediation": "# Remediation Steps\n\n* Ensure that the [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) is referenced in an [aws_flog_log](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) `vpc_id` field.\n\n#### Example Configuration\n\n```hcl\nresource \"aws_vpc\" \"valid_vpc\" {\n  # other required fields here\n}\n\nresource \"aws_flow_log\" \"test_flow_log\" {\n  vpc_id         = \"${aws_vpc.valid_vpc.id}\"\n  # other required fields here\n}\n```\n",
+        "remediation": "Reference the `aws_vpc` in an `aws_flog_log` `vpc_id` field.\n\n# Example Configuration\n\n```hcl\nresource \"aws_vpc\" \"valid_vpc\" {\n# other required fields here\n}\n\nresource \"aws_flow_log\" \"test_flow_log\" {\nvpc_id         = \"${aws_vpc.valid_vpc.id}\"\n# other required fields here\n}\n```\n",
         "severity": "medium",
         "ignored": false,
         "resource": {
@@ -126,7 +126,7 @@
           "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-5"
         },
         "message": "Inbound traffic to VPC should be more restrictive",
-        "remediation": "# Remediation Steps\nEnsure that an [aws_default_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group) or [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) `ingress` block does NOT contain the value `0.0.0.0/0` in the `cidr_blocks` (`ipv6_cidr_blocks` for ipv6) field.\n\n# Example configuration\n```hcl\nresource \"aws_security_group\" \"example\" {\n  ingress {\n    cidr_blocks = [10.0.0.0/16]\n    from_port   = 5900\n    to_port     = 5900\n    # other required fields here\n  }\n}\n```\n",
+        "remediation": "Remove any invalid `ingress` block from the `aws_security_group` or `aws_default_security_group`.\n\nEnsure that an [aws_default_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group) or [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) `ingress` block does NOT contain the value `0.0.0.0/0` in the `cidr_blocks` (`ipv6_cidr_blocks` for ipv6) field.\n\n# Example configuration\n```hcl\nresource \"aws_security_group\" \"example\" {\n  ingress {\n    cidr_blocks = [10.0.0.0/16]\n    from_port   = 5900\n    to_port     = 5900\n    # other required fields here\n  }\n}\n```\n",
         "severity": "medium",
         "ignored": false,
         "resource": {

--- a/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-text-output-data.json
+++ b/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-text-output-data.json
@@ -13,11 +13,14 @@
           ],
           "issue": "VPC flow logging should be enabled",
           "impact": "VPC flow logging should be enabled. AWS VPC Flow Logs provide visibility into network traffic that traverses the AWS VPC.\nUsers can use the flow logs to detect anomalous traffic or insight during security workflows.\n",
-          "resolve": "",
+          "resolve": "Reference the `aws_vpc` in an `aws_flog_log` `vpc_id` field.",
+          "remediation": {
+            "terraform": "Reference the `aws_vpc` in an `aws_flog_log` `vpc_id` field."
+          },
           "documentation": "https://snyk.io/security-rules/SNYK-CC-00151"
         },
         "targetFile": "plan.json",
-        "projectType": "aws_vpc"
+        "projectType": "terraformconfig"
       },
       {
         "issue": {
@@ -35,11 +38,14 @@
           ],
           "issue": "VPC default security group allows unrestricted ingress traffic",
           "impact": "Configuring all VPC default security groups to restrict all traffic encourages least privilege security\ngroup development and mindful placement of AWS resources into security groups which in turn reduces the exposure of those resources.\n",
-          "resolve": "",
+          "resolve": "Remove any invalid `ingress` block from the `aws_security_group` or `aws_default_security_group`.",
+          "remediation": {
+            "terraform": "Remove any invalid `ingress` block from the `aws_security_group` or `aws_default_security_group`."
+          },
           "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-5"
         },
         "targetFile": "plan.json",
-        "projectType": "aws_default_security_group"
+        "projectType": "terraformconfig"
       },
       {
         "issue": {
@@ -53,11 +59,14 @@
           ],
           "issue": "VPC flow logging should be enabled",
           "impact": "VPC flow logging should be enabled. AWS VPC Flow Logs provide visibility into network traffic that traverses the AWS VPC.\nUsers can use the flow logs to detect anomalous traffic or insight during security workflows.\n",
-          "resolve": "",
+          "resolve": "Reference the `aws_vpc` in an `aws_flog_log` `vpc_id` field.",
+          "remediation": {
+            "terraform": "Reference the `aws_vpc` in an `aws_flog_log` `vpc_id` field."
+          },
           "documentation": "https://snyk.io/security-rules/SNYK-CC-00151"
         },
         "targetFile": "vpc_group.tf",
-        "projectType": "aws_vpc"
+        "projectType": "terraformconfig"
       },
       {
         "issue": {
@@ -75,11 +84,14 @@
           ],
           "issue": "VPC default security group allows unrestricted ingress traffic",
           "impact": "Configuring all VPC default security groups to restrict all traffic encourages least privilege security\ngroup development and mindful placement of AWS resources into security groups which in turn reduces the exposure of those resources.\n",
-          "resolve": "",
+          "resolve": "Remove any invalid `ingress` block from the `aws_security_group` or `aws_default_security_group`.",
+          "remediation": {
+            "terraform": "Remove any invalid `ingress` block from the `aws_security_group` or `aws_default_security_group`."
+          },
           "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-5"
         },
         "targetFile": "vpc_group.tf",
-        "projectType": "aws_default_security_group"
+        "projectType": "terraformconfig"
       }
     ]
   },


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Includes the one-liner remediation advices from `policy-engine` for any issues in the test output in all relevant output formats:
- Text
- JSON
- SARIF

#### How should this be manually tested?

- Run `snyk iac test --experimental` and ensure any displayed issues include the expected one-liner remediation advice.
- Run `snyk iac test --experimental --json` and ensure any displayed issues include the expected one-liner remediation advice.
- Run `snyk iac test --experimental --sarif` and ensure any displayed issues include the expected one-liner remediation advice.

#### Any background context you want to provide?

[A proposal](https://docs.google.com/document/d/13k8rYyTREl6yvGb47EbzR91gTcXIXvnVVlEZcewiGQo/edit#heading=h.2r18umlrg1im) was approved to keep the one-liner format for security rules. In the new format, the remediation property is a dictionary that maps project types to their respective remediation advice. In each remediation advice, the first paragraph is a one-liner version that summarizes the recommended actions. The changes were applied ([PR](https://github.com/snyk/opa-rules/pull/160)) and are available through policy-engine.

#### What are the relevant tickets?

- [CFG-2124](https://snyksec.atlassian.net/browse/CFG-2124)