### PR TITLE
fix: bump golang plugin version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.20.0",
         "snyk-docker-plugin": "^5.1.2",
-        "snyk-go-plugin": "^1.19.0",
+        "snyk-go-plugin": "1.19.2",
         "snyk-gradle-plugin": "^3.22.1",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.31.0",
@@ -12608,6 +12608,17 @@
       "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
       "dev": true
     },
+    "node_modules/lookpath": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/lookpath/-/lookpath-1.2.2.tgz",
+      "integrity": "sha512-k2Gmn8iV6qdME3ztZC2spubmQISimFOPLuQKiPaLcVdRz0IpdxrNClVepMlyTJlhodm/zG/VfbkWERm3kUIh+Q==",
+      "bin": {
+        "lookpath": "bin/lookpath.js"
+      },
+      "engines": {
+        "npm": ">=6.13.4"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -16730,13 +16741,14 @@
       }
     },
     "node_modules/snyk-go-plugin": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.19.0.tgz",
-      "integrity": "sha512-KC8kBXBx3Qd2ro9ZQv+AGqMrElRLogmmLac/uuSt5rfV3o2wVHnuxPN+YUfr0PgH5lOdMeIeqaYCpWEsc4GhJQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.19.2.tgz",
+      "integrity": "sha512-Lu4HOqbQFQn8eRWbZLqJeHrSxl+y6sOxU5GpHbQN5N3jxB4el49DngLktdef4P285rBvsv2MSwAZnRDEMPeTmw==",
       "dependencies": {
         "@snyk/dep-graph": "^1.23.1",
         "@snyk/graphlib": "2.1.9-patch.3",
         "debug": "^4.1.1",
+        "lookpath": "^1.2.2",
         "snyk-go-parser": "1.4.1",
         "tmp": "0.2.1",
         "tslib": "^1.10.0"
@@ -29935,6 +29947,11 @@
       "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
       "dev": true
     },
+    "lookpath": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/lookpath/-/lookpath-1.2.2.tgz",
+      "integrity": "sha512-k2Gmn8iV6qdME3ztZC2spubmQISimFOPLuQKiPaLcVdRz0IpdxrNClVepMlyTJlhodm/zG/VfbkWERm3kUIh+Q=="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -33085,13 +33102,14 @@
       }
     },
     "snyk-go-plugin": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.19.0.tgz",
-      "integrity": "sha512-KC8kBXBx3Qd2ro9ZQv+AGqMrElRLogmmLac/uuSt5rfV3o2wVHnuxPN+YUfr0PgH5lOdMeIeqaYCpWEsc4GhJQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.19.2.tgz",
+      "integrity": "sha512-Lu4HOqbQFQn8eRWbZLqJeHrSxl+y6sOxU5GpHbQN5N3jxB4el49DngLktdef4P285rBvsv2MSwAZnRDEMPeTmw==",
       "requires": {
         "@snyk/dep-graph": "^1.23.1",
         "@snyk/graphlib": "2.1.9-patch.3",
         "debug": "^4.1.1",
+        "lookpath": "^1.2.2",
         "snyk-go-parser": "1.4.1",
         "tmp": "0.2.1",
         "tslib": "^1.10.0"

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.20.0",
     "snyk-docker-plugin": "^5.1.2",
-    "snyk-go-plugin": "^1.19.0",
+    "snyk-go-plugin": "1.19.2",
     "snyk-gradle-plugin": "^3.22.1",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.31.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- add meaningful error for `golang` when binary is not available on the host machine
- bump the plugin version