### PR TITLE
fix: filter subprojects on unique path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "snyk-cpp-plugin": "2.20.0",
         "snyk-docker-plugin": "^5.1.2",
         "snyk-go-plugin": "^1.19.0",
-        "snyk-gradle-plugin": "^3.22.1",
+        "snyk-gradle-plugin": "^3.22.2",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.31.0",
         "snyk-nodejs-lockfile-parser": "1.38.0",
@@ -16702,9 +16702,9 @@
       }
     },
     "node_modules/snyk-gradle-plugin": {
-      "version": "3.22.1",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.22.1.tgz",
-      "integrity": "sha512-MXLo1aGoE95d2rKNajwFZ4GcpYj/ap0WkyQXnVMfFM0NeYHOeZU/cQqIbY49/14vtu/Gtqlc5phHjDhERYx3Rg==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.22.2.tgz",
+      "integrity": "sha512-5zBsEEq9SrQI59OFAnalZJ5hWCKM/LF/JUa3x8F1HVayqNzjMSIqiNa4d4oleMzHo9Rp6QUih1I1J8nbtpwnHg==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",
@@ -32990,9 +32990,9 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "3.22.1",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.22.1.tgz",
-      "integrity": "sha512-MXLo1aGoE95d2rKNajwFZ4GcpYj/ap0WkyQXnVMfFM0NeYHOeZU/cQqIbY49/14vtu/Gtqlc5phHjDhERYx3Rg==",
+      "version": "3.22.2",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.22.2.tgz",
+      "integrity": "sha512-5zBsEEq9SrQI59OFAnalZJ5hWCKM/LF/JUa3x8F1HVayqNzjMSIqiNa4d4oleMzHo9Rp6QUih1I1J8nbtpwnHg==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "snyk-cpp-plugin": "2.20.0",
     "snyk-docker-plugin": "^5.1.2",
     "snyk-go-plugin": "^1.19.0",
-    "snyk-gradle-plugin": "^3.22.1",
+    "snyk-gradle-plugin": "3.22.2",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.31.0",
     "snyk-nodejs-lockfile-parser": "1.38.0",


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Bumpes the version of snyk-gradle-plugin
The latest version includes a change to the way subprojects are filtered. Instead of checking if the subproject has the same name as the root project, check if it has the same path. This helps when a project contains a nested subproject with the same name as root. Do not override one with the other.

[Relevant PR ](https://github.com/snyk/snyk-gradle-plugin/pull/222)