### PR TITLE
chore: implement --about

### DIFF
--- a/cliv2/.gitignore
+++ b/cliv2/.gitignore
@@ -10,3 +10,4 @@ _cache
 .dccache
 .vscode
 bin
+internal/embedded/_data

--- a/cliv2/Makefile
+++ b/cliv2/Makefile
@@ -2,6 +2,8 @@
 GOCMD = go
 GOOS = $(shell go env GOOS)
 GOARCH = $(shell go env GOARCH)
+GOHOSTOS = $(shell go env GOHOSTOS)
+GOHOSTARCH = $(shell go env GOHOSTARCH)
 HASH = sha
 HASH_ALGORITHM = 256
 CLI_V2_VERSION_TAG = 2.0.0-prerelease
@@ -79,6 +81,7 @@ TEST_SNYK_EXECUTABLE_PATH=$(BUILD_DIR)/$(V2_EXECUTABLE_NAME)
 TEST_EXECUTABLE_NAME = $(TEST_NAME)$(_SEPARATOR)$(V2_PLATFORM_STRING)$(_EXE_POSTFIX)
 SIGN_SCRIPT = sign_$(_GO_OS).sh
 ISSIGNED_SCRIPT = issigned_$(_GO_OS).sh
+EMBEDDED_DATA_DIR = $(WORKING_DIR)/internal/embedded/_data
 
 # some make file variables
 LOG_PREFIX = --
@@ -140,7 +143,7 @@ dependencies: $(V1_DIRECTORY)/$(V1_EXECUTABLE_NAME) $(V1_DIRECTORY)/$(V1_EXECUTA
 
 # prepare the workspace and cache global parameters
 .PHONY: configure
-configure: $(V2_DIRECTORY)/cliv2.version $(CACHE_DIR) $(CACHE_DIR)/version.mk $(CACHE_DIR)/variables.mk $(V1_DIRECTORY)/$(V1_EMBEDDED_FILE_OUTPUT) dependencies
+configure: $(V2_DIRECTORY)/cliv2.version $(CACHE_DIR) $(CACHE_DIR)/version.mk $(CACHE_DIR)/variables.mk $(V1_DIRECTORY)/$(V1_EMBEDDED_FILE_OUTPUT) dependencies $(CACHE_DIR)/prepare-3rd-party-licenses
 
 $(BUILD_DIR)/$(V2_EXECUTABLE_NAME): $(BUILD_DIR) $(SRCS)
 	@echo "$(LOG_PREFIX) Building ( $(BUILD_DIR)/$(V2_EXECUTABLE_NAME) )"
@@ -173,6 +176,11 @@ $(WORKING_DIR)/internal/httpauth/generated/httpauth_generated_mock.go:
 
 $(WORKING_DIR)/internal/httpauth/generated/spnego_generated_mock.go:
 	@$(GOCMD) generate ./internal/httpauth/
+
+
+$(CACHE_DIR)/prepare-3rd-party-licenses: 
+	@echo "$(LOG_PREFIX) Preparing 3rd Party Licenses"
+	@GOOS=$(GOHOSTOS) GOARCH=$(GOHOSTARCH) scripts/prepare_licenses.sh > $(CACHE_DIR)/prepare-3rd-party-licenses
 
 .PHONY: generate
 generate: $(WORKING_DIR)/internal/httpauth/generated/httpauth_generated_mock.go $(WORKING_DIR)/internal/httpauth/generated/spnego_generated_mock.go
@@ -227,6 +235,7 @@ clean:
 	@rm -f $(V1_DIRECTORY)/$(V1_EMBEDDED_FILE_OUTPUT)
 	@rm -f $(V1_DIRECTORY)/cliv1.version
 	@rm -f $(V2_DIRECTORY)/cliv2.version
+	@rm -f -r $(EMBEDDED_DATA_DIR)/licenses
 
 .PHONY: install
 install:

--- a/cliv2/cmd/cliv2/main_test.go
+++ b/cliv2/cmd/cliv2/main_test.go
@@ -33,6 +33,8 @@ func Test_MainWithErrorCode_no_cache(t *testing.T) {
 
 	assert.Equal(t, mainErr, 0)
 	assert.DirExists(t, cacheDirectory)
+
+	os.RemoveAll(cacheDirectory)
 }
 
 func Test_GetConfiguration(t *testing.T) {

--- a/cliv2/internal/embedded/_data/README.md
+++ b/cliv2/internal/embedded/_data/README.md
@@ -1,0 +1,1 @@
+This directory includes files that'll be compiled into the final application.

--- a/cliv2/internal/embedded/file.go
+++ b/cliv2/internal/embedded/file.go
@@ -1,0 +1,88 @@
+package embedded
+
+import (
+	"embed"
+	"io/fs"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	rootDirectory string = "_data"
+)
+
+//go:embed _data
+var data embed.FS
+
+type File struct {
+	name       string
+	path       string
+	cachedData []byte
+}
+
+func ListFiles() []File {
+	var result []File
+
+	fs.WalkDir(data, rootDirectory, func(path string, d fs.DirEntry, err error) error {
+		if !d.IsDir() {
+			f := File{
+				name: d.Name(),
+				path: path,
+			}
+			result = append(result, f)
+		}
+
+		return err
+	})
+
+	return result
+}
+
+func (f *File) data() ([]byte, error) {
+	var err error
+	if f.cachedData == nil {
+		f.cachedData, err = data.ReadFile(f.path)
+	}
+	return f.cachedData, err
+}
+
+func (f *File) Read(p []byte) (n int, err error) {
+	tmp, err := f.data()
+	n = int(math.Min(float64(len(tmp)), float64(len(p))))
+	copy(p, tmp)
+	return n, err
+}
+
+func (f *File) Size() int {
+	d, _ := f.data()
+	return len(d)
+}
+
+func (f *File) Name() string {
+	return f.name
+}
+
+func (f *File) Path() string {
+	return strings.Replace(f.path, rootDirectory, "", 1)
+}
+
+func (f *File) SaveToLocalFilesystem(destPath string, fileMode fs.FileMode) (err error) {
+	size := f.Size()
+	data := make([]byte, size)
+
+	_, err = f.Read(data)
+	if err == nil {
+		folder := filepath.Dir(destPath)
+		_, err = os.Stat(folder)
+		if os.IsNotExist(err) {
+			err = os.MkdirAll(folder, fileMode)
+		}
+	}
+
+	if err == nil {
+		err = os.WriteFile(destPath, data, fileMode)
+	}
+	return err
+}

--- a/cliv2/scripts/prepare_licenses.sh
+++ b/cliv2/scripts/prepare_licenses.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function manualLicenseDownload
+{
+    mkdir -p "./internal/embedded/_data/licenses/$2"
+    curl -L --progress-bar --fail "$1" > "./internal/embedded/_data/licenses/$2/LICENSE"
+}
+
+# try to find all licenses via the go.mod file
+export GOBIN=$(pwd)/_cache
+go install github.com/google/go-licenses@latest
+PATH="$PATH:$GOBIN" go-licenses save ./... --save_path=./internal/embedded/_data/licenses --force --ignore github.com/snyk/cli/cliv2/
+
+manualLicenseDownload "https://raw.githubusercontent.com/davecgh/go-spew/master/LICENSE" github.com/davecgh/go-spew
+manualLicenseDownload "https://raw.githubusercontent.com/alexbrainman/sspi/master/LICENSE" github.com/alexbrainman/sspi
+manualLicenseDownload "https://raw.githubusercontent.com/pmezard/go-difflib/master/LICENSE" github.com/pmezard/go-difflib
+manualLicenseDownload "https://raw.githubusercontent.com/go-yaml/yaml/v3.0.1/LICENSE" gopkg.in/yaml.v3
+manualLicenseDownload "https://go.dev/LICENSE?m=text" go.dev
+
+# clean up and print result
+pushd . > /dev/null
+cd ./internal/embedded/_data/licenses
+find . -type f -name '*.*' -delete
+find . -type f -name '*' -exec echo "    {}" \;
+popd > /dev/null


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This PR add golang based licenses to the --about dialog. It adds retrieving the licenses on the fly to the build process, bundles them into the binary and prints them to the end of the typescript based license content.

#### Where should the reviewer start?
* Retrieve licenses: scripts/prepare_licenses.sh
* Bundle licenses: internal/embedded/file.go
* Print licenses: internal/cliv2/cliv2.go

#### How should this be manually tested?
Run the cli with `--about`, pipe the output into a file and compare the output with the same output for the typescript cli
