### PR TITLE
feat: custom message for IaC cloud context errors

### DIFF
--- a/src/cli/commands/test/iac/local-execution/types.ts
+++ b/src/cli/commands/test/iac/local-execution/types.ts
@@ -387,6 +387,7 @@ export enum IaCErrorCodes {
   UnableToReadPath = 2113,
   NoLoadableInput = 2114,
   FailedToMakeResourcesResolvers = 2115,
+  ResourcesResolverError = 2116,
   FailedToShareResults = 2200,
 }
 

--- a/src/lib/iac/test/v2/errors.ts
+++ b/src/lib/iac/test/v2/errors.ts
@@ -32,6 +32,8 @@ const snykIacTestErrorsUserMessages = {
     "The Snyk CLI couldn't find any valid IaC configuration files to scan",
   FailedToMakeResourcesResolvers:
     'An error occurred preparing the requested cloud context. Please run the command again with the `-d` flag for more information.',
+  ResourcesResolverError:
+    'An error occurred scanning cloud resources. Please run the command again with the `-d` flag for more information.',
   FailedToShareResults: 'Failed to upload the test results with the platform',
 };
 

--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -1,11 +1,11 @@
 import * as os from 'os';
 
-const policyEngineChecksums = `0cbcdc8f4a7652835355f010d5cb97597055577e624799428c62819d74773b7e  snyk-iac-test_0.28.0_Windows_arm64.exe
-28637249844c060dc950c6d3fdb31e1ff2d96bfe76291fb383d5c94ee2db7b26  snyk-iac-test_0.28.0_Linux_x86_64
-45629e08ff8c3bfc601773d38705c19ea3abc2b8c33ee7174c97eb5669aa73f9  snyk-iac-test_0.28.0_Linux_arm64
-5a5066edc9dc8daf61fe57f57e844cff59c91c0fdb70f3efda3fe8260f06e801  snyk-iac-test_0.28.0_Windows_x86_64.exe
-db669ad313d222184e07c02f3540b06c62de283ef2e57a75ee1df4116f1831a3  snyk-iac-test_0.28.0_Darwin_x86_64
-eb0b99c469eb31f930852466bb1e8b9e576a0bf22ea17dc951762f824009c18a  snyk-iac-test_0.28.0_Darwin_arm64
+const policyEngineChecksums = `11bcf635e209023478f4291fe29e4aa5e4e719dde54dc0e333bae7a626ed6b6d  snyk-iac-test_0.29.0_Linux_arm64
+557d4ab7b3c23b34ed81c31109140833dcc4863946774a4ba72d7b18800d4d34  snyk-iac-test_0.29.0_Darwin_x86_64
+7f5db81dad9f7ae4d80c472757b67c37ab29bbb9a18174b30c3354e494fc1505  snyk-iac-test_0.29.0_Linux_x86_64
+89de8e29d0aca232870bd1896aa5c66abb7917566de22d69ff847402b9566690  snyk-iac-test_0.29.0_Darwin_arm64
+cc9d1b48530b69774162e06774fef930e91fb3fe4be8f73e8605a2a6ac7eedfb  snyk-iac-test_0.29.0_Windows_x86_64.exe
+f1ea52361d5409ad0e2a492425a70c31797d91c999aa510eb7e99f27f575f0a8  snyk-iac-test_0.29.0_Windows_arm64.exe
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

There will be a request-specific error in the debug log, but we lack the
plumbing to propagate this up without that flag as far as I know. The
message contains a hint to run again with debug logs for this reason.

#### Where should the reviewer start?


#### How should this be manually tested?

We tested this with a few scenarios. First, we built snyk-iac-test so that we could use a pre-release version in tests.

On top of this PR, we applied the following patch to hack cloud context into the CLI flow, as that's not actually exposed yet:

```diff
diff --git a/src/lib/iac/test/v2/scan/index.ts b/src/lib/iac/test/v2/scan/index.ts
index 088e84e5a..76f6a0846 100644
--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -87,6 +87,8 @@ function processFlags(
   outputPath: string,
 ) {
   const flags = [
+    '-cloud-context',
+    process.env.CLOUD_CONTEXT as string,
     '-cache-dir',
     systemCachePath,
     '-bundle',

```

We ran the following scenarios:

1. No cloud context: `SNYK_IAC_POLICY_ENGINE_PATH=$PWD/../../snyk/snyk-iac-test/snyk-iac-test ./bin/snyk iac test --experimental opa-rules/SNYK_CC_TF_3/fixtures/terraform/ebs_volume_encryption.tf`
1. Cloud context: `aws-vault exec lab-sandbox -- env CLOUD_CONTEXT=aws SNYK_IAC_POLICY_ENGINE_PATH=$PWD/../../snyk/snyk-iac-test/snyk-iac-test ./bin/snyk iac test --experimental opa-rules/SNYK_CC_TF_3/fixtures/terraform/ebs_volume_encryption.tf`
1. New scenario - cloud context error during policy evaluation: `(source ../driftctl/billy-no-permissions.env && env CLOUD_CONTEXT=aws SNYK_IAC_POLICY_ENGINE_PATH=$PWD/../../snyk/snyk-iac-test/snyk-iac-test ./bin/snyk iac test --experimental opa-rules/SNYK_CC_TF_3/fixtures/terraform/ebs_volume_encryption.tf)`
   1. "billy-no-permissions" is a valid IAM keypair for a user without permissions to enumerate resources requested by that particular policy.

#### Any background context you want to provide?

This PR depends on an error introduced in https://github.com/snyk/snyk-iac-test/pull/111. See that PR for more background context. If that PR is merged, we need to update this one with a new release reference before merging.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/CTX-373


#### Screenshots


#### Additional questions
