### PR TITLE
chore: Added short-width terminals support for text output

### DIFF
--- a/src/lib/formatters/iac-output/text/utils.ts
+++ b/src/lib/formatters/iac-output/text/utils.ts
@@ -30,4 +30,6 @@ export const colors: IacOutputColors = {
 
 export const contentPadding = ' '.repeat(2);
 
-export const maxLineWidth = 80;
+export const maxLineWidth = process.stdout.columns
+  ? Math.min(process.stdout.columns, 80)
+  : 80;


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Ensures readability for terminals with a width lower than the default `80` columns.

#### Where should the reviewer start?

```
src/lib/formatters/iac-output/text/utils.ts
```

#### How should this be manually tested?

- Narrow your CLI to a width lower than `80` columns.
- Run `snyk iac test` to test files.
- Ensures the issue descriptions remain readable and that the indentation acts as expected.

#### Screenshots

<img width="603" alt="image" src="https://user-images.githubusercontent.com/46415136/188472524-94d74b0e-4e7f-427f-9ab6-111b12677b5c.png">
