### PR TITLE
[CTX-403] feat: IaC context-suppressed issue count

### DIFF
--- a/src/lib/formatters/iac-output/text/formatters.ts
+++ b/src/lib/formatters/iac-output/text/formatters.ts
@@ -109,6 +109,18 @@ export function formatSnykIacTestTestData(
     ? snykIacTestScanResult.metadata.ignoredCount
     : 0;
 
+  let contextSuppressedIssueCount: number | undefined;
+  const suppressedResults =
+    snykIacTestScanResult?.scanAnalytics.suppressedResults;
+  if (suppressedResults) {
+    contextSuppressedIssueCount = Object.values(suppressedResults).reduce(
+      function(count, resourcesForRuleId) {
+        return (count += resourcesForRuleId.length);
+      },
+      0,
+    );
+  }
+
   return {
     resultsBySeverity,
     metadata: { projectName, orgName },
@@ -118,6 +130,7 @@ export function formatSnykIacTestTestData(
       filesWithoutIssues: filesWithoutIssuesCount,
       issues: totalIssues,
       issuesBySeverity: issuesCountBySeverity,
+      contextSuppressedIssues: contextSuppressedIssueCount,
     },
   };
 }

--- a/src/lib/formatters/iac-output/text/test-summary.ts
+++ b/src/lib/formatters/iac-output/text/test-summary.ts
@@ -62,6 +62,14 @@ function formatCountsSection(testCounts: IacTestCounts): string {
     `${INDENT}Ignored issues: ${colors.info.bold(`${testCounts.ignores}`)}`,
   );
 
+  if (testCounts.contextSuppressedIssues) {
+    countsSectionProperties.push(
+      `${INDENT}Cloud context - suppressed issues: ${colors.info.bold(
+        `${testCounts.contextSuppressedIssues}`,
+      )}`,
+    );
+  }
+
   countsSectionProperties.push(
     `${INDENT}Total issues: ${colors.info.bold(
       `${testCounts.issues}`,

--- a/src/lib/formatters/iac-output/text/types.ts
+++ b/src/lib/formatters/iac-output/text/types.ts
@@ -26,6 +26,7 @@ export interface IacTestCounts {
   filesWithoutIssues: number;
   issues: number;
   issuesBySeverity: { [severity in SEVERITY]: number };
+  contextSuppressedIssues?: number;
 }
 
 export type IaCTestFailure = {

--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -1,11 +1,11 @@
 import * as os from 'os';
 
-const policyEngineChecksums = `11bcf635e209023478f4291fe29e4aa5e4e719dde54dc0e333bae7a626ed6b6d  snyk-iac-test_0.29.0_Linux_arm64
-557d4ab7b3c23b34ed81c31109140833dcc4863946774a4ba72d7b18800d4d34  snyk-iac-test_0.29.0_Darwin_x86_64
-7f5db81dad9f7ae4d80c472757b67c37ab29bbb9a18174b30c3354e494fc1505  snyk-iac-test_0.29.0_Linux_x86_64
-89de8e29d0aca232870bd1896aa5c66abb7917566de22d69ff847402b9566690  snyk-iac-test_0.29.0_Darwin_arm64
-cc9d1b48530b69774162e06774fef930e91fb3fe4be8f73e8605a2a6ac7eedfb  snyk-iac-test_0.29.0_Windows_x86_64.exe
-f1ea52361d5409ad0e2a492425a70c31797d91c999aa510eb7e99f27f575f0a8  snyk-iac-test_0.29.0_Windows_arm64.exe
+const policyEngineChecksums = `1ab888458215d8ba45452117854adb95060d9dac45f4b602e2e34f500b7b8a3a  snyk-iac-test_0.30.1_Linux_arm64
+85e181989cde63797095107c38772edb4cba75a8becd82aad9c609b4c273789b  snyk-iac-test_0.30.1_Windows_arm64.exe
+8e4bb3f55d6332706485f278d194f09ef08f46db5516b1008db9c152c636ae24  snyk-iac-test_0.30.1_Windows_x86_64.exe
+ba478316de02fd69de4463edca221550d5f4eb962e514220b0a9d9a014d18128  snyk-iac-test_0.30.1_Darwin_arm64
+f218a8e8cc25024f7936947c091e9c9ad34c33178cd6558bdda906fc47c1a598  snyk-iac-test_0.30.1_Darwin_x86_64
+ff23fe190e2392ed4b42ee231171806c300bfe2b9983353497c9f1a195c5c499  snyk-iac-test_0.30.1_Linux_x86_64
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();

--- a/src/lib/iac/test/v2/scan/results.ts
+++ b/src/lib/iac/test/v2/scan/results.ts
@@ -34,11 +34,16 @@ export interface Results {
   resources?: Resource[];
   vulnerabilities?: Vulnerability[];
   metadata: Metadata;
+  scanAnalytics: ScanAnalytics;
 }
 
 export interface Metadata {
   projectName: string;
   ignoredCount: number;
+}
+
+export interface ScanAnalytics {
+  suppressedResults?: Record<string, string[]>;
 }
 
 export interface Vulnerability {

--- a/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results-with-suppressions.json
+++ b/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results-with-suppressions.json
@@ -150,7 +150,12 @@
       "projectName": "input-files-for-json-v2",
       "ignoredCount": 3
     },
-    "scanAnalytics": {}
+    "scanAnalytics": {
+      "suppressedResults": {
+        "issue-1": ["resource1", "resource2"],
+        "issue-2": ["resource3"]
+      }
+    }
   },
   "errors": [
     {

--- a/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-text-output-data-with-suppressions.json
+++ b/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-text-output-data-with-suppressions.json
@@ -1,0 +1,115 @@
+{
+  "resultsBySeverity": {
+    "medium": [
+      {
+        "issue": {
+          "id": "SNYK-CC-00151",
+          "severity": "medium",
+          "title": "VPC flow logging should be enabled",
+          "lineNumber": -1,
+          "cloudConfigPath": [
+            "aws_vpc",
+            "mainvpc"
+          ],
+          "issue": "VPC flow logging should be enabled",
+          "impact": "VPC flow logging should be enabled. AWS VPC Flow Logs provide visibility into network traffic that traverses the AWS VPC.\nUsers can use the flow logs to detect anomalous traffic or insight during security workflows.\n",
+          "resolve": "Reference the `aws_vpc` in an `aws_flog_log` `vpc_id` field.",
+          "remediation": {
+            "terraform": "Reference the `aws_vpc` in an `aws_flog_log` `vpc_id` field."
+          },
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-00151"
+        },
+        "targetFile": "plan.json",
+        "projectType": "terraformconfig"
+      },
+      {
+        "issue": {
+          "id": "SNYK-CC-TF-5",
+          "severity": "medium",
+          "title": "VPC default security group allows unrestricted ingress traffic",
+          "lineNumber": -1,
+          "cloudConfigPath": [
+            "aws_default_security_group",
+            "default",
+            "ingress",
+            0,
+            "cidr_blocks",
+            0
+          ],
+          "issue": "VPC default security group allows unrestricted ingress traffic",
+          "impact": "Configuring all VPC default security groups to restrict all traffic encourages least privilege security\ngroup development and mindful placement of AWS resources into security groups which in turn reduces the exposure of those resources.\n",
+          "resolve": "Remove any invalid `ingress` block from the `aws_security_group` or `aws_default_security_group`.",
+          "remediation": {
+            "terraform": "Remove any invalid `ingress` block from the `aws_security_group` or `aws_default_security_group`."
+          },
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-5"
+        },
+        "targetFile": "plan.json",
+        "projectType": "terraformconfig"
+      },
+      {
+        "issue": {
+          "id": "SNYK-CC-00151",
+          "severity": "medium",
+          "title": "VPC flow logging should be enabled",
+          "lineNumber": 5,
+          "cloudConfigPath": [
+            "aws_vpc",
+            "mainvpc"
+          ],
+          "issue": "VPC flow logging should be enabled",
+          "impact": "VPC flow logging should be enabled. AWS VPC Flow Logs provide visibility into network traffic that traverses the AWS VPC.\nUsers can use the flow logs to detect anomalous traffic or insight during security workflows.\n",
+          "resolve": "Reference the `aws_vpc` in an `aws_flog_log` `vpc_id` field.",
+          "remediation": {
+            "terraform": "Reference the `aws_vpc` in an `aws_flog_log` `vpc_id` field."
+          },
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-00151"
+        },
+        "targetFile": "vpc_group.tf",
+        "projectType": "terraformconfig"
+      },
+      {
+        "issue": {
+          "id": "SNYK-CC-TF-5",
+          "severity": "medium",
+          "title": "VPC default security group allows unrestricted ingress traffic",
+          "lineNumber": 16,
+          "cloudConfigPath": [
+            "aws_default_security_group",
+            "default",
+            "ingress",
+            0,
+            "cidr_blocks",
+            0
+          ],
+          "issue": "VPC default security group allows unrestricted ingress traffic",
+          "impact": "Configuring all VPC default security groups to restrict all traffic encourages least privilege security\ngroup development and mindful placement of AWS resources into security groups which in turn reduces the exposure of those resources.\n",
+          "resolve": "Remove any invalid `ingress` block from the `aws_security_group` or `aws_default_security_group`.",
+          "remediation": {
+            "terraform": "Remove any invalid `ingress` block from the `aws_security_group` or `aws_default_security_group`."
+          },
+          "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-5"
+        },
+        "targetFile": "vpc_group.tf",
+        "projectType": "terraformconfig"
+      }
+    ]
+  },
+  "metadata": {
+    "projectName": "project-name",
+    "orgName": "org-name"
+  },
+  "counts": {
+    "ignores": 3,
+    "filesWithIssues": 2,
+    "filesWithoutIssues": 0,
+    "issues": 4,
+    "issuesBySeverity": {
+      "low": 0,
+      "medium": 4,
+      "high": 0,
+      "critical": 0
+    },
+    "contextSuppressedIssues": 3
+  }
+}

--- a/test/jest/unit/iac/process-results/fixtures/test-data-with-suppressions.json
+++ b/test/jest/unit/iac/process-results/fixtures/test-data-with-suppressions.json
@@ -1,0 +1,859 @@
+{
+    "resultsBySeverity": {
+            "low": [
+                    {
+                            "issue": {
+                                    "severity": "low",
+                                    "resolve": "Set `disable_api_termination` attribute  with value `true`",
+                                    "id": "SNYK-CC-AWS-426",
+                                    "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+                                    "msg": "resource.aws_instance[denied].disable_api_termination",
+                                    "remediation": {
+                                            "cloudformation": "Set `DisableApiTermination` attribute with value `true`",
+                                            "terraform": "Set `disable_api_termination` attribute  with value `true`"
+                                    },
+                                    "subType": "EC2",
+                                    "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+                                    "publicId": "SNYK-CC-AWS-426",
+                                    "title": "EC2 API termination protection is not enabled",
+                                    "references": [
+                                            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+                                    ],
+                                    "name": "EC2 API termination protection is not enabled",
+                                    "cloudConfigPath": [
+                                            "resource",
+                                            "aws_instance[denied]",
+                                            "disable_api_termination"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+                                            "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+                                            "resolve": "Set `disable_api_termination` attribute  with value `true`"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
+                            },
+                            "targetFile": "aws_ec2_metadata_secrets.tf",
+                            "projectType": "terraformconfig"
+                    },
+                    {
+                            "issue": {
+                                    "severity": "low",
+                                    "resolve": "Set `disable_api_termination` attribute  with value `true`",
+                                    "id": "SNYK-CC-AWS-426",
+                                    "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+                                    "msg": "resource.aws_instance[denied_3].disable_api_termination",
+                                    "remediation": {
+                                            "cloudformation": "Set `DisableApiTermination` attribute with value `true`",
+                                            "terraform": "Set `disable_api_termination` attribute  with value `true`"
+                                    },
+                                    "subType": "EC2",
+                                    "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+                                    "publicId": "SNYK-CC-AWS-426",
+                                    "title": "EC2 API termination protection is not enabled",
+                                    "references": [
+                                            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+                                    ],
+                                    "name": "EC2 API termination protection is not enabled",
+                                    "cloudConfigPath": [
+                                            "resource",
+                                            "aws_instance[denied_3]",
+                                            "disable_api_termination"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+                                            "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+                                            "resolve": "Set `disable_api_termination` attribute  with value `true`"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
+                            },
+                            "targetFile": "aws_ec2_metadata_secrets.tf",
+                            "projectType": "terraformconfig"
+                    },
+                    {
+                            "issue": {
+                                    "severity": "low",
+                                    "resolve": "Set `disable_api_termination` attribute  with value `true`",
+                                    "id": "SNYK-CC-AWS-426",
+                                    "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+                                    "msg": "resource.aws_instance[allowed_3].disable_api_termination",
+                                    "remediation": {
+                                            "cloudformation": "Set `DisableApiTermination` attribute with value `true`",
+                                            "terraform": "Set `disable_api_termination` attribute  with value `true`"
+                                    },
+                                    "subType": "EC2",
+                                    "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+                                    "publicId": "SNYK-CC-AWS-426",
+                                    "title": "EC2 API termination protection is not enabled",
+                                    "references": [
+                                            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+                                    ],
+                                    "name": "EC2 API termination protection is not enabled",
+                                    "cloudConfigPath": [
+                                            "resource",
+                                            "aws_instance[allowed_3]",
+                                            "disable_api_termination"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+                                            "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+                                            "resolve": "Set `disable_api_termination` attribute  with value `true`"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
+                            },
+                            "targetFile": "aws_ec2_metadata_secrets.tf",
+                            "projectType": "terraformconfig"
+                    },
+                    {
+                            "issue": {
+                                    "severity": "low",
+                                    "resolve": "Set `disable_api_termination` attribute  with value `true`",
+                                    "id": "SNYK-CC-AWS-426",
+                                    "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+                                    "msg": "resource.aws_instance[allowed].disable_api_termination",
+                                    "remediation": {
+                                            "cloudformation": "Set `DisableApiTermination` attribute with value `true`",
+                                            "terraform": "Set `disable_api_termination` attribute  with value `true`"
+                                    },
+                                    "subType": "EC2",
+                                    "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+                                    "publicId": "SNYK-CC-AWS-426",
+                                    "title": "EC2 API termination protection is not enabled",
+                                    "references": [
+                                            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+                                    ],
+                                    "name": "EC2 API termination protection is not enabled",
+                                    "cloudConfigPath": [
+                                            "resource",
+                                            "aws_instance[allowed]",
+                                            "disable_api_termination"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+                                            "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+                                            "resolve": "Set `disable_api_termination` attribute  with value `true`"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
+                            },
+                            "targetFile": "aws_ec2_metadata_secrets.tf",
+                            "projectType": "terraformconfig"
+                    },
+                    {
+                            "issue": {
+                                    "severity": "low",
+                                    "resolve": "Set `disable_api_termination` attribute  with value `true`",
+                                    "id": "SNYK-CC-AWS-426",
+                                    "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+                                    "msg": "resource.aws_instance[denied_2].disable_api_termination",
+                                    "remediation": {
+                                            "cloudformation": "Set `DisableApiTermination` attribute with value `true`",
+                                            "terraform": "Set `disable_api_termination` attribute  with value `true`"
+                                    },
+                                    "subType": "EC2",
+                                    "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+                                    "publicId": "SNYK-CC-AWS-426",
+                                    "title": "EC2 API termination protection is not enabled",
+                                    "references": [
+                                            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+                                    ],
+                                    "name": "EC2 API termination protection is not enabled",
+                                    "cloudConfigPath": [
+                                            "resource",
+                                            "aws_instance[denied_2]",
+                                            "disable_api_termination"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+                                            "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+                                            "resolve": "Set `disable_api_termination` attribute  with value `true`"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
+                            },
+                            "targetFile": "aws_ec2_metadata_secrets.tf",
+                            "projectType": "terraformconfig"
+                    },
+                    {
+                            "issue": {
+                                    "severity": "low",
+                                    "resolve": "Set `disable_api_termination` attribute  with value `true`",
+                                    "id": "SNYK-CC-AWS-426",
+                                    "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+                                    "msg": "resource.aws_instance[allowed_2].disable_api_termination",
+                                    "remediation": {
+                                            "cloudformation": "Set `DisableApiTermination` attribute with value `true`",
+                                            "terraform": "Set `disable_api_termination` attribute  with value `true`"
+                                    },
+                                    "subType": "EC2",
+                                    "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+                                    "publicId": "SNYK-CC-AWS-426",
+                                    "title": "EC2 API termination protection is not enabled",
+                                    "references": [
+                                            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+                                    ],
+                                    "name": "EC2 API termination protection is not enabled",
+                                    "cloudConfigPath": [
+                                            "resource",
+                                            "aws_instance[allowed_2]",
+                                            "disable_api_termination"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+                                            "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+                                            "resolve": "Set `disable_api_termination` attribute  with value `true`"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
+                            },
+                            "targetFile": "aws_ec2_metadata_secrets.tf",
+                            "projectType": "terraformconfig"
+                    },
+                    {
+                            "issue": {
+                                    "severity": "low",
+                                    "resolve": "Set `DisableApiTermination` attribute with value `true`",
+                                    "id": "SNYK-CC-AWS-426",
+                                    "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+                                    "msg": "Resources[BastionHost].Properties.DisableApiTermination",
+                                    "remediation": {
+                                            "cloudformation": "Set `DisableApiTermination` attribute with value `true`",
+                                            "terraform": "Set `disable_api_termination` attribute  with value `true`"
+                                    },
+                                    "subType": "EC2",
+                                    "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+                                    "publicId": "SNYK-CC-AWS-426",
+                                    "title": "EC2 API termination protection is not enabled",
+                                    "references": [
+                                            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination"
+                                    ],
+                                    "name": "EC2 API termination protection is not enabled",
+                                    "cloudConfigPath": [
+                                            "[DocId: 0]",
+                                            "Resources[BastionHost]",
+                                            "Properties",
+                                            "DisableApiTermination"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "To prevent instance from being accidentally terminated using Amazon EC2, you can enable termination protection for the instance",
+                                            "impact": "Without this setting enabled the instances can be terminated by accident. This setting should only be used for instances with high availability requirements. Enabling this may prevent IaC workflows from updating the instance, for example terraform will not be able to terminate the instance to update instance type",
+                                            "resolve": "Set `DisableApiTermination` attribute with value `true`"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-426"
+                            },
+                            "targetFile": "bastion.yml",
+                            "projectType": "cloudformationconfig"
+                    },
+                    {
+                            "issue": {
+                                    "severity": "low",
+                                    "resolve": "Set `Properties.KmsKeyId` attribute with customer managed key id",
+                                    "id": "SNYK-CC-AWS-415",
+                                    "impact": "Scope of use of the key cannot be controlled via KMS/IAM policies",
+                                    "msg": "Resources[BastionSecureLogGroup].Properties.KmsKeyId",
+                                    "remediation": {
+                                            "cloudformation": "Set `Properties.KmsKeyId` attribute with customer managed key id",
+                                            "terraform": "Set `kms_key_id` attribute with customer managed key id"
+                                    },
+                                    "subType": "CloudWatch",
+                                    "issue": "Log group is not encrypted with customer managed key",
+                                    "publicId": "SNYK-CC-AWS-415",
+                                    "title": "CloudWatch log group not encrypted with managed key",
+                                    "references": [
+                                            "https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html",
+                                            "https://docs.aws.amazon.com/whitepapers/latest/kms-best-practices/aws-managed-and-customer-managed-cmks.html"
+                                    ],
+                                    "name": "CloudWatch log group not encrypted with managed key",
+                                    "cloudConfigPath": [
+                                            "[DocId: 0]",
+                                            "Resources[BastionSecureLogGroup]",
+                                            "Properties",
+                                            "KmsKeyId"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "Log group is not encrypted with customer managed key",
+                                            "impact": "Scope of use of the key cannot be controlled via KMS/IAM policies",
+                                            "resolve": "Set `Properties.KmsKeyId` attribute with customer managed key id"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-AWS-415"
+                            },
+                            "targetFile": "bastion.yml",
+                            "projectType": "cloudformationconfig"
+                    },
+                    {
+                            "issue": {
+                                    "severity": "low",
+                                    "description": "",
+                                    "resolve": "Set `imagePullPolicy` attribute to `Always`",
+                                    "id": "SNYK-CC-K8S-42",
+                                    "impact": "The container may run with outdated or unauthorized image",
+                                    "msg": "spec.template.spec.containers[web].imagePullPolicy",
+                                    "subType": "Deployment",
+                                    "issue": "The image policy does not prevent image reuse",
+                                    "publicId": "SNYK-CC-K8S-42",
+                                    "title": "Container could be running with outdated image",
+                                    "references": [
+                                            "5.27 Ensure that Docker commands always make use of the latest version of their image",
+                                            "https://kubernetes.io/docs/concepts/containers/images/",
+                                            "https://kubernetes.io/docs/concepts/configuration/overview/#container-images"
+                                    ],
+                                    "name": "Container could be running with outdated image",
+                                    "cloudConfigPath": [
+                                            "[DocId: 0]",
+                                            "spec",
+                                            "template",
+                                            "spec",
+                                            "containers[web]",
+                                            "imagePullPolicy"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "The image policy does not prevent image reuse",
+                                            "impact": "The container may run with outdated or unauthorized image",
+                                            "resolve": "Set `imagePullPolicy` attribute to `Always`"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-42"
+                            },
+                            "targetFile": "k8s.yaml",
+                            "projectType": "k8sconfig"
+                    },
+                    {
+                            "issue": {
+                                    "severity": "low",
+                                    "description": "",
+                                    "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`",
+                                    "id": "SNYK-CC-K8S-8",
+                                    "impact": "Compromised process could abuse writable root filesystem to elevate privileges",
+                                    "msg": "input.spec.template.spec.containers[web].securityContext.readOnlyRootFilesystem",
+                                    "subType": "Deployment",
+                                    "issue": "`readOnlyRootFilesystem` attribute is not set to `true`",
+                                    "publicId": "SNYK-CC-K8S-8",
+                                    "title": "Container is running with writable root filesystem",
+                                    "references": [
+                                            "CIS Docker Benchmark 1.2.0 - Ensure that the container's root filesystem is mounted as read only",
+                                            "https://kubernetes.io/docs/concepts/policy/pod-security-policy/#volumes-and-file-systems",
+                                            "https://kubernetes.io/blog/2016/08/security-best-practices-kubernetes-deployment/"
+                                    ],
+                                    "name": "Container is running with writable root filesystem",
+                                    "cloudConfigPath": [
+                                            "[DocId: 0]",
+                                            "input",
+                                            "spec",
+                                            "template",
+                                            "spec",
+                                            "containers[web]",
+                                            "securityContext",
+                                            "readOnlyRootFilesystem"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "`readOnlyRootFilesystem` attribute is not set to `true`",
+                                            "impact": "Compromised process could abuse writable root filesystem to elevate privileges",
+                                            "resolve": "Set `securityContext.readOnlyRootFilesystem` to `true`"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-8"
+                            },
+                            "targetFile": "k8s.yaml",
+                            "projectType": "k8sconfig"
+                    },
+                    {
+                            "issue": {
+                                    "severity": "low",
+                                    "description": "",
+                                    "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`",
+                                    "id": "SNYK-CC-K8S-32",
+                                    "impact": "AppArmor will not enforce mandatory access control, which can increase the attack vectors.",
+                                    "msg": "metadata.annotations['container.apparmor.security.beta.kubernetes.io/web']",
+                                    "subType": "Deployment",
+                                    "issue": "The AppArmor profile is not set correctly",
+                                    "publicId": "SNYK-CC-K8S-32",
+                                    "title": "Container is running without AppArmor profile",
+                                    "references": [
+                                            "CIS Docker Benchmark 1.2.0 - 5.1 Ensure that, if applicable, an AppArmor Profile is enabled",
+                                            "https://kubernetes.io/docs/tutorials/clusters/apparmor/",
+                                            "https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor"
+                                    ],
+                                    "name": "Container is running without AppArmor profile",
+                                    "cloudConfigPath": [
+                                            "[DocId: 0]",
+                                            "metadata",
+                                            "annotations['container.apparmor.security.beta.kubernetes.io/web']"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "The AppArmor profile is not set correctly",
+                                            "impact": "AppArmor will not enforce mandatory access control, which can increase the attack vectors.",
+                                            "resolve": "Add `container.apparmor.security.beta.kubernetes.io/<container-name>` annotation with value `runtime/default` or `localhost/<name-of-profile`"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-32"
+                            },
+                            "targetFile": "k8s.yaml",
+                            "projectType": "k8sconfig"
+                    },
+                    {
+                            "issue": {
+                                    "severity": "low",
+                                    "description": "",
+                                    "resolve": "Set `resources.limits.memory` value",
+                                    "id": "SNYK-CC-K8S-4",
+                                    "impact": "Containers without memory limits are more likely to be terminated when the node runs out of memory",
+                                    "msg": "input.spec.template.spec.containers[web].resources.limits.memory",
+                                    "subType": "Deployment",
+                                    "issue": "Memory limit is not defined",
+                                    "publicId": "SNYK-CC-K8S-4",
+                                    "title": "Container is running without memory limit",
+                                    "references": [
+                                            "CIS Docker Benchmark 1.2.0 - 5.10 Ensure that the memory usage for containers is limited",
+                                            "https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource/",
+                                            "https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/"
+                                    ],
+                                    "name": "Container is running without memory limit",
+                                    "cloudConfigPath": [
+                                            "[DocId: 0]",
+                                            "input",
+                                            "spec",
+                                            "template",
+                                            "spec",
+                                            "containers[web]",
+                                            "resources",
+                                            "limits",
+                                            "memory"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "Memory limit is not defined",
+                                            "impact": "Containers without memory limits are more likely to be terminated when the node runs out of memory",
+                                            "resolve": "Set `resources.limits.memory` value"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-4"
+                            },
+                            "targetFile": "k8s.yaml",
+                            "projectType": "k8sconfig"
+                    },
+                    {
+                            "issue": {
+                                    "severity": "low",
+                                    "description": "",
+                                    "resolve": "Add `resources.limits.cpu` field with required CPU limit value",
+                                    "id": "SNYK-CC-K8S-5",
+                                    "impact": "Containers without limits can exceed the capacity of the node, and affect availability/performance of the host and other containers.",
+                                    "msg": "input.spec.template.spec.containers[web].resources.limits.cpu",
+                                    "subType": "Deployment",
+                                    "issue": "CPU limit is not defined",
+                                    "publicId": "SNYK-CC-K8S-5",
+                                    "title": "Container is running without cpu limit",
+                                    "references": [
+                                            "CIS Docker Benchmark 1.2.0 - 5.11 Ensure that CPU priority is set appropriately on containers",
+                                            "https://kubernetes.io/docs/tasks/configure-pod-container/assign-cpu-resource/",
+                                            "https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                            "https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/cpu-default-namespace/"
+                                    ],
+                                    "name": "Container is running without cpu limit",
+                                    "cloudConfigPath": [
+                                            "[DocId: 0]",
+                                            "input",
+                                            "spec",
+                                            "template",
+                                            "spec",
+                                            "containers[web]",
+                                            "resources",
+                                            "limits",
+                                            "cpu"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "CPU limit is not defined",
+                                            "impact": "Containers without limits can exceed the capacity of the node, and affect availability/performance of the host and other containers.",
+                                            "resolve": "Add `resources.limits.cpu` field with required CPU limit value"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-5"
+                            },
+                            "targetFile": "k8s.yaml",
+                            "projectType": "k8sconfig"
+                    }
+            ],
+            "high": [
+                    {
+                            "issue": {
+                                    "severity": "high",
+                                    "resolve": "Remove secret value from `user_data` attribute",
+                                    "id": "SNYK-CC-TF-123",
+                                    "impact": "Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+                                    "msg": "resource.aws_instance[denied_2].user_data_base64[aws_access_key_id]",
+                                    "remediation": {
+                                            "cloudformation": "Remove secret value from `Properties.UserData` attribute",
+                                            "terraform": "Remove secret value from `user_data` attribute"
+                                    },
+                                    "subType": "EC2",
+                                    "issue": "Secret keys have been hardcoded in user_data script",
+                                    "publicId": "SNYK-CC-TF-123",
+                                    "title": "Hard coded secrets in EC2 metadata",
+                                    "references": [
+                                            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html"
+                                    ],
+                                    "name": "Hard coded secrets in EC2 metadata",
+                                    "cloudConfigPath": [
+                                            "resource",
+                                            "aws_instance[denied_2]",
+                                            "user_data_base64[aws_access_key_id]"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "Secret keys have been hardcoded in user_data script",
+                                            "impact": "Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+                                            "resolve": "Remove secret value from `user_data` attribute"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-123"
+                            },
+                            "targetFile": "aws_ec2_metadata_secrets.tf",
+                            "projectType": "terraformconfig"
+                    },
+                    {
+                            "issue": {
+                                    "severity": "high",
+                                    "resolve": "Remove secret value from `user_data` attribute",
+                                    "id": "SNYK-CC-TF-123",
+                                    "impact": "Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+                                    "msg": "resource.aws_instance[denied_3].user_data[aws_secret_access_key]",
+                                    "remediation": {
+                                            "cloudformation": "Remove secret value from `Properties.UserData` attribute",
+                                            "terraform": "Remove secret value from `user_data` attribute"
+                                    },
+                                    "subType": "EC2",
+                                    "issue": "Secret keys have been hardcoded in user_data script",
+                                    "publicId": "SNYK-CC-TF-123",
+                                    "title": "Hard coded secrets in EC2 metadata",
+                                    "references": [
+                                            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html"
+                                    ],
+                                    "name": "Hard coded secrets in EC2 metadata",
+                                    "cloudConfigPath": [
+                                            "resource",
+                                            "aws_instance[denied_3]",
+                                            "user_data[aws_secret_access_key]"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "Secret keys have been hardcoded in user_data script",
+                                            "impact": "Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+                                            "resolve": "Remove secret value from `user_data` attribute"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-123"
+                            },
+                            "targetFile": "aws_ec2_metadata_secrets.tf",
+                            "projectType": "terraformconfig"
+                    },
+                    {
+                            "issue": {
+                                    "severity": "high",
+                                    "resolve": "Remove secret value from `user_data` attribute",
+                                    "id": "SNYK-CC-TF-123",
+                                    "impact": "Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+                                    "msg": "resource.aws_instance[denied].user_data[aws_access_key_id]",
+                                    "remediation": {
+                                            "cloudformation": "Remove secret value from `Properties.UserData` attribute",
+                                            "terraform": "Remove secret value from `user_data` attribute"
+                                    },
+                                    "subType": "EC2",
+                                    "issue": "Secret keys have been hardcoded in user_data script",
+                                    "publicId": "SNYK-CC-TF-123",
+                                    "title": "Hard coded secrets in EC2 metadata",
+                                    "references": [
+                                            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html"
+                                    ],
+                                    "name": "Hard coded secrets in EC2 metadata",
+                                    "cloudConfigPath": [
+                                            "resource",
+                                            "aws_instance[denied]",
+                                            "user_data[aws_access_key_id]"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "Secret keys have been hardcoded in user_data script",
+                                            "impact": "Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+                                            "resolve": "Remove secret value from `user_data` attribute"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-123"
+                            },
+                            "targetFile": "aws_ec2_metadata_secrets.tf",
+                            "projectType": "terraformconfig"
+                    },
+                    {
+                            "issue": {
+                                    "severity": "high",
+                                    "resolve": "Remove secret value from `user_data` attribute",
+                                    "id": "SNYK-CC-TF-123",
+                                    "impact": "Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+                                    "msg": "resource.aws_instance[denied_2].user_data_base64[aws_secret_access_key]",
+                                    "remediation": {
+                                            "cloudformation": "Remove secret value from `Properties.UserData` attribute",
+                                            "terraform": "Remove secret value from `user_data` attribute"
+                                    },
+                                    "subType": "EC2",
+                                    "issue": "Secret keys have been hardcoded in user_data script",
+                                    "publicId": "SNYK-CC-TF-123",
+                                    "title": "Hard coded secrets in EC2 metadata",
+                                    "references": [
+                                            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html"
+                                    ],
+                                    "name": "Hard coded secrets in EC2 metadata",
+                                    "cloudConfigPath": [
+                                            "resource",
+                                            "aws_instance[denied_2]",
+                                            "user_data_base64[aws_secret_access_key]"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "Secret keys have been hardcoded in user_data script",
+                                            "impact": "Anyone with access to VCS will be able to obtain the secret keys, and access the unauthorized resources",
+                                            "resolve": "Remove secret value from `user_data` attribute"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-123"
+                            },
+                            "targetFile": "aws_ec2_metadata_secrets.tf",
+                            "projectType": "terraformconfig"
+                    },
+                    {
+                            "issue": {
+                                    "severity": "high",
+                                    "description": "",
+                                    "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`",
+                                    "id": "SNYK-CC-K8S-1",
+                                    "impact": "Compromised container could potentially modify the underlying host’s kernel by loading unauthorized modules (i.e. drivers).",
+                                    "msg": "input.spec.template.spec.containers[web].securityContext.privileged",
+                                    "subType": "Deployment",
+                                    "issue": "Container is running in privileged mode",
+                                    "publicId": "SNYK-CC-K8S-1",
+                                    "title": "Container is running in privileged mode",
+                                    "references": [
+                                            "CIS Kubernetes Benchmark 1.6.0 - 5.2.1 Minimize the admission of privileged containers",
+                                            "https://kubernetes.io/docs/concepts/policy/pod-security-policy/#privileged",
+                                            "https://kubernetes.io/blog/2016/08/security-best-practices-kubernetes-deployment/"
+                                    ],
+                                    "name": "Container is running in privileged mode",
+                                    "cloudConfigPath": [
+                                            "[DocId: 0]",
+                                            "input",
+                                            "spec",
+                                            "template",
+                                            "spec",
+                                            "containers[web]",
+                                            "securityContext",
+                                            "privileged"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "Container is running in privileged mode",
+                                            "impact": "Compromised container could potentially modify the underlying host’s kernel by loading unauthorized modules (i.e. drivers).",
+                                            "resolve": "Remove `securityContext.privileged` attribute, or set value to `false`"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-1"
+                            },
+                            "targetFile": "k8s.yaml",
+                            "projectType": "k8sconfig"
+                    }
+            ],
+            "medium": [
+                    {
+                            "issue": {
+                                    "severity": "medium",
+                                    "resolve": "Set `BlockDeviceMappings.Encrypted` attribute of root device to `true`",
+                                    "id": "SNYK-CC-TF-53",
+                                    "impact": "That should someone gain unauthorized access to the data they would be able to read the contents.",
+                                    "msg": "Resources.BastionHost.Properties.BlockDeviceMappings",
+                                    "remediation": {
+                                            "cloudformation": "Set `BlockDeviceMappings.Encrypted` attribute of root device to `true`",
+                                            "terraform": "Set `root_block_device.encrypted` attribute to `true`"
+                                    },
+                                    "subType": "EC2",
+                                    "issue": "The root block device for ec2 instance is not encrypted",
+                                    "publicId": "SNYK-CC-TF-53",
+                                    "title": "Non-Encrypted root block device",
+                                    "references": [
+                                            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/RootDeviceStorage.html",
+                                            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html",
+                                            "https://aws.amazon.com/premiumsupport/knowledge-center/cloudformation-root-volume-property/",
+                                            "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html"
+                                    ],
+                                    "name": "Non-Encrypted root block device",
+                                    "cloudConfigPath": [
+                                            "[DocId: 0]",
+                                            "Resources",
+                                            "BastionHost",
+                                            "Properties",
+                                            "BlockDeviceMappings"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "The root block device for ec2 instance is not encrypted",
+                                            "impact": "That should someone gain unauthorized access to the data they would be able to read the contents.",
+                                            "resolve": "Set `BlockDeviceMappings.Encrypted` attribute of root device to `true`"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-TF-53"
+                            },
+                            "targetFile": "bastion.yml",
+                            "projectType": "cloudformationconfig"
+                    },
+                    {
+                            "issue": {
+                                    "severity": "medium",
+                                    "description": "",
+                                    "resolve": "Set `securityContext.runAsNonRoot` to `true`",
+                                    "id": "SNYK-CC-K8S-10",
+                                    "impact": "Container could be running with full administrative privileges",
+                                    "msg": "input.spec.template.spec.containers[web].securityContext.runAsNonRoot",
+                                    "subType": "Deployment",
+                                    "issue": "Container is running without root user control",
+                                    "publicId": "SNYK-CC-K8S-10",
+                                    "title": "Container is running without root user control",
+                                    "references": [
+                                            "CIS Docker Benchmark 1.2.0 - 5.5 Ensure sensitive host system directories are not mounted on containers",
+                                            "https://kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups",
+                                            "https://kubernetes.io/blog/2016/08/security-best-practices-kubernetes-deployment/"
+                                    ],
+                                    "name": "Container is running without root user control",
+                                    "cloudConfigPath": [
+                                            "[DocId: 0]",
+                                            "input",
+                                            "spec",
+                                            "template",
+                                            "spec",
+                                            "containers[web]",
+                                            "securityContext",
+                                            "runAsNonRoot"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "Container is running without root user control",
+                                            "impact": "Container could be running with full administrative privileges",
+                                            "resolve": "Set `securityContext.runAsNonRoot` to `true`"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-10"
+                            },
+                            "targetFile": "k8s.yaml",
+                            "projectType": "k8sconfig"
+                    },
+                    {
+                            "issue": {
+                                    "severity": "medium",
+                                    "description": "",
+                                    "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`",
+                                    "id": "SNYK-CC-K8S-6",
+                                    "impact": "Containers are running with potentially unnecessary privileges",
+                                    "msg": "input.spec.template.spec.containers[web].securityContext.capabilities.drop",
+                                    "subType": "Deployment",
+                                    "issue": "All default capabilities are not explicitly dropped",
+                                    "publicId": "SNYK-CC-K8S-6",
+                                    "title": "Container does not drop all default capabilities",
+                                    "references": [
+                                            "https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                                            "https://linux-audit.com/linux-capabilities-hardening-linux-binaries-by-removing-setuid/"
+                                    ],
+                                    "name": "Container does not drop all default capabilities",
+                                    "cloudConfigPath": [
+                                            "[DocId: 0]",
+                                            "input",
+                                            "spec",
+                                            "template",
+                                            "spec",
+                                            "containers[web]",
+                                            "securityContext",
+                                            "capabilities",
+                                            "drop"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "All default capabilities are not explicitly dropped",
+                                            "impact": "Containers are running with potentially unnecessary privileges",
+                                            "resolve": "Add `ALL` to `securityContext.capabilities.drop` list, and add only required capabilities in `securityContext.capabilities.add`"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-6"
+                            },
+                            "targetFile": "k8s.yaml",
+                            "projectType": "k8sconfig"
+                    },
+                    {
+                            "issue": {
+                                    "severity": "medium",
+                                    "description": "",
+                                    "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`",
+                                    "id": "SNYK-CC-K8S-9",
+                                    "impact": "Processes could elevate current privileges via known vectors, for example SUID binaries",
+                                    "msg": "input.spec.template.spec.containers[web].securityContext.allowPrivilegeEscalation",
+                                    "subType": "Deployment",
+                                    "issue": "`allowPrivilegeEscalation` attribute is not set to `false`",
+                                    "publicId": "SNYK-CC-K8S-9",
+                                    "title": "Container is running without privilege escalation control",
+                                    "references": [
+                                            "CIS Docker Benchmark 1.2.0 - 5.25 Ensure that the container is restricted from acquiring additional privileges",
+                                            "https://kubernetes.io/docs/concepts/policy/pod-security-policy/#privilege-escalation",
+                                            "https://www.kernel.org/doc/html/latest/userspace-api/no_new_privs.html"
+                                    ],
+                                    "name": "Container is running without privilege escalation control",
+                                    "cloudConfigPath": [
+                                            "[DocId: 0]",
+                                            "input",
+                                            "spec",
+                                            "template",
+                                            "spec",
+                                            "containers[web]",
+                                            "securityContext",
+                                            "allowPrivilegeEscalation"
+                                    ],
+                                    "isIgnored": false,
+                                    "iacDescription": {
+                                            "issue": "`allowPrivilegeEscalation` attribute is not set to `false`",
+                                            "impact": "Processes could elevate current privileges via known vectors, for example SUID binaries",
+                                            "resolve": "Set `securityContext.allowPrivilegeEscalation` to `false`"
+                                    },
+                                    "lineNumber": -1,
+                                    "documentation": "https://snyk.io/security-rules/SNYK-CC-K8S-9"
+                            },
+                            "targetFile": "k8s.yaml",
+                            "projectType": "k8sconfig"
+                    }
+            ]
+    },
+    "metadata": {
+            "orgName": "Shmulik.Kipod",
+            "projectName": "project-name"
+    },
+    "counts": {
+        "ignores": 3,
+        "filesWithIssues": 3,
+        "filesWithoutIssues": 0,
+        "issues": 22,
+        "issuesBySeverity": {
+            "critical": 0,
+            "high": 5,
+            "medium": 4,
+            "low": 13
+        },
+        "contextSuppressedIssues": 42
+    }
+}

--- a/test/jest/unit/lib/formatters/iac-output/text/formatters.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/text/formatters.spec.ts
@@ -80,6 +80,22 @@ describe('formatSnykIacTestTestData', () => {
       'utf-8',
     ),
   );
+  const snykIacTestOutputWithSuppressionsFixture: SnykIacTestOutput = JSON.parse(
+    fs.readFileSync(
+      path.join(
+        __dirname,
+        '..',
+        '..',
+        '..',
+        '..',
+        'iac',
+        'process-results',
+        'fixtures',
+        'snyk-iac-test-results-with-suppressions.json',
+      ),
+      'utf-8',
+    ),
+  );
 
   const testDataFixture: IacTestData = JSON.parse(
     fs.readFileSync(
@@ -97,6 +113,22 @@ describe('formatSnykIacTestTestData', () => {
       'utf-8',
     ),
   );
+  const testDataWithSuppressionsFixture: IacTestData = JSON.parse(
+    fs.readFileSync(
+      path.join(
+        __dirname,
+        '..',
+        '..',
+        '..',
+        '..',
+        'iac',
+        'process-results',
+        'fixtures',
+        'snyk-iac-test-text-output-data-with-suppressions.json',
+      ),
+      'utf-8',
+    ),
+  );
 
   it('formats the test data correctly', () => {
     const result = formatSnykIacTestTestData(
@@ -106,5 +138,15 @@ describe('formatSnykIacTestTestData', () => {
     );
 
     expect(result).toEqual(testDataFixture);
+  });
+
+  it('formats the test data correctly when suppressions are present', () => {
+    const result = formatSnykIacTestTestData(
+      snykIacTestOutputWithSuppressionsFixture.results,
+      'project-name',
+      'org-name',
+    );
+
+    expect(result).toEqual(testDataWithSuppressionsFixture);
   });
 });

--- a/test/jest/unit/lib/formatters/iac-output/text/test-summary.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/text/test-summary.spec.ts
@@ -7,7 +7,7 @@ import { colors } from '../../../../../../../src/lib/formatters/iac-output/text/
 import { IacTestData } from '../../../../../../../src/lib/formatters/iac-output/text/types';
 
 describe('formatIacTestSummary', () => {
-  let testDataFixture: IacTestData;
+  let testDataFixture, testDataFixtureWithSuppressions: IacTestData;
 
   beforeAll(async () => {
     testDataFixture = JSON.parse(
@@ -22,6 +22,22 @@ describe('formatIacTestSummary', () => {
           'process-results',
           'fixtures',
           'test-data.json',
+        ),
+        'utf8',
+      ),
+    );
+    testDataFixtureWithSuppressions = JSON.parse(
+      fs.readFileSync(
+        pathLib.join(
+          __dirname,
+          '..',
+          '..',
+          '..',
+          '..',
+          'iac',
+          'process-results',
+          'fixtures',
+          'test-data-with-suppressions.json',
         ),
         'utf8',
       ),
@@ -65,6 +81,30 @@ describe('formatIacTestSummary', () => {
       )}
 ${colors.failure.bold('✗')} Files with issues: ${colors.info.bold('3')}
   Ignored issues: ${colors.info.bold('3')}
+  Total issues: ${colors.info.bold('22')} [ ${colors.severities.critical(
+        '0 critical',
+      )}, ${colors.severities.high('5 high')}, ${colors.severities.medium(
+        '4 medium',
+      )}, ${colors.severities.low('13 low')} ]`,
+    );
+
+    expect(result).not.toContain('suppressed issues');
+  });
+
+  it('should include the counts section with the correct values when suppressions are present', () => {
+    const testTestData: IacTestData = clonedeep(
+      testDataFixtureWithSuppressions,
+    );
+
+    const result = formatIacTestSummary(testTestData);
+
+    expect(result).toContain(
+      `${colors.success.bold('✔')} Files without issues: ${colors.info.bold(
+        '0',
+      )}
+${colors.failure.bold('✗')} Files with issues: ${colors.info.bold('3')}
+  Ignored issues: ${colors.info.bold('3')}
+  Cloud context - suppressed issues: ${colors.info.bold('42')}
   Total issues: ${colors.info.bold('22')} [ ${colors.severities.critical(
         '0 critical',
       )}, ${colors.severities.high('5 high')}, ${colors.severities.medium(


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

When snyk-iac-test returns suppressedResults in scan analytics, display a total count of suppressed issues alongside the other scan counts.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?

This feature `iac test --cloud-context=...` is still undocumented and is only available behind a feature flag. The context-suppressed count will only appear when any issues are actually suppressed, which should not actually occur for non-snyk-developer users yet.

This PR depends on the PR'ed ~+ unmerged~ scanAnalytics field in snyk-iac-test's return payload. If approved, this PR should be updated with the new pinned version that is released after https://github.com/snyk/snyk-iac-test/pull/115 is merged, before merging this one.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/CTX-403

#### Screenshots

When cloud-context has found issues:

<img width="551" alt="Screenshot 2022-09-12 at 09 46 39" src="https://user-images.githubusercontent.com/4772216/189611933-0cc5a894-27d3-47c1-b368-7b557175640a.png">

Note that this field does not appear when `--cloud-context` is not requested:

<img width="545" alt="Screenshot 2022-09-12 at 09 46 45" src="https://user-images.githubusercontent.com/4772216/189611975-2457f137-dee3-44ff-bda1-471e3a129509.png">


#### Additional questions
