### PR TITLE
fix: container python app scan errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.20.0",
-        "snyk-docker-plugin": "^5.4.0",
+        "snyk-docker-plugin": "^5.4.1",
         "snyk-go-plugin": "1.19.2",
         "snyk-gradle-plugin": "3.22.2",
         "snyk-module": "3.1.0",
@@ -16512,9 +16512,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.4.0.tgz",
-      "integrity": "sha512-9aba6EJqmbJBfYUoYMbqz/ghV2xt02hl8LbFC8OzooXIyu4z72BBRUSfs3geRuLnhSYUIp4etzsOryCuqQdG2g==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.4.1.tgz",
+      "integrity": "sha512-x0erNrYCc72ZCj81LL85xibmU763otQACLW8aSUEAsLnSFpoKoE+tnQG5Z9BiEXYbSNXRsll/eS82gzhpHcFKQ==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.3.0",
@@ -32919,9 +32919,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.4.0.tgz",
-      "integrity": "sha512-9aba6EJqmbJBfYUoYMbqz/ghV2xt02hl8LbFC8OzooXIyu4z72BBRUSfs3geRuLnhSYUIp4etzsOryCuqQdG2g==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.4.1.tgz",
+      "integrity": "sha512-x0erNrYCc72ZCj81LL85xibmU763otQACLW8aSUEAsLnSFpoKoE+tnQG5Z9BiEXYbSNXRsll/eS82gzhpHcFKQ==",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.20.0",
-    "snyk-docker-plugin": "^5.4.0",
+    "snyk-docker-plugin": "^5.4.1",
     "snyk-go-plugin": "1.19.2",
     "snyk-gradle-plugin": "3.22.2",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This dependency bump should fix the "Invalid version" error we're seeing when scanning some Python projects in containers
