### PR TITLE
feat: pass the org public ID to snyk-iac-test

### DIFF
--- a/src/cli/commands/test/iac/local-execution/types.ts
+++ b/src/cli/commands/test/iac/local-execution/types.ts
@@ -117,6 +117,7 @@ export interface TestMeta {
   isPrivate: boolean;
   isLicensesEnabled: boolean;
   org: string;
+  orgPublicId: string;
   ignoreSettings?: IgnoreSettings | null;
   projectId?: string;
   policy?: string;

--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -173,6 +173,7 @@ function createTemporaryFiles(
 
     const configData = JSON.stringify({
       org: options.orgSettings.meta.org,
+      orgPublicId: options.orgSettings.meta.orgPublicId,
       apiUrl: config.API,
       apiAuth: getAuthHeader(),
       allowAnalytics: allowAnalytics(),

--- a/test/jest/unit/cli/commands/test/iac/meta.spec.ts
+++ b/test/jest/unit/cli/commands/test/iac/meta.spec.ts
@@ -249,6 +249,7 @@ function orgSettingsFor(org) {
       isPrivate: false,
       isLicensesEnabled: false,
       org,
+      orgPublicId: '7bfa4159-6f90-4acd-82a4-0b2ad2aaf80b',
     },
   };
 }

--- a/test/jest/unit/cli/commands/test/iac/v2/index.spec.ts
+++ b/test/jest/unit/cli/commands/test/iac/v2/index.spec.ts
@@ -49,6 +49,7 @@ describe('test', () => {
     customPolicies: {},
     meta: {
       org: 'my-org-name',
+      orgPublicId: '7bfa4159-6f90-4acd-82a4-0b2ad2aaf80b',
       isLicensesEnabled: false,
       isPrivate: false,
     },

--- a/test/jest/unit/iac/index.spec.ts
+++ b/test/jest/unit/iac/index.spec.ts
@@ -84,6 +84,7 @@ describe('test()', () => {
         isLicensesEnabled: false,
         ignoreSettings: null,
         org: 'org-name',
+        orgPublicId: '7bfa4159-6f90-4acd-82a4-0b2ad2aaf80b',
       },
       customPolicies: {},
       customRules: {},

--- a/test/jest/unit/iac/results-formatter.fixtures.ts
+++ b/test/jest/unit/iac/results-formatter.fixtures.ts
@@ -97,6 +97,7 @@ export const meta: TestMeta = {
   isPrivate: false,
   isLicensesEnabled: false,
   org: 'org-name',
+  orgPublicId: '7bfa4159-6f90-4acd-82a4-0b2ad2aaf80b',
 };
 
 export function generateCloudConfigResults({

--- a/test/jest/unit/iac/rules/rules.spec.ts
+++ b/test/jest/unit/iac/rules/rules.spec.ts
@@ -11,6 +11,7 @@ describe('initRules', () => {
       isPrivate: false,
       isLicensesEnabled: false,
       org: 'my-org',
+      orgPublicId: '7bfa4159-6f90-4acd-82a4-0b2ad2aaf80b',
     },
     customPolicies: {},
     entitlements: {
@@ -72,6 +73,7 @@ describe('initRules', () => {
         isPrivate: false,
         isLicensesEnabled: false,
         org: 'my-org',
+        orgPublicId: '7bfa4159-6f90-4acd-82a4-0b2ad2aaf80b',
       },
       customPolicies: {},
       entitlements: {

--- a/test/jest/unit/lib/iac/test/v2/json.spec.ts
+++ b/test/jest/unit/lib/iac/test/v2/json.spec.ts
@@ -58,6 +58,7 @@ describe('convertEngineToJsonResults', () => {
       isLicensesEnabled: false,
       ignoreSettings: null,
       org: 'org-name',
+      orgPublicId: '7bfa4159-6f90-4acd-82a4-0b2ad2aaf80b',
     },
     customPolicies: {},
     customRules: {},


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR includes the org public ID, returned from the IaC org settings endpoint, into the configuration passed to `snyk-iac-test`. This piece of information is necessary to `snyk-iac-test` to invoke the Snyk Cloud API.

The changes in this PR are only relevant to the experimental flow of `snyk iac test`.