### PR TITLE
feat: can override IaC experimental bundle

### DIFF
--- a/src/lib/iac/test/v2/local-cache/rules-bundle/download.ts
+++ b/src/lib/iac/test/v2/local-cache/rules-bundle/download.ts
@@ -9,12 +9,19 @@ import { saveFile } from '../../../../file-utils';
 import { TestConfig } from '../../types';
 import { fetchCacheResource } from '../utils';
 import { rulesBundleName } from './constants';
+import config from '../../../../../config';
 
 const debugLog = createDebugLogger('snyk-iac');
 
 export async function downloadRulesBundle(
   testConfig: TestConfig,
 ): Promise<string> {
+  // IAC_BUNDLE_PATH is a developer setting that is not useful to most users. It
+  // is not a replacement for custom rules.
+  if (config.IAC_BUNDLE_PATH) {
+    return config.IAC_BUNDLE_PATH;
+  }
+
   let downloadDurationSeconds = 0;
 
   const timer = new TimerMetricInstance('iac_rules_bundle_download');


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

feat: can override IaC experimental bundle

Using the same environment variable as we do for the regular bundle. This is intended as a developer feature, and is not useful for most users.


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
