### PR TITLE
feat: add support for an HTTP proxy  when using snyk-iac-test

### DIFF
--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -61,6 +61,7 @@ async function prepareTestConfig(
   const scan = options.scan ?? 'resource-changes';
   const varFile = options['var-file'];
   const cloudContext = getFlag(options, 'cloud-context');
+  const insecure = options.insecure;
 
   return {
     paths,
@@ -80,6 +81,7 @@ async function prepareTestConfig(
     varFile,
     depthDetection,
     cloudContext,
+    insecure,
   };
 }
 

--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -160,6 +160,10 @@ function processFlags(
     flags.push('-cloud-context', options.cloudContext);
   }
 
+  if (options.insecure) {
+    flags.push('-http-tls-skip-verify');
+  }
+
   return flags;
 }
 

--- a/src/lib/iac/test/v2/types.ts
+++ b/src/lib/iac/test/v2/types.ts
@@ -20,4 +20,5 @@ export interface TestConfig {
   varFile?: string;
   depthDetection?: number;
   cloudContext?: string;
+  insecure?: boolean;
 }


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

When a user configures `HTTPS_PROXY` and `--insecure` to use an HTTP proxy, the settings should be propagated to `snyk-iac-test` so that the requests sent from that component will go through the proxy, too. `snyk-iac-test` already provide support for proxies, so this PR is just about propagating the right settings and flags from the `snyk` CLI to `snyk-iac-test`.

#### How should this be manually tested?

Start a proxy and run the command like this:

```
HTTPS_PROXY=http://localhost:8080 snyk iac test --experimental --insecure path/to/scan
```
