### PR TITLE
fix: iac test result undefined

### DIFF
--- a/src/lib/formatters/iac-output/text/formatters.ts
+++ b/src/lib/formatters/iac-output/text/formatters.ts
@@ -111,7 +111,7 @@ export function formatSnykIacTestTestData(
 
   let contextSuppressedIssueCount: number | undefined;
   const suppressedResults =
-    snykIacTestScanResult?.scanAnalytics.suppressedResults;
+    snykIacTestScanResult?.scanAnalytics?.suppressedResults;
   if (suppressedResults) {
     contextSuppressedIssueCount = Object.values(suppressedResults).reduce(
       function(count, resourcesForRuleId) {


### PR DESCRIPTION
snyk iac test scan would fail when trying to access `snykIacTestScanResult?.scanAnalytics.supressedResults`, in the case of `snykIacTestScanResult` being undefined. 

This is because the whole `snykIacTestScanResult?.scanAnalytics` would evaluate to u`ndefine` and `suppressedResults` would fail to read an undefined value. 

Added a "?" operator to scanAnalytics to fix this error.