### PR TITLE
chore: add golang binary for windows to releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -534,6 +534,12 @@ jobs:
           at: .
       - setup_npm
       - run:
+          name: Copy Windows cliv2 binaries to binary-releases staging area
+          command: |
+            ls -la cliv2/bin
+            cp cliv2/bin/snyk-win.exe binary-releases/snyk-win.exe
+            cp cliv2/bin/snyk-win.exe.sha256 binary-releases/snyk-win.exe.sha256
+      - run:
           name: Signing shasums
           command: make binary-releases/sha256sums.txt.asc
       - run:
@@ -667,6 +673,34 @@ jobs:
           paths:
             - ./cliv2/bin
 
+  v2-rename-windows-artifact:
+    executor: linux
+    working_directory: /home/circleci/snyk
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Rename snyk_windows_amd64.exe artifact
+          command: mv snyk_windows_amd64.exe snyk-win.exe
+          working_directory: ./cliv2/bin
+      - run:
+          name: Regenerate sha256
+          command: |
+            shasum -a 256 snyk-win.exe > snyk-win.exe.sha256
+            shasum -a 256 -c snyk-win.exe.sha256
+          working_directory: ./cliv2/bin
+      - run:
+          name: Show files
+          command: |
+            ls -la
+            cat snyk-win.exe.sha256
+          working_directory: ./cliv2/bin
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./cliv2/bin
+
   v2-prepare-release:
     executor: linux
     working_directory: /home/circleci/snyk
@@ -755,7 +789,7 @@ jobs:
           name: Run integration tests
           working_directory: ./cliv2
           environment:
-            TEST_SNYK_EXECUTABLE_PATH: ./bin/snyk_windows_amd64.exe
+            TEST_SNYK_EXECUTABLE_PATH: ./bin/snyk-win.exe
           command: |
             $env:SNYK_TOKEN = $env:SNYK_API_KEY
             ./bin/snyk_tests_windows_amd64.exe
@@ -772,7 +806,7 @@ jobs:
           name: Run integration tests
           working_directory: ./cliv2
           environment:
-            TEST_SNYK_EXECUTABLE_PATH: ./bin/snyk_windows_amd64.exe
+            TEST_SNYK_EXECUTABLE_PATH: ./bin/snyk-win.exe
             HTTPS_PROXY: http://localhost:8080
           command: |
             $env:SNYK_TOKEN = $env:SNYK_API_KEY
@@ -923,6 +957,7 @@ workflows:
             - Build (snyk-for-docker-desktop-darwin-x64.tar.gz)
             - Build (snyk-for-docker-desktop-darwin-arm64.tar.gz)
             - Build (docker-mac-signed-bundle.tar.gz)
+            - v2 / Prepare Release
       - should-release:
           name: Release?
           type: approval
@@ -1012,11 +1047,11 @@ workflows:
       - v2-test-windows-amd64:
           name: v2 / Integration Tests (windows/amd64)
           requires:
-            - v2 / Build (windows/amd64)
+            - v2 / Rename windows/amd64 artifact
       - v2-test-proxy-windows-amd64:
           name: v2 / Proxy Integration Tests (windows/amd64)
           requires:
-            - v2 / Build (windows/amd64)
+            - v2 / Rename windows/amd64 artifact
       # Tests for backwards compatibility with CLIv1
       - test-alpine:
           name: v2 / Jest Acceptance Tests (alpine/amd64)
@@ -1040,8 +1075,8 @@ workflows:
           name: v2 / Jest Acceptance Tests (windows/amd64)
           context: nodejs-install
           requires:
-            - v2 / Build (windows/amd64)
-          test_snyk_command: C:\Users\circleci\snyk\cliv2\bin\snyk_windows_amd64.exe
+            - v2 / Rename windows/amd64 artifact
+          test_snyk_command: C:\Users\circleci\snyk\cliv2\bin\snyk-win.exe
       - test-macos:
           name: v2 / Jest Acceptance Tests (darwin/amd64)
           context: nodejs-install
@@ -1071,4 +1106,4 @@ workflows:
             - v2 / Build (linux/amd64)
             - v2 / Build (linux/arm64)
             - v2 / Sign (darwin/amd64)
-            - v2 / Sign (windows/amd64)
+            - v2 / Rename windows/amd64 artifact

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -859,13 +859,6 @@ workflows:
           name: Version
           requires:
             - Build
-          filters:
-            branches:
-              only:
-                - /^chore\/.+$/
-                - /^.*test.*$/
-                - /^.*cliv2.*$/
-                - master
       - build-artifact:
           name: Build (<< matrix.artifact >>)
           requires:
@@ -963,62 +956,36 @@ workflows:
       #
       - v2-lint:
           name: v2 / Lint
-          filters:
-            branches:
-              only:
-                - /^.*cliv2.*$/
-                - master
       - v2-unit-test:
           name: v2 / Unit Tests
-          filters:
-            branches:
-              only:
-                - /^.*cliv2.*$/
-                - master
       - v2-build-artifact:
           name: v2 / Build (linux/amd64)
           requires:
             - Build (snyk-linux)
           go_os: linux
           go_arch: amd64
-          filters:
-            branches:
-              only:
-                - /^.*cliv2.*$/
-                - master
       - v2-build-artifact:
           name: v2 / Build (linux/arm64)
           requires:
             - Build (snyk-linux-arm64)
           go_os: linux
           go_arch: arm64
-          filters:
-            branches:
-              only:
-                - /^.*cliv2.*$/
-                - master
       - v2-build-artifact:
           name: v2 / Build (darwin/amd64)
           requires:
             - Build (snyk-macos)
           go_os: darwin
           go_arch: amd64
-          filters:
-            branches:
-              only:
-                - /^.*cliv2.*$/
-                - master
       - v2-build-artifact:
           name: v2 / Build (windows/amd64)
           requires:
             - Build (snyk-win.exe)
           go_os: windows
           go_arch: amd64
-          filters:
-            branches:
-              only:
-                - /^.*cliv2.*$/
-                - master
+      - v2-rename-windows-artifact:
+          name: v2 / Rename windows/amd64 artifact
+          requires:
+            - v2 / Sign (windows/amd64)
       - v2-build-artifact:
           name: v2 / Build (alpine/amd64)
           requires:
@@ -1026,11 +993,6 @@ workflows:
           go_os: alpine
           go_arch: amd64
           c_compiler: /usr/bin/musl-gcc
-          filters:
-            branches:
-              only:
-                - /^.*cliv2.*$/
-                - master
       - v2-test-linux-amd64:
           name: v2 / Integration Tests (linux/amd64)
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -953,7 +953,6 @@ workflows:
             - Build (snyk-linux)
             - Build (snyk-linux-arm64)
             - Build (snyk-macos)
-            - Build (snyk-win.exe)
             - Build (snyk-for-docker-desktop-darwin-x64.tar.gz)
             - Build (snyk-for-docker-desktop-darwin-arm64.tar.gz)
             - Build (docker-mac-signed-bundle.tar.gz)


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

Publishes the new golang CLI as the snyk.exe binary (and corresponding sha256 file) to GH releases and the CDN.