### PR TITLE
feat: show Cloud Issues URL when sharing results with snyk iac test

### DIFF
--- a/src/cli/commands/test/iac/local-execution/types.ts
+++ b/src/cli/commands/test/iac/local-execution/types.ts
@@ -390,7 +390,7 @@ export enum IaCErrorCodes {
   NoLoadableInput = 2114,
   FailedToMakeResourcesResolvers = 2115,
   ResourcesResolverError = 2116,
-  FailedToShareResults = 2200,
+  FailedToProcessResults = 2200,
 }
 
 export interface TestReturnValue {

--- a/src/cli/commands/test/iac/output.ts
+++ b/src/cli/commands/test/iac/output.ts
@@ -32,6 +32,7 @@ import {
   shareResultsTip,
   formatTestData,
 } from '../../../../lib/formatters/iac-output/text';
+import { formatShareResultsOutputV2 } from '../../../../lib/formatters/iac-output/text/share-results';
 
 const SEPARATOR = '\n-------------------------------------------------------\n';
 
@@ -255,6 +256,37 @@ export function buildShareResultsSummary({
   let response = '';
 
   response += SEPARATOR + EOL + formatShareResultsOutput(orgName, projectName);
+
+  if (
+    shouldPrintShareCustomRulesDisclaimer(
+      options,
+      isIacCustomRulesEntitlementEnabled,
+      isIacShareCliResultsCustomRulesSupported,
+    )
+  ) {
+    response += EOL + EOL + shareCustomRulesDisclaimer;
+  }
+
+  return response;
+}
+
+export function buildShareResultsSummaryV2({
+  orgName,
+  projectName,
+  options,
+  isIacCustomRulesEntitlementEnabled,
+  isIacShareCliResultsCustomRulesSupported,
+}: {
+  orgName: string;
+  projectName: string;
+  options: IaCTestFlags;
+  isIacCustomRulesEntitlementEnabled: boolean;
+  isIacShareCliResultsCustomRulesSupported: boolean;
+}): string {
+  let response = '';
+
+  response +=
+    SEPARATOR + EOL + formatShareResultsOutputV2(orgName, projectName);
 
   if (
     shouldPrintShareCustomRulesDisclaimer(

--- a/src/lib/formatters/iac-output/text/share-results.ts
+++ b/src/lib/formatters/iac-output/text/share-results.ts
@@ -17,6 +17,26 @@ export function formatShareResultsOutput(orgName: string, projectName: string) {
   );
 }
 
+export function formatShareResultsOutputV2(
+  orgName: string,
+  projectName: string,
+) {
+  return (
+    colors.title('Report Complete') +
+    EOL +
+    EOL +
+    contentPadding +
+    'Your test results are available at: ' +
+    colors.title(
+      `${
+        config.ROOT
+      }/org/${orgName}/cloud/issues?environment_name=${encodeURIComponent(
+        projectName,
+      )}`,
+    )
+  );
+}
+
 export const shareResultsTip =
   colors.title('Tip') +
   EOL +

--- a/src/lib/iac/test/v2/errors.ts
+++ b/src/lib/iac/test/v2/errors.ts
@@ -34,7 +34,8 @@ const snykIacTestErrorsUserMessages = {
     'An error occurred preparing the requested cloud context. Please run the command again with the `-d` flag for more information.',
   ResourcesResolverError:
     'An error occurred scanning cloud resources. Please run the command again with the `-d` flag for more information.',
-  FailedToShareResults: 'Failed to upload the test results with the platform',
+  FailedToProcessResults:
+    'An error occurred while processing results. Please run the command again with the `-d` flag for more information.',
 };
 
 export function getErrorUserMessage(code: number): string {

--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -1,12 +1,12 @@
 import * as os from 'os';
 
 const policyEngineChecksums = `
-16211f1b806a85127cad2f1165e39a679a82c6c3d0d6a0bc4fde196710280b73  snyk-iac-test_0.31.2_Linux_x86_64
-931a8eb829c912251ae1d47c7b729148dca2bd3c60a4c8b564f614aeeee9d7c9  snyk-iac-test_0.31.2_Darwin_x86_64
-9536c5b4b4bf6fef94dd110033311b4447857c43bb07d64f5d2bc498cb53366b  snyk-iac-test_0.31.2_Windows_arm64.exe
-cf24c3b562f5c4282c029510cf679cabb5fa2a96bbf207cdd57f42e960173fb4  snyk-iac-test_0.31.2_Darwin_arm64
-d3bc0efa5e7eec34e9cd2f226e3686329e4a4f371e532851e4d10226e250505d  snyk-iac-test_0.31.2_Linux_arm64
-fcebb81c0745d8636d55ac9aa4582acbc38d93a496970d3069c19ab278b5ebb6  snyk-iac-test_0.31.2_Windows_x86_64.exe
+287c2b8c97b2b6208264e5bf9dab3132c34355efdecf29974a84bd56e7e1654d  snyk-iac-test_0.31.3_Darwin_x86_64
+4cb497eac74ed543dde6935e5cc0519cffbcced6bfe9a98c697b125edfb75a2e  snyk-iac-test_0.31.3_Linux_arm64
+6059e32181c32f364757cb39204beea73c1ed4c477d5ae8fa8e970d5c792bb37  snyk-iac-test_0.31.3_Darwin_arm64
+7767548480f2479205bdf3d792a66d43313717a471e1c300841504b63ae2581b  snyk-iac-test_0.31.3_Windows_arm64.exe
+8363ae002cf64f4bb0c65ddc2312d4c6b23098032983d61d8c4c439b705750ed  snyk-iac-test_0.31.3_Windows_x86_64.exe
+e36cc18b60f7b41fccf5a097f685f437813b9183aa9c6fa97ea4c1fe36ac0e42  snyk-iac-test_0.31.3_Linux_x86_64
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();

--- a/src/lib/iac/test/v2/output.ts
+++ b/src/lib/iac/test/v2/output.ts
@@ -26,7 +26,7 @@ import stripAnsi from 'strip-ansi';
 import * as path from 'path';
 import { getErrorStringCode } from '../../../../cli/commands/test/iac/local-execution/error-utils';
 import {
-  buildShareResultsSummary,
+  buildShareResultsSummaryV2,
   shouldPrintShareResultsTip,
 } from '../../../../cli/commands/test/iac/output';
 
@@ -167,7 +167,7 @@ function buildTextOutput({
   response += EOL;
 
   if (options.report) {
-    response += buildShareResultsSummary({
+    response += buildShareResultsSummaryV2({
       orgName: orgSettings.meta.org,
       projectName,
       options,


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

When sharing results with the experimental flow of `snyk iac test`, the CLI shows the URL pointing to the projects page. This PR changes the implementation so that the CLI shows a URL pointing to the cloud issues UI, with a query filter that shows only the resources scanned in the execution of the CLI.

#### How should this be manually tested?

Share results with the experimental flow:

```
snyk iac test --experimental --report path/to/scan
```

The CLI will show a summary at the end of the scan with the updated URL:

```
Report Complete

  Your test results are available at: https://snyk.io/org/francescomari/cloud/issues?environment_name=snyk%2Fcli
```

#### What are the relevant tickets?

[CFG-2155](https://snyksec.atlassian.net/browse/CFG-2155)