### PR TITLE
feat: pass config to plugin.inspect

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -223,6 +223,7 @@ export function args(rawArgv: string[]): Args {
     'prune-repeated-subdependencies',
     'dry-run',
     'sequential',
+    'gradle-normalize-deps',
   ];
   for (const dashedArg of argumentsToTransform) {
     if (argv[dashedArg]) {

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -1,4 +1,5 @@
 import * as snykConfig from 'snyk-config';
+import { getAuthHeader } from '../api-token';
 import { config as userConfig } from '../user-config';
 import { getBaseApiUrl, getRestApiUrl, getV1ApiUrl } from './api-url';
 
@@ -25,6 +26,7 @@ interface Config {
   IAC_BUNDLE_PATH?: string;
   IAC_POLICY_ENGINE_PATH?: string;
   PUBLIC_VULN_DB_URL: string;
+  API_REST_AUTH_HEADER: string;
 }
 
 // TODO: fix the types!
@@ -79,3 +81,6 @@ if (!config.ROOT) {
 config.PUBLIC_VULN_DB_URL = 'https://security.snyk.io';
 
 export default config;
+
+// Note: after export to avoid circular imports
+config.API_REST_AUTH_HEADER = getAuthHeader();

--- a/src/lib/module-info/index.ts
+++ b/src/lib/module-info/index.ts
@@ -10,6 +10,7 @@ export function ModuleInfo(plugin, policy) {
       root,
       targetFile,
       options,
+      config,
     ): Promise<pluginApi.SinglePackageResult | pluginApi.MultiProjectResult> {
       const pluginOptions = merge(
         {
@@ -19,7 +20,12 @@ export function ModuleInfo(plugin, policy) {
       );
 
       debug('calling plugin inspect()', { root, targetFile, pluginOptions });
-      const info = await plugin.inspect(root, targetFile, pluginOptions);
+      const info = await plugin.inspect(
+        root,
+        targetFile,
+        pluginOptions,
+        config,
+      );
       debug('plugin inspect() done');
 
       // attach policy if not provided by plugin

--- a/src/lib/plugins/get-single-plugin-result.ts
+++ b/src/lib/plugins/get-single-plugin-result.ts
@@ -2,6 +2,7 @@ import plugins = require('.');
 import { ModuleInfo } from '../module-info';
 import { legacyPlugin as pluginApi } from '@snyk/cli-interface';
 import { TestOptions, Options, MonitorOptions } from '../types';
+import config from '../config';
 
 export async function getSinglePluginResult(
   root: string,
@@ -14,6 +15,7 @@ export async function getSinglePluginResult(
     root,
     targetFile || options.file,
     { ...options },
+    config,
   );
   return inspectRes;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -225,7 +225,8 @@ export type SupportedUserReachableFacingCliArgs =
   | 'sub-project'
   | 'trust-policies'
   | 'yarn-workspaces'
-  | 'maven-aggregate-project';
+  | 'maven-aggregate-project'
+  | 'gradle-normalize-deps';
 
 export enum SupportedCliCommands {
   version = 'version',

--- a/test/tap/cli-monitor.acceptance.test.ts
+++ b/test/tap/cli-monitor.acceptance.test.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as sinon from 'sinon';
 import * as cli from '../../src/cli/commands';
+import config from '../../src/lib/config';
 import { fakeServer } from '../acceptance/fake-server';
 import * as subProcess from '../../src/lib/sub-process';
 import { getVersion } from '../../src/lib/version';
@@ -927,6 +928,7 @@ if (!isWindows) {
           packageManager: 'pip',
           path: 'pip-app',
         },
+        config,
       ],
       'calls python plugin',
     );
@@ -990,6 +992,7 @@ if (!isWindows) {
           packageManager: 'pip',
           path: 'pip-app',
         },
+        config,
       ],
       'calls python plugin',
     );
@@ -1042,6 +1045,7 @@ if (!isWindows) {
           file: 'build.gradle',
           path: 'gradle-app',
         },
+        config,
       ],
       'calls gradle plugin',
     );
@@ -1111,6 +1115,7 @@ if (!isWindows) {
           packageManager: 'gradle',
           path: 'gradle-app',
         },
+        config,
       ],
       'calls gradle plugin',
     );
@@ -1170,6 +1175,7 @@ if (!isWindows) {
           packageManager: 'gradle',
           path: 'gradle-app',
         },
+        config,
       ],
       'calls gradle plugin',
     );
@@ -1224,6 +1230,7 @@ if (!isWindows) {
           packageManager: 'gradle',
           path: 'gradle-app',
         },
+        config,
       ],
       'calls plugin for the 1st path',
     );
@@ -1316,6 +1323,7 @@ if (!isWindows) {
           packageManager: 'gomodules',
           path: 'golang-gomodules',
         },
+        config,
       ],
       'calls golang plugin',
     );
@@ -1364,6 +1372,7 @@ if (!isWindows) {
           packageManager: 'golangdep',
           path: 'golang-app',
         },
+        config,
       ],
       'calls golang plugin',
     );
@@ -1412,6 +1421,7 @@ if (!isWindows) {
           packageManager: 'govendor',
           path: 'golang-app',
         },
+        config,
       ],
       'calls golang plugin',
     );
@@ -1458,6 +1468,7 @@ if (!isWindows) {
           packageManager: 'cocoapods',
           path: './',
         },
+        config,
       ],
       'calls CocoaPods plugin',
     );
@@ -1506,6 +1517,7 @@ if (!isWindows) {
           packageManager: 'cocoapods',
           path: './',
         },
+        config,
       ],
       'calls CocoaPods plugin',
     );
@@ -1560,6 +1572,7 @@ if (!isWindows) {
           packageManager: 'cocoapods',
           path: './',
         },
+        config,
       ],
       'calls CocoaPods plugin',
     );

--- a/test/tap/cli-monitor.acceptance.test.ts
+++ b/test/tap/cli-monitor.acceptance.test.ts
@@ -1246,6 +1246,7 @@ if (!isWindows) {
           packageManager: 'pip',
           path: 'pip-app',
         },
+        config,
       ],
       'calls plugin for the 2nd path',
     );

--- a/test/tap/cli-monitor.acceptance.test.ts
+++ b/test/tap/cli-monitor.acceptance.test.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as sinon from 'sinon';
 import * as cli from '../../src/cli/commands';
-import config from '../../src/lib/config';
 import { fakeServer } from '../acceptance/fake-server';
 import * as subProcess from '../../src/lib/sub-process';
 import { getVersion } from '../../src/lib/version';
@@ -42,6 +41,7 @@ import { DepGraphBuilder } from '@snyk/dep-graph';
 import * as depGraphLib from '@snyk/dep-graph';
 import { getFixturePath } from '../jest/util/getFixturePath';
 import { getWorkspacePath } from '../jest/util/getWorkspacePath';
+import config from '../../src/lib/config';
 
 /*
   TODO: enable these tests, once we switch from node-tap

--- a/test/tap/cli-test.acceptance.test.ts
+++ b/test/tap/cli-test.acceptance.test.ts
@@ -65,7 +65,7 @@ const after = tap.runOnly ? only : test;
 // Should be after `process.env` setup.
 import * as plugins from '../../src/lib/plugins/index';
 import * as ecoSystemPlugins from '../../src/lib/ecosystems/plugins';
-import * as config from '../../src/lib/config'
+import * as config from '../../src/lib/config';
 /*
   TODO: enable these tests, once we switch from node-tap
   I couldn't get them to run reliably under Windows, spent ~3 days on it

--- a/test/tap/cli-test.acceptance.test.ts
+++ b/test/tap/cli-test.acceptance.test.ts
@@ -65,7 +65,7 @@ const after = tap.runOnly ? only : test;
 // Should be after `process.env` setup.
 import * as plugins from '../../src/lib/plugins/index';
 import * as ecoSystemPlugins from '../../src/lib/ecosystems/plugins';
-
+import * as config from '../../src/lib/config'
 /*
   TODO: enable these tests, once we switch from node-tap
   I couldn't get them to run reliably under Windows, spent ~3 days on it
@@ -134,6 +134,7 @@ test('Languages', async (t) => {
           languageTest.tests[testName](
             { server, plugins, ecoSystemPlugins, versionNumber, cli },
             { chdirWorkspaces },
+            config,
           ),
         );
         server.restore();

--- a/test/tap/cli-test/cli-test.composer.spec.ts
+++ b/test/tap/cli-test/cli-test.composer.spec.ts
@@ -5,9 +5,11 @@ import { AcceptanceTests } from '../cli-test.acceptance.test';
 export const ComposerTests: AcceptanceTests = {
   language: 'Composer',
   tests: {
-    '`test composer-app --file=composer.lock`': (params, utils) => async (
-      t,
-    ) => {
+    '`test composer-app --file=composer.lock`': (
+      params,
+      utils,
+      config,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -49,14 +51,17 @@ export const ComposerTests: AcceptanceTests = {
             path: 'composer-app',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls composer plugin',
       );
     },
 
-    '`test composer-app` auto-detects composer.lock': (params, utils) => async (
-      t,
-    ) => {
+    '`test composer-app` auto-detects composer.lock': (
+      params,
+      utils,
+      config,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -96,14 +101,17 @@ export const ComposerTests: AcceptanceTests = {
             path: 'composer-app',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls composer plugin',
       );
     },
 
-    '`test composer-app --file=composer.lock --dev`': (params, utils) => async (
-      t,
-    ) => {
+    '`test composer-app --file=composer.lock --dev`': (
+      params,
+      utils,
+      config,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -147,6 +155,7 @@ export const ComposerTests: AcceptanceTests = {
             path: 'composer-app',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls composer plugin',
       );
@@ -155,6 +164,7 @@ export const ComposerTests: AcceptanceTests = {
     '`test composer-app golang-app nuget-app` auto-detects all three projects': (
       params,
       utils,
+      config,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -223,6 +233,7 @@ export const ComposerTests: AcceptanceTests = {
             path: 'composer-app',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls composer plugin',
       );
@@ -240,6 +251,7 @@ export const ComposerTests: AcceptanceTests = {
             path: 'golang-app',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls golangdep plugin',
       );
@@ -257,6 +269,7 @@ export const ComposerTests: AcceptanceTests = {
             path: 'nuget-app',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls nuget plugin',
       );

--- a/test/tap/cli-test/cli-test.elixir.spec.ts
+++ b/test/tap/cli-test/cli-test.elixir.spec.ts
@@ -5,7 +5,7 @@ import * as depGraphLib from '@snyk/dep-graph';
 export const ElixirTests: AcceptanceTests = {
   language: 'Elixir',
   tests: {
-    '`test elixir --file=mix.exs`': (params, utils) => async (t) => {
+    '`test elixir --file=mix.exs`': (params, utils, config) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -52,12 +52,15 @@ export const ElixirTests: AcceptanceTests = {
             path: 'elixir-hex',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls golang plugin',
       );
     },
 
-    '`test elixir-hex` auto-detects hex': (params, utils) => async (t) => {
+    '`test elixir-hex` auto-detects hex': (params, utils, config) => async (
+      t,
+    ) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -103,6 +106,7 @@ export const ElixirTests: AcceptanceTests = {
             path: 'elixir-hex',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls elixir-hex plugin',
       );

--- a/test/tap/cli-test/cli-test.go.spec.ts
+++ b/test/tap/cli-test/cli-test.go.spec.ts
@@ -4,7 +4,9 @@ import { AcceptanceTests } from '../cli-test.acceptance.test';
 export const GoTests: AcceptanceTests = {
   language: 'Go',
   tests: {
-    '`test golang-gomodules --file=go.mod`': (params, utils) => async (t) => {
+    '`test golang-gomodules --file=go.mod`': (params, utils, config) => async (
+      t,
+    ) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -51,6 +53,7 @@ export const GoTests: AcceptanceTests = {
             path: 'golang-gomodules',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls golang plugin',
       );
@@ -59,6 +62,7 @@ export const GoTests: AcceptanceTests = {
     '`test golang-app` auto-detects golang-gomodules': (
       params,
       utils,
+      config,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -104,12 +108,15 @@ export const GoTests: AcceptanceTests = {
             path: 'golang-gomodules',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls golang-gomodules plugin',
       );
     },
 
-    '`test golang-app --file=Gopkg.lock`': (params, utils) => async (t) => {
+    '`test golang-app --file=Gopkg.lock`': (params, utils, config) => async (
+      t,
+    ) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -156,14 +163,17 @@ export const GoTests: AcceptanceTests = {
             path: 'golang-app',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls golang plugin',
       );
     },
 
-    '`test golang-app --file=vendor/vendor.json`': (params, utils) => async (
-      t,
-    ) => {
+    '`test golang-app --file=vendor/vendor.json`': (
+      params,
+      utils,
+      config,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -210,14 +220,17 @@ export const GoTests: AcceptanceTests = {
             path: 'golang-app',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls golang plugin',
       );
     },
 
-    '`test golang-app` auto-detects golang/dep': (params, utils) => async (
-      t,
-    ) => {
+    '`test golang-app` auto-detects golang/dep': (
+      params,
+      utils,
+      config,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -262,6 +275,7 @@ export const GoTests: AcceptanceTests = {
             path: 'golang-app',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls golang plugin',
       );
@@ -270,6 +284,7 @@ export const GoTests: AcceptanceTests = {
     '`test golang-app-govendor` auto-detects govendor': (
       params,
       utils,
+      config,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -310,6 +325,7 @@ export const GoTests: AcceptanceTests = {
             path: 'golang-app-govendor',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls golang plugin',
       );

--- a/test/tap/cli-test/cli-test.maven.spec.ts
+++ b/test/tap/cli-test/cli-test.maven.spec.ts
@@ -65,6 +65,7 @@ export const MavenTests: AcceptanceTests = {
     '`test maven-app-with-jars --file=example.jar` sends package info': (
       params,
       utils,
+      config,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -109,6 +110,7 @@ export const MavenTests: AcceptanceTests = {
             path: 'maven-app-with-jars',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls mvn plugin',
       );
@@ -117,6 +119,7 @@ export const MavenTests: AcceptanceTests = {
     '`test maven-app-with-jars --file=example.war` sends package info': (
       params,
       utils,
+      config,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -161,6 +164,7 @@ export const MavenTests: AcceptanceTests = {
             path: 'maven-app-with-jars',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls mvn plugin',
       );
@@ -169,6 +173,7 @@ export const MavenTests: AcceptanceTests = {
     '`test maven-app-with-jars --scan-all-unmanaged` sends package info': (
       params,
       utils,
+      config,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -211,6 +216,7 @@ export const MavenTests: AcceptanceTests = {
             showVulnPaths: 'some',
             scanAllUnmanaged: true,
           },
+          config,
         ],
         'calls mvn plugin',
       );

--- a/test/tap/cli-test/cli-test.nuget.spec.ts
+++ b/test/tap/cli-test/cli-test.nuget.spec.ts
@@ -27,6 +27,7 @@ export const NugetTests: AcceptanceTests = {
     '`test nuget-app-2 auto-detects project.assets.json`': (
       params,
       utils,
+      config,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -71,6 +72,7 @@ export const NugetTests: AcceptanceTests = {
             path: 'nuget-app-2',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls nuget plugin',
       );
@@ -79,6 +81,7 @@ export const NugetTests: AcceptanceTests = {
     '`test nuget-app-2.1 auto-detects obj/project.assets.json`': (
       params,
       utils,
+      config,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -123,6 +126,7 @@ export const NugetTests: AcceptanceTests = {
             path: 'nuget-app-2.1',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls nuget plugin',
       );
@@ -131,6 +135,7 @@ export const NugetTests: AcceptanceTests = {
     '`test nuget-app-4 auto-detects packages.config`': (
       params,
       utils,
+      config,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -176,14 +181,17 @@ export const NugetTests: AcceptanceTests = {
             path: 'nuget-app-4',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls nuget plugin',
       );
     },
 
-    '`test nuget-app --file=project.assets.json`': (params, utils) => async (
-      t,
-    ) => {
+    '`test nuget-app --file=project.assets.json`': (
+      params,
+      utils,
+      config,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -230,12 +238,17 @@ export const NugetTests: AcceptanceTests = {
             path: 'nuget-app',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls nuget plugin',
       );
     },
 
-    '`test nuget-app --file=packages.config`': (params, utils) => async (t) => {
+    '`test nuget-app --file=packages.config`': (
+      params,
+      utils,
+      config,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -282,12 +295,15 @@ export const NugetTests: AcceptanceTests = {
             path: 'nuget-app',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls nuget plugin',
       );
     },
 
-    '`test nuget-app --file=project.json`': (params, utils) => async (t) => {
+    '`test nuget-app --file=project.json`': (params, utils, config) => async (
+      t,
+    ) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -334,6 +350,7 @@ export const NugetTests: AcceptanceTests = {
             path: 'nuget-app',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls nuget plugin',
       );
@@ -342,6 +359,7 @@ export const NugetTests: AcceptanceTests = {
     '`test paket-app auto-detects paket.dependencies`': (
       params,
       utils,
+      config,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -387,6 +405,7 @@ export const NugetTests: AcceptanceTests = {
             path: 'paket-app',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls nuget plugin',
       );
@@ -395,6 +414,7 @@ export const NugetTests: AcceptanceTests = {
     '`test paket-obj-app auto-detects obj/project.assets.json if exists`': (
       params,
       utils,
+      config,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -440,14 +460,17 @@ export const NugetTests: AcceptanceTests = {
             path: 'paket-obj-app',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls nuget plugin',
       );
     },
 
-    '`test paket-app --file=paket.dependencies`': (params, utils) => async (
-      t,
-    ) => {
+    '`test paket-app --file=paket.dependencies`': (
+      params,
+      utils,
+      config,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -494,6 +517,7 @@ export const NugetTests: AcceptanceTests = {
             path: 'paket-app',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls nuget plugin',
       );

--- a/test/tap/cli-test/cli-test.python.spec.ts
+++ b/test/tap/cli-test/cli-test.python.spec.ts
@@ -6,7 +6,9 @@ import { loadJson } from '../../utils';
 export const PythonTests: AcceptanceTests = {
   language: 'Python',
   tests: {
-    '`test pip-app --file=requirements.txt`': (params, utils) => async (t) => {
+    '`test pip-app --file=requirements.txt`': (params, utils, config) => async (
+      t,
+    ) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -48,12 +50,15 @@ export const PythonTests: AcceptanceTests = {
             path: 'pip-app',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls python plugin',
       );
     },
 
-    '`test pipenv-app --file=Pipfile`': (params, utils) => async (t) => {
+    '`test pipenv-app --file=Pipfile`': (params, utils, config) => async (
+      t,
+    ) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -100,6 +105,7 @@ export const PythonTests: AcceptanceTests = {
             path: 'pipenv-app',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls python plugin',
       );
@@ -108,6 +114,7 @@ export const PythonTests: AcceptanceTests = {
     '`test pip-app-transitive-vuln --file=requirements.txt (actionableCliRemediation=false)`': (
       params,
       utils,
+      config,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -160,6 +167,7 @@ export const PythonTests: AcceptanceTests = {
             path: 'pip-app-transitive-vuln',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls python plugin',
       );
@@ -168,6 +176,7 @@ export const PythonTests: AcceptanceTests = {
     '`test pip-app-transitive-vuln --file=requirements.txt (actionableCliRemediation=true)`': (
       params,
       utils,
+      config,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -223,11 +232,14 @@ export const PythonTests: AcceptanceTests = {
             path: 'pip-app-transitive-vuln',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls python plugin',
       );
     },
-    '`test setup_py-app --file=setup.py`': (params, utils) => async (t) => {
+    '`test setup_py-app --file=setup.py`': (params, utils, config) => async (
+      t,
+    ) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -275,6 +287,7 @@ export const PythonTests: AcceptanceTests = {
             path: 'setup_py-app',
             showVulnPaths: 'some',
           },
+          config,
         ],
         'calls python plugin',
       );


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Passes config as an additional argument to the plugin.inspect.

#### Any background context you want to provide?
We're adding a plugin feature that needs to make requests to Snyk's backend, so we require the resolved API URL and auth token to be made available to inspect.