### PR TITLE
chore: Add experimental test analytics [CFG-2157]

### DIFF
--- a/src/lib/formatters/iac-output/text/formatters.ts
+++ b/src/lib/formatters/iac-output/text/formatters.ts
@@ -106,7 +106,7 @@ export function formatSnykIacTestTestData(
   const filesWithIssuesCount = countFilesWithIssues(snykIacTestScanResult);
   const filesWithoutIssuesCount = allFilesCount - filesWithIssuesCount;
   const ignores = snykIacTestScanResult
-    ? snykIacTestScanResult.metadata.ignoredCount
+    ? snykIacTestScanResult.scanAnalytics.ignoredCount
     : 0;
 
   let contextSuppressedIssueCount: number | undefined;

--- a/src/lib/iac/test/v2/analytics/iac-type.ts
+++ b/src/lib/iac/test/v2/analytics/iac-type.ts
@@ -1,0 +1,123 @@
+import { SEVERITY } from '../../../../snyk-test/legacy';
+import { ResourceKind, TestOutput } from '../scan/results';
+
+export function getIacType(testOutput: TestOutput): IacType {
+  const resourcesCountByPackageManager = getResourcesCountByPackageManager(
+    testOutput,
+  );
+
+  const filesCountByPackageManager = getFilesCountByPackageManager(testOutput);
+
+  const vulnAnalyticsByPackageManager = getVulnerabilityAnalyticsByPackageManager(
+    testOutput,
+  );
+
+  return Object.keys(resourcesCountByPackageManager).reduce(
+    (acc, packageManager) => {
+      acc[packageManager] = {
+        count: filesCountByPackageManager[packageManager],
+        'resource-count': resourcesCountByPackageManager[packageManager],
+        ...vulnAnalyticsByPackageManager[packageManager],
+      };
+      return acc;
+    },
+    {},
+  );
+}
+
+export type PackageManager = ResourceKind;
+
+export type IacType = {
+  [packageManager in PackageManager]?: {
+    count: number;
+    'resource-count': number;
+  } & {
+    [severity in SEVERITY]?: number;
+  };
+};
+
+function getResourcesCountByPackageManager(
+  testOutput: TestOutput,
+): ResourcesCountByPackageManager {
+  if (!testOutput.results?.resources?.length) {
+    return {};
+  }
+
+  return testOutput.results.resources.reduce((acc, resource) => {
+    const packageManager = resource.kind;
+
+    if (!acc[packageManager]) {
+      acc[packageManager] = 0;
+    }
+
+    acc[packageManager]++;
+
+    return acc;
+  }, {});
+}
+
+export type ResourcesCountByPackageManager = {
+  [packageManager in PackageManager]?: number;
+};
+
+function getFilesCountByPackageManager(
+  testOutput: TestOutput,
+): FilesCountByPackageManager {
+  if (!testOutput.results?.resources?.length) {
+    return {};
+  }
+
+  return Object.entries(
+    testOutput.results.resources.reduce((acc, resource) => {
+      const packageManager = resource.kind;
+
+      if (!acc[packageManager]) {
+        acc[packageManager] = new Set();
+      }
+
+      acc[packageManager].add(resource.file);
+
+      return acc;
+    }, {} as { [packageManager in PackageManager]: Set<string> }),
+  ).reduce((acc, [packageManager, filesSet]) => {
+    acc[packageManager] = filesSet.size;
+
+    return acc;
+  }, {});
+}
+
+export type FilesCountByPackageManager = {
+  [packageManager in PackageManager]?: number;
+};
+
+function getVulnerabilityAnalyticsByPackageManager(
+  testOutput: TestOutput,
+): VulnerabilityAnalyticsByPackageManager {
+  if (!testOutput.results?.vulnerabilities?.length) {
+    return {};
+  }
+
+  return testOutput.results.vulnerabilities.reduce((acc, vuln) => {
+    const packageManager = vuln.resource.kind;
+
+    if (!acc[packageManager]) {
+      acc[packageManager] = {};
+    }
+
+    if (!acc[packageManager][vuln.severity]) {
+      acc[packageManager][vuln.severity] = 0;
+    }
+
+    acc[packageManager][vuln.severity]++;
+
+    return acc;
+  }, {});
+}
+
+export type VulnerabilityAnalyticsByPackageManager = {
+  [packageManager in PackageManager]?: VulnerabilityAnalitycs;
+};
+
+export type VulnerabilityAnalitycs = {
+  [severity in SEVERITY]?: number;
+};

--- a/src/lib/iac/test/v2/analytics/index.ts
+++ b/src/lib/iac/test/v2/analytics/index.ts
@@ -1,0 +1,46 @@
+import * as createDebugLogger from 'debug';
+
+import { policyEngineReleaseVersion } from '../local-cache/policy-engine/constants';
+import { ResourceKind, TestOutput } from '../scan/results';
+import { getIacType, IacType } from './iac-type';
+
+const debugLog = createDebugLogger('snyk-iac');
+
+export interface IacAnalytics {
+  packageManager: ResourceKind[];
+  'iac-type': IacType;
+  'iac-issues-count': number;
+  'iac-ignored-issues-count': number;
+  'iac-files-count': number;
+  'iac-resources-count': number;
+  'iac-test-binary-version': string;
+  'iac-error-codes': number[];
+  // 'iac-rules-bundle-version': string; // TODO: Add when we have the rules bundle version
+}
+
+export function addIacAnalytics(testOutput: TestOutput): void {
+  const iacAnalytics = computeIacAnalytics(testOutput);
+
+  debugLog(iacAnalytics);
+}
+
+export function computeIacAnalytics(testOutput: TestOutput): IacAnalytics {
+  const iacType = getIacType(testOutput);
+
+  return {
+    'iac-type': iacType,
+    packageManager: Object.keys(iacType) as ResourceKind[],
+    'iac-issues-count': testOutput.results?.vulnerabilities?.length || 0,
+    'iac-ignored-issues-count':
+      testOutput.results?.scanAnalytics.ignoredCount || 0,
+    'iac-files-count': Object.values(iacType).reduce(
+      (acc, packageManagerAnalytics) => acc + packageManagerAnalytics!.count,
+      0,
+    ),
+    'iac-resources-count': testOutput.results?.resources?.length || 0,
+    'iac-error-codes':
+      [...new Set(testOutput.errors?.map((error) => error.code!))] || [],
+    'iac-test-binary-version': policyEngineReleaseVersion,
+    // iacAnalytics['iac-rules-bundle-version'] = ''; // TODO: Add when we have the rules bundle version
+  };
+}

--- a/src/lib/iac/test/v2/index.ts
+++ b/src/lib/iac/test/v2/index.ts
@@ -2,6 +2,7 @@ import { TestConfig } from './types';
 import { scan } from './scan';
 import { TestOutput } from './scan/results';
 import { initLocalCache } from './local-cache';
+import { addIacAnalytics } from './analytics';
 
 export { TestConfig } from './types';
 
@@ -10,5 +11,9 @@ export async function test(testConfig: TestConfig): Promise<TestOutput> {
     testConfig,
   );
 
-  return scan(testConfig, policyEnginePath, rulesBundlePath);
+  const testOutput = scan(testConfig, policyEnginePath, rulesBundlePath);
+
+  addIacAnalytics(testOutput);
+
+  return testOutput;
 }

--- a/src/lib/iac/test/v2/scan/results.ts
+++ b/src/lib/iac/test/v2/scan/results.ts
@@ -39,11 +39,11 @@ export interface Results {
 
 export interface Metadata {
   projectName: string;
-  ignoredCount: number;
 }
 
 export interface ScanAnalytics {
   suppressedResults?: Record<string, string[]>;
+  ignoredCount: number;
 }
 
 export interface Vulnerability {

--- a/src/lib/iac/test/v2/scan/results.ts
+++ b/src/lib/iac/test/v2/scan/results.ts
@@ -71,10 +71,14 @@ export interface Resource {
   path?: any[];
   formattedPath: string;
   file: string;
-  kind: IacProjectType | PolicyEngineTypes.State.InputTypeEnum;
+  kind: ResourceKind;
   line?: number;
   column?: number;
 }
+
+export type ResourceKind =
+  | IacProjectType
+  | PolicyEngineTypes.State.InputTypeEnum;
 
 export interface ScanError {
   message: string;

--- a/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results-with-suppressions.json
+++ b/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results-with-suppressions.json
@@ -147,14 +147,14 @@
       }
     ],
     "metadata": {
-      "projectName": "input-files-for-json-v2",
-      "ignoredCount": 3
+      "projectName": "input-files-for-json-v2"
     },
     "scanAnalytics": {
       "suppressedResults": {
         "issue-1": ["resource1", "resource2"],
         "issue-2": ["resource3"]
-      }
+      },
+      "ignoredCount": 3
     }
   },
   "errors": [

--- a/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results.json
+++ b/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results.json
@@ -147,10 +147,11 @@
       }
     ],
     "metadata": {
-      "projectName": "input-files-for-json-v2",
-      "ignoredCount": 3
+      "projectName": "input-files-for-json-v2"
     },
-    "scanAnalytics": {}
+    "scanAnalytics": {
+      "ignoredCount": 3
+    }
   },
   "errors": [
     {

--- a/test/jest/unit/lib/iac/test/v2/analytics/fixtures/iac-analytics.json
+++ b/test/jest/unit/lib/iac/test/v2/analytics/fixtures/iac-analytics.json
@@ -1,0 +1,21 @@
+{
+    "iac-type": {
+      "terraformconfig": {
+        "count": 2,
+        "resource-count": 4,
+        "medium": 4
+      }
+    },
+    "packageManager": [
+      "terraformconfig"
+    ],
+    "iac-issues-count": 4,
+    "iac-ignored-issues-count": 3,
+    "iac-files-count": 2,
+    "iac-error-codes": [
+     2114
+    ],
+    "iac-resources-count": 4,
+    "iac-test-binary-version": "test-policy-engine-release-version"
+  }
+  

--- a/test/jest/unit/lib/iac/test/v2/analytics/index.spec.ts
+++ b/test/jest/unit/lib/iac/test/v2/analytics/index.spec.ts
@@ -1,0 +1,58 @@
+import * as clonedeep from 'lodash.clonedeep';
+import * as path from 'path';
+import * as fs from 'fs';
+
+import { SnykIacTestOutput } from '../../../../../../../../src/lib/iac/test/v2/scan/results';
+import {
+  computeIacAnalytics,
+  IacAnalytics,
+} from '../../../../../../../../src/lib/iac/test/v2/analytics';
+
+jest.mock(
+  '../../../../../../../../src/lib/iac/test/v2/local-cache/policy-engine/constants',
+  () => ({
+    ...jest.requireActual(
+      '../../../../../../../../src/lib/iac/test/v2/local-cache/policy-engine/constants',
+    ),
+    policyEngineReleaseVersion: 'test-policy-engine-release-version',
+  }),
+);
+
+describe('computeIacAnalytics', () => {
+  const snykIacTestOutputFixture: SnykIacTestOutput = JSON.parse(
+    fs.readFileSync(
+      path.join(
+        __dirname,
+        '..',
+        '..',
+        '..',
+        '..',
+        '..',
+        'iac',
+        'process-results',
+        'fixtures',
+        'snyk-iac-test-results.json',
+      ),
+      'utf-8',
+    ),
+  );
+
+  const iacAnalyticsFixture: IacAnalytics = JSON.parse(
+    fs.readFileSync(
+      path.join(__dirname, 'fixtures', 'iac-analytics.json'),
+      'utf-8',
+    ),
+  );
+
+  it('generates the correct analytics', async () => {
+    // Arrange
+    const testOutput = clonedeep(snykIacTestOutputFixture);
+    const expectedAnalytics = clonedeep(iacAnalyticsFixture);
+
+    // Act
+    const result = computeIacAnalytics(testOutput);
+
+    // Assert
+    expect(result).toStrictEqual(expectedAnalytics);
+  });
+});


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Computes analytics for the experimental test flow.
- Prints the analytics to the debug logs.
- **DOES NOT** send the analytics.

#### Where should the reviewer start?

```
src/lib/iac/test/v2/analytics
```

#### How should this be manually tested?

- Run `snyk iac test --experimental -d`
- Ensure the printed analytics are the expected ones.

#### Any background context you want to provide?

- The current implementation is discussed in [this Notion page](https://www.notion.so/snyk/Analytics-545ce0ef48e8459a94a8afa5b382b635). The page also describes the analytics that should be computed by the experimental flow, and some ideas for more analytics information that could be useful in the future.

- Because the analytics information that we are going to compute cannot be sent over the network yet, it will be sufficient to print them to a debug logger for the time being. The information we compute must not be shared with the analytics module in the CLI.

- This feature must be implemented in snyk and not in snyk-iac-test, because when we will eventually send the analytics over the network, we must use the analytics package as implemented in the CLI.

<details>
    <summary>IaC analytics example</summary>

  ```json
{
    "iac-type": {
        "armconfig": {
            "count": 1,
            "resource-count": 3
        },
        "cloudformationconfig": {
            "count": 2,
            "resource-count": 13
        },
        "terraformconfig": {
            "count": 10,
            "resource-count": 26,
            "low": 27,
            "high": 22,
            "medium": 10
        },
        "k8sconfig": {
            "count": 4,
            "resource-count": 5
        }
    },
    "packageManager": [
        "armconfig",
        "cloudformationconfig",
        "terraformconfig",
        "k8sconfig"
    ],
    "iac-issues-count": 59,
    "iac-ignored-issues-count": 0,
    "iac-files-count": 17,
    "iac-resources-count": 47,
    "iac-test-binary-version": "0.31.3"
}
  ```
</details>

#### What are the relevant tickets?

- [CFG-2157](https://snyksec.atlassian.net/browse/CFG-2157)