### PR TITLE
chore: Add Slack alerts for IaC smoke tests [CFG-2165]

### DIFF
--- a/.github/workflows/iac-smoke-tests-pulls.yml
+++ b/.github/workflows/iac-smoke-tests-pulls.yml
@@ -84,9 +84,11 @@ jobs:
 
           echo "::set-output name=is_changed::$IS_CHANGED"
 
-  run_iac_smoke_tests:
-    name: Run IaC smoke tests
+  run_iac_smoke_tests_pulls:
+    name: Run IaC smoke tests (Pull Requests)
     uses: ./.github/workflows/iac-smoke-tests.yml
     needs: check_for_changed_iac_files
     if: ${{ needs.check_for_changed_iac_files.outputs.is_changed == 'true' }}
     secrets: inherit
+    with:
+      is_skip_alert: true

--- a/.github/workflows/iac-smoke-tests.yml
+++ b/.github/workflows/iac-smoke-tests.yml
@@ -55,7 +55,7 @@ jobs:
           IAC_SMOKE_TESTS_SNYK_TOKEN: ${{ secrets.IAC_SMOKE_TESTS_SNYK_TOKEN }}
           TEST_SNYK_COMMAND: ${{ format('node {0}/dist/cli/index.js', github.workspace) }}
         run: |
-          npm run test:smoke:iac
+          npx jest --runInBand --testPathPattern '/test/smoke(/jest)?/iac/'
 
       - name: Run IaC smoke tests - Windows
         if: ${{ matrix.os == 'windows' }}
@@ -64,4 +64,4 @@ jobs:
           IAC_SMOKE_TESTS_SNYK_TOKEN: ${{ secrets.IAC_SMOKE_TESTS_SNYK_TOKEN }}
           TEST_SNYK_COMMAND: ${{ format('node {0}\dist\cli\index.js', github.workspace) }}
         run: |
-          npm run test:smoke:iac
+          npx jest --runInBand --testPathPattern '/test/smoke(/jest)?/iac/'

--- a/.github/workflows/iac-smoke-tests.yml
+++ b/.github/workflows/iac-smoke-tests.yml
@@ -6,9 +6,15 @@ on:
   release:
     types: [published]
   workflow_call:
+    inputs:
+      is_skip_alert:
+        type: boolean
+        required: true
+        default: false
 
 jobs:
-  run_iac_e2e_tests:
+  run_iac_smoke_tests:
+    name: Run IaC smoke tests
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
@@ -22,9 +28,10 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 15
+          node-version: 16.16.0
 
       - name: Install jq on macOS
+        id: test
         if: ${{ matrix.os == 'macos' }}
         run: |
           brew install jq
@@ -47,9 +54,10 @@ jobs:
 
       - name: Build Snyk CLI
         run: |
-          npm run build
+          npm run build:prod
 
       - name: Run IaC smoke tests - non-Windows
+        id: run_smoke_tests_non_windows
         if: ${{ matrix.os != 'windows' }}
         env:
           IAC_SMOKE_TESTS_SNYK_TOKEN: ${{ secrets.IAC_SMOKE_TESTS_SNYK_TOKEN }}
@@ -58,6 +66,7 @@ jobs:
           npx jest --runInBand --testPathPattern '/test/smoke(/jest)?/iac/'
 
       - name: Run IaC smoke tests - Windows
+        id: run_smoke_tests_windows
         if: ${{ matrix.os == 'windows' }}
         shell: pwsh
         env:
@@ -65,3 +74,25 @@ jobs:
           TEST_SNYK_COMMAND: ${{ format('node {0}\dist\cli\index.js', github.workspace) }}
         run: |
           npx jest --runInBand --testPathPattern '/test/smoke(/jest)?/iac/'
+
+  trigger_iac_cli_alert:
+    name: Alert for failed IaC smoke tests
+    needs: [run_iac_smoke_tests]
+    if: ${{ failure() && !inputs.is_skip_alert && needs.run_iac_smoke_tests.result == 'failures' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./packages/iac-cli-alert
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.16.0'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm start
+        env:
+          IAC_SMOKE_TESTS_SLACK_WEBHOOK_URL: ${{ secrets.IAC_SMOKE_TESTS_SLACK_WEBHOOK_URL }}
+          IAC_SMOKE_TESTS_OS: ${{ matrix.os }}

--- a/.github/workflows/iac-smoke-tests.yml
+++ b/.github/workflows/iac-smoke-tests.yml
@@ -78,7 +78,7 @@ jobs:
   trigger_iac_cli_alert:
     name: Alert for failed IaC smoke tests
     needs: [run_iac_smoke_tests]
-    if: ${{ failure() && !inputs.is_skip_alert && needs.run_iac_smoke_tests.result == 'failures' }}
+    if: ${{ failure() && !inputs.is_skip_alert && needs.run_iac_smoke_tests.result == 'failure' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -95,4 +95,3 @@ jobs:
       - run: npm start
         env:
           IAC_SMOKE_TESTS_SLACK_WEBHOOK_URL: ${{ secrets.IAC_SMOKE_TESTS_SLACK_WEBHOOK_URL }}
-          IAC_SMOKE_TESTS_OS: ${{ matrix.os }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2223,6 +2223,10 @@
         "lodash.values": "^4.3.0"
       }
     },
+    "node_modules/@snyk/iac-cli-alert": {
+      "resolved": "packages/iac-cli-alert",
+      "link": true
+    },
     "node_modules/@snyk/java-call-graph-builder": {
       "version": "1.23.6",
       "resolved": "https://registry.npmjs.org/@snyk/java-call-graph-builder/-/java-call-graph-builder-1.23.6.tgz",
@@ -19990,6 +19994,29 @@
         "node": ">=4.2.0"
       }
     },
+    "packages/iac-cli-alert": {
+      "name": "@snyk/iac-cli-alert",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@octokit/rest": "^18.0.5",
+        "@pagerduty/pdjs": "^2.2.0",
+        "@slack/webhook": "^5.0.3",
+        "typescript": "^4.0.2"
+      }
+    },
+    "packages/iac-cli-alert/node_modules/typescript": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "packages/snyk-fix": {
       "name": "@snyk/fix",
       "version": "1.0.0-monorepo",
@@ -21804,6 +21831,22 @@
         "lodash.transform": "^4.6.0",
         "lodash.union": "^4.6.0",
         "lodash.values": "^4.3.0"
+      }
+    },
+    "@snyk/iac-cli-alert": {
+      "version": "file:packages/iac-cli-alert",
+      "requires": {
+        "@octokit/rest": "^18.0.5",
+        "@pagerduty/pdjs": "^2.2.0",
+        "@slack/webhook": "^5.0.3",
+        "typescript": "^4.0.2"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.8.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+          "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig=="
+        }
       }
     },
     "@snyk/java-call-graph-builder": {

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "test:unit": "jest --runInBand --testPathPattern '/test(/jest)?/unit/'",
     "test:acceptance": "jest --runInBand --testPathPattern '/test(/jest)?/acceptance/'",
     "test:tap": "tap -Rspec --timeout=300 --node-arg=-r --node-arg=ts-node/register test/tap/*.test.* ",
-    "test:smoke": "./scripts/run-smoke-tests-locally.sh",
-    "test:smoke:iac": "jest --runInBand --testPathPattern '/test/smoke(/jest)?/iac/'"
+    "test:smoke": "./scripts/run-smoke-tests-locally.sh"
   },
   "keywords": [
     "security",

--- a/packages/iac-cli-alert/jest.config.js
+++ b/packages/iac-cli-alert/jest.config.js
@@ -1,0 +1,3 @@
+const { createJestConfig } = require('../../test/createJestConfig');
+
+module.exports = createJestConfig({ displayName: '@snyk/cli-alert' });

--- a/packages/iac-cli-alert/package.json
+++ b/packages/iac-cli-alert/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@snyk/iac-cli-alert",
+  "version": "1.0.0",
+  "description": "Script for alerting on failing IaC smoke tests",
+  "main": "dist/index.js",
+  "private": true,
+  "scripts": {
+    "start": "npm run build && node dist/index.js",
+    "build": "tsc",
+    "dev": "tsc -w"
+  },
+  "keywords": [],
+  "author": "snyk.io",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@slack/webhook": "^5.0.3",
+    "typescript": "^4.0.2"
+  }
+}

--- a/packages/iac-cli-alert/src/index.ts
+++ b/packages/iac-cli-alert/src/index.ts
@@ -1,0 +1,50 @@
+import {
+  IncomingWebhook,
+  IncomingWebhookDefaultArguments,
+} from '@slack/webhook';
+
+if (!process.env.IAC_SMOKE_TESTS_SLACK_WEBHOOK_URL) {
+  console.error(
+    'Missing the IAC_SMOKE_TESTS_SLACK_WEBHOOK_URL environment variable',
+  );
+  process.exit(1);
+}
+
+if (!process.env.IAC_SMOKE_TESTS_OS) {
+  console.error('Missing the IAC_SMOKE_TESTS_OS environment variable');
+  process.exit(1);
+}
+
+const IAC_SMOKE_TESTS_SLACK_WEBHOOK_URL =
+  process.env.IAC_SMOKE_TESTS_SLACK_WEBHOOK_URL;
+const IAC_SMOKE_TESTS_OS = process.env.IAC_SMOKE_TESTS_OS;
+
+const slackWebhook = new IncomingWebhook(IAC_SMOKE_TESTS_SLACK_WEBHOOK_URL);
+
+async function sendSlackAlert() {
+  console.log('IaC smoke tests failed. Sending Slack alert...');
+  const args: IncomingWebhookDefaultArguments = {
+    username: 'IaC CLI Alerts',
+    text: `An Infrastructure as Code Smoke Tests job failed. \n Operating system - ${IAC_SMOKE_TESTS_OS} \n<https://github.com/snyk/cli/actions?query=workflow%3A+%22Infrastructure+as+Code+Smoke+Tests%22|Infrastructure as Code Smoke Tests Results>`,
+    icon_emoji: 'snyk-iac',
+  };
+  await slackWebhook.send(args);
+  console.log('Slack alert sent.');
+}
+
+async function run() {
+  try {
+    await sendSlackAlert();
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+process.on('uncaughtException', (err) => {
+  console.error(err);
+  process.exit(1);
+});
+
+// Exec
+run();

--- a/packages/iac-cli-alert/src/index.ts
+++ b/packages/iac-cli-alert/src/index.ts
@@ -10,23 +10,16 @@ if (!process.env.IAC_SMOKE_TESTS_SLACK_WEBHOOK_URL) {
   process.exit(1);
 }
 
-if (!process.env.IAC_SMOKE_TESTS_OS) {
-  console.error('Missing the IAC_SMOKE_TESTS_OS environment variable');
-  process.exit(1);
-}
-
 const IAC_SMOKE_TESTS_SLACK_WEBHOOK_URL =
   process.env.IAC_SMOKE_TESTS_SLACK_WEBHOOK_URL;
-const IAC_SMOKE_TESTS_OS = process.env.IAC_SMOKE_TESTS_OS;
 
 const slackWebhook = new IncomingWebhook(IAC_SMOKE_TESTS_SLACK_WEBHOOK_URL);
 
 async function sendSlackAlert() {
   console.log('IaC smoke tests failed. Sending Slack alert...');
   const args: IncomingWebhookDefaultArguments = {
-    username: 'IaC CLI Alerts',
-    text: `An Infrastructure as Code Smoke Tests job failed. \n Operating system - ${IAC_SMOKE_TESTS_OS} \n<https://github.com/snyk/cli/actions?query=workflow%3A+%22Infrastructure+as+Code+Smoke+Tests%22|Infrastructure as Code Smoke Tests Results>`,
-    icon_emoji: 'snyk-iac',
+    text:
+      'An Infrastructure as Code Smoke Tests job failed. \n<https://github.com/snyk/cli/actions/workflows/iac-smoke-tests.yml?query=workflow%3A|Infrastructure as Code Smoke Tests Results>',
   };
   await slackWebhook.send(args);
   console.log('Slack alert sent.');

--- a/packages/iac-cli-alert/tsconfig.json
+++ b/packages/iac-cli-alert/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.settings.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["./src/**/*"]
+}

--- a/test/smoke/iac/test.spec.ts
+++ b/test/smoke/iac/test.spec.ts
@@ -1,6 +1,6 @@
 import { run } from '../../jest/acceptance/iac/helpers';
 
-jest.setTimeout(1_000 * 90);
+jest.setTimeout(1_000 * 120);
 
 describe('snyk iac test --experimental', () => {
   beforeAll(async () => {


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Adds Slack alerts for failing Snyk IaC smoke tests triggered by:
    - Scheduled executions.
    - Releases.
- These alerts will not be triggered by failing smoke tests triggered by pull requests.

#### Any background context you want to provide?

- As part of [CFG-2106](https://snyksec.atlassian.net/browse/CFG-2106), we created a smoke tests suite for the experimental test flow in the Snyk CLI. Further details can be found [here](https://github.com/snyk/cli/tree/chore/create-iac-e2e-tests-cfg-2106/test/smoke/iac). 
These tests are triggered for pull requests, new CLI releases, and are also scheduled to run every hour.

Failing tests can currently block pull requests to the master branch of `snyk/cli`.

We are currently not alerted whenever a smoke test fails after a CLI release or on a scheduled execution of these tests, and we would like to be.

Alerts should be routed to the [#group-infrastructure-as-code-alerts](https://snyk.slack.com/archives/C023NA9FQCU) Slack channel.


#### What are the relevant tickets?

- [CFG-2165](https://snyksec.atlassian.net/browse/CFG-2165)