### PR TITLE
feat: pass snykHttpClient to plugin.inspect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "snyk-cpp-plugin": "2.20.1",
         "snyk-docker-plugin": "^5.4.3",
         "snyk-go-plugin": "1.19.2",
-        "snyk-gradle-plugin": "3.22.2",
+        "snyk-gradle-plugin": "3.23.0",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.31.0",
         "snyk-nodejs-lockfile-parser": "1.38.0",
@@ -14321,6 +14321,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -16534,20 +16548,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/snyk-cpp-plugin/node_modules/p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/snyk-cpp-plugin/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -16839,9 +16839,9 @@
       }
     },
     "node_modules/snyk-gradle-plugin": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.22.2.tgz",
-      "integrity": "sha512-5zBsEEq9SrQI59OFAnalZJ5hWCKM/LF/JUa3x8F1HVayqNzjMSIqiNa4d4oleMzHo9Rp6QUih1I1J8nbtpwnHg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.23.0.tgz",
+      "integrity": "sha512-cx4frLM6UDdAi8h7XGPBBHNzAFj6mcgYRIwR2ibnE72CgIGx0gGZ7iMhjhlqFHTDgYNliQdAXb3GHB8V/UXFNw==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",
@@ -16849,11 +16849,12 @@
         "@types/debug": "^4.1.4",
         "chalk": "^3.0.0",
         "debug": "^4.1.1",
+        "p-map": "^4.0.0",
         "tmp": "0.2.1",
         "tslib": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       }
     },
     "node_modules/snyk-gradle-plugin/node_modules/@snyk/cli-interface": {
@@ -20059,19 +20060,6 @@
         "node": ">=8"
       }
     },
-    "packages/snyk-fix/node_modules/p-map": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "packages/snyk-fix/node_modules/strip-ansi": {
       "version": "6.0.0",
       "license": "MIT",
@@ -21718,12 +21706,6 @@
         },
         "has-flag": {
           "version": "4.0.0"
-        },
-        "p-map": {
-          "version": "4.0.0",
-          "requires": {
-            "aggregate-error": "^3.0.0"
-          }
         },
         "strip-ansi": {
           "version": "6.0.0",
@@ -31264,6 +31246,14 @@
         }
       }
     },
+    "p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
+    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -32932,14 +32922,6 @@
             "yallist": "^4.0.0"
           }
         },
-        "p-map": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-          "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-          "requires": {
-            "aggregate-error": "^3.0.0"
-          }
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -33178,9 +33160,9 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.22.2.tgz",
-      "integrity": "sha512-5zBsEEq9SrQI59OFAnalZJ5hWCKM/LF/JUa3x8F1HVayqNzjMSIqiNa4d4oleMzHo9Rp6QUih1I1J8nbtpwnHg==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.23.0.tgz",
+      "integrity": "sha512-cx4frLM6UDdAi8h7XGPBBHNzAFj6mcgYRIwR2ibnE72CgIGx0gGZ7iMhjhlqFHTDgYNliQdAXb3GHB8V/UXFNw==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",
@@ -33188,6 +33170,7 @@
         "@types/debug": "^4.1.4",
         "chalk": "^3.0.0",
         "debug": "^4.1.1",
+        "p-map": "^4.0.0",
         "tmp": "0.2.1",
         "tslib": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "snyk-cpp-plugin": "2.20.1",
     "snyk-docker-plugin": "^5.4.3",
     "snyk-go-plugin": "1.19.2",
-    "snyk-gradle-plugin": "3.22.2",
+    "snyk-gradle-plugin": "3.23.0",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.31.0",
     "snyk-nodejs-lockfile-parser": "1.38.0",

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -223,6 +223,7 @@ export function args(rawArgv: string[]): Args {
     'prune-repeated-subdependencies',
     'dry-run',
     'sequential',
+    'gradle-normalize-deps',
   ];
   for (const dashedArg of argumentsToTransform) {
     if (argv[dashedArg]) {

--- a/src/lib/module-info/index.ts
+++ b/src/lib/module-info/index.ts
@@ -10,6 +10,7 @@ export function ModuleInfo(plugin, policy) {
       root,
       targetFile,
       options,
+      snykHttpClient,
     ): Promise<pluginApi.SinglePackageResult | pluginApi.MultiProjectResult> {
       const pluginOptions = merge(
         {
@@ -19,7 +20,12 @@ export function ModuleInfo(plugin, policy) {
       );
 
       debug('calling plugin inspect()', { root, targetFile, pluginOptions });
-      const info = await plugin.inspect(root, targetFile, pluginOptions);
+      const info = await plugin.inspect(
+        root,
+        targetFile,
+        pluginOptions,
+        snykHttpClient,
+      );
       debug('plugin inspect() done');
 
       // attach policy if not provided by plugin

--- a/src/lib/plugins/get-single-plugin-result.ts
+++ b/src/lib/plugins/get-single-plugin-result.ts
@@ -2,6 +2,7 @@ import plugins = require('.');
 import { ModuleInfo } from '../module-info';
 import { legacyPlugin as pluginApi } from '@snyk/cli-interface';
 import { TestOptions, Options, MonitorOptions } from '../types';
+import { snykHttpClient } from '../request/snyk-http-client';
 
 export async function getSinglePluginResult(
   root: string,
@@ -14,6 +15,7 @@ export async function getSinglePluginResult(
     root,
     targetFile || options.file,
     { ...options },
+    snykHttpClient,
   );
   return inspectRes;
 }

--- a/src/lib/request/snyk-http-client.ts
+++ b/src/lib/request/snyk-http-client.ts
@@ -1,0 +1,39 @@
+import * as needle from 'needle';
+import { OutgoingHttpHeaders } from 'http';
+import { NeedleHttpVerbs } from 'needle';
+import { makeRequest } from '../request/index';
+import { getAuthHeader } from '../api-token';
+import config from '../config';
+import { Payload } from '../request/types';
+
+interface RequestInfo {
+  method: NeedleHttpVerbs;
+  path: string;
+  body: any;
+  headers?: OutgoingHttpHeaders;
+  qs?: {};
+  json?: boolean;
+  timeout?: number;
+  family?: number;
+}
+
+export async function snykHttpClient(
+  requestInfo: RequestInfo,
+): Promise<{
+  res: needle.NeedleResponse;
+  body: any;
+}> {
+  let { path } = requestInfo;
+  if (!path.startsWith('/')) path = `/${path}`;
+
+  const payload: Payload = {
+    ...requestInfo,
+    url: `${config.API_REST_URL}${path}`,
+    headers: {
+      ...requestInfo.headers,
+      Authorization: getAuthHeader(),
+    },
+  };
+
+  return makeRequest(payload);
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -225,7 +225,8 @@ export type SupportedUserReachableFacingCliArgs =
   | 'sub-project'
   | 'trust-policies'
   | 'yarn-workspaces'
-  | 'maven-aggregate-project';
+  | 'maven-aggregate-project'
+  | 'gradle-normalize-deps';
 
 export enum SupportedCliCommands {
   version = 'version',

--- a/test/tap/cli-monitor.acceptance.test.ts
+++ b/test/tap/cli-monitor.acceptance.test.ts
@@ -41,6 +41,7 @@ import { DepGraphBuilder } from '@snyk/dep-graph';
 import * as depGraphLib from '@snyk/dep-graph';
 import { getFixturePath } from '../jest/util/getFixturePath';
 import { getWorkspacePath } from '../jest/util/getWorkspacePath';
+import { snykHttpClient } from '../../src/lib/request/snyk-http-client';
 
 /*
   TODO: enable these tests, once we switch from node-tap
@@ -927,6 +928,7 @@ if (!isWindows) {
           packageManager: 'pip',
           path: 'pip-app',
         },
+        snykHttpClient,
       ],
       'calls python plugin',
     );
@@ -990,6 +992,7 @@ if (!isWindows) {
           packageManager: 'pip',
           path: 'pip-app',
         },
+        snykHttpClient,
       ],
       'calls python plugin',
     );
@@ -1042,6 +1045,7 @@ if (!isWindows) {
           file: 'build.gradle',
           path: 'gradle-app',
         },
+        snykHttpClient,
       ],
       'calls gradle plugin',
     );
@@ -1111,6 +1115,7 @@ if (!isWindows) {
           packageManager: 'gradle',
           path: 'gradle-app',
         },
+        snykHttpClient,
       ],
       'calls gradle plugin',
     );
@@ -1170,6 +1175,7 @@ if (!isWindows) {
           packageManager: 'gradle',
           path: 'gradle-app',
         },
+        snykHttpClient,
       ],
       'calls gradle plugin',
     );
@@ -1224,6 +1230,7 @@ if (!isWindows) {
           packageManager: 'gradle',
           path: 'gradle-app',
         },
+        snykHttpClient,
       ],
       'calls plugin for the 1st path',
     );
@@ -1239,6 +1246,7 @@ if (!isWindows) {
           packageManager: 'pip',
           path: 'pip-app',
         },
+        snykHttpClient,
       ],
       'calls plugin for the 2nd path',
     );
@@ -1316,6 +1324,7 @@ if (!isWindows) {
           packageManager: 'gomodules',
           path: 'golang-gomodules',
         },
+        snykHttpClient,
       ],
       'calls golang plugin',
     );
@@ -1364,6 +1373,7 @@ if (!isWindows) {
           packageManager: 'golangdep',
           path: 'golang-app',
         },
+        snykHttpClient,
       ],
       'calls golang plugin',
     );
@@ -1412,6 +1422,7 @@ if (!isWindows) {
           packageManager: 'govendor',
           path: 'golang-app',
         },
+        snykHttpClient,
       ],
       'calls golang plugin',
     );
@@ -1458,6 +1469,7 @@ if (!isWindows) {
           packageManager: 'cocoapods',
           path: './',
         },
+        snykHttpClient,
       ],
       'calls CocoaPods plugin',
     );
@@ -1506,6 +1518,7 @@ if (!isWindows) {
           packageManager: 'cocoapods',
           path: './',
         },
+        snykHttpClient,
       ],
       'calls CocoaPods plugin',
     );
@@ -1560,6 +1573,7 @@ if (!isWindows) {
           packageManager: 'cocoapods',
           path: './',
         },
+        snykHttpClient,
       ],
       'calls CocoaPods plugin',
     );

--- a/test/tap/cli-test.acceptance.test.ts
+++ b/test/tap/cli-test.acceptance.test.ts
@@ -65,6 +65,7 @@ const after = tap.runOnly ? only : test;
 // Should be after `process.env` setup.
 import * as plugins from '../../src/lib/plugins/index';
 import * as ecoSystemPlugins from '../../src/lib/ecosystems/plugins';
+import { snykHttpClient } from '../../src/lib/request/snyk-http-client';
 
 /*
   TODO: enable these tests, once we switch from node-tap
@@ -134,6 +135,7 @@ test('Languages', async (t) => {
           languageTest.tests[testName](
             { server, plugins, ecoSystemPlugins, versionNumber, cli },
             { chdirWorkspaces },
+            snykHttpClient,
           ),
         );
         server.restore();

--- a/test/tap/cli-test/cli-test.composer.spec.ts
+++ b/test/tap/cli-test/cli-test.composer.spec.ts
@@ -5,9 +5,11 @@ import { AcceptanceTests } from '../cli-test.acceptance.test';
 export const ComposerTests: AcceptanceTests = {
   language: 'Composer',
   tests: {
-    '`test composer-app --file=composer.lock`': (params, utils) => async (
-      t,
-    ) => {
+    '`test composer-app --file=composer.lock`': (
+      params,
+      utils,
+      snykHttpClient,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -49,14 +51,17 @@ export const ComposerTests: AcceptanceTests = {
             path: 'composer-app',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls composer plugin',
       );
     },
 
-    '`test composer-app` auto-detects composer.lock': (params, utils) => async (
-      t,
-    ) => {
+    '`test composer-app` auto-detects composer.lock': (
+      params,
+      utils,
+      snykHttpClient,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -96,14 +101,17 @@ export const ComposerTests: AcceptanceTests = {
             path: 'composer-app',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls composer plugin',
       );
     },
 
-    '`test composer-app --file=composer.lock --dev`': (params, utils) => async (
-      t,
-    ) => {
+    '`test composer-app --file=composer.lock --dev`': (
+      params,
+      utils,
+      snykHttpClient,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -147,6 +155,7 @@ export const ComposerTests: AcceptanceTests = {
             path: 'composer-app',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls composer plugin',
       );
@@ -155,6 +164,7 @@ export const ComposerTests: AcceptanceTests = {
     '`test composer-app golang-app nuget-app` auto-detects all three projects': (
       params,
       utils,
+      snykHttpClient,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -223,6 +233,7 @@ export const ComposerTests: AcceptanceTests = {
             path: 'composer-app',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls composer plugin',
       );
@@ -240,6 +251,7 @@ export const ComposerTests: AcceptanceTests = {
             path: 'golang-app',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls golangdep plugin',
       );
@@ -257,6 +269,7 @@ export const ComposerTests: AcceptanceTests = {
             path: 'nuget-app',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls nuget plugin',
       );

--- a/test/tap/cli-test/cli-test.elixir.spec.ts
+++ b/test/tap/cli-test/cli-test.elixir.spec.ts
@@ -5,7 +5,9 @@ import * as depGraphLib from '@snyk/dep-graph';
 export const ElixirTests: AcceptanceTests = {
   language: 'Elixir',
   tests: {
-    '`test elixir --file=mix.exs`': (params, utils) => async (t) => {
+    '`test elixir --file=mix.exs`': (params, utils, snykHttpClient) => async (
+      t,
+    ) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -52,12 +54,17 @@ export const ElixirTests: AcceptanceTests = {
             path: 'elixir-hex',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls golang plugin',
       );
     },
 
-    '`test elixir-hex` auto-detects hex': (params, utils) => async (t) => {
+    '`test elixir-hex` auto-detects hex': (
+      params,
+      utils,
+      snykHttpClient,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -103,6 +110,7 @@ export const ElixirTests: AcceptanceTests = {
             path: 'elixir-hex',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls elixir-hex plugin',
       );

--- a/test/tap/cli-test/cli-test.go.spec.ts
+++ b/test/tap/cli-test/cli-test.go.spec.ts
@@ -4,7 +4,11 @@ import { AcceptanceTests } from '../cli-test.acceptance.test';
 export const GoTests: AcceptanceTests = {
   language: 'Go',
   tests: {
-    '`test golang-gomodules --file=go.mod`': (params, utils) => async (t) => {
+    '`test golang-gomodules --file=go.mod`': (
+      params,
+      utils,
+      snykHttpClient,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -51,6 +55,7 @@ export const GoTests: AcceptanceTests = {
             path: 'golang-gomodules',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls golang plugin',
       );
@@ -59,6 +64,7 @@ export const GoTests: AcceptanceTests = {
     '`test golang-app` auto-detects golang-gomodules': (
       params,
       utils,
+      snykHttpClient,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -104,12 +110,17 @@ export const GoTests: AcceptanceTests = {
             path: 'golang-gomodules',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls golang-gomodules plugin',
       );
     },
 
-    '`test golang-app --file=Gopkg.lock`': (params, utils) => async (t) => {
+    '`test golang-app --file=Gopkg.lock`': (
+      params,
+      utils,
+      snykHttpClient,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -156,14 +167,17 @@ export const GoTests: AcceptanceTests = {
             path: 'golang-app',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls golang plugin',
       );
     },
 
-    '`test golang-app --file=vendor/vendor.json`': (params, utils) => async (
-      t,
-    ) => {
+    '`test golang-app --file=vendor/vendor.json`': (
+      params,
+      utils,
+      snykHttpClient,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -210,14 +224,17 @@ export const GoTests: AcceptanceTests = {
             path: 'golang-app',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls golang plugin',
       );
     },
 
-    '`test golang-app` auto-detects golang/dep': (params, utils) => async (
-      t,
-    ) => {
+    '`test golang-app` auto-detects golang/dep': (
+      params,
+      utils,
+      snykHttpClient,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -262,6 +279,7 @@ export const GoTests: AcceptanceTests = {
             path: 'golang-app',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls golang plugin',
       );
@@ -270,6 +288,7 @@ export const GoTests: AcceptanceTests = {
     '`test golang-app-govendor` auto-detects govendor': (
       params,
       utils,
+      snykHttpClient,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -310,6 +329,7 @@ export const GoTests: AcceptanceTests = {
             path: 'golang-app-govendor',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls golang plugin',
       );

--- a/test/tap/cli-test/cli-test.maven.spec.ts
+++ b/test/tap/cli-test/cli-test.maven.spec.ts
@@ -65,6 +65,7 @@ export const MavenTests: AcceptanceTests = {
     '`test maven-app-with-jars --file=example.jar` sends package info': (
       params,
       utils,
+      snykHttpClient,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -109,6 +110,7 @@ export const MavenTests: AcceptanceTests = {
             path: 'maven-app-with-jars',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls mvn plugin',
       );
@@ -117,6 +119,7 @@ export const MavenTests: AcceptanceTests = {
     '`test maven-app-with-jars --file=example.war` sends package info': (
       params,
       utils,
+      snykHttpClient,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -161,6 +164,7 @@ export const MavenTests: AcceptanceTests = {
             path: 'maven-app-with-jars',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls mvn plugin',
       );
@@ -169,6 +173,7 @@ export const MavenTests: AcceptanceTests = {
     '`test maven-app-with-jars --scan-all-unmanaged` sends package info': (
       params,
       utils,
+      snykHttpClient,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -211,6 +216,7 @@ export const MavenTests: AcceptanceTests = {
             showVulnPaths: 'some',
             scanAllUnmanaged: true,
           },
+          snykHttpClient,
         ],
         'calls mvn plugin',
       );

--- a/test/tap/cli-test/cli-test.nuget.spec.ts
+++ b/test/tap/cli-test/cli-test.nuget.spec.ts
@@ -27,6 +27,7 @@ export const NugetTests: AcceptanceTests = {
     '`test nuget-app-2 auto-detects project.assets.json`': (
       params,
       utils,
+      snykHttpClient,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -71,6 +72,7 @@ export const NugetTests: AcceptanceTests = {
             path: 'nuget-app-2',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls nuget plugin',
       );
@@ -79,6 +81,7 @@ export const NugetTests: AcceptanceTests = {
     '`test nuget-app-2.1 auto-detects obj/project.assets.json`': (
       params,
       utils,
+      snykHttpClient,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -123,6 +126,7 @@ export const NugetTests: AcceptanceTests = {
             path: 'nuget-app-2.1',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls nuget plugin',
       );
@@ -131,6 +135,7 @@ export const NugetTests: AcceptanceTests = {
     '`test nuget-app-4 auto-detects packages.config`': (
       params,
       utils,
+      snykHttpClient,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -176,14 +181,17 @@ export const NugetTests: AcceptanceTests = {
             path: 'nuget-app-4',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls nuget plugin',
       );
     },
 
-    '`test nuget-app --file=project.assets.json`': (params, utils) => async (
-      t,
-    ) => {
+    '`test nuget-app --file=project.assets.json`': (
+      params,
+      utils,
+      snykHttpClient,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -230,12 +238,17 @@ export const NugetTests: AcceptanceTests = {
             path: 'nuget-app',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls nuget plugin',
       );
     },
 
-    '`test nuget-app --file=packages.config`': (params, utils) => async (t) => {
+    '`test nuget-app --file=packages.config`': (
+      params,
+      utils,
+      snykHttpClient,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -282,12 +295,17 @@ export const NugetTests: AcceptanceTests = {
             path: 'nuget-app',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls nuget plugin',
       );
     },
 
-    '`test nuget-app --file=project.json`': (params, utils) => async (t) => {
+    '`test nuget-app --file=project.json`': (
+      params,
+      utils,
+      snykHttpClient,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -334,6 +352,7 @@ export const NugetTests: AcceptanceTests = {
             path: 'nuget-app',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls nuget plugin',
       );
@@ -342,6 +361,7 @@ export const NugetTests: AcceptanceTests = {
     '`test paket-app auto-detects paket.dependencies`': (
       params,
       utils,
+      snykHttpClient,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -387,6 +407,7 @@ export const NugetTests: AcceptanceTests = {
             path: 'paket-app',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls nuget plugin',
       );
@@ -395,6 +416,7 @@ export const NugetTests: AcceptanceTests = {
     '`test paket-obj-app auto-detects obj/project.assets.json if exists`': (
       params,
       utils,
+      snykHttpClient,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -440,14 +462,17 @@ export const NugetTests: AcceptanceTests = {
             path: 'paket-obj-app',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls nuget plugin',
       );
     },
 
-    '`test paket-app --file=paket.dependencies`': (params, utils) => async (
-      t,
-    ) => {
+    '`test paket-app --file=paket.dependencies`': (
+      params,
+      utils,
+      snykHttpClient,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -494,6 +519,7 @@ export const NugetTests: AcceptanceTests = {
             path: 'paket-app',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls nuget plugin',
       );

--- a/test/tap/cli-test/cli-test.python.spec.ts
+++ b/test/tap/cli-test/cli-test.python.spec.ts
@@ -6,7 +6,11 @@ import { loadJson } from '../../utils';
 export const PythonTests: AcceptanceTests = {
   language: 'Python',
   tests: {
-    '`test pip-app --file=requirements.txt`': (params, utils) => async (t) => {
+    '`test pip-app --file=requirements.txt`': (
+      params,
+      utils,
+      snykHttpClient,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -48,12 +52,17 @@ export const PythonTests: AcceptanceTests = {
             path: 'pip-app',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls python plugin',
       );
     },
 
-    '`test pipenv-app --file=Pipfile`': (params, utils) => async (t) => {
+    '`test pipenv-app --file=Pipfile`': (
+      params,
+      utils,
+      snykHttpClient,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -100,6 +109,7 @@ export const PythonTests: AcceptanceTests = {
             path: 'pipenv-app',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls python plugin',
       );
@@ -108,6 +118,7 @@ export const PythonTests: AcceptanceTests = {
     '`test pip-app-transitive-vuln --file=requirements.txt (actionableCliRemediation=false)`': (
       params,
       utils,
+      snykHttpClient,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -160,6 +171,7 @@ export const PythonTests: AcceptanceTests = {
             path: 'pip-app-transitive-vuln',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls python plugin',
       );
@@ -168,6 +180,7 @@ export const PythonTests: AcceptanceTests = {
     '`test pip-app-transitive-vuln --file=requirements.txt (actionableCliRemediation=true)`': (
       params,
       utils,
+      snykHttpClient,
     ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
@@ -223,11 +236,16 @@ export const PythonTests: AcceptanceTests = {
             path: 'pip-app-transitive-vuln',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls python plugin',
       );
     },
-    '`test setup_py-app --file=setup.py`': (params, utils) => async (t) => {
+    '`test setup_py-app --file=setup.py`': (
+      params,
+      utils,
+      snykHttpClient,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -275,6 +293,7 @@ export const PythonTests: AcceptanceTests = {
             path: 'setup_py-app',
             showVulnPaths: 'some',
           },
+          snykHttpClient,
         ],
         'calls python plugin',
       );


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Creates an HTTP request client wrapper that allows plugins to make authenticated requests to Snyk's backend.
Passes this as an additional argument to `plugin.inspect`

Introduced new snyk-gradle-plugin flag 'gradle-normalize-deps' see https://github.com/snyk/snyk-gradle-plugin/pull/226

