### PR TITLE
feat: add flag to exclude app vulnerabilities

### DIFF
--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -88,7 +88,10 @@ export default async function monitor(...args0: MethodArgs): Promise<any> {
   }
 
   // TODO remove once https://github.com/snyk/cli/pull/3433 is merged
-  if (options.docker && !options['app-vulns']) {
+  if (
+    options.docker &&
+    (!options['app-vulns'] || options['exclude-app-vulns'])
+  ) {
     options['exclude-app-vulns'] = true;
   }
 

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -89,7 +89,10 @@ export default async function test(
   }
 
   // TODO remove once https://github.com/snyk/cli/pull/3433 is merged
-  if (options.docker && !options['app-vulns']) {
+  if (
+    options.docker &&
+    (!options['app-vulns'] || options['exclude-app-vulns'])
+  ) {
     options['exclude-app-vulns'] = true;
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -73,6 +73,7 @@ export interface Options {
   experimental?: boolean;
   // Used with the Docker plugin only. Allows application scanning.
   'app-vulns'?: boolean;
+  'exclude-app-vulns'?: boolean;
   debug?: boolean;
   sarif?: boolean;
   'group-issues'?: boolean;
@@ -107,6 +108,7 @@ export interface MonitorOptions {
   experimental?: boolean;
   // Used with the Docker plugin only. Allows application scanning.
   'app-vulns'?: boolean;
+  'exclude-app-vulns'?: boolean;
   initScript?: string;
   yarnWorkspaces?: boolean;
   'max-depth'?: number;

--- a/test/jest/acceptance/snyk-test/app-vuln-container-project.spec.ts
+++ b/test/jest/acceptance/snyk-test/app-vuln-container-project.spec.ts
@@ -24,6 +24,30 @@ describe('container test projects behavior with --app-vulns, --file and --exclud
     expect(jsonOutput[1].uniqueCount).toBeGreaterThan(0);
     expect(code).toEqual(1);
   }, 10000);
+  it('should find nothing when app-vulns are explicitly disabled', async () => {
+    const { code, stdout } = await runSnykCLI(
+      `container test docker-archive:test/fixtures/container-projects/os-packages-and-app-vulns.tar --json --exclude-app-vulns`,
+    );
+    const jsonOutput = JSON.parse(stdout);
+    expect(Array.isArray(jsonOutput)).toBeFalsy();
+    expect(jsonOutput.applications).toBeUndefined();
+    expect(jsonOutput.ok).toEqual(false);
+    expect(jsonOutput.uniqueCount).toBeGreaterThan(0);
+    expect(code).toEqual(1);
+  }, 10000);
+  it('should find nothing on conflicting app-vulns flags', async () => {
+    // if both flags are set, --exclude-app-vulns should take precedence and
+    // disable it.
+    const { code, stdout } = await runSnykCLI(
+      `container test docker-archive:test/fixtures/container-projects/os-packages-and-app-vulns.tar --json --app-vulns --exclude-app-vulns --experimental`,
+    );
+    const jsonOutput = JSON.parse(stdout);
+    expect(Array.isArray(jsonOutput)).toBeFalsy();
+    expect(jsonOutput.applications).toBeUndefined();
+    expect(jsonOutput.ok).toEqual(false);
+    expect(jsonOutput.uniqueCount).toBeGreaterThan(0);
+    expect(code).toEqual(1);
+  }, 10000);
   it('should find all vulns when using --app-vulns without experimental flag', async () => {
     const { code, stdout } = await runSnykCLI(
       `container test docker-archive:test/fixtures/container-projects/os-packages-and-app-vulns.tar --json --app-vulns`,


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Although we already have a `--app-vulns` flag, the plan is to enable app-vulnerability scanning in containers by default. Before doing that, we want to give customers the opportunity to explicitly opt-out of the change in the default by introducing a new flag `--exclude-app-vulns`. This flag will co-exist with the `--app-vulns` flag until it's enabled by default, at which point the `--app-vulns` flag can be removed.

Additionally (second commit) it adds a warning message regarding the app-vuln enablement: 
<img width="1709" alt="image" src="https://user-images.githubusercontent.com/16387735/192969049-ce920d79-7d18-49d9-8e16-b450a5973ae3.png">

#### How should this be manually tested?

Run `snyk container test` without the `--app-vulns` flag, where the message should show up. Add `--json` and see how the message magically disappears :) 

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/MYC-163
https://snyksec.atlassian.net/browse/MYC-175
