### PR TITLE
feat: gradle plugin to use maven-deps /packages endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "snyk-cpp-plugin": "2.20.1",
         "snyk-docker-plugin": "^5.6.0",
         "snyk-go-plugin": "1.19.2",
-        "snyk-gradle-plugin": "3.23.0",
+        "snyk-gradle-plugin": "3.24.0",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.31.0",
         "snyk-nodejs-lockfile-parser": "1.38.0",
@@ -14358,6 +14358,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/packageurl-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-1.0.0.tgz",
+      "integrity": "sha512-06kNFU+yB2pjDf5JyXouQeKfwSScGP8hrZK6VgB+W4SlVy4y5yB4vl+AVmh3R0GBNd+fBt0dEiSx3HKmuchuJQ=="
+    },
     "node_modules/pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
@@ -16839,9 +16844,9 @@
       }
     },
     "node_modules/snyk-gradle-plugin": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.23.0.tgz",
-      "integrity": "sha512-cx4frLM6UDdAi8h7XGPBBHNzAFj6mcgYRIwR2ibnE72CgIGx0gGZ7iMhjhlqFHTDgYNliQdAXb3GHB8V/UXFNw==",
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.24.0.tgz",
+      "integrity": "sha512-AC2OPYoxq4BWoOGsIjJ75TaruvTtGnCJcjB6woMOC/sFM9YpaQnnhp02Aw4qxOD9MlG1wzRM1YgYXFZwCt3big==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",
@@ -16850,6 +16855,7 @@
         "chalk": "^3.0.0",
         "debug": "^4.1.1",
         "p-map": "^4.0.0",
+        "packageurl-js": "^1.0.0",
         "tmp": "0.2.1",
         "tslib": "^2.0.0"
       },
@@ -31271,6 +31277,11 @@
         "release-zalgo": "^1.0.0"
       }
     },
+    "packageurl-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-1.0.0.tgz",
+      "integrity": "sha512-06kNFU+yB2pjDf5JyXouQeKfwSScGP8hrZK6VgB+W4SlVy4y5yB4vl+AVmh3R0GBNd+fBt0dEiSx3HKmuchuJQ=="
+    },
     "pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
@@ -33160,9 +33171,9 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "3.23.0",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.23.0.tgz",
-      "integrity": "sha512-cx4frLM6UDdAi8h7XGPBBHNzAFj6mcgYRIwR2ibnE72CgIGx0gGZ7iMhjhlqFHTDgYNliQdAXb3GHB8V/UXFNw==",
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.24.0.tgz",
+      "integrity": "sha512-AC2OPYoxq4BWoOGsIjJ75TaruvTtGnCJcjB6woMOC/sFM9YpaQnnhp02Aw4qxOD9MlG1wzRM1YgYXFZwCt3big==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",
@@ -33171,6 +33182,7 @@
         "chalk": "^3.0.0",
         "debug": "^4.1.1",
         "p-map": "^4.0.0",
+        "packageurl-js": "^1.0.0",
         "tmp": "0.2.1",
         "tslib": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "snyk-cpp-plugin": "2.20.1",
     "snyk-docker-plugin": "^5.6.0",
     "snyk-go-plugin": "1.19.2",
-    "snyk-gradle-plugin": "3.23.0",
+    "snyk-gradle-plugin": "3.24.0",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.31.0",
     "snyk-nodejs-lockfile-parser": "1.38.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
- Bump `snyk-gradle-plugin` so that it uses the new `/rest/packages` endpoint exposed by [maven-deps](https://github.com/snyk/maven-deps/pull/1036) conforming to Snyk  REST API best practices.
