### PR TITLE
feat: add an info message to the new iac test command

### DIFF
--- a/src/lib/iac/test/v2/output.ts
+++ b/src/lib/iac/test/v2/output.ts
@@ -29,6 +29,10 @@ import {
   buildShareResultsSummaryV2,
   shouldPrintShareResultsTip,
 } from '../../../../cli/commands/test/iac/output';
+import {
+  colors,
+  contentPadding,
+} from '../../../formatters/iac-output/text/utils';
 
 export function buildOutput({
   scanResult,
@@ -180,6 +184,24 @@ function buildTextOutput({
   if (shouldPrintShareResultsTip(options)) {
     response += SEPARATOR + EOL + shareResultsTip + EOL;
   }
+
+  response += EOL;
+  response += colors.title('Info') + EOL;
+  response += EOL;
+  response +=
+    contentPadding +
+    `Your organization ${orgSettings.meta.org} is using Integrated IaC. To switch to Current IaC,` +
+    EOL;
+  response +=
+    contentPadding +
+    `use --org=<ORG_ID> to select a different organization. For more information about Integrated IaC, see:` +
+    EOL;
+  response += EOL;
+  response +=
+    contentPadding +
+    contentPadding +
+    'https://docs.snyk.io/products/snyk-infrastructure-as-code/snyk-cli-for-infrastructure-as-code/integrated-infrastructure-as-code' +
+    EOL;
 
   return response;
 }


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR adds an info message to the end of the new flow of the `snyk iac test` command.

#### How should this be manually tested?

Run the new flow of the `snyk iac test` command, with and without the `--report` flag, and check that the info message is printed correctly.

#### Screenshots

![image](https://user-images.githubusercontent.com/404227/193232233-bfd41807-1c7c-40b3-8627-7babcb05ea40.png)

![image](https://user-images.githubusercontent.com/404227/193232381-703fb487-3644-4c00-bff9-a2d258e5b22a.png)
