### PR TITLE
chore: Send integrated IaC test analytics

### DIFF
--- a/src/lib/iac/test/v2/analytics/index.ts
+++ b/src/lib/iac/test/v2/analytics/index.ts
@@ -2,45 +2,53 @@ import * as createDebugLogger from 'debug';
 
 import { policyEngineReleaseVersion } from '../local-cache/policy-engine/constants';
 import { ResourceKind, TestOutput } from '../scan/results';
+import * as analytics from '../../../../../lib/analytics';
 import { getIacType, IacType } from './iac-type';
 
 const debugLog = createDebugLogger('snyk-iac');
 
 export interface IacAnalytics {
+  iacType: IacType;
   packageManager: ResourceKind[];
-  'iac-type': IacType;
-  'iac-issues-count': number;
-  'iac-ignored-issues-count': number;
-  'iac-files-count': number;
-  'iac-resources-count': number;
-  'iac-test-binary-version': string;
-  'iac-error-codes': number[];
-  // 'iac-rules-bundle-version': string; // TODO: Add when we have the rules bundle version
+  iacIssuesCount: number;
+  iacIgnoredIssuesCount: number;
+  iacFilesCount: number;
+  iacResourcesCount: number;
+  iacErrorCodes: number[];
+  iacTestBinaryVersion: string;
+  // iacRulesBundleVersion: string; // TODO: Add when we have the rules bundle version
 }
 
 export function addIacAnalytics(testOutput: TestOutput): void {
   const iacAnalytics = computeIacAnalytics(testOutput);
 
-  debugLog(iacAnalytics);
+  analytics.add('iac-type', iacAnalytics.iacType);
+  analytics.add('packageManager', iacAnalytics.packageManager);
+  analytics.add('iac-issues-count', iacAnalytics.iacIssuesCount);
+  analytics.add('iac-ignored-issues-count', iacAnalytics.iacIgnoredIssuesCount);
+  analytics.add('iac-files-count', iacAnalytics.iacFilesCount);
+  analytics.add('iac-resources-count', iacAnalytics.iacResourcesCount);
+  analytics.add('iac-error-codes', iacAnalytics.iacErrorCodes);
+  analytics.add('iac-test-binary-version', iacAnalytics.iacTestBinaryVersion);
 }
 
-export function computeIacAnalytics(testOutput: TestOutput): IacAnalytics {
+function computeIacAnalytics(testOutput: TestOutput): IacAnalytics {
   const iacType = getIacType(testOutput);
 
   return {
-    'iac-type': iacType,
+    iacType,
     packageManager: Object.keys(iacType) as ResourceKind[],
-    'iac-issues-count': testOutput.results?.vulnerabilities?.length || 0,
-    'iac-ignored-issues-count':
+    iacIssuesCount: testOutput.results?.vulnerabilities?.length || 0,
+    iacIgnoredIssuesCount:
       testOutput.results?.scanAnalytics.ignoredCount || 0,
-    'iac-files-count': Object.values(iacType).reduce(
+    iacFilesCount: Object.values(iacType).reduce(
       (acc, packageManagerAnalytics) => acc + packageManagerAnalytics!.count,
       0,
     ),
-    'iac-resources-count': testOutput.results?.resources?.length || 0,
-    'iac-error-codes':
+    iacResourcesCount: testOutput.results?.resources?.length || 0,
+    iacErrorCodes:
       [...new Set(testOutput.errors?.map((error) => error.code!))] || [],
-    'iac-test-binary-version': policyEngineReleaseVersion,
-    // iacAnalytics['iac-rules-bundle-version'] = ''; // TODO: Add when we have the rules bundle version
+    iacTestBinaryVersion: policyEngineReleaseVersion,
+    // iacRulesBundleVersion = ''; // TODO: Add when we have the rules bundle version
   };
 }

--- a/test/jest/unit/lib/iac/test/v2/analytics/index.spec.ts
+++ b/test/jest/unit/lib/iac/test/v2/analytics/index.spec.ts
@@ -1,10 +1,11 @@
 import * as clonedeep from 'lodash.clonedeep';
 import * as path from 'path';
+import * as analytics from '../../../../../../../../src/lib/analytics';
 import * as fs from 'fs';
 
 import { SnykIacTestOutput } from '../../../../../../../../src/lib/iac/test/v2/scan/results';
 import {
-  computeIacAnalytics,
+  addIacAnalytics,
   IacAnalytics,
 } from '../../../../../../../../src/lib/iac/test/v2/analytics';
 
@@ -43,16 +44,25 @@ describe('computeIacAnalytics', () => {
       'utf-8',
     ),
   );
+  
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
-  it('generates the correct analytics', async () => {
+  it('sends the expected analytics', async () => {
     // Arrange
+    const addedAnalytics: Record<string, any> = {};
+    jest.spyOn(analytics, 'add').mockImplementation((key, value) => {
+      addedAnalytics[key] = value;
+    });
+
     const testOutput = clonedeep(snykIacTestOutputFixture);
     const expectedAnalytics = clonedeep(iacAnalyticsFixture);
 
     // Act
-    const result = computeIacAnalytics(testOutput);
+    addIacAnalytics(testOutput);
 
     // Assert
-    expect(result).toStrictEqual(expectedAnalytics);
+    expect(addedAnalytics).toStrictEqual(expectedAnalytics);
   });
 });


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Adds the analytics computed for the integrated IaC test flow to the Snyk CLI analytics.

#### Where should the reviewer start?

```
src/lib/iac/test/v2/analytics/index.ts
```

#### Any background context you want to provide?

- In [CFG-2157](https://snyksec.atlassian.net/browse/CFG-2157) we’ve computed the analytics we would like to save and after [coordinating with BI](https://snyk.slack.com/archives/CFVCSBXN0/p1663515295811279) we are ready to send them over the network to be saved.

- BI clarified that the new analytics should be saved in `snyk_cli_was_run` (which is the new 2nd “version” of `cli_tracking_data`).

- The CLI is using the [add](https://github.com/snyk/cli/blob/master/src/lib/analytics/index.ts#L125-L165) function to add new data to the metadata field of the analytics, then at the end of each scan the CLI sends those analytics [to registry to get processed](https://github.com/snyk/registry/blob/main/src/lib/analytics/cli.ts#L220-L346) and then saved, Avishag from team hammer [confirmed](https://snyk.slack.com/archives/CFVCSBXN0/p1663660426769049?thread_ts=1663515295.811279&cid=CFVCSBXN0) that this data is saved in both cli_tracking_data and snyk_cli_was_run.

#### What are the relevant tickets?

- [CFG-2169](https://snyksec.atlassian.net/browse/CFG-2169)