### PR TITLE
Snyk Protect: embed patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20089,11 +20089,45 @@
       },
       "devDependencies": {
         "cross-spawn": "^6.0.5",
-        "fs-extra": "^9.1.0"
+        "fs-extra": "^9.1.0",
+        "semver": "^7.3.7"
       },
       "engines": {
         "node": ">=10"
       }
+    },
+    "packages/snyk-protect/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/snyk-protect/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/snyk-protect/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     }
   },
   "dependencies": {
@@ -21851,7 +21885,34 @@
       "version": "file:packages/snyk-protect",
       "requires": {
         "cross-spawn": "^6.0.5",
-        "fs-extra": "^9.1.0"
+        "fs-extra": "^9.1.0",
+        "semver": "*"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
       }
     },
     "@snyk/rpm-parser": {

--- a/packages/snyk-protect/.gitignore
+++ b/packages/snyk-protect/.gitignore
@@ -1,0 +1,1 @@
+/patched-packages

--- a/packages/snyk-protect/embed-patches.js
+++ b/packages/snyk-protect/embed-patches.js
@@ -1,0 +1,177 @@
+/*
+  This script should be run only once
+  It will generate a list of all the patches available for all the static libraries taken from our S3 bucket
+*/
+
+const { execSync } = require('child_process');
+const semver = require('semver');
+const fs = require('fs');
+const { request } = require('./dist/lib/http'); // using a built version as not to add dependencies
+
+// List taken from our S3 bucket of all patches we offer
+const patchedLibraries = [
+  'axios',
+  'backbone',
+  'bassmaster',
+  'bl',
+  'call',
+  'connect',
+  'debug',
+  'ejs',
+  'electron-packager',
+  'engine.io-client',
+  'ep_imageconvert',
+  'extend',
+  'geddy',
+  'gm',
+  'handlebars',
+  'hapi',
+  'hawk',
+  'hoek',
+  'http-signature',
+  'https-proxy-agent',
+  'i18n-node-angular',
+  'inert',
+  'is-my-json-valid',
+  'jsonwebtoken',
+  'keystone',
+  'ldapauth-fork',
+  'libnotify',
+  'lodash',
+  'mapbox.js',
+  'markdown-it',
+  'marked',
+  'millisecond',
+  'mime',
+  'minimatch',
+  'moment',
+  'mongoose',
+  'ms',
+  'mustache',
+  'negotiator',
+  'node-uuid',
+  'printer',
+  'qs',
+  'request',
+  'secure-compare',
+  'semver',
+  'send',
+  'sequelize',
+  'serve-index',
+  'serve-static',
+  'shell-quote',
+  'shout',
+  'st',
+  'stringstream',
+  'tar',
+  'tomato',
+  'tough-cookie',
+  'tree-kill',
+  'tunnel-agent',
+  'uglify-js',
+  'validator',
+  'ws',
+  'yar',
+];
+
+/**
+ * @description Generate a JSON file with all the patches available
+ * Find existing versions for all libraries with patches
+ * Test each library-version with the Snyk Test to get the patches
+ * Save the patches data in a JSON file
+ * Save actual patches to disk
+ */
+async function generate(resultsFile = 'patches.json') {
+  const finalPatches = fs.existsSync(resultsFile)
+    ? JSON.parse(fs.readFileSync(resultsFile, 'utf8'))
+    : [];
+
+  let libraryVersionsToCheck = 0;
+  for (const libraryName of patchedLibraries) {
+    console.log(libraryName);
+    if (fs.existsSync(`./patched-packages/${libraryName}.json`)) {
+      // "cache" folder to allow rerunning the script
+      console.log('  Skipping, already processed\n');
+      continue;
+    }
+    let libraryPatches = [];
+    const libraryVersions = JSON.parse(
+      // An _issue_ with this approach is that this skips library versions marked as deprecated on the npm
+      execSync(`npm view ${libraryName} versions --json --silent`),
+    );
+    console.log('  Versions to check:', libraryVersions.length);
+    console.log('  Versions with patches:');
+    libraryVersionsToCheck += libraryVersions.length;
+    for (const libraryVersion of libraryVersions) {
+      try {
+        execSync(
+          `SNYK_API=https://dev.snyk.io/api snyk test ${libraryName}@${libraryVersion} --json`,
+          {
+            maxBuffer: 1024 * 1024 * 10, // for really long snyk responses
+          },
+        );
+        // Nothing to do for no vulns
+      } catch (error) {
+        const snykTestResult = JSON.parse(error.stdout.toString());
+        for (const vulnerability of snykTestResult.vulnerabilities) {
+          if (
+            vulnerability.moduleName === libraryName && // don't check for transient vulns
+            vulnerability.isPatchable
+          ) {
+            console.log('    -', libraryVersion);
+            libraryPatches.push({
+              vulnerabilityId: vulnerability.id,
+              libraryVersion,
+              patches: vulnerability.patches,
+            });
+          }
+        }
+      }
+    }
+    console.log('\n');
+    fs.writeFileSync(
+      `patched-packages/${libraryName}.json`,
+      JSON.stringify(libraryPatches, null, 2),
+    );
+    finalPatches.push(...libraryPatches);
+    fs.writeFileSync(resultsFile, JSON.stringify(finalPatches, null, 2));
+  }
+
+  console.log('Checked versions:', libraryVersionsToCheck);
+
+  const patchesToDownload = [];
+  finalPatches.map((patchMetadata) => {
+    const libraryVersion = patchMetadata.libraryVersion;
+    patchMetadata.patches = patchMetadata.patches.filter((patch) => {
+      return semver.satisfies(libraryVersion, patch.version);
+    });
+    patchMetadata.patches = patchMetadata.patches.map((patch) => {
+      delete patch.id; // We don't need these fields
+      delete patch.comments;
+      delete patch.modificationTime;
+      patch.urls.forEach(async (url) => {
+        const patchFilename = url.split('/').pop();
+        if (fs.existsSync('patches/' + patchFilename)) {
+          return;
+        }
+        patchesToDownload.push({
+          url,
+          patchFilename,
+        });
+      });
+      patch.urls = patch.urls.map((url) => {
+        return url.split('/').pop();
+      });
+      return patch;
+    });
+    return patchMetadata;
+  });
+  fs.writeFileSync(resultsFile, JSON.stringify(finalPatches, null, 2));
+
+  patchesToDownload.forEach(async ({ url, patchFilename }) => {
+    const { body: diff } = await request(url); // Download patches from the URL
+    fs.writeFileSync('patches/' + patchFilename, diff);
+  });
+}
+
+generate();

--- a/packages/snyk-protect/package.json
+++ b/packages/snyk-protect/package.json
@@ -10,7 +10,9 @@
     "bin",
     "SECURITY.md",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "patches.json",
+    "patches"
   ],
   "directories": {
     "lib": "src",
@@ -28,7 +30,8 @@
     "test:unit": "jest \"/test/unit/((.+)/)*[^/]+\\.spec\\.ts\"",
     "test:acceptance": "jest \"/test/acceptance/((.+)/)*[^/]+\\.spec\\.ts\"",
     "test:smoke": "jest \"/test/acceptance/((.+)/)*[^/]+\\.smoke\\.spec\\.ts\"",
-    "format": "prettier --write '{src,test,scripts}/**/*.{js,ts}'"
+    "format": "prettier --write '{src,test,scripts}/**/*.{js,ts}'",
+    "embed-patches": "npm run build && node ./embed-patches.js"
   },
   "keywords": [
     "security",
@@ -53,6 +56,7 @@
   },
   "devDependencies": {
     "cross-spawn": "^6.0.5",
-    "fs-extra": "^9.1.0"
+    "fs-extra": "^9.1.0",
+    "semver": "^7.3.7"
   }
 }

--- a/packages/snyk-protect/patches.json
+++ b/packages/snyk-protect/patches.json
@@ -1048,9 +1048,7 @@
     "libraryVersion": "3.0.2",
     "patches": [
       {
-        "urls": [
-          "handlebars_0.patch"
-        ],
+        "urls": ["handlebars_0.patch"],
         "version": "<4.0.0 >=3.0.2"
       }
     ]
@@ -1060,9 +1058,7 @@
     "libraryVersion": "3.0.3",
     "patches": [
       {
-        "urls": [
-          "handlebars_0.patch"
-        ],
+        "urls": ["handlebars_0.patch"],
         "version": "<4.0.0 >=3.0.2"
       }
     ]
@@ -1072,9 +1068,7 @@
     "libraryVersion": "3.0.4",
     "patches": [
       {
-        "urls": [
-          "handlebars_0.patch"
-        ],
+        "urls": ["handlebars_0.patch"],
         "version": "<4.0.0 >=3.0.2"
       }
     ]
@@ -1084,9 +1078,7 @@
     "libraryVersion": "3.0.5",
     "patches": [
       {
-        "urls": [
-          "handlebars_0.patch"
-        ],
+        "urls": ["handlebars_0.patch"],
         "version": "<4.0.0 >=3.0.2"
       }
     ]
@@ -1096,9 +1088,7 @@
     "libraryVersion": "3.0.6",
     "patches": [
       {
-        "urls": [
-          "handlebars_0.patch"
-        ],
+        "urls": ["handlebars_0.patch"],
         "version": "<4.0.0 >=3.0.2"
       }
     ]
@@ -1108,9 +1098,7 @@
     "libraryVersion": "3.0.7",
     "patches": [
       {
-        "urls": [
-          "handlebars_0.patch"
-        ],
+        "urls": ["handlebars_0.patch"],
         "version": "<4.0.0 >=3.0.2"
       }
     ]
@@ -1120,9 +1108,7 @@
     "libraryVersion": "3.0.8",
     "patches": [
       {
-        "urls": [
-          "handlebars_0.patch"
-        ],
+        "urls": ["handlebars_0.patch"],
         "version": "<4.0.0 >=3.0.2"
       }
     ]
@@ -1996,9 +1982,7 @@
     "libraryVersion": "2.2.1",
     "patches": [
       {
-        "urls": [
-          "https-proxy-agent_0_0_20190929.patch"
-        ],
+        "urls": ["https-proxy-agent_0_0_20190929.patch"],
         "version": "=2.2.1"
       }
     ]
@@ -2008,9 +1992,7 @@
     "libraryVersion": "2.2.2",
     "patches": [
       {
-        "urls": [
-          "https-proxy-agent_0_1_20190929.patch"
-        ],
+        "urls": ["https-proxy-agent_0_1_20190929.patch"],
         "version": "=2.2.2"
       }
     ]
@@ -2596,9 +2578,7 @@
     "libraryVersion": "0.3.13",
     "patches": [
       {
-        "urls": [
-          "v0.3.15.patch"
-        ],
+        "urls": ["v0.3.15.patch"],
         "version": "<0.3.16 >=0.3.13"
       }
     ]
@@ -2608,9 +2588,7 @@
     "libraryVersion": "0.3.14",
     "patches": [
       {
-        "urls": [
-          "v0.3.15.patch"
-        ],
+        "urls": ["v0.3.15.patch"],
         "version": "<0.3.16 >=0.3.13"
       }
     ]
@@ -2620,9 +2598,7 @@
     "libraryVersion": "0.3.15",
     "patches": [
       {
-        "urls": [
-          "v0.3.15.patch"
-        ],
+        "urls": ["v0.3.15.patch"],
         "version": "<0.3.16 >=0.3.13"
       }
     ]
@@ -3988,9 +3964,7 @@
     "libraryVersion": "2.12.0",
     "patches": [
       {
-        "urls": [
-          "moment_20161019_0_0.patch"
-        ],
+        "urls": ["moment_20161019_0_0.patch"],
         "version": "<2.14.0 >=2.12.0"
       }
     ]
@@ -4000,9 +3974,7 @@
     "libraryVersion": "2.13.0",
     "patches": [
       {
-        "urls": [
-          "moment_20161019_0_0.patch"
-        ],
+        "urls": ["moment_20161019_0_0.patch"],
         "version": "<2.14.0 >=2.12.0"
       }
     ]
@@ -4012,9 +3984,7 @@
     "libraryVersion": "2.14.0",
     "patches": [
       {
-        "urls": [
-          "moment_20161019_0_1.patch"
-        ],
+        "urls": ["moment_20161019_0_1.patch"],
         "version": "<2.15.2 >=2.14.0"
       }
     ]
@@ -4024,9 +3994,7 @@
     "libraryVersion": "2.14.1",
     "patches": [
       {
-        "urls": [
-          "moment_20161019_0_1.patch"
-        ],
+        "urls": ["moment_20161019_0_1.patch"],
         "version": "<2.15.2 >=2.14.0"
       }
     ]
@@ -4036,9 +4004,7 @@
     "libraryVersion": "2.15.0",
     "patches": [
       {
-        "urls": [
-          "moment_20161019_0_1.patch"
-        ],
+        "urls": ["moment_20161019_0_1.patch"],
         "version": "<2.15.2 >=2.14.0"
       }
     ]
@@ -4048,9 +4014,7 @@
     "libraryVersion": "2.15.1",
     "patches": [
       {
-        "urls": [
-          "moment_20161019_0_1.patch"
-        ],
+        "urls": ["moment_20161019_0_1.patch"],
         "version": "<2.15.2 >=2.14.0"
       }
     ]
@@ -4060,9 +4024,7 @@
     "libraryVersion": "2.16.0",
     "patches": [
       {
-        "urls": [
-          "moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"
-        ],
+        "urls": ["moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"],
         "version": "<2.19.3 >=2.16.0"
       }
     ]
@@ -4072,9 +4034,7 @@
     "libraryVersion": "2.17.0",
     "patches": [
       {
-        "urls": [
-          "moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"
-        ],
+        "urls": ["moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"],
         "version": "<2.19.3 >=2.16.0"
       }
     ]
@@ -4084,9 +4044,7 @@
     "libraryVersion": "2.17.1",
     "patches": [
       {
-        "urls": [
-          "moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"
-        ],
+        "urls": ["moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"],
         "version": "<2.19.3 >=2.16.0"
       }
     ]
@@ -4096,9 +4054,7 @@
     "libraryVersion": "2.18.0",
     "patches": [
       {
-        "urls": [
-          "moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"
-        ],
+        "urls": ["moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"],
         "version": "<2.19.3 >=2.16.0"
       }
     ]
@@ -4108,9 +4064,7 @@
     "libraryVersion": "2.18.1",
     "patches": [
       {
-        "urls": [
-          "moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"
-        ],
+        "urls": ["moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"],
         "version": "<2.19.3 >=2.16.0"
       }
     ]
@@ -4120,9 +4074,7 @@
     "libraryVersion": "2.19.0",
     "patches": [
       {
-        "urls": [
-          "moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"
-        ],
+        "urls": ["moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"],
         "version": "<2.19.3 >=2.16.0"
       }
     ]
@@ -4132,9 +4084,7 @@
     "libraryVersion": "2.19.1",
     "patches": [
       {
-        "urls": [
-          "moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"
-        ],
+        "urls": ["moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"],
         "version": "<2.19.3 >=2.16.0"
       }
     ]
@@ -4144,9 +4094,7 @@
     "libraryVersion": "2.19.2",
     "patches": [
       {
-        "urls": [
-          "moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"
-        ],
+        "urls": ["moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"],
         "version": "<2.19.3 >=2.16.0"
       }
     ]
@@ -5602,9 +5550,7 @@
     "libraryVersion": "0.7.1",
     "patches": [
       {
-        "urls": [
-          "ms_071.patch"
-        ],
+        "urls": ["ms_071.patch"],
         "version": "=0.7.1"
       }
     ]
@@ -5614,9 +5560,7 @@
     "libraryVersion": "0.7.2",
     "patches": [
       {
-        "urls": [
-          "ms_072-073.patch"
-        ],
+        "urls": ["ms_072-073.patch"],
         "version": "=0.7.2 || =0.7.3"
       }
     ]
@@ -5626,9 +5570,7 @@
     "libraryVersion": "0.7.3",
     "patches": [
       {
-        "urls": [
-          "ms_072-073.patch"
-        ],
+        "urls": ["ms_072-073.patch"],
         "version": "=0.7.2 || =0.7.3"
       }
     ]
@@ -5638,9 +5580,7 @@
     "libraryVersion": "1.0.0",
     "patches": [
       {
-        "urls": [
-          "ms_100.patch"
-        ],
+        "urls": ["ms_100.patch"],
         "version": "=1.0.0"
       }
     ]
@@ -5650,9 +5590,7 @@
     "libraryVersion": "2.1.0",
     "patches": [
       {
-        "urls": [
-          "mustache_0.patch"
-        ],
+        "urls": ["mustache_0.patch"],
         "version": "<2.2.1 >=2.1.0"
       }
     ]
@@ -5662,9 +5600,7 @@
     "libraryVersion": "2.1.1",
     "patches": [
       {
-        "urls": [
-          "mustache_0.patch"
-        ],
+        "urls": ["mustache_0.patch"],
         "version": "<2.2.1 >=2.1.0"
       }
     ]
@@ -5674,9 +5610,7 @@
     "libraryVersion": "2.1.2",
     "patches": [
       {
-        "urls": [
-          "mustache_0.patch"
-        ],
+        "urls": ["mustache_0.patch"],
         "version": "<2.2.1 >=2.1.0"
       }
     ]
@@ -5686,9 +5620,7 @@
     "libraryVersion": "2.1.3",
     "patches": [
       {
-        "urls": [
-          "mustache_0.patch"
-        ],
+        "urls": ["mustache_0.patch"],
         "version": "<2.2.1 >=2.1.0"
       }
     ]
@@ -5698,9 +5630,7 @@
     "libraryVersion": "2.2.0",
     "patches": [
       {
-        "urls": [
-          "mustache_0.patch"
-        ],
+        "urls": ["mustache_0.patch"],
         "version": "<2.2.1 >=2.1.0"
       }
     ]
@@ -6022,9 +5952,7 @@
     "libraryVersion": "0.5.6",
     "patches": [
       {
-        "urls": [
-          "qs_20140806_0_1_snyk_npm.patch"
-        ],
+        "urls": ["qs_20140806_0_1_snyk_npm.patch"],
         "version": "=0.5.6"
       }
     ]
@@ -6034,9 +5962,7 @@
     "libraryVersion": "0.5.6",
     "patches": [
       {
-        "urls": [
-          "qs_20140806-1_0_1_snyk.patch"
-        ],
+        "urls": ["qs_20140806-1_0_1_snyk.patch"],
         "version": "=0.5.6"
       }
     ]
@@ -6058,9 +5984,7 @@
     "libraryVersion": "0.6.5",
     "patches": [
       {
-        "urls": [
-          "qs_20140806-1_0_0_snyk.patch"
-        ],
+        "urls": ["qs_20140806-1_0_0_snyk.patch"],
         "version": "<1.0.0 >=0.6.5"
       }
     ]
@@ -6082,9 +6006,7 @@
     "libraryVersion": "0.6.6",
     "patches": [
       {
-        "urls": [
-          "qs_20140806-1_0_0_snyk.patch"
-        ],
+        "urls": ["qs_20140806-1_0_0_snyk.patch"],
         "version": "<1.0.0 >=0.6.5"
       }
     ]
@@ -6094,9 +6016,7 @@
     "libraryVersion": "6.0.2",
     "patches": [
       {
-        "urls": [
-          "602_604.patch"
-        ],
+        "urls": ["602_604.patch"],
         "version": "=6.0.2"
       }
     ]
@@ -6106,9 +6026,7 @@
     "libraryVersion": "6.0.3",
     "patches": [
       {
-        "urls": [
-          "603_604.patch"
-        ],
+        "urls": ["603_604.patch"],
         "version": "=6.0.3"
       }
     ]
@@ -6118,9 +6036,7 @@
     "libraryVersion": "6.1.0",
     "patches": [
       {
-        "urls": [
-          "610_612.patch"
-        ],
+        "urls": ["610_612.patch"],
         "version": "=6.1.0"
       }
     ]
@@ -6130,9 +6046,7 @@
     "libraryVersion": "6.1.1",
     "patches": [
       {
-        "urls": [
-          "611_612.patch"
-        ],
+        "urls": ["611_612.patch"],
         "version": "=6.1.1"
       }
     ]
@@ -6142,9 +6056,7 @@
     "libraryVersion": "6.2.1",
     "patches": [
       {
-        "urls": [
-          "621_623.patch"
-        ],
+        "urls": ["621_623.patch"],
         "version": "=6.2.1"
       }
     ]
@@ -6154,9 +6066,7 @@
     "libraryVersion": "6.2.2",
     "patches": [
       {
-        "urls": [
-          "622_623.patch"
-        ],
+        "urls": ["622_623.patch"],
         "version": "=6.2.2"
       }
     ]
@@ -6166,9 +6076,7 @@
     "libraryVersion": "6.3.0",
     "patches": [
       {
-        "urls": [
-          "630_632.patch"
-        ],
+        "urls": ["630_632.patch"],
         "version": "=6.3.0"
       }
     ]
@@ -6178,9 +6086,7 @@
     "libraryVersion": "6.3.1",
     "patches": [
       {
-        "urls": [
-          "631_632.patch"
-        ],
+        "urls": ["631_632.patch"],
         "version": "=6.3.1"
       }
     ]
@@ -8290,9 +8196,7 @@
     "libraryVersion": "1.4.3",
     "patches": [
       {
-        "urls": [
-          "shell-quote_20160621_0_0.patch"
-        ],
+        "urls": ["shell-quote_20160621_0_0.patch"],
         "version": "<=1.6.0 >1.4.2"
       }
     ]
@@ -8302,9 +8206,7 @@
     "libraryVersion": "1.5.0",
     "patches": [
       {
-        "urls": [
-          "shell-quote_20160621_0_0.patch"
-        ],
+        "urls": ["shell-quote_20160621_0_0.patch"],
         "version": "<=1.6.0 >1.4.2"
       }
     ]
@@ -8314,9 +8216,7 @@
     "libraryVersion": "1.6.0",
     "patches": [
       {
-        "urls": [
-          "shell-quote_20160621_0_0.patch"
-        ],
+        "urls": ["shell-quote_20160621_0_0.patch"],
         "version": "<=1.6.0 >1.4.2"
       }
     ]
@@ -8830,9 +8730,7 @@
     "libraryVersion": "2.2.0",
     "patches": [
       {
-        "urls": [
-          "220_221.patch"
-        ],
+        "urls": ["220_221.patch"],
         "version": "=2.2.0 || =2.2.1"
       }
     ]
@@ -8854,9 +8752,7 @@
     "libraryVersion": "2.2.1",
     "patches": [
       {
-        "urls": [
-          "220_221.patch"
-        ],
+        "urls": ["220_221.patch"],
         "version": "=2.2.0 || =2.2.1"
       }
     ]
@@ -8878,9 +8774,7 @@
     "libraryVersion": "2.2.2",
     "patches": [
       {
-        "urls": [
-          "222.patch"
-        ],
+        "urls": ["222.patch"],
         "version": "=2.2.2"
       }
     ]
@@ -8890,9 +8784,7 @@
     "libraryVersion": "2.3.0",
     "patches": [
       {
-        "urls": [
-          "230_232.patch"
-        ],
+        "urls": ["230_232.patch"],
         "version": "=2.3.0 || =2.3.1 || =2.3.2"
       }
     ]
@@ -8902,9 +8794,7 @@
     "libraryVersion": "2.3.1",
     "patches": [
       {
-        "urls": [
-          "230_232.patch"
-        ],
+        "urls": ["230_232.patch"],
         "version": "=2.3.0 || =2.3.1 || =2.3.2"
       }
     ]
@@ -8914,9 +8804,7 @@
     "libraryVersion": "2.3.2",
     "patches": [
       {
-        "urls": [
-          "230_232.patch"
-        ],
+        "urls": ["230_232.patch"],
         "version": "=2.3.0 || =2.3.1 || =2.3.2"
       }
     ]
@@ -9010,9 +8898,7 @@
     "libraryVersion": "2.2.0",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9034,9 +8920,7 @@
     "libraryVersion": "2.2.1",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9058,9 +8942,7 @@
     "libraryVersion": "2.2.2",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9082,9 +8964,7 @@
     "libraryVersion": "2.2.3",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9106,9 +8986,7 @@
     "libraryVersion": "2.2.4",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9130,9 +9008,7 @@
     "libraryVersion": "2.2.5",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9154,9 +9030,7 @@
     "libraryVersion": "2.3.0",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9178,9 +9052,7 @@
     "libraryVersion": "2.3.1",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9202,9 +9074,7 @@
     "libraryVersion": "2.3.2",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9226,9 +9096,7 @@
     "libraryVersion": "2.3.3",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9250,9 +9118,7 @@
     "libraryVersion": "2.3.4",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9274,9 +9140,7 @@
     "libraryVersion": "2.3.5",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9298,9 +9162,7 @@
     "libraryVersion": "2.3.6",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9322,9 +9184,7 @@
     "libraryVersion": "2.4.0",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9346,9 +9206,7 @@
     "libraryVersion": "2.4.1",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9370,9 +9228,7 @@
     "libraryVersion": "2.4.2",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9394,9 +9250,7 @@
     "libraryVersion": "2.4.3",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9418,9 +9272,7 @@
     "libraryVersion": "2.4.4",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9442,9 +9294,7 @@
     "libraryVersion": "2.4.5",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9466,9 +9316,7 @@
     "libraryVersion": "2.4.6",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9490,9 +9338,7 @@
     "libraryVersion": "2.4.7",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9514,9 +9360,7 @@
     "libraryVersion": "2.4.8",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9538,9 +9382,7 @@
     "libraryVersion": "2.4.9",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9562,9 +9404,7 @@
     "libraryVersion": "2.4.10",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9586,9 +9426,7 @@
     "libraryVersion": "2.4.11",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9610,9 +9448,7 @@
     "libraryVersion": "2.4.12",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9634,9 +9470,7 @@
     "libraryVersion": "2.4.13",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9658,9 +9492,7 @@
     "libraryVersion": "2.4.14",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9682,9 +9514,7 @@
     "libraryVersion": "2.4.15",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9706,9 +9536,7 @@
     "libraryVersion": "2.4.16",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9730,9 +9558,7 @@
     "libraryVersion": "2.4.17",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9754,9 +9580,7 @@
     "libraryVersion": "2.4.18",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9778,9 +9602,7 @@
     "libraryVersion": "2.4.19",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9802,9 +9624,7 @@
     "libraryVersion": "2.4.20",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9826,9 +9646,7 @@
     "libraryVersion": "2.4.21",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9850,9 +9668,7 @@
     "libraryVersion": "2.4.22",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9874,9 +9690,7 @@
     "libraryVersion": "2.4.23",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"],
         "version": "<= 2.4.23 >=2.2.0"
       }
     ]
@@ -9886,9 +9700,7 @@
     "libraryVersion": "2.4.24",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk.patch"],
         "version": "<2.6.0 >2.4.23"
       }
     ]
@@ -9898,9 +9710,7 @@
     "libraryVersion": "2.5.0",
     "patches": [
       {
-        "urls": [
-          "uglify-js_20151024_0_0_63d35f8_snyk.patch"
-        ],
+        "urls": ["uglify-js_20151024_0_0_63d35f8_snyk.patch"],
         "version": "<2.6.0 >2.4.23"
       }
     ]
@@ -10306,9 +10116,7 @@
     "libraryVersion": "0.4.31",
     "patches": [
       {
-        "urls": [
-          "ws_20160920_0_0.patch"
-        ],
+        "urls": ["ws_20160920_0_0.patch"],
         "version": "<1.1.2 >=0.4.31"
       }
     ]
@@ -10330,9 +10138,7 @@
     "libraryVersion": "0.4.32",
     "patches": [
       {
-        "urls": [
-          "ws_20160920_0_0.patch"
-        ],
+        "urls": ["ws_20160920_0_0.patch"],
         "version": "<1.1.2 >=0.4.31"
       }
     ]
@@ -10354,9 +10160,7 @@
     "libraryVersion": "0.5.0",
     "patches": [
       {
-        "urls": [
-          "ws_20160920_0_0.patch"
-        ],
+        "urls": ["ws_20160920_0_0.patch"],
         "version": "<1.1.2 >=0.4.31"
       }
     ]
@@ -10378,9 +10182,7 @@
     "libraryVersion": "0.6.0",
     "patches": [
       {
-        "urls": [
-          "ws_20160920_0_0.patch"
-        ],
+        "urls": ["ws_20160920_0_0.patch"],
         "version": "<1.1.2 >=0.4.31"
       }
     ]
@@ -10402,9 +10204,7 @@
     "libraryVersion": "0.6.1",
     "patches": [
       {
-        "urls": [
-          "ws_20160920_0_0.patch"
-        ],
+        "urls": ["ws_20160920_0_0.patch"],
         "version": "<1.1.2 >=0.4.31"
       }
     ]
@@ -10426,9 +10226,7 @@
     "libraryVersion": "0.6.2",
     "patches": [
       {
-        "urls": [
-          "ws_20160920_0_0.patch"
-        ],
+        "urls": ["ws_20160920_0_0.patch"],
         "version": "<1.1.2 >=0.4.31"
       }
     ]
@@ -10450,9 +10248,7 @@
     "libraryVersion": "0.6.3",
     "patches": [
       {
-        "urls": [
-          "ws_20160920_0_0.patch"
-        ],
+        "urls": ["ws_20160920_0_0.patch"],
         "version": "<1.1.2 >=0.4.31"
       }
     ]
@@ -10474,9 +10270,7 @@
     "libraryVersion": "0.6.4",
     "patches": [
       {
-        "urls": [
-          "ws_20160920_0_0.patch"
-        ],
+        "urls": ["ws_20160920_0_0.patch"],
         "version": "<1.1.2 >=0.4.31"
       }
     ]
@@ -10498,9 +10292,7 @@
     "libraryVersion": "0.6.5",
     "patches": [
       {
-        "urls": [
-          "ws_20160920_0_0.patch"
-        ],
+        "urls": ["ws_20160920_0_0.patch"],
         "version": "<1.1.2 >=0.4.31"
       }
     ]
@@ -10522,9 +10314,7 @@
     "libraryVersion": "0.7.0",
     "patches": [
       {
-        "urls": [
-          "ws_20160920_0_0.patch"
-        ],
+        "urls": ["ws_20160920_0_0.patch"],
         "version": "<1.1.2 >=0.4.31"
       }
     ]
@@ -10546,9 +10336,7 @@
     "libraryVersion": "0.7.1",
     "patches": [
       {
-        "urls": [
-          "ws_20160920_0_0.patch"
-        ],
+        "urls": ["ws_20160920_0_0.patch"],
         "version": "<1.1.2 >=0.4.31"
       }
     ]
@@ -10570,9 +10358,7 @@
     "libraryVersion": "0.7.2",
     "patches": [
       {
-        "urls": [
-          "ws_20160920_0_0.patch"
-        ],
+        "urls": ["ws_20160920_0_0.patch"],
         "version": "<1.1.2 >=0.4.31"
       }
     ]
@@ -10594,9 +10380,7 @@
     "libraryVersion": "0.8.0",
     "patches": [
       {
-        "urls": [
-          "ws_20160920_0_0.patch"
-        ],
+        "urls": ["ws_20160920_0_0.patch"],
         "version": "<1.1.2 >=0.4.31"
       }
     ]
@@ -10618,9 +10402,7 @@
     "libraryVersion": "0.8.1",
     "patches": [
       {
-        "urls": [
-          "ws_20160920_0_0.patch"
-        ],
+        "urls": ["ws_20160920_0_0.patch"],
         "version": "<1.1.2 >=0.4.31"
       }
     ]
@@ -10642,9 +10424,7 @@
     "libraryVersion": "1.0.0",
     "patches": [
       {
-        "urls": [
-          "ws_20160920_0_0.patch"
-        ],
+        "urls": ["ws_20160920_0_0.patch"],
         "version": "<1.1.2 >=0.4.31"
       }
     ]
@@ -10654,9 +10434,7 @@
     "libraryVersion": "1.0.1",
     "patches": [
       {
-        "urls": [
-          "ws_20160624_0_1_101_sio.patch"
-        ],
+        "urls": ["ws_20160624_0_1_101_sio.patch"],
         "version": "=1.0.1"
       }
     ]
@@ -10666,9 +10444,7 @@
     "libraryVersion": "1.0.1",
     "patches": [
       {
-        "urls": [
-          "ws_20160920_0_0.patch"
-        ],
+        "urls": ["ws_20160920_0_0.patch"],
         "version": "<1.1.2 >=0.4.31"
       }
     ]
@@ -10690,9 +10466,7 @@
     "libraryVersion": "1.1.0",
     "patches": [
       {
-        "urls": [
-          "ws_20160920_0_0.patch"
-        ],
+        "urls": ["ws_20160920_0_0.patch"],
         "version": "<1.1.2 >=0.4.31"
       }
     ]
@@ -10702,9 +10476,7 @@
     "libraryVersion": "1.1.1",
     "patches": [
       {
-        "urls": [
-          "ws_20160920_0_0.patch"
-        ],
+        "urls": ["ws_20160920_0_0.patch"],
         "version": "<1.1.2 >=0.4.31"
       }
     ]

--- a/packages/snyk-protect/patches.json
+++ b/packages/snyk-protect/patches.json
@@ -1,0 +1,10808 @@
+[
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.0.0",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_3_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.0.0 <2.4.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.1.0",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_3_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.0.0 <2.4.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.1.1",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_3_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.0.0 <2.4.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.1.2",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_3_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.0.0 <2.4.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.1.3",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_3_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.0.0 <2.4.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.2.0",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_3_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.0.0 <2.4.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.3.0",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_3_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.0.0 <2.4.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.3.1",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_3_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.0.0 <2.4.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.3.2",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_3_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.0.0 <2.4.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.3.3",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_3_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.0.0 <2.4.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.4.0",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_2_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.4.0 <2.5.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.4.1",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_2_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.4.0 <2.5.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.4.2",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_2_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.4.0 <2.5.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.4.3",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_2_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.4.0 <2.5.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.4.4",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_2_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.4.0 <2.5.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.4.5",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_2_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.4.0 <2.5.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.5.1",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_1_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.5.1 <2.6.9"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.5.2",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_1_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.5.1 <2.6.9"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.6.0",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_1_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.5.1 <2.6.9"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.6.1",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_1_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.5.1 <2.6.9"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.6.2",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_1_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.5.1 <2.6.9"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.6.3",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_1_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.5.1 <2.6.9"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.6.4",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_1_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.5.1 <2.6.9"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.6.5",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_1_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.5.1 <2.6.9"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.6.6",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_1_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.5.1 <2.6.9"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.6.7",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_1_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.5.1 <2.6.9"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "2.6.8",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_1_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch"
+        ],
+        "version": ">=2.5.1 <2.6.9"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "3.0.0",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_0_c38a0166c266a679c8de012d4eaccec3f944e685.patch"
+        ],
+        "version": ">= 3.0.0 <=3.0.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:debug:20170905",
+    "libraryVersion": "3.0.1",
+    "patches": [
+      {
+        "urls": [
+          "debug_20170905_0_0_c38a0166c266a679c8de012d4eaccec3f944e685.patch"
+        ],
+        "version": ">= 3.0.0 <=3.0.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ejs:20161128",
+    "libraryVersion": "2.2.4",
+    "patches": [
+      {
+        "urls": [
+          "ejs_20161128_0_0_3d447c5a335844b25faec04b1132dbc721f9c8f6.patch"
+        ],
+        "version": "<2.5.3 >=2.2.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ejs:20161128",
+    "libraryVersion": "2.3.1",
+    "patches": [
+      {
+        "urls": [
+          "ejs_20161128_0_0_3d447c5a335844b25faec04b1132dbc721f9c8f6.patch"
+        ],
+        "version": "<2.5.3 >=2.2.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ejs:20161128",
+    "libraryVersion": "2.3.2",
+    "patches": [
+      {
+        "urls": [
+          "ejs_20161128_0_0_3d447c5a335844b25faec04b1132dbc721f9c8f6.patch"
+        ],
+        "version": "<2.5.3 >=2.2.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ejs:20161128",
+    "libraryVersion": "2.3.3",
+    "patches": [
+      {
+        "urls": [
+          "ejs_20161128_0_0_3d447c5a335844b25faec04b1132dbc721f9c8f6.patch"
+        ],
+        "version": "<2.5.3 >=2.2.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ejs:20161128",
+    "libraryVersion": "2.3.4",
+    "patches": [
+      {
+        "urls": [
+          "ejs_20161128_0_0_3d447c5a335844b25faec04b1132dbc721f9c8f6.patch"
+        ],
+        "version": "<2.5.3 >=2.2.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ejs:20161128",
+    "libraryVersion": "2.4.1",
+    "patches": [
+      {
+        "urls": [
+          "ejs_20161128_0_0_3d447c5a335844b25faec04b1132dbc721f9c8f6.patch"
+        ],
+        "version": "<2.5.3 >=2.2.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ejs:20161128",
+    "libraryVersion": "2.4.2",
+    "patches": [
+      {
+        "urls": [
+          "ejs_20161128_0_0_3d447c5a335844b25faec04b1132dbc721f9c8f6.patch"
+        ],
+        "version": "<2.5.3 >=2.2.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ejs:20161128",
+    "libraryVersion": "2.5.1",
+    "patches": [
+      {
+        "urls": [
+          "ejs_20161128_0_0_3d447c5a335844b25faec04b1132dbc721f9c8f6.patch"
+        ],
+        "version": "<2.5.3 >=2.2.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ejs:20161128",
+    "libraryVersion": "2.5.2",
+    "patches": [
+      {
+        "urls": [
+          "ejs_20161128_0_0_3d447c5a335844b25faec04b1132dbc721f9c8f6.patch"
+        ],
+        "version": "<2.5.3 >=2.2.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:electron-packager:20160422",
+    "libraryVersion": "5.2.1",
+    "patches": [
+      {
+        "urls": [
+          "electron-packager_20160422_ebea1d8c177f2a2816687c4a445998cc35375a18.patch"
+        ],
+        "version": ">= 5.2.1 <= 6.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:electron-packager:20160422",
+    "libraryVersion": "6.0.0",
+    "patches": [
+      {
+        "urls": [
+          "electron-packager_20160422_ebea1d8c177f2a2816687c4a445998cc35375a18.patch"
+        ],
+        "version": ">= 5.2.1 <= 6.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:electron-packager:20160422",
+    "libraryVersion": "6.0.1",
+    "patches": [
+      {
+        "urls": [
+          "electron-packager_20160422_ebea1d8c177f2a2816687c4a445998cc35375a18.patch"
+        ],
+        "version": ">= 5.2.1 <= 6.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:electron-packager:20160422",
+    "libraryVersion": "6.0.2",
+    "patches": [
+      {
+        "urls": [
+          "electron-packager_20160422_ebea1d8c177f2a2816687c4a445998cc35375a18.patch"
+        ],
+        "version": ">= 5.2.1 <= 6.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:engine.io-client:20160426",
+    "libraryVersion": "1.5.0",
+    "patches": [
+      {
+        "urls": [
+          "engine.io-client_20160426_0_1_2a7a011932094d4970dc68abd32e78265495a621.patch"
+        ],
+        "version": "<1.6.0 >=1.5.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:engine.io-client:20160426",
+    "libraryVersion": "1.5.1",
+    "patches": [
+      {
+        "urls": [
+          "engine.io-client_20160426_0_1_2a7a011932094d4970dc68abd32e78265495a621.patch"
+        ],
+        "version": "<1.6.0 >=1.5.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:engine.io-client:20160426",
+    "libraryVersion": "1.5.2",
+    "patches": [
+      {
+        "urls": [
+          "engine.io-client_20160426_0_1_2a7a011932094d4970dc68abd32e78265495a621.patch"
+        ],
+        "version": "<1.6.0 >=1.5.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:engine.io-client:20160426",
+    "libraryVersion": "1.5.3",
+    "patches": [
+      {
+        "urls": [
+          "engine.io-client_20160426_0_1_2a7a011932094d4970dc68abd32e78265495a621.patch"
+        ],
+        "version": "<1.6.0 >=1.5.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:engine.io-client:20160426",
+    "libraryVersion": "1.5.4",
+    "patches": [
+      {
+        "urls": [
+          "engine.io-client_20160426_0_1_2a7a011932094d4970dc68abd32e78265495a621.patch"
+        ],
+        "version": "<1.6.0 >=1.5.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:engine.io-client:20160426",
+    "libraryVersion": "1.6.0",
+    "patches": [
+      {
+        "urls": [
+          "engine.io-client_20160426_0_0_2a7a011932094d4970dc68abd32e78265495a621.patch"
+        ],
+        "version": "<= 1.6.8 >=1.6.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:engine.io-client:20160426",
+    "libraryVersion": "1.6.1",
+    "patches": [
+      {
+        "urls": [
+          "engine.io-client_20160426_0_0_2a7a011932094d4970dc68abd32e78265495a621.patch"
+        ],
+        "version": "<= 1.6.8 >=1.6.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:engine.io-client:20160426",
+    "libraryVersion": "1.6.2",
+    "patches": [
+      {
+        "urls": [
+          "engine.io-client_20160426_0_0_2a7a011932094d4970dc68abd32e78265495a621.patch"
+        ],
+        "version": "<= 1.6.8 >=1.6.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:engine.io-client:20160426",
+    "libraryVersion": "1.6.3",
+    "patches": [
+      {
+        "urls": [
+          "engine.io-client_20160426_0_0_2a7a011932094d4970dc68abd32e78265495a621.patch"
+        ],
+        "version": "<= 1.6.8 >=1.6.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:engine.io-client:20160426",
+    "libraryVersion": "1.6.4",
+    "patches": [
+      {
+        "urls": [
+          "engine.io-client_20160426_0_0_2a7a011932094d4970dc68abd32e78265495a621.patch"
+        ],
+        "version": "<= 1.6.8 >=1.6.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:engine.io-client:20160426",
+    "libraryVersion": "1.6.5",
+    "patches": [
+      {
+        "urls": [
+          "engine.io-client_20160426_0_0_2a7a011932094d4970dc68abd32e78265495a621.patch"
+        ],
+        "version": "<= 1.6.8 >=1.6.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:engine.io-client:20160426",
+    "libraryVersion": "1.6.6",
+    "patches": [
+      {
+        "urls": [
+          "engine.io-client_20160426_0_0_2a7a011932094d4970dc68abd32e78265495a621.patch"
+        ],
+        "version": "<= 1.6.8 >=1.6.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:engine.io-client:20160426",
+    "libraryVersion": "1.6.7",
+    "patches": [
+      {
+        "urls": [
+          "engine.io-client_20160426_0_0_2a7a011932094d4970dc68abd32e78265495a621.patch"
+        ],
+        "version": "<= 1.6.8 >=1.6.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:engine.io-client:20160426",
+    "libraryVersion": "1.6.8",
+    "patches": [
+      {
+        "urls": [
+          "engine.io-client_20160426_0_0_2a7a011932094d4970dc68abd32e78265495a621.patch"
+        ],
+        "version": "<= 1.6.8 >=1.6.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:extend:20180424",
+    "libraryVersion": "3.0.0",
+    "patches": [
+      {
+        "urls": [
+          "extend_20180424_0_0_0e68e71d93507fcc391e398bc84abd0666b28190.patch"
+        ],
+        "version": ">=3.0.0 <3.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:extend:20180424",
+    "libraryVersion": "3.0.1",
+    "patches": [
+      {
+        "urls": [
+          "extend_20180424_0_0_0e68e71d93507fcc391e398bc84abd0666b28190.patch"
+        ],
+        "version": ">=3.0.0 <3.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "0.12.1",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "0.12.2",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "0.12.3",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "0.12.4",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "0.12.5",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "0.12.6",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "0.12.7",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "0.12.8",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "0.12.9",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "0.12.10",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "0.12.11",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "0.12.12",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "0.12.13",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "0.12.14",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "0.12.15",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "0.12.16",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "13.0.1",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "13.0.2",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "13.0.3",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "13.0.4",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "13.0.5",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "13.0.6",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:geddy:20150727",
+    "libraryVersion": "13.0.7",
+    "patches": [
+      {
+        "urls": [
+          "geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch"
+        ],
+        "version": "<13.0.8 >=0.12.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:gm:20151026",
+    "libraryVersion": "1.15.0",
+    "patches": [
+      {
+        "urls": [
+          "gm_20151026_2_0_5f5c77490aa84ed313405c88905eb4566135be31_snyk_c2.patch"
+        ],
+        "version": "<1.16.0 >=1.15.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:gm:20151026",
+    "libraryVersion": "1.16.0",
+    "patches": [
+      {
+        "urls": [
+          "gm_20151026_1_0_5f5c77490aa84ed313405c88905eb4566135be31_snyk_c1.patch"
+        ],
+        "version": "<1.17.0 >=1.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:gm:20151026",
+    "libraryVersion": "1.17.0",
+    "patches": [
+      {
+        "urls": [
+          "gm_20151026_0_0_5f5c77490aa84ed313405c88905eb4566135be31_snyk.patch"
+        ],
+        "version": "<=1.20.0 >=1.17.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:gm:20151026",
+    "libraryVersion": "1.18.1",
+    "patches": [
+      {
+        "urls": [
+          "gm_20151026_0_0_5f5c77490aa84ed313405c88905eb4566135be31_snyk.patch"
+        ],
+        "version": "<=1.20.0 >=1.17.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:gm:20151026",
+    "libraryVersion": "1.19.0",
+    "patches": [
+      {
+        "urls": [
+          "gm_20151026_0_0_5f5c77490aa84ed313405c88905eb4566135be31_snyk.patch"
+        ],
+        "version": "<=1.20.0 >=1.17.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:gm:20151026",
+    "libraryVersion": "1.20.0",
+    "patches": [
+      {
+        "urls": [
+          "gm_20151026_0_0_5f5c77490aa84ed313405c88905eb4566135be31_snyk.patch"
+        ],
+        "version": "<=1.20.0 >=1.17.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:handlebars:20151207",
+    "libraryVersion": "3.0.2",
+    "patches": [
+      {
+        "urls": [
+          "handlebars_0.patch"
+        ],
+        "version": "<4.0.0 >=3.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:handlebars:20151207",
+    "libraryVersion": "3.0.3",
+    "patches": [
+      {
+        "urls": [
+          "handlebars_0.patch"
+        ],
+        "version": "<4.0.0 >=3.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:handlebars:20151207",
+    "libraryVersion": "3.0.4",
+    "patches": [
+      {
+        "urls": [
+          "handlebars_0.patch"
+        ],
+        "version": "<4.0.0 >=3.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:handlebars:20151207",
+    "libraryVersion": "3.0.5",
+    "patches": [
+      {
+        "urls": [
+          "handlebars_0.patch"
+        ],
+        "version": "<4.0.0 >=3.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:handlebars:20151207",
+    "libraryVersion": "3.0.6",
+    "patches": [
+      {
+        "urls": [
+          "handlebars_0.patch"
+        ],
+        "version": "<4.0.0 >=3.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:handlebars:20151207",
+    "libraryVersion": "3.0.7",
+    "patches": [
+      {
+        "urls": [
+          "handlebars_0.patch"
+        ],
+        "version": "<4.0.0 >=3.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:handlebars:20151207",
+    "libraryVersion": "3.0.8",
+    "patches": [
+      {
+        "urls": [
+          "handlebars_0.patch"
+        ],
+        "version": "<4.0.0 >=3.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "2.3.0",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "2.4.0",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "2.5.0",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "2.6.0",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "3.0.0",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "3.0.1",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "3.0.2",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "3.1.0",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "4.0.0",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "4.0.1",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "4.0.2",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "4.0.3",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "4.1.0",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "4.1.1",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "4.1.2",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "4.1.3",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "4.1.4",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "5.0.0",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "5.1.0",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "6.0.0",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "6.0.1",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hapi:20140708-1",
+    "libraryVersion": "6.0.2",
+    "patches": [
+      {
+        "urls": [
+          "hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch"
+        ],
+        "version": "< 6.1.0 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hawk:20160119",
+    "libraryVersion": "1.0.0",
+    "patches": [
+      {
+        "urls": [
+          "hawk_20160119_0_3_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+        ],
+        "version": "<= 1.1.1 >= 1.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hawk:20160119",
+    "libraryVersion": "1.1.1",
+    "patches": [
+      {
+        "urls": [
+          "hawk_20160119_0_3_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+        ],
+        "version": "<= 1.1.1 >= 1.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hawk:20160119",
+    "libraryVersion": "2.2.0",
+    "patches": [
+      {
+        "urls": [
+          "hawk_20160119_0_2_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+        ],
+        "version": "<= 2.3.1 >= 2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hawk:20160119",
+    "libraryVersion": "2.2.1",
+    "patches": [
+      {
+        "urls": [
+          "hawk_20160119_0_2_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+        ],
+        "version": "<= 2.3.1 >= 2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hawk:20160119",
+    "libraryVersion": "2.2.2",
+    "patches": [
+      {
+        "urls": [
+          "hawk_20160119_0_2_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+        ],
+        "version": "<= 2.3.1 >= 2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hawk:20160119",
+    "libraryVersion": "2.2.3",
+    "patches": [
+      {
+        "urls": [
+          "hawk_20160119_0_2_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+        ],
+        "version": "<= 2.3.1 >= 2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hawk:20160119",
+    "libraryVersion": "2.3.0",
+    "patches": [
+      {
+        "urls": [
+          "hawk_20160119_0_2_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+        ],
+        "version": "<= 2.3.1 >= 2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hawk:20160119",
+    "libraryVersion": "2.3.1",
+    "patches": [
+      {
+        "urls": [
+          "hawk_20160119_0_2_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+        ],
+        "version": "<= 2.3.1 >= 2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hawk:20160119",
+    "libraryVersion": "3.0.0",
+    "patches": [
+      {
+        "urls": [
+          "hawk_20160119_0_1_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+        ],
+        "version": "<=3.1.2 >=3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hawk:20160119",
+    "libraryVersion": "3.1.0",
+    "patches": [
+      {
+        "urls": [
+          "hawk_20160119_0_1_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+        ],
+        "version": "<=3.1.2 >=3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hawk:20160119",
+    "libraryVersion": "3.1.1",
+    "patches": [
+      {
+        "urls": [
+          "hawk_20160119_0_1_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+        ],
+        "version": "<=3.1.2 >=3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hawk:20160119",
+    "libraryVersion": "3.1.2",
+    "patches": [
+      {
+        "urls": [
+          "hawk_20160119_0_1_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+        ],
+        "version": "<=3.1.2 >=3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hawk:20160119",
+    "libraryVersion": "4.0.0",
+    "patches": [
+      {
+        "urls": [
+          "hawk_20160119_0_0_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+        ],
+        "version": "<4.1.1 >=4.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hawk:20160119",
+    "libraryVersion": "4.0.1",
+    "patches": [
+      {
+        "urls": [
+          "hawk_20160119_0_0_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+        ],
+        "version": "<4.1.1 >=4.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hawk:20160119",
+    "libraryVersion": "4.1.0",
+    "patches": [
+      {
+        "urls": [
+          "hawk_20160119_0_0_0833f99ba64558525995a7e21d4093da1f3e15fa.patch"
+        ],
+        "version": "<4.1.1 >=4.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.0.0",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.1.0",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.1.1",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.2.0",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.3.0",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.4.0",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.4.1",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.5.0",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.5.1",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.6.0",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.7.0",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.8.0",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.8.1",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.9.0",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.9.1",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.10.0",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.11.0",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.11.1",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.12.0",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.13.0",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.13.1",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.14.0",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.15.0",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.16.0",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.16.1",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.16.2",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "2.16.3",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch"
+        ],
+        "version": ">=2.0.0 <3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "3.0.0",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_0_hoek_5aed1a8c4a3d55722d1c799f2368857bf418d6df.patch"
+        ],
+        "version": "<4.2.1 >=4.1.0 || <3.0.4 >=3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "3.0.1",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_0_hoek_5aed1a8c4a3d55722d1c799f2368857bf418d6df.patch"
+        ],
+        "version": "<4.2.1 >=4.1.0 || <3.0.4 >=3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "3.0.2",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_0_hoek_5aed1a8c4a3d55722d1c799f2368857bf418d6df.patch"
+        ],
+        "version": "<4.2.1 >=4.1.0 || <3.0.4 >=3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "3.0.3",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_0_hoek_5aed1a8c4a3d55722d1c799f2368857bf418d6df.patch"
+        ],
+        "version": "<4.2.1 >=4.1.0 || <3.0.4 >=3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "4.1.0",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_0_hoek_5aed1a8c4a3d55722d1c799f2368857bf418d6df.patch"
+        ],
+        "version": "<4.2.1 >=4.1.0 || <3.0.4 >=3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "4.1.1",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_0_hoek_5aed1a8c4a3d55722d1c799f2368857bf418d6df.patch"
+        ],
+        "version": "<4.2.1 >=4.1.0 || <3.0.4 >=3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:hoek:20180212",
+    "libraryVersion": "4.2.0",
+    "patches": [
+      {
+        "urls": [
+          "20180212_0_0_hoek_5aed1a8c4a3d55722d1c799f2368857bf418d6df.patch"
+        ],
+        "version": "<4.2.1 >=4.1.0 || <3.0.4 >=3.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:http-signature:20150122",
+    "libraryVersion": "0.10.1",
+    "patches": [
+      {
+        "urls": [
+          "20150122_0_0_http-signature_78ab1da232f31f695f5c362d863593a143aa8b56.patch"
+        ],
+        "version": "=0.10.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-HTTPSPROXYAGENT-469131",
+    "libraryVersion": "2.2.1",
+    "patches": [
+      {
+        "urls": [
+          "https-proxy-agent_0_0_20190929.patch"
+        ],
+        "version": "=2.2.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-HTTPSPROXYAGENT-469131",
+    "libraryVersion": "2.2.2",
+    "patches": [
+      {
+        "urls": [
+          "https-proxy-agent_0_1_20190929.patch"
+        ],
+        "version": "=2.2.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:i18n-node-angular:20160125",
+    "libraryVersion": "1.1.3",
+    "patches": [
+      {
+        "urls": [
+          "i1n-20160125_0_0_877720d2d9bb90dc8233706e81ffa03f99fc9dc8.patch"
+        ],
+        "version": "<1.4.0 >1.2.1 || <1.2.1 >0.3.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:i18n-node-angular:20160125",
+    "libraryVersion": "1.2.0",
+    "patches": [
+      {
+        "urls": [
+          "i1n-20160125_0_0_877720d2d9bb90dc8233706e81ffa03f99fc9dc8.patch"
+        ],
+        "version": "<1.4.0 >1.2.1 || <1.2.1 >0.3.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:i18n-node-angular:20160125",
+    "libraryVersion": "1.3.0",
+    "patches": [
+      {
+        "urls": [
+          "i1n-20160125_0_0_877720d2d9bb90dc8233706e81ffa03f99fc9dc8.patch"
+        ],
+        "version": "<1.4.0 >1.2.1 || <1.2.1 >0.3.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:i18n-node-angular:20160125",
+    "libraryVersion": "1.3.2",
+    "patches": [
+      {
+        "urls": [
+          "i1n-20160125_0_0_877720d2d9bb90dc8233706e81ffa03f99fc9dc8.patch"
+        ],
+        "version": "<1.4.0 >1.2.1 || <1.2.1 >0.3.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:i18n-node-angular:20160125",
+    "libraryVersion": "1.3.3",
+    "patches": [
+      {
+        "urls": [
+          "i1n-20160125_0_0_877720d2d9bb90dc8233706e81ffa03f99fc9dc8.patch"
+        ],
+        "version": "<1.4.0 >1.2.1 || <1.2.1 >0.3.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:i18n-node-angular:20160125",
+    "libraryVersion": "1.3.4",
+    "patches": [
+      {
+        "urls": [
+          "i1n-20160125_0_0_877720d2d9bb90dc8233706e81ffa03f99fc9dc8.patch"
+        ],
+        "version": "<1.4.0 >1.2.1 || <1.2.1 >0.3.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:i18n-node-angular:20160125",
+    "libraryVersion": "1.3.5",
+    "patches": [
+      {
+        "urls": [
+          "i1n-20160125_0_0_877720d2d9bb90dc8233706e81ffa03f99fc9dc8.patch"
+        ],
+        "version": "<1.4.0 >1.2.1 || <1.2.1 >0.3.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:inert:20141215",
+    "libraryVersion": "1.0.0",
+    "patches": [
+      {
+        "urls": [
+          "inert_20141215_0_0_e8f99f94da4cb08e8032eda984761c3f111e3e82_snyk.patch"
+        ],
+        "version": "<1.1.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:inert:20141215",
+    "libraryVersion": "1.1.0",
+    "patches": [
+      {
+        "urls": [
+          "inert_20141215_0_0_e8f99f94da4cb08e8032eda984761c3f111e3e82_snyk.patch"
+        ],
+        "version": "<1.1.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "1.3.4",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_1_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<2.0.3 >=1.3.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "1.3.5",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_1_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<2.0.3 >=1.3.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "1.3.6",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_1_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<2.0.3 >=1.3.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "1.3.7",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_1_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<2.0.3 >=1.3.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "1.3.8",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_1_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<2.0.3 >=1.3.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "1.3.9",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_1_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<2.0.3 >=1.3.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "1.4.0",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_1_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<2.0.3 >=1.3.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "1.4.1",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_1_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<2.0.3 >=1.3.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "1.4.2",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_1_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<2.0.3 >=1.3.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.0.0",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_1_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<2.0.3 >=1.3.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.0.1",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_1_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<2.0.3 >=1.3.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.0.2",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_1_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<2.0.3 >=1.3.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.0.3",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.1.0",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.2.0",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.2.1",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.3.0",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.3.1",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.4.0",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.4.1",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.5.0",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.6.0",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.7.0",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.8.0",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.9.0",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.9.1",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.9.2",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.9.3",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.9.4",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.10.0",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.10.1",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.11.0",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.12.0",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.12.1",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.12.2",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:is-my-json-valid:20160118",
+    "libraryVersion": "2.12.3",
+    "patches": [
+      {
+        "urls": [
+          "imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch"
+        ],
+        "version": "<=2.12.3 >=2.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:jsonwebtoken:20150331",
+    "libraryVersion": "4.0.0",
+    "patches": [
+      {
+        "urls": [
+          "jsonwebtoken_20150331_0_0_1bb584bc382295eeb7ee8c4452a673a77a68b687_snyk.patch"
+        ],
+        "version": "=4.0.0 || =4.1.0 || =4.2.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:jsonwebtoken:20150331",
+    "libraryVersion": "4.1.0",
+    "patches": [
+      {
+        "urls": [
+          "jsonwebtoken_20150331_0_0_1bb584bc382295eeb7ee8c4452a673a77a68b687_snyk.patch"
+        ],
+        "version": "=4.0.0 || =4.1.0 || =4.2.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:jsonwebtoken:20150331",
+    "libraryVersion": "4.2.1",
+    "patches": [
+      {
+        "urls": [
+          "jsonwebtoken_20150331_0_0_1bb584bc382295eeb7ee8c4452a673a77a68b687_snyk.patch"
+        ],
+        "version": "=4.0.0 || =4.1.0 || =4.2.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:keystone:20151204",
+    "libraryVersion": "0.3.13",
+    "patches": [
+      {
+        "urls": [
+          "v0.3.15.patch"
+        ],
+        "version": "<0.3.16 >=0.3.13"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:keystone:20151204",
+    "libraryVersion": "0.3.14",
+    "patches": [
+      {
+        "urls": [
+          "v0.3.15.patch"
+        ],
+        "version": "<0.3.16 >=0.3.13"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:keystone:20151204",
+    "libraryVersion": "0.3.15",
+    "patches": [
+      {
+        "urls": [
+          "v0.3.15.patch"
+        ],
+        "version": "<0.3.16 >=0.3.13"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ldapauth-fork:20150918",
+    "libraryVersion": "2.3.0",
+    "patches": [
+      {
+        "urls": [
+          "ldapauth-fork_20150918_0_0_3feea43e243698bcaeffa904a7324f4d96df60e4.patch"
+        ],
+        "version": "<2.3.3 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ldapauth-fork:20150918",
+    "libraryVersion": "2.3.1",
+    "patches": [
+      {
+        "urls": [
+          "ldapauth-fork_20150918_0_0_3feea43e243698bcaeffa904a7324f4d96df60e4.patch"
+        ],
+        "version": "<2.3.3 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ldapauth-fork:20150918",
+    "libraryVersion": "2.3.2",
+    "patches": [
+      {
+        "urls": [
+          "ldapauth-fork_20150918_0_0_3feea43e243698bcaeffa904a7324f4d96df60e4.patch"
+        ],
+        "version": "<2.3.3 >=2.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:libnotify:20130515",
+    "libraryVersion": "1.0.1",
+    "patches": [
+      {
+        "urls": [
+          "libnotify_20130515_0_0_8e2e7306088624503ba5eec592b502c4f97d8846.patch"
+        ],
+        "version": "<= 1.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:libnotify:20130515",
+    "libraryVersion": "1.0.2",
+    "patches": [
+      {
+        "urls": [
+          "libnotify_20130515_0_0_8e2e7306088624503ba5eec592b502c4f97d8846.patch"
+        ],
+        "version": "<= 1.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:libnotify:20130515",
+    "libraryVersion": "1.0.3",
+    "patches": [
+      {
+        "urls": [
+          "libnotify_20130515_0_0_8e2e7306088624503ba5eec592b502c4f97d8846.patch"
+        ],
+        "version": "<= 1.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:lodash:20180130",
+    "libraryVersion": "3.10.1",
+    "patches": [
+      {
+        "urls": [
+          "20180130_0_0_lodash_d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a.patch"
+        ],
+        "version": "=3.10.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.14.2",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.15.0",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.16.0",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.16.1",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.16.2",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.16.3",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.16.4",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.16.5",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.16.6",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.17.0",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.17.1",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.17.2",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.17.3",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.17.4",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.17.5",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.17.9",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.17.10",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-450202",
+    "libraryVersion": "4.17.11",
+    "patches": [
+      {
+        "urls": [
+          "lodash_20190702_0_0_1f8ea07746963a535385a5befc19fa687a627d2b.patch"
+        ],
+        "version": "=4.17.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.17.11",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.17.12",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.17.13",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.17.14",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.17.15",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.17.16",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.17.17",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.17.18",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-LODASH-567746",
+    "libraryVersion": "4.17.19",
+    "patches": [
+      {
+        "urls": [
+          "lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+        ],
+        "version": ">=4.14.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mapbox.js:20151024",
+    "libraryVersion": "2.1.6",
+    "patches": [
+      {
+        "urls": [
+          "mapbox.js_20151024_0_0_538d229ab6767bb4c3f3969c417f9884189c1512.patch"
+        ],
+        "version": "=2.1.6"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:markdown-it:20160912",
+    "libraryVersion": "4.0.3",
+    "patches": [
+      {
+        "urls": [
+          "markdown-it_20160912_0_0_f76d3beb46abd121892a2e2e5c78376354c214e3.patch"
+        ],
+        "version": "4.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:marked:20140131-1",
+    "libraryVersion": "0.2.8",
+    "patches": [
+      {
+        "urls": [
+          "marked_20140131-1_0_0_a37bd643f05bf95ff18cafa2b06e7d741d2e2157.patch"
+        ],
+        "version": "<=0.3.3 >=0.2.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:marked:20140131-1",
+    "libraryVersion": "0.2.9",
+    "patches": [
+      {
+        "urls": [
+          "marked_20140131-1_0_0_a37bd643f05bf95ff18cafa2b06e7d741d2e2157.patch"
+        ],
+        "version": "<=0.3.3 >=0.2.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:marked:20140131-1",
+    "libraryVersion": "0.2.10",
+    "patches": [
+      {
+        "urls": [
+          "marked_20140131-1_0_0_a37bd643f05bf95ff18cafa2b06e7d741d2e2157.patch"
+        ],
+        "version": "<=0.3.3 >=0.2.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:marked:20140131-1",
+    "libraryVersion": "0.3.0",
+    "patches": [
+      {
+        "urls": [
+          "marked_20140131-1_0_0_a37bd643f05bf95ff18cafa2b06e7d741d2e2157.patch"
+        ],
+        "version": "<=0.3.3 >=0.2.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:marked:20140131-1",
+    "libraryVersion": "0.3.1",
+    "patches": [
+      {
+        "urls": [
+          "marked_20140131-1_0_0_a37bd643f05bf95ff18cafa2b06e7d741d2e2157.patch"
+        ],
+        "version": "<=0.3.3 >=0.2.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:marked:20140131-2",
+    "libraryVersion": "0.3.1",
+    "patches": [
+      {
+        "urls": [
+          "marked_20140131-2_0_0_3c191144939107c45a7fa11ab6cb88be6694a1ba.patch"
+        ],
+        "version": "<=0.3.2 >=0.3.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:marked:20150520",
+    "libraryVersion": "0.3.1",
+    "patches": [
+      {
+        "urls": [
+          "marked_20150520_0_2_2cff85979be8e7a026a9aca35542c470cf5da523_20140131-1-2.patch"
+        ],
+        "version": "<=0.3.2 >0.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:marked:20140131-1",
+    "libraryVersion": "0.3.2",
+    "patches": [
+      {
+        "urls": [
+          "marked_20140131-1_0_0_a37bd643f05bf95ff18cafa2b06e7d741d2e2157.patch"
+        ],
+        "version": "<=0.3.3 >=0.2.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:marked:20140131-2",
+    "libraryVersion": "0.3.2",
+    "patches": [
+      {
+        "urls": [
+          "marked_20140131-2_0_0_3c191144939107c45a7fa11ab6cb88be6694a1ba.patch"
+        ],
+        "version": "<=0.3.2 >=0.3.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:marked:20150520",
+    "libraryVersion": "0.3.2",
+    "patches": [
+      {
+        "urls": [
+          "marked_20150520_0_2_2cff85979be8e7a026a9aca35542c470cf5da523_20140131-1-2.patch"
+        ],
+        "version": "<=0.3.2 >0.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:marked:20140131-1",
+    "libraryVersion": "0.3.3",
+    "patches": [
+      {
+        "urls": [
+          "marked_20140131-1_0_0_a37bd643f05bf95ff18cafa2b06e7d741d2e2157.patch"
+        ],
+        "version": "<=0.3.3 >=0.2.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:marked:20150520",
+    "libraryVersion": "0.3.3",
+    "patches": [
+      {
+        "urls": [
+          "marked_20150520_0_1_2cff85979be8e7a026a9aca35542c470cf5da523_20140131-1.patch"
+        ],
+        "version": "=0.3.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:marked:20150520",
+    "libraryVersion": "0.3.4",
+    "patches": [
+      {
+        "urls": [
+          "marked_20150520_0_0_2cff85979be8e7a026a9aca35542c470cf5da523.patch"
+        ],
+        "version": "<=0.3.5 >0.3.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:marked:20170112",
+    "libraryVersion": "0.3.4",
+    "patches": [
+      {
+        "urls": [
+          "marked_20170112_0_0_cd2f6f5b7091154c5526e79b5f3bfb4d15995a51.patch"
+        ],
+        "version": "<=0.3.6 >0.3.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:marked:20170907",
+    "libraryVersion": "0.3.4",
+    "patches": [
+      {
+        "urls": [
+          "marked_20170907_0_0_4afb8ce135a1e020e48f7084340333dd0c18229f.patch"
+        ],
+        "version": "<=0.3.6 >0.3.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:marked:20150520",
+    "libraryVersion": "0.3.5",
+    "patches": [
+      {
+        "urls": [
+          "marked_20150520_0_0_2cff85979be8e7a026a9aca35542c470cf5da523.patch"
+        ],
+        "version": "<=0.3.5 >0.3.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:marked:20170112",
+    "libraryVersion": "0.3.5",
+    "patches": [
+      {
+        "urls": [
+          "marked_20170112_0_0_cd2f6f5b7091154c5526e79b5f3bfb4d15995a51.patch"
+        ],
+        "version": "<=0.3.6 >0.3.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:marked:20170907",
+    "libraryVersion": "0.3.5",
+    "patches": [
+      {
+        "urls": [
+          "marked_20170907_0_0_4afb8ce135a1e020e48f7084340333dd0c18229f.patch"
+        ],
+        "version": "<=0.3.6 >0.3.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:marked:20170112",
+    "libraryVersion": "0.3.6",
+    "patches": [
+      {
+        "urls": [
+          "marked_20170112_0_0_cd2f6f5b7091154c5526e79b5f3bfb4d15995a51.patch"
+        ],
+        "version": "<=0.3.6 >0.3.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:marked:20170907",
+    "libraryVersion": "0.3.6",
+    "patches": [
+      {
+        "urls": [
+          "marked_20170907_0_0_4afb8ce135a1e020e48f7084340333dd0c18229f.patch"
+        ],
+        "version": "<=0.3.6 >0.3.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:millisecond:20151120",
+    "libraryVersion": "0.1.1",
+    "patches": [
+      {
+        "urls": [
+          "millisecond_20151120_0_0_d3e03f8cd2089806b522e867505e14444fbac838.patch"
+        ],
+        "version": "=0.1.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mime:20170907",
+    "libraryVersion": "1.2.11",
+    "patches": [
+      {
+        "urls": [
+          "mime_20170907_0_0_855d0c4b8b22e4a80b9401a81f2872058eae274d.patch"
+        ],
+        "version": "=1.2.11 || =1.3.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mime:20170907",
+    "libraryVersion": "1.3.4",
+    "patches": [
+      {
+        "urls": [
+          "mime_20170907_0_0_855d0c4b8b22e4a80b9401a81f2872058eae274d.patch"
+        ],
+        "version": "=1.2.11 || =1.3.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.1.1",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.1.2",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.1.3",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.1.4",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.1.5",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.2.0",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.2.2",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.2.3",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.2.4",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.2.5",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.2.6",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.2.7",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.2.8",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.2.9",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.2.10",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.2.11",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.2.12",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.2.13",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.2.14",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.3.0",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "0.4.0",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "1.0.0",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "2.0.0",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "2.0.1",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "2.0.2",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "2.0.3",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "2.0.4",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "2.0.5",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=2.0.5 >0.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "2.0.6",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_0_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=3.0.1 >2.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "2.0.7",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_0_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=3.0.1 >2.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "2.0.8",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_0_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=3.0.1 >2.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "2.0.9",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_0_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=3.0.1 >2.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "2.0.10",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_0_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=3.0.1 >2.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:minimatch:20160620",
+    "libraryVersion": "3.0.0",
+    "patches": [
+      {
+        "urls": [
+          "minimatch_20160620_0_0_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+        ],
+        "version": "<=3.0.1 >2.0.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20160126",
+    "libraryVersion": "2.1.0",
+    "patches": [
+      {
+        "urls": [
+          "moment_20160126_0_4_34af63b8b21208a949dfaf42d228502c73d20ec0.patch"
+        ],
+        "version": "<2.2.1 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20160126",
+    "libraryVersion": "2.2.1",
+    "patches": [
+      {
+        "urls": [
+          "moment_20160126_0_3_34af63b8b21208a949dfaf42d228502c73d20ec0.patch"
+        ],
+        "version": "=2.2.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20160126",
+    "libraryVersion": "2.3.0",
+    "patches": [
+      {
+        "urls": [
+          "moment_20160126_0_2_34af63b8b21208a949dfaf42d228502c73d20ec0.patch"
+        ],
+        "version": "<=2.9.0 >2.2.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20160126",
+    "libraryVersion": "2.3.1",
+    "patches": [
+      {
+        "urls": [
+          "moment_20160126_0_2_34af63b8b21208a949dfaf42d228502c73d20ec0.patch"
+        ],
+        "version": "<=2.9.0 >2.2.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20160126",
+    "libraryVersion": "2.4.0",
+    "patches": [
+      {
+        "urls": [
+          "moment_20160126_0_2_34af63b8b21208a949dfaf42d228502c73d20ec0.patch"
+        ],
+        "version": "<=2.9.0 >2.2.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20160126",
+    "libraryVersion": "2.5.0",
+    "patches": [
+      {
+        "urls": [
+          "moment_20160126_0_2_34af63b8b21208a949dfaf42d228502c73d20ec0.patch"
+        ],
+        "version": "<=2.9.0 >2.2.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20160126",
+    "libraryVersion": "2.5.1",
+    "patches": [
+      {
+        "urls": [
+          "moment_20160126_0_2_34af63b8b21208a949dfaf42d228502c73d20ec0.patch"
+        ],
+        "version": "<=2.9.0 >2.2.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20160126",
+    "libraryVersion": "2.6.0",
+    "patches": [
+      {
+        "urls": [
+          "moment_20160126_0_2_34af63b8b21208a949dfaf42d228502c73d20ec0.patch"
+        ],
+        "version": "<=2.9.0 >2.2.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20160126",
+    "libraryVersion": "2.7.0",
+    "patches": [
+      {
+        "urls": [
+          "moment_20160126_0_2_34af63b8b21208a949dfaf42d228502c73d20ec0.patch"
+        ],
+        "version": "<=2.9.0 >2.2.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20160126",
+    "libraryVersion": "2.8.1",
+    "patches": [
+      {
+        "urls": [
+          "moment_20160126_0_2_34af63b8b21208a949dfaf42d228502c73d20ec0.patch"
+        ],
+        "version": "<=2.9.0 >2.2.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20160126",
+    "libraryVersion": "2.8.2",
+    "patches": [
+      {
+        "urls": [
+          "moment_20160126_0_2_34af63b8b21208a949dfaf42d228502c73d20ec0.patch"
+        ],
+        "version": "<=2.9.0 >2.2.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20160126",
+    "libraryVersion": "2.8.3",
+    "patches": [
+      {
+        "urls": [
+          "moment_20160126_0_2_34af63b8b21208a949dfaf42d228502c73d20ec0.patch"
+        ],
+        "version": "<=2.9.0 >2.2.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20160126",
+    "libraryVersion": "2.8.4",
+    "patches": [
+      {
+        "urls": [
+          "moment_20160126_0_2_34af63b8b21208a949dfaf42d228502c73d20ec0.patch"
+        ],
+        "version": "<=2.9.0 >2.2.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20160126",
+    "libraryVersion": "2.9.0",
+    "patches": [
+      {
+        "urls": [
+          "moment_20160126_0_2_34af63b8b21208a949dfaf42d228502c73d20ec0.patch"
+        ],
+        "version": "<=2.9.0 >2.2.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20160126",
+    "libraryVersion": "2.10.2",
+    "patches": [
+      {
+        "urls": [
+          "moment_20160126_0_1_34af63b8b21208a949dfaf42d228502c73d20ec0.patch"
+        ],
+        "version": "<=2.10.6 >2.9.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20160126",
+    "libraryVersion": "2.10.3",
+    "patches": [
+      {
+        "urls": [
+          "moment_20160126_0_1_34af63b8b21208a949dfaf42d228502c73d20ec0.patch"
+        ],
+        "version": "<=2.10.6 >2.9.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20160126",
+    "libraryVersion": "2.10.5",
+    "patches": [
+      {
+        "urls": [
+          "moment_20160126_0_1_34af63b8b21208a949dfaf42d228502c73d20ec0.patch"
+        ],
+        "version": "<=2.10.6 >2.9.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20160126",
+    "libraryVersion": "2.10.6",
+    "patches": [
+      {
+        "urls": [
+          "moment_20160126_0_1_34af63b8b21208a949dfaf42d228502c73d20ec0.patch"
+        ],
+        "version": "<=2.10.6 >2.9.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20160126",
+    "libraryVersion": "2.11.0",
+    "patches": [
+      {
+        "urls": [
+          "moment_20160126_0_0_34af63b8b21208a949dfaf42d228502c73d20ec0.patch"
+        ],
+        "version": "<=2.11.1 >2.10.6"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20160126",
+    "libraryVersion": "2.11.1",
+    "patches": [
+      {
+        "urls": [
+          "moment_20160126_0_0_34af63b8b21208a949dfaf42d228502c73d20ec0.patch"
+        ],
+        "version": "<=2.11.1 >2.10.6"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20161019",
+    "libraryVersion": "2.12.0",
+    "patches": [
+      {
+        "urls": [
+          "moment_20161019_0_0.patch"
+        ],
+        "version": "<2.14.0 >=2.12.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20161019",
+    "libraryVersion": "2.13.0",
+    "patches": [
+      {
+        "urls": [
+          "moment_20161019_0_0.patch"
+        ],
+        "version": "<2.14.0 >=2.12.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20161019",
+    "libraryVersion": "2.14.0",
+    "patches": [
+      {
+        "urls": [
+          "moment_20161019_0_1.patch"
+        ],
+        "version": "<2.15.2 >=2.14.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20161019",
+    "libraryVersion": "2.14.1",
+    "patches": [
+      {
+        "urls": [
+          "moment_20161019_0_1.patch"
+        ],
+        "version": "<2.15.2 >=2.14.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20161019",
+    "libraryVersion": "2.15.0",
+    "patches": [
+      {
+        "urls": [
+          "moment_20161019_0_1.patch"
+        ],
+        "version": "<2.15.2 >=2.14.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20161019",
+    "libraryVersion": "2.15.1",
+    "patches": [
+      {
+        "urls": [
+          "moment_20161019_0_1.patch"
+        ],
+        "version": "<2.15.2 >=2.14.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20170905",
+    "libraryVersion": "2.16.0",
+    "patches": [
+      {
+        "urls": [
+          "moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"
+        ],
+        "version": "<2.19.3 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20170905",
+    "libraryVersion": "2.17.0",
+    "patches": [
+      {
+        "urls": [
+          "moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"
+        ],
+        "version": "<2.19.3 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20170905",
+    "libraryVersion": "2.17.1",
+    "patches": [
+      {
+        "urls": [
+          "moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"
+        ],
+        "version": "<2.19.3 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20170905",
+    "libraryVersion": "2.18.0",
+    "patches": [
+      {
+        "urls": [
+          "moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"
+        ],
+        "version": "<2.19.3 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20170905",
+    "libraryVersion": "2.18.1",
+    "patches": [
+      {
+        "urls": [
+          "moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"
+        ],
+        "version": "<2.19.3 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20170905",
+    "libraryVersion": "2.19.0",
+    "patches": [
+      {
+        "urls": [
+          "moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"
+        ],
+        "version": "<2.19.3 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20170905",
+    "libraryVersion": "2.19.1",
+    "patches": [
+      {
+        "urls": [
+          "moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"
+        ],
+        "version": "<2.19.3 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:moment:20170905",
+    "libraryVersion": "2.19.2",
+    "patches": [
+      {
+        "urls": [
+          "moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch"
+        ],
+        "version": "<2.19.3 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.5.5",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.6.10 >=3.5.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.5.6",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.6.10 >=3.5.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.5.7",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.6.10 >=3.5.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.5.8",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.6.10 >=3.5.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.5.9",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.6.10 >=3.5.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.5.10",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.6.10 >=3.5.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.5.11",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.6.10 >=3.5.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.5.12",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.6.10 >=3.5.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.5.13",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.6.10 >=3.5.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.5.14",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.6.10 >=3.5.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.5.15",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.6.10 >=3.5.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.5.16",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.6.10 >=3.5.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.6.2",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.6.10 >=3.5.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.6.3",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.6.10 >=3.5.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.6.4",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.6.10 >=3.5.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.6.5",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.6.10 >=3.5.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.6.6",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.6.10 >=3.5.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.6.7",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.6.10 >=3.5.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.6.8",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.6.10 >=3.5.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.6.9",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.6.10 >=3.5.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.6.11",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      },
+      {
+        "urls": [
+          "20160116_0_5_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.6.12",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.6.13",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.6.14",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.6.15",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.6.16",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.6.17",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.6.18",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.6.19",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.6.20",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.7.0",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.7.2",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.7.3",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.7.4",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.0",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.1",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.2",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.3",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.4",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.5",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.6",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.7",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.8",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.9",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.10",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.11",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.12",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.13",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.14",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.15",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.16",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.17",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.18",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.19",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.20",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.21",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.22",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.23",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.24",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.25",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.26",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.27",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.28",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.29",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.30",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.31",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.33",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.34",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.35",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.36",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.37",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "3.8.38",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch"
+        ],
+        "version": "<3.8.39 >=3.6.11"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.0.0",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_1_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.1.2 >=4.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.0.1",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_1_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.1.2 >=4.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.0.2",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_1_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.1.2 >=4.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.0.3",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_1_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.1.2 >=4.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.0.4",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_1_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.1.2 >=4.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.0.5",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_1_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.1.2 >=4.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.0.6",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_1_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.1.2 >=4.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.0.7",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_1_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.1.2 >=4.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.0.8",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_1_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.1.2 >=4.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.1.0",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_1_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.1.2 >=4.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.1.1",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_1_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.1.2 >=4.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.1.2",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.1.3",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.1.5",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.1.6",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.1.7",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.1.8",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.1.9",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.1.10",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.1.11",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.1.12",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.2.0",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.2.1",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.2.2",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.2.3",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.2.4",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.2.5",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.2.6",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.2.7",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.2.8",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.2.9",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.2.10",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.3.0",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.3.1",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.3.2",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.3.3",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.3.4",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mongoose:20160116",
+    "libraryVersion": "4.3.5",
+    "patches": [
+      {
+        "urls": [
+          "20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch"
+        ],
+        "version": "<4.3.6 >=4.1.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ms:20151024",
+    "libraryVersion": "0.1.0",
+    "patches": [
+      {
+        "urls": [
+          "ms_20151024_5_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk5.patch"
+        ],
+        "version": "=0.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ms:20151024",
+    "libraryVersion": "0.2.0",
+    "patches": [
+      {
+        "urls": [
+          "ms_20151024_4_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk4.patch"
+        ],
+        "version": "=0.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ms:20151024",
+    "libraryVersion": "0.3.0",
+    "patches": [
+      {
+        "urls": [
+          "ms_20151024_3_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk3.patch"
+        ],
+        "version": "=0.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ms:20151024",
+    "libraryVersion": "0.4.0",
+    "patches": [
+      {
+        "urls": [
+          "ms_20151024_2_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk2.patch"
+        ],
+        "version": "<0.6.0 >0.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ms:20151024",
+    "libraryVersion": "0.5.0",
+    "patches": [
+      {
+        "urls": [
+          "ms_20151024_2_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk2.patch"
+        ],
+        "version": "<0.6.0 >0.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ms:20151024",
+    "libraryVersion": "0.5.1",
+    "patches": [
+      {
+        "urls": [
+          "ms_20151024_2_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk2.patch"
+        ],
+        "version": "<0.6.0 >0.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ms:20151024",
+    "libraryVersion": "0.6.0",
+    "patches": [
+      {
+        "urls": [
+          "ms_20151024_1_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk.patch"
+        ],
+        "version": "<0.7.0 >=0.6.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ms:20151024",
+    "libraryVersion": "0.6.1",
+    "patches": [
+      {
+        "urls": [
+          "ms_20151024_1_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk.patch"
+        ],
+        "version": "<0.7.0 >=0.6.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ms:20151024",
+    "libraryVersion": "0.6.2",
+    "patches": [
+      {
+        "urls": [
+          "ms_20151024_1_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk.patch"
+        ],
+        "version": "<0.7.0 >=0.6.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ms:20151024",
+    "libraryVersion": "0.7.0",
+    "patches": [
+      {
+        "urls": [
+          "ms_20151024_0_0_48701f029417faf65e6f5e0b61a3cebe5436b07b.patch"
+        ],
+        "version": "=0.7.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ms:20170412",
+    "libraryVersion": "0.7.1",
+    "patches": [
+      {
+        "urls": [
+          "ms_071.patch"
+        ],
+        "version": "=0.7.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ms:20170412",
+    "libraryVersion": "0.7.2",
+    "patches": [
+      {
+        "urls": [
+          "ms_072-073.patch"
+        ],
+        "version": "=0.7.2 || =0.7.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ms:20170412",
+    "libraryVersion": "0.7.3",
+    "patches": [
+      {
+        "urls": [
+          "ms_072-073.patch"
+        ],
+        "version": "=0.7.2 || =0.7.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ms:20170412",
+    "libraryVersion": "1.0.0",
+    "patches": [
+      {
+        "urls": [
+          "ms_100.patch"
+        ],
+        "version": "=1.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mustache:20151207",
+    "libraryVersion": "2.1.0",
+    "patches": [
+      {
+        "urls": [
+          "mustache_0.patch"
+        ],
+        "version": "<2.2.1 >=2.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mustache:20151207",
+    "libraryVersion": "2.1.1",
+    "patches": [
+      {
+        "urls": [
+          "mustache_0.patch"
+        ],
+        "version": "<2.2.1 >=2.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mustache:20151207",
+    "libraryVersion": "2.1.2",
+    "patches": [
+      {
+        "urls": [
+          "mustache_0.patch"
+        ],
+        "version": "<2.2.1 >=2.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mustache:20151207",
+    "libraryVersion": "2.1.3",
+    "patches": [
+      {
+        "urls": [
+          "mustache_0.patch"
+        ],
+        "version": "<2.2.1 >=2.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:mustache:20151207",
+    "libraryVersion": "2.2.0",
+    "patches": [
+      {
+        "urls": [
+          "mustache_0.patch"
+        ],
+        "version": "<2.2.1 >=2.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.1.0",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_3_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "0.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.2.3",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_2_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.4.7 > 0.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.2.4",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_2_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.4.7 > 0.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.2.5",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_2_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.4.7 > 0.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.2.6",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_2_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.4.7 > 0.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.2.7",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_2_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.4.7 > 0.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.2.8",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_2_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.4.7 > 0.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.3.0",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_2_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.4.7 > 0.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.4.0",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_2_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.4.7 > 0.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.4.1",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_2_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.4.7 > 0.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.4.2",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_2_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.4.7 > 0.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.4.3",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_2_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.4.7 > 0.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.4.4",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_2_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.4.7 > 0.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.4.5",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_2_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.4.7 > 0.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.4.6",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_2_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.4.7 > 0.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.4.7",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_2_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.4.7 > 0.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.4.8",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_1_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.5.3 > 0.4.7"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.4.9",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_1_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.5.3 > 0.4.7"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.5.0",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_1_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.5.3 > 0.4.7"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.5.1",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_1_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.5.3 > 0.4.7"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.5.2",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_1_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.5.3 > 0.4.7"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.5.3",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_1_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "<= 0.5.3 > 0.4.7"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:negotiator:20160616",
+    "libraryVersion": "0.6.0",
+    "patches": [
+      {
+        "urls": [
+          "negotiator_20160616_0_0_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch"
+        ],
+        "version": "0.6.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:node-uuid:20160328",
+    "libraryVersion": "1.4.2",
+    "patches": [
+      {
+        "urls": [
+          "node-uuid_20160328_0_0_616ad3800f35cf58089215f420db9654801a5a02.patch"
+        ],
+        "version": "<=1.4.3 >=1.4.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:node-uuid:20160328",
+    "libraryVersion": "1.4.3",
+    "patches": [
+      {
+        "urls": [
+          "node-uuid_20160328_0_0_616ad3800f35cf58089215f420db9654801a5a02.patch"
+        ],
+        "version": "<=1.4.3 >=1.4.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:printer:20140306",
+    "libraryVersion": "0.0.1",
+    "patches": [
+      {
+        "urls": [
+          "printer_20140306_0_0_e001e38738c17219a1d9dd8c31f7d82b9c0013c7.patch"
+        ],
+        "version": "<= 0.0.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:qs:20140806",
+    "libraryVersion": "0.5.6",
+    "patches": [
+      {
+        "urls": [
+          "qs_20140806_0_1_snyk_npm.patch"
+        ],
+        "version": "=0.5.6"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:qs:20140806-1",
+    "libraryVersion": "0.5.6",
+    "patches": [
+      {
+        "urls": [
+          "qs_20140806-1_0_1_snyk.patch"
+        ],
+        "version": "=0.5.6"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:qs:20140806",
+    "libraryVersion": "0.6.5",
+    "patches": [
+      {
+        "urls": [
+          "qs_20140806_0_0_43a604b7847e56bba49d0ce3e222fe89569354d8_snyk.patch"
+        ],
+        "version": "<1.0.0 >=0.6.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:qs:20140806-1",
+    "libraryVersion": "0.6.5",
+    "patches": [
+      {
+        "urls": [
+          "qs_20140806-1_0_0_snyk.patch"
+        ],
+        "version": "<1.0.0 >=0.6.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:qs:20140806",
+    "libraryVersion": "0.6.6",
+    "patches": [
+      {
+        "urls": [
+          "qs_20140806_0_0_43a604b7847e56bba49d0ce3e222fe89569354d8_snyk.patch"
+        ],
+        "version": "<1.0.0 >=0.6.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:qs:20140806-1",
+    "libraryVersion": "0.6.6",
+    "patches": [
+      {
+        "urls": [
+          "qs_20140806-1_0_0_snyk.patch"
+        ],
+        "version": "<1.0.0 >=0.6.5"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:qs:20170213",
+    "libraryVersion": "6.0.2",
+    "patches": [
+      {
+        "urls": [
+          "602_604.patch"
+        ],
+        "version": "=6.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:qs:20170213",
+    "libraryVersion": "6.0.3",
+    "patches": [
+      {
+        "urls": [
+          "603_604.patch"
+        ],
+        "version": "=6.0.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:qs:20170213",
+    "libraryVersion": "6.1.0",
+    "patches": [
+      {
+        "urls": [
+          "610_612.patch"
+        ],
+        "version": "=6.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:qs:20170213",
+    "libraryVersion": "6.1.1",
+    "patches": [
+      {
+        "urls": [
+          "611_612.patch"
+        ],
+        "version": "=6.1.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:qs:20170213",
+    "libraryVersion": "6.2.1",
+    "patches": [
+      {
+        "urls": [
+          "621_623.patch"
+        ],
+        "version": "=6.2.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:qs:20170213",
+    "libraryVersion": "6.2.2",
+    "patches": [
+      {
+        "urls": [
+          "622_623.patch"
+        ],
+        "version": "=6.2.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:qs:20170213",
+    "libraryVersion": "6.3.0",
+    "patches": [
+      {
+        "urls": [
+          "630_632.patch"
+        ],
+        "version": "=6.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:qs:20170213",
+    "libraryVersion": "6.3.1",
+    "patches": [
+      {
+        "urls": [
+          "631_632.patch"
+        ],
+        "version": "=6.3.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.2.6",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_8_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.9.3 >=2.2.6"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.2.9",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_8_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.9.3 >=2.2.6"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.9.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_8_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.9.3 >=2.2.6"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.9.1",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_8_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.9.3 >=2.2.6"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.9.2",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_8_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.9.3 >=2.2.6"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.9.3",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_7_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.9.150 >=2.9.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.9.100",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_7_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.9.150 >=2.9.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.9.150",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_6_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.16.0 >=2.9.150"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.9.151",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_6_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.16.0 >=2.9.150"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.9.152",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_6_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.16.0 >=2.9.150"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.9.153",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_6_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.16.0 >=2.9.150"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.9.200",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_6_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.16.0 >=2.9.150"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.9.201",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_6_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.16.0 >=2.9.150"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.9.202",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_6_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.16.0 >=2.9.150"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.9.203",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_6_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.16.0 >=2.9.150"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.10.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_6_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.16.0 >=2.9.150"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.11.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_6_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.16.0 >=2.9.150"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.11.1",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_6_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.16.0 >=2.9.150"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.11.2",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_6_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.16.0 >=2.9.150"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.11.3",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_6_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.16.0 >=2.9.150"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.11.4",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_6_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.16.0 >=2.9.150"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.12.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_6_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.16.0 >=2.9.150"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.14.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_6_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.16.0 >=2.9.150"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.16.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_5_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.27.0 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.16.2",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_5_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.27.0 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.16.4",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_5_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.27.0 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.16.6",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_5_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.27.0 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.18.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_5_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.27.0 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.19.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_5_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.27.0 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.20.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_5_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.27.0 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.21.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_5_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.27.0 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.22.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_5_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.27.0 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.23.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_5_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.27.0 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.24.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_5_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.27.0 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.25.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_5_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.27.0 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.26.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_5_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.27.0 >=2.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.27.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.47.0 >=2.27.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.28.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.47.0 >=2.27.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.29.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.47.0 >=2.27.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.30.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.47.0 >=2.27.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.31.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.47.0 >=2.27.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.32.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.47.0 >=2.27.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.33.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.47.0 >=2.27.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.34.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.47.0 >=2.27.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.35.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.47.0 >=2.27.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.36.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.47.0 >=2.27.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.37.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.47.0 >=2.27.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.38.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.47.0 >=2.27.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.39.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.47.0 >=2.27.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.40.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.47.0 >=2.27.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.41.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.47.0 >=2.27.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.42.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.47.0 >=2.27.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.43.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.47.0 >=2.27.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.44.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.47.0 >=2.27.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.45.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.47.0 >=2.27.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.46.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.47.0 >=2.27.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.47.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_3_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "=2.47.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.48.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_2_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<=2.51.0 >2.47.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.49.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_2_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<=2.51.0 >2.47.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.50.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_2_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<=2.51.0 >2.47.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.51.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_2_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<=2.51.0 >2.47.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.52.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_1_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.54.0 >2.51.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.53.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_1_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.54.0 >2.51.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.54.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_0_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.68.0 >=2.54.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.55.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_0_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.68.0 >=2.54.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.56.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_0_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.68.0 >=2.54.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.57.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_0_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.68.0 >=2.54.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.58.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_0_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.68.0 >=2.54.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.59.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_0_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.68.0 >=2.54.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.60.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_0_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.68.0 >=2.54.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.61.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_0_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.68.0 >=2.54.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.62.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_0_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.68.0 >=2.54.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.63.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_0_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.68.0 >=2.54.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.64.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_0_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.68.0 >=2.54.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.65.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_0_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.68.0 >=2.54.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.66.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_0_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.68.0 >=2.54.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:request:20160119",
+    "libraryVersion": "2.67.0",
+    "patches": [
+      {
+        "urls": [
+          "request_20160119_0_0_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch"
+        ],
+        "version": "<2.68.0 >=2.54.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "2.0.2",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "2.0.3",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "2.0.4",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "2.0.5",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "2.0.6",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "2.0.7",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "2.0.8",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "2.0.9",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "2.0.10",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "2.0.11",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "2.1.0",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "2.2.0",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "2.2.1",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "2.3.0",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "2.3.1",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "2.3.2",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "3.0.0",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "3.0.1",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "4.0.0",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "4.0.2",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "4.0.3",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "4.1.0",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "4.1.1",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "4.2.0",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "4.2.1",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "4.2.2",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "4.3.0",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:semver:20150403",
+    "libraryVersion": "4.3.1",
+    "patches": [
+      {
+        "urls": [
+          "semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch"
+        ],
+        "version": "<4.3.2 >= 2.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:send:20140912",
+    "libraryVersion": "0.7.3",
+    "patches": [
+      {
+        "urls": [
+          "send_20140912_0_0_9c6ca9b2c0b880afd3ff91ce0d211213c5fa_snyk.patch"
+        ],
+        "version": "< 0.8.4 >=0.7.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:send:20140912",
+    "libraryVersion": "0.7.4",
+    "patches": [
+      {
+        "urls": [
+          "send_20140912_0_0_9c6ca9b2c0b880afd3ff91ce0d211213c5fa_snyk.patch"
+        ],
+        "version": "< 0.8.4 >=0.7.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:send:20140912",
+    "libraryVersion": "0.8.0",
+    "patches": [
+      {
+        "urls": [
+          "send_20140912_0_0_9c6ca9b2c0b880afd3ff91ce0d211213c5fa_snyk.patch"
+        ],
+        "version": "< 0.8.4 >=0.7.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:send:20140912",
+    "libraryVersion": "0.8.1",
+    "patches": [
+      {
+        "urls": [
+          "send_20140912_0_0_9c6ca9b2c0b880afd3ff91ce0d211213c5fa_snyk.patch"
+        ],
+        "version": "< 0.8.4 >=0.7.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:send:20140912",
+    "libraryVersion": "0.8.2",
+    "patches": [
+      {
+        "urls": [
+          "send_20140912_0_0_9c6ca9b2c0b880afd3ff91ce0d211213c5fa_snyk.patch"
+        ],
+        "version": "< 0.8.4 >=0.7.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:send:20140912",
+    "libraryVersion": "0.8.3",
+    "patches": [
+      {
+        "urls": [
+          "send_20140912_0_0_9c6ca9b2c0b880afd3ff91ce0d211213c5fa_snyk.patch"
+        ],
+        "version": "< 0.8.4 >=0.7.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:send:20151103",
+    "libraryVersion": "0.9.0",
+    "patches": [
+      {
+        "urls": [
+          "send_20151103_0_1_98a5b89982b38e79db684177cf94730ce7fc7aed.patch"
+        ],
+        "version": "<0.11.1 >=0.9.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:send:20151103",
+    "libraryVersion": "0.9.1",
+    "patches": [
+      {
+        "urls": [
+          "send_20151103_0_1_98a5b89982b38e79db684177cf94730ce7fc7aed.patch"
+        ],
+        "version": "<0.11.1 >=0.9.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:send:20151103",
+    "libraryVersion": "0.9.2",
+    "patches": [
+      {
+        "urls": [
+          "send_20151103_0_1_98a5b89982b38e79db684177cf94730ce7fc7aed.patch"
+        ],
+        "version": "<0.11.1 >=0.9.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:send:20151103",
+    "libraryVersion": "0.9.3",
+    "patches": [
+      {
+        "urls": [
+          "send_20151103_0_1_98a5b89982b38e79db684177cf94730ce7fc7aed.patch"
+        ],
+        "version": "<0.11.1 >=0.9.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:send:20151103",
+    "libraryVersion": "0.10.0",
+    "patches": [
+      {
+        "urls": [
+          "send_20151103_0_1_98a5b89982b38e79db684177cf94730ce7fc7aed.patch"
+        ],
+        "version": "<0.11.1 >=0.9.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:send:20151103",
+    "libraryVersion": "0.10.1",
+    "patches": [
+      {
+        "urls": [
+          "send_20151103_0_1_98a5b89982b38e79db684177cf94730ce7fc7aed.patch"
+        ],
+        "version": "<0.11.1 >=0.9.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:send:20151103",
+    "libraryVersion": "0.11.0",
+    "patches": [
+      {
+        "urls": [
+          "send_20151103_0_1_98a5b89982b38e79db684177cf94730ce7fc7aed.patch"
+        ],
+        "version": "<0.11.1 >=0.9.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20150118",
+    "libraryVersion": "2.0.0-rc7",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20150118_0_0_f6ff86f7af6e2d15906ad1511b234d19adcccb07_snyk.patch"
+        ],
+        "version": "=2.0.0-rc7"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160106",
+    "libraryVersion": "3.2.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch"
+        ],
+        "version": "<=3.16.0 >=3.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160106",
+    "libraryVersion": "3.3.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch"
+        ],
+        "version": "<=3.16.0 >=3.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160106",
+    "libraryVersion": "3.3.1",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch"
+        ],
+        "version": "<=3.16.0 >=3.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160106",
+    "libraryVersion": "3.3.2",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch"
+        ],
+        "version": "<=3.16.0 >=3.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160106",
+    "libraryVersion": "3.4.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch"
+        ],
+        "version": "<=3.16.0 >=3.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160106",
+    "libraryVersion": "3.4.1",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch"
+        ],
+        "version": "<=3.16.0 >=3.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160106",
+    "libraryVersion": "3.5.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch"
+        ],
+        "version": "<=3.16.0 >=3.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160106",
+    "libraryVersion": "3.5.1",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch"
+        ],
+        "version": "<=3.16.0 >=3.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160106",
+    "libraryVersion": "3.6.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch"
+        ],
+        "version": "<=3.16.0 >=3.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160106",
+    "libraryVersion": "3.7.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch"
+        ],
+        "version": "<=3.16.0 >=3.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160106",
+    "libraryVersion": "3.7.1",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch"
+        ],
+        "version": "<=3.16.0 >=3.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160106",
+    "libraryVersion": "3.8.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch"
+        ],
+        "version": "<=3.16.0 >=3.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160106",
+    "libraryVersion": "3.9.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch"
+        ],
+        "version": "<=3.16.0 >=3.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160106",
+    "libraryVersion": "3.10.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch"
+        ],
+        "version": "<=3.16.0 >=3.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160106",
+    "libraryVersion": "3.11.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch"
+        ],
+        "version": "<=3.16.0 >=3.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160106",
+    "libraryVersion": "3.12.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch"
+        ],
+        "version": "<=3.16.0 >=3.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160106",
+    "libraryVersion": "3.12.1",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch"
+        ],
+        "version": "<=3.16.0 >=3.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160106",
+    "libraryVersion": "3.12.2",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch"
+        ],
+        "version": "<=3.16.0 >=3.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160106",
+    "libraryVersion": "3.13.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch"
+        ],
+        "version": "<=3.16.0 >=3.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160115",
+    "libraryVersion": "3.14.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160115_0_0_b85f78a318e6f7112a3374498171a3e148cdc4da_w_20160106.patch"
+        ],
+        "version": "<=3.16.0 >3.13.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160115",
+    "libraryVersion": "3.14.1",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160115_0_0_b85f78a318e6f7112a3374498171a3e148cdc4da_w_20160106.patch"
+        ],
+        "version": "<=3.16.0 >3.13.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160115",
+    "libraryVersion": "3.14.2",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160115_0_0_b85f78a318e6f7112a3374498171a3e148cdc4da_w_20160106.patch"
+        ],
+        "version": "<=3.16.0 >3.13.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160115",
+    "libraryVersion": "3.15.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160115_0_0_b85f78a318e6f7112a3374498171a3e148cdc4da_w_20160106.patch"
+        ],
+        "version": "<=3.16.0 >3.13.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160115",
+    "libraryVersion": "3.15.1",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160115_0_0_b85f78a318e6f7112a3374498171a3e148cdc4da_w_20160106.patch"
+        ],
+        "version": "<=3.16.0 >3.13.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160115",
+    "libraryVersion": "3.16.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160115_0_0_b85f78a318e6f7112a3374498171a3e148cdc4da_w_20160106.patch"
+        ],
+        "version": "<=3.16.0 >3.13.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160329",
+    "libraryVersion": "3.16.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160329_0_0_23952a2b020cc3571f090e67dae7feb084e1be71_w_20160115_w_20160106.patch"
+        ],
+        "version": "=3.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160115",
+    "libraryVersion": "3.17.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160115_0_0_b85f78a318e6f7112a3374498171a3e148cdc4da.patch"
+        ],
+        "version": "<3.17.2 >3.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160329",
+    "libraryVersion": "3.17.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160329_0_0_23952a2b020cc3571f090e67dae7feb084e1be71_w_20160115.patch"
+        ],
+        "version": "<3.17.2 >3.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160115",
+    "libraryVersion": "3.17.1",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160115_0_0_b85f78a318e6f7112a3374498171a3e148cdc4da.patch"
+        ],
+        "version": "<3.17.2 >3.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160329",
+    "libraryVersion": "3.17.1",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160329_0_0_23952a2b020cc3571f090e67dae7feb084e1be71_w_20160115.patch"
+        ],
+        "version": "<3.17.2 >3.16.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160329",
+    "libraryVersion": "3.17.2",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160329_0_0_23952a2b020cc3571f090e67dae7feb084e1be71.patch"
+        ],
+        "version": "<=3.19.3 >=3.17.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160329",
+    "libraryVersion": "3.17.3",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160329_0_0_23952a2b020cc3571f090e67dae7feb084e1be71.patch"
+        ],
+        "version": "<=3.19.3 >=3.17.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160329",
+    "libraryVersion": "3.18.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160329_0_0_23952a2b020cc3571f090e67dae7feb084e1be71.patch"
+        ],
+        "version": "<=3.19.3 >=3.17.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160329",
+    "libraryVersion": "3.19.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160329_0_0_23952a2b020cc3571f090e67dae7feb084e1be71.patch"
+        ],
+        "version": "<=3.19.3 >=3.17.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160718",
+    "libraryVersion": "3.19.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160718_0_1_f93af43a1d86400487f5e3d9762f1a4b7cf6b1e1_w_20160329.patch"
+        ],
+        "version": "<= 3.19.3 > 3.18.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160329",
+    "libraryVersion": "3.19.1",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160329_0_0_23952a2b020cc3571f090e67dae7feb084e1be71.patch"
+        ],
+        "version": "<=3.19.3 >=3.17.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160718",
+    "libraryVersion": "3.19.1",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160718_0_1_f93af43a1d86400487f5e3d9762f1a4b7cf6b1e1_w_20160329.patch"
+        ],
+        "version": "<= 3.19.3 > 3.18.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160329",
+    "libraryVersion": "3.19.2",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160329_0_0_23952a2b020cc3571f090e67dae7feb084e1be71.patch"
+        ],
+        "version": "<=3.19.3 >=3.17.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160718",
+    "libraryVersion": "3.19.2",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160718_0_1_f93af43a1d86400487f5e3d9762f1a4b7cf6b1e1_w_20160329.patch"
+        ],
+        "version": "<= 3.19.3 > 3.18.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160329",
+    "libraryVersion": "3.19.3",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160329_0_0_23952a2b020cc3571f090e67dae7feb084e1be71.patch"
+        ],
+        "version": "<=3.19.3 >=3.17.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160718",
+    "libraryVersion": "3.19.3",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160718_0_1_f93af43a1d86400487f5e3d9762f1a4b7cf6b1e1_w_20160329.patch"
+        ],
+        "version": "<= 3.19.3 > 3.18.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160718",
+    "libraryVersion": "3.20.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160718_0_1_f93af43a1d86400487f5e3d9762f1a4b7cf6b1e1.patch"
+        ],
+        "version": "<= 3.20.0 > 3.19.3"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160718",
+    "libraryVersion": "3.21.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160718_0_0_f93af43a1d86400487f5e3d9762f1a4b7cf6b1e1.patch"
+        ],
+        "version": "<= 3.23.4 > 3.20.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160718",
+    "libraryVersion": "3.22.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160718_0_0_f93af43a1d86400487f5e3d9762f1a4b7cf6b1e1.patch"
+        ],
+        "version": "<= 3.23.4 > 3.20.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160718",
+    "libraryVersion": "3.23.0",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160718_0_0_f93af43a1d86400487f5e3d9762f1a4b7cf6b1e1.patch"
+        ],
+        "version": "<= 3.23.4 > 3.20.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160718",
+    "libraryVersion": "3.23.1",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160718_0_0_f93af43a1d86400487f5e3d9762f1a4b7cf6b1e1.patch"
+        ],
+        "version": "<= 3.23.4 > 3.20.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160718",
+    "libraryVersion": "3.23.2",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160718_0_0_f93af43a1d86400487f5e3d9762f1a4b7cf6b1e1.patch"
+        ],
+        "version": "<= 3.23.4 > 3.20.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160718",
+    "libraryVersion": "3.23.3",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160718_0_0_f93af43a1d86400487f5e3d9762f1a4b7cf6b1e1.patch"
+        ],
+        "version": "<= 3.23.4 > 3.20.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:sequelize:20160718",
+    "libraryVersion": "3.23.4",
+    "patches": [
+      {
+        "urls": [
+          "sequelize_20160718_0_0_f93af43a1d86400487f5e3d9762f1a4b7cf6b1e1.patch"
+        ],
+        "version": "<= 3.23.4 > 3.20.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:serve-index:20150314",
+    "libraryVersion": "1.5.2",
+    "patches": [
+      {
+        "urls": [
+          "serve-index_20150314_0_0_0d135e710d717d7d9a3a3994f611214fb42e2191_snyk.patch"
+        ],
+        "version": "<1.6.3 >1.5.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:serve-index:20150314",
+    "libraryVersion": "1.5.3",
+    "patches": [
+      {
+        "urls": [
+          "serve-index_20150314_0_0_0d135e710d717d7d9a3a3994f611214fb42e2191_snyk.patch"
+        ],
+        "version": "<1.6.3 >1.5.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:serve-index:20150314",
+    "libraryVersion": "1.6.0",
+    "patches": [
+      {
+        "urls": [
+          "serve-index_20150314_0_0_0d135e710d717d7d9a3a3994f611214fb42e2191_snyk.patch"
+        ],
+        "version": "<1.6.3 >1.5.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:serve-index:20150314",
+    "libraryVersion": "1.6.1",
+    "patches": [
+      {
+        "urls": [
+          "serve-index_20150314_0_0_0d135e710d717d7d9a3a3994f611214fb42e2191_snyk.patch"
+        ],
+        "version": "<1.6.3 >1.5.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:serve-index:20150314",
+    "libraryVersion": "1.6.2",
+    "patches": [
+      {
+        "urls": [
+          "serve-index_20150314_0_0_0d135e710d717d7d9a3a3994f611214fb42e2191_snyk.patch"
+        ],
+        "version": "<1.6.3 >1.5.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:serve-static:20150113",
+    "libraryVersion": "1.7.0",
+    "patches": [
+      {
+        "urls": [
+          "serve-static_20150113_0_0_0399e399935bab99530d6926094b4451438c2d50_snyk.patch"
+        ],
+        "version": ">=1.7.0 <1.7.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:serve-static:20150113",
+    "libraryVersion": "1.7.1",
+    "patches": [
+      {
+        "urls": [
+          "serve-static_20150113_0_0_0399e399935bab99530d6926094b4451438c2d50_snyk.patch"
+        ],
+        "version": ">=1.7.0 <1.7.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:shell-quote:20160621",
+    "libraryVersion": "1.4.3",
+    "patches": [
+      {
+        "urls": [
+          "shell-quote_20160621_0_0.patch"
+        ],
+        "version": "<=1.6.0 >1.4.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:shell-quote:20160621",
+    "libraryVersion": "1.5.0",
+    "patches": [
+      {
+        "urls": [
+          "shell-quote_20160621_0_0.patch"
+        ],
+        "version": "<=1.6.0 >1.4.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:shell-quote:20160621",
+    "libraryVersion": "1.6.0",
+    "patches": [
+      {
+        "urls": [
+          "shell-quote_20160621_0_0.patch"
+        ],
+        "version": "<=1.6.0 >1.4.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:shout:20160913",
+    "libraryVersion": "0.51.0",
+    "patches": [
+      {
+        "urls": [
+          "shout_20160913_0_0_7ef2da0c832175cea1776a651a3c14051468fdc2.patch"
+        ],
+        "version": "0.51.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:st:20140206",
+    "libraryVersion": "0.2.0",
+    "patches": [
+      {
+        "urls": [
+          "st-20140206_0_0_6b54ce2d2fb912eadd31e2c25c65456d2c8666e1.patch"
+        ],
+        "version": "<0.2.5 >0.1.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:st:20140206",
+    "libraryVersion": "0.2.1",
+    "patches": [
+      {
+        "urls": [
+          "st-20140206_0_0_6b54ce2d2fb912eadd31e2c25c65456d2c8666e1.patch"
+        ],
+        "version": "<0.2.5 >0.1.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:st:20140206",
+    "libraryVersion": "0.2.2",
+    "patches": [
+      {
+        "urls": [
+          "st-20140206_0_0_6b54ce2d2fb912eadd31e2c25c65456d2c8666e1.patch"
+        ],
+        "version": "<0.2.5 >0.1.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:st:20140206",
+    "libraryVersion": "0.2.3",
+    "patches": [
+      {
+        "urls": [
+          "st-20140206_0_0_6b54ce2d2fb912eadd31e2c25c65456d2c8666e1.patch"
+        ],
+        "version": "<0.2.5 >0.1.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:st:20140206",
+    "libraryVersion": "0.2.4",
+    "patches": [
+      {
+        "urls": [
+          "st-20140206_0_0_6b54ce2d2fb912eadd31e2c25c65456d2c8666e1.patch"
+        ],
+        "version": "<0.2.5 >0.1.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:stringstream:20180511",
+    "libraryVersion": "0.0.4",
+    "patches": [
+      {
+        "urls": [
+          "20180511_0_0_stringstream_afbc7442220358419e330618e47f3a65fc265b1b.patch"
+        ],
+        "version": "<0.0.6 >=0.0.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:stringstream:20180511",
+    "libraryVersion": "0.0.5",
+    "patches": [
+      {
+        "urls": [
+          "20180511_0_0_stringstream_afbc7442220358419e330618e47f3a65fc265b1b.patch"
+        ],
+        "version": "<0.0.6 >=0.0.4"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "0.1.0",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_1_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<0.1.13 >0.0.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "0.1.2",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_1_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<0.1.13 >0.0.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "0.1.3",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_1_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<0.1.13 >0.0.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "0.1.4",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_1_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<0.1.13 >0.0.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "0.1.5",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_1_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<0.1.13 >0.0.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "0.1.6",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_1_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<0.1.13 >0.0.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "0.1.7",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_1_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<0.1.13 >0.0.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "0.1.8",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_1_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<0.1.13 >0.0.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "0.1.9",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_1_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<0.1.13 >0.0.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "0.1.10",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_1_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<0.1.13 >0.0.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "0.1.11",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_1_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<0.1.13 >0.0.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "0.1.12",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_1_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<0.1.13 >0.0.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "0.1.13",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_0_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<2.0.0 >=0.1.13"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "0.1.14",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_0_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<2.0.0 >=0.1.13"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "0.1.15",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_0_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<2.0.0 >=0.1.13"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "0.1.16",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_0_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<2.0.0 >=0.1.13"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "0.1.17",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_0_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<2.0.0 >=0.1.13"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "0.1.18",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_0_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<2.0.0 >=0.1.13"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "0.1.19",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_0_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<2.0.0 >=0.1.13"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "0.1.20",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_0_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<2.0.0 >=0.1.13"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "1.0.0",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_0_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<2.0.0 >=0.1.13"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "1.0.1",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_0_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<2.0.0 >=0.1.13"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "1.0.2",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_0_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<2.0.0 >=0.1.13"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tar:20151103",
+    "libraryVersion": "1.0.3",
+    "patches": [
+      {
+        "urls": [
+          "tar_20151103_0_0_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch"
+        ],
+        "version": "<2.0.0 >=0.1.13"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tomato:20130307",
+    "libraryVersion": "0.0.2",
+    "patches": [
+      {
+        "urls": [
+          "tomato_20130307_0_0_9e427d524e04a905312a3294c85e939ed7d57b8c.patch"
+        ],
+        "version": "<= 0.0.5 >=0.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tomato:20130307",
+    "libraryVersion": "0.0.3",
+    "patches": [
+      {
+        "urls": [
+          "tomato_20130307_0_0_9e427d524e04a905312a3294c85e939ed7d57b8c.patch"
+        ],
+        "version": "<= 0.0.5 >=0.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tomato:20130307",
+    "libraryVersion": "0.0.4",
+    "patches": [
+      {
+        "urls": [
+          "tomato_20130307_0_0_9e427d524e04a905312a3294c85e939ed7d57b8c.patch"
+        ],
+        "version": "<= 0.0.5 >=0.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tomato:20130307",
+    "libraryVersion": "0.0.5",
+    "patches": [
+      {
+        "urls": [
+          "tomato_20130307_0_0_9e427d524e04a905312a3294c85e939ed7d57b8c.patch"
+        ],
+        "version": "<= 0.0.5 >=0.0.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tough-cookie:20160722",
+    "libraryVersion": "1.0.0",
+    "patches": [
+      {
+        "urls": [
+          "tough-cookie_20160722_0_0_e4fc2e0f9ee1b7a818d68f0ac7ea696f377b1534.patch"
+        ],
+        "version": "<=2.2.2 >=1.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tough-cookie:20160722",
+    "libraryVersion": "1.1.0",
+    "patches": [
+      {
+        "urls": [
+          "tough-cookie_20160722_0_0_e4fc2e0f9ee1b7a818d68f0ac7ea696f377b1534.patch"
+        ],
+        "version": "<=2.2.2 >=1.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tough-cookie:20160722",
+    "libraryVersion": "1.2.0",
+    "patches": [
+      {
+        "urls": [
+          "tough-cookie_20160722_0_0_e4fc2e0f9ee1b7a818d68f0ac7ea696f377b1534.patch"
+        ],
+        "version": "<=2.2.2 >=1.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tough-cookie:20160722",
+    "libraryVersion": "2.0.0",
+    "patches": [
+      {
+        "urls": [
+          "tough-cookie_20160722_0_0_e4fc2e0f9ee1b7a818d68f0ac7ea696f377b1534.patch"
+        ],
+        "version": "<=2.2.2 >=1.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tough-cookie:20160722",
+    "libraryVersion": "2.1.0",
+    "patches": [
+      {
+        "urls": [
+          "tough-cookie_20160722_0_0_e4fc2e0f9ee1b7a818d68f0ac7ea696f377b1534.patch"
+        ],
+        "version": "<=2.2.2 >=1.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tough-cookie:20160722",
+    "libraryVersion": "2.2.0",
+    "patches": [
+      {
+        "urls": [
+          "tough-cookie_20160722_0_0_e4fc2e0f9ee1b7a818d68f0ac7ea696f377b1534.patch"
+        ],
+        "version": "<=2.2.2 >=1.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tough-cookie:20170905",
+    "libraryVersion": "2.2.0",
+    "patches": [
+      {
+        "urls": [
+          "220_221.patch"
+        ],
+        "version": "=2.2.0 || =2.2.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tough-cookie:20160722",
+    "libraryVersion": "2.2.1",
+    "patches": [
+      {
+        "urls": [
+          "tough-cookie_20160722_0_0_e4fc2e0f9ee1b7a818d68f0ac7ea696f377b1534.patch"
+        ],
+        "version": "<=2.2.2 >=1.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tough-cookie:20170905",
+    "libraryVersion": "2.2.1",
+    "patches": [
+      {
+        "urls": [
+          "220_221.patch"
+        ],
+        "version": "=2.2.0 || =2.2.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tough-cookie:20160722",
+    "libraryVersion": "2.2.2",
+    "patches": [
+      {
+        "urls": [
+          "tough-cookie_20160722_0_0_e4fc2e0f9ee1b7a818d68f0ac7ea696f377b1534.patch"
+        ],
+        "version": "<=2.2.2 >=1.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tough-cookie:20170905",
+    "libraryVersion": "2.2.2",
+    "patches": [
+      {
+        "urls": [
+          "222.patch"
+        ],
+        "version": "=2.2.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tough-cookie:20170905",
+    "libraryVersion": "2.3.0",
+    "patches": [
+      {
+        "urls": [
+          "230_232.patch"
+        ],
+        "version": "=2.3.0 || =2.3.1 || =2.3.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tough-cookie:20170905",
+    "libraryVersion": "2.3.1",
+    "patches": [
+      {
+        "urls": [
+          "230_232.patch"
+        ],
+        "version": "=2.3.0 || =2.3.1 || =2.3.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tough-cookie:20170905",
+    "libraryVersion": "2.3.2",
+    "patches": [
+      {
+        "urls": [
+          "230_232.patch"
+        ],
+        "version": "=2.3.0 || =2.3.1 || =2.3.2"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-TREEKILL-536781",
+    "libraryVersion": "1.0.0",
+    "patches": [
+      {
+        "urls": [
+          "tree-kill_0_0_20191210_e5d66d1fbd4b392294512d4644ac22bdc888573c.patch"
+        ],
+        "version": ">=1.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-TREEKILL-536781",
+    "libraryVersion": "1.1.0",
+    "patches": [
+      {
+        "urls": [
+          "tree-kill_0_0_20191210_e5d66d1fbd4b392294512d4644ac22bdc888573c.patch"
+        ],
+        "version": ">=1.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-TREEKILL-536781",
+    "libraryVersion": "1.2.0",
+    "patches": [
+      {
+        "urls": [
+          "tree-kill_0_0_20191210_e5d66d1fbd4b392294512d4644ac22bdc888573c.patch"
+        ],
+        "version": ">=1.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "SNYK-JS-TREEKILL-536781",
+    "libraryVersion": "1.2.1",
+    "patches": [
+      {
+        "urls": [
+          "tree-kill_0_0_20191210_e5d66d1fbd4b392294512d4644ac22bdc888573c.patch"
+        ],
+        "version": ">=1.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tunnel-agent:20170305",
+    "libraryVersion": "0.4.3",
+    "patches": [
+      {
+        "urls": [
+          "tunnel-agent_20170305_0_0_9ca95ec7219daface8a6fc2674000653de0922c0.patch"
+        ],
+        "version": "=0.4.3 || =0.5.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:tunnel-agent:20170305",
+    "libraryVersion": "0.5.0",
+    "patches": [
+      {
+        "urls": [
+          "tunnel-agent_20170305_0_0_9ca95ec7219daface8a6fc2674000653de0922c0.patch"
+        ],
+        "version": "=0.4.3 || =0.5.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.2.0",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.2.0",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.2.1",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.2.1",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.2.2",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.2.2",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.2.3",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.2.3",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.2.4",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.2.4",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.2.5",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.2.5",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.3.0",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.3.0",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.3.1",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.3.1",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.3.2",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.3.2",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.3.3",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.3.3",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.3.4",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.3.4",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.3.5",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.3.5",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.3.6",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.3.6",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.0",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.0",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.1",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.1",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.2",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.2",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.3",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.3",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.4",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.4",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.5",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.5",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.6",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.6",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.7",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.7",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.8",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.8",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.9",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.9",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.10",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.10",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.11",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.11",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.12",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.12",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.13",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.13",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.14",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.14",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.15",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.15",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.16",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.16",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.17",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.17",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.18",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.18",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.19",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.19",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.20",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.20",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.21",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.21",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.22",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.22",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20150824",
+    "libraryVersion": "2.4.23",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch"
+        ],
+        "version": "<= 2.4.23 >2.0.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.23",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk_inc.patch"
+        ],
+        "version": "<= 2.4.23 >=2.2.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.4.24",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk.patch"
+        ],
+        "version": "<2.6.0 >2.4.23"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:uglify-js:20151024",
+    "libraryVersion": "2.5.0",
+    "patches": [
+      {
+        "urls": [
+          "uglify-js_20151024_0_0_63d35f8_snyk.patch"
+        ],
+        "version": "<2.6.0 >2.4.23"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:validator:20130705-1",
+    "libraryVersion": "1.5.1",
+    "patches": [
+      {
+        "urls": [
+          "validator_20130705-1_0_0_2d5d6999541add350fb396ef02dc42ca3215049e_snyk.patch"
+        ],
+        "version": "<2.0.0 >=1.5.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.3.8",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_3_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "=0.3.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.3.9",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_2_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.8 >= 0.3.9"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.0",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_2_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.8 >= 0.3.9"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.1",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_2_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.8 >= 0.3.9"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.2",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_2_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.8 >= 0.3.9"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.3",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_2_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.8 >= 0.3.9"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.5",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_2_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.8 >= 0.3.9"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.6",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_2_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.8 >= 0.3.9"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.7",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_2_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.8 >= 0.3.9"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.8",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_1_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.27 >= 0.4.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.9",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_1_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.27 >= 0.4.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.10",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_1_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.27 >= 0.4.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.11",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_1_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.27 >= 0.4.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.12",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_1_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.27 >= 0.4.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.13",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_1_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.27 >= 0.4.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.14",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_1_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.27 >= 0.4.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.15",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_1_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.27 >= 0.4.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.16",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_1_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.27 >= 0.4.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.17",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_1_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.27 >= 0.4.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.18",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_1_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.27 >= 0.4.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.19",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_1_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.27 >= 0.4.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.20",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_1_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.27 >= 0.4.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.21",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_1_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.27 >= 0.4.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.22",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_1_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.27 >= 0.4.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.23",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_1_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.27 >= 0.4.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.24",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_1_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.27 >= 0.4.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.25",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_1_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 0.4.27 >= 0.4.8"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.27",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 1.0.1 >= 0.4.27"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.28",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 1.0.1 >= 0.4.27"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.29",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 1.0.1 >= 0.4.27"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.30",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 1.0.1 >= 0.4.27"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.31",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 1.0.1 >= 0.4.27"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160920",
+    "libraryVersion": "0.4.31",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160920_0_0.patch"
+        ],
+        "version": "<1.1.2 >=0.4.31"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.4.32",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 1.0.1 >= 0.4.27"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160920",
+    "libraryVersion": "0.4.32",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160920_0_0.patch"
+        ],
+        "version": "<1.1.2 >=0.4.31"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.5.0",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 1.0.1 >= 0.4.27"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160920",
+    "libraryVersion": "0.5.0",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160920_0_0.patch"
+        ],
+        "version": "<1.1.2 >=0.4.31"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.6.0",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 1.0.1 >= 0.4.27"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160920",
+    "libraryVersion": "0.6.0",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160920_0_0.patch"
+        ],
+        "version": "<1.1.2 >=0.4.31"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.6.1",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 1.0.1 >= 0.4.27"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160920",
+    "libraryVersion": "0.6.1",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160920_0_0.patch"
+        ],
+        "version": "<1.1.2 >=0.4.31"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.6.2",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 1.0.1 >= 0.4.27"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160920",
+    "libraryVersion": "0.6.2",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160920_0_0.patch"
+        ],
+        "version": "<1.1.2 >=0.4.31"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.6.3",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 1.0.1 >= 0.4.27"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160920",
+    "libraryVersion": "0.6.3",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160920_0_0.patch"
+        ],
+        "version": "<1.1.2 >=0.4.31"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.6.4",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 1.0.1 >= 0.4.27"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160920",
+    "libraryVersion": "0.6.4",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160920_0_0.patch"
+        ],
+        "version": "<1.1.2 >=0.4.31"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.6.5",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 1.0.1 >= 0.4.27"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160920",
+    "libraryVersion": "0.6.5",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160920_0_0.patch"
+        ],
+        "version": "<1.1.2 >=0.4.31"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.7.0",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 1.0.1 >= 0.4.27"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160920",
+    "libraryVersion": "0.7.0",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160920_0_0.patch"
+        ],
+        "version": "<1.1.2 >=0.4.31"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.7.1",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 1.0.1 >= 0.4.27"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160920",
+    "libraryVersion": "0.7.1",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160920_0_0.patch"
+        ],
+        "version": "<1.1.2 >=0.4.31"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.7.2",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 1.0.1 >= 0.4.27"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160920",
+    "libraryVersion": "0.7.2",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160920_0_0.patch"
+        ],
+        "version": "<1.1.2 >=0.4.31"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.8.0",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 1.0.1 >= 0.4.27"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160920",
+    "libraryVersion": "0.8.0",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160920_0_0.patch"
+        ],
+        "version": "<1.1.2 >=0.4.31"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "0.8.1",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 1.0.1 >= 0.4.27"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160920",
+    "libraryVersion": "0.8.1",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160920_0_0.patch"
+        ],
+        "version": "<1.1.2 >=0.4.31"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160104",
+    "libraryVersion": "1.0.0",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch"
+        ],
+        "version": "< 1.0.1 >= 0.4.27"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160920",
+    "libraryVersion": "1.0.0",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160920_0_0.patch"
+        ],
+        "version": "<1.1.2 >=0.4.31"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160624",
+    "libraryVersion": "1.0.1",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160624_0_1_101_sio.patch"
+        ],
+        "version": "=1.0.1"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160920",
+    "libraryVersion": "1.0.1",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160920_0_0.patch"
+        ],
+        "version": "<1.1.2 >=0.4.31"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160624",
+    "libraryVersion": "1.1.0",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160624_0_0_0328a8f49f004f98d2913016214e93b2fc2713bc.patch"
+        ],
+        "version": "=1.1.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160920",
+    "libraryVersion": "1.1.0",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160920_0_0.patch"
+        ],
+        "version": "<1.1.2 >=0.4.31"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:ws:20160920",
+    "libraryVersion": "1.1.1",
+    "patches": [
+      {
+        "urls": [
+          "ws_20160920_0_0.patch"
+        ],
+        "version": "<1.1.2 >=0.4.31"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:yar:20140616",
+    "libraryVersion": "0.3.0",
+    "patches": [
+      {
+        "urls": [
+          "yar_20140616_0_0_66b981a47655bef2fed84f90b86fc5b43edaea8e.patch"
+        ],
+        "version": "<2.2.0 >=0.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:yar:20140616",
+    "libraryVersion": "0.3.1",
+    "patches": [
+      {
+        "urls": [
+          "yar_20140616_0_0_66b981a47655bef2fed84f90b86fc5b43edaea8e.patch"
+        ],
+        "version": "<2.2.0 >=0.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:yar:20140616",
+    "libraryVersion": "0.4.0",
+    "patches": [
+      {
+        "urls": [
+          "yar_20140616_0_0_66b981a47655bef2fed84f90b86fc5b43edaea8e.patch"
+        ],
+        "version": "<2.2.0 >=0.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:yar:20140616",
+    "libraryVersion": "0.4.1",
+    "patches": [
+      {
+        "urls": [
+          "yar_20140616_0_0_66b981a47655bef2fed84f90b86fc5b43edaea8e.patch"
+        ],
+        "version": "<2.2.0 >=0.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:yar:20140616",
+    "libraryVersion": "1.0.0",
+    "patches": [
+      {
+        "urls": [
+          "yar_20140616_0_0_66b981a47655bef2fed84f90b86fc5b43edaea8e.patch"
+        ],
+        "version": "<2.2.0 >=0.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:yar:20140616",
+    "libraryVersion": "1.1.0",
+    "patches": [
+      {
+        "urls": [
+          "yar_20140616_0_0_66b981a47655bef2fed84f90b86fc5b43edaea8e.patch"
+        ],
+        "version": "<2.2.0 >=0.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:yar:20140616",
+    "libraryVersion": "2.0.0",
+    "patches": [
+      {
+        "urls": [
+          "yar_20140616_0_0_66b981a47655bef2fed84f90b86fc5b43edaea8e.patch"
+        ],
+        "version": "<2.2.0 >=0.3.0"
+      }
+    ]
+  },
+  {
+    "vulnerabilityId": "npm:yar:20140616",
+    "libraryVersion": "2.1.0",
+    "patches": [
+      {
+        "urls": [
+          "yar_20140616_0_0_66b981a47655bef2fed84f90b86fc5b43edaea8e.patch"
+        ],
+        "version": "<2.2.0 >=0.3.0"
+      }
+    ]
+  }
+]

--- a/packages/snyk-protect/patches/20150122_0_0_http-signature_78ab1da232f31f695f5c362d863593a143aa8b56.patch
+++ b/packages/snyk-protect/patches/20150122_0_0_http-signature_78ab1da232f31f695f5c362d863593a143aa8b56.patch
@@ -1,0 +1,45 @@
+// code derived from https://github.com/joyent/node-http-signature/commit/78ab1da232f31f695f5c362d863593a143aa8b56
+/*
+Copyright Joyent, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+
+*/
+
+--- a/lib/verify.js
++++ b/lib/verify.js
+@@ -29,9 +29,17 @@ module.exports = {
+                           parsedSignature.algorithm);
+ 
+     if (alg[1] === 'HMAC') {
+-      var hmac = crypto.createHmac(alg[2].toUpperCase(), key);
++      var hashAlg = alg[1];
++
++      var hmac = crypto.createHmac(hashAlg, key);
+       hmac.update(parsedSignature.signingString);
+-      return (hmac.digest('base64') === parsedSignature.params.signature);
++     
++      var h1 = crypto.createHmac(hashAlg, secret);
++      h1.update(hmac.digest());
++      var h2 = crypto.createHmac(hashAlg, secret);
++      h2.update(new Buffer(parsedSignature.params.signature, 'base64'));
++
++      return (h1.digest().equals(h2.digest()));
+     } else {
+       var verify = crypto.createVerify(alg[0]);
+       verify.update(parsedSignature.signingString);

--- a/packages/snyk-protect/patches/20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch
+++ b/packages/snyk-protect/patches/20160116_0_0_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch
@@ -1,0 +1,30 @@
+// code derived from https://github.com/Automattic/mongoose
+// reference: 
+//  https://github.com/Automattic/mongoose/commit/2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f
+//  https://github.com/Automattic/mongoose/commit/8066b145c07984c8b7e56dbb51721c0a3d48e18a 
+
+// https://github.com/Automattic/mongoose#license
+/*
+Copyright (c) 2010 LearnBoost <dev@learnboost.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/lib/schema/buffer.js b/lib/schema/buffer.js
+index d26cc33..b64234f 100644
+--- a/lib/schema/buffer.js
++++ b/lib/schema/buffer.js
+@@ -125,6 +125,9 @@ SchemaBuffer.prototype.cast = function(value, doc, init) {
+ 
+   var type = typeof value;
+   if ('string' == type || 'number' == type || Array.isArray(value)) {
++    if (type === 'number') {
++      value = [value];
++    }
+     ret = new MongooseBuffer(value, [this.path, doc]);
+     return ret;
+   }

--- a/packages/snyk-protect/patches/20160116_0_1_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch
+++ b/packages/snyk-protect/patches/20160116_0_1_mongoose_8066b145c07984c8b7e56dbb51721c0a3d48e18a.patch
@@ -1,0 +1,30 @@
+// code derived from https://github.com/Automattic/mongoose
+// reference: 
+//  https://github.com/Automattic/mongoose/commit/2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f
+//  https://github.com/Automattic/mongoose/commit/8066b145c07984c8b7e56dbb51721c0a3d48e18a 
+
+// https://github.com/Automattic/mongoose#license
+/*
+Copyright (c) 2010 LearnBoost <dev@learnboost.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/lib/schema/buffer.js b/lib/schema/buffer.js
+index d26cc33..b64234f 100644
+--- a/lib/schema/buffer.js
++++ b/lib/schema/buffer.js
+@@ -123,6 +123,9 @@
+
+   var type = typeof value;
+   if ('string' == type || 'number' == type || Array.isArray(value)) {
++    if (type === 'number') {
++      value = [value];
++    }
+     var ret = new MongooseBuffer(value, [this.path, doc]);
+     return ret;
+   }

--- a/packages/snyk-protect/patches/20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch
+++ b/packages/snyk-protect/patches/20160116_0_3_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch
@@ -1,0 +1,30 @@
+// code derived from https://github.com/Automattic/mongoose
+// reference: 
+//  https://github.com/Automattic/mongoose/commit/2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f
+//  https://github.com/Automattic/mongoose/commit/8066b145c07984c8b7e56dbb51721c0a3d48e18a 
+
+// https://github.com/Automattic/mongoose#license
+/*
+Copyright (c) 2010 LearnBoost <dev@learnboost.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/lib/schema/buffer.js b/lib/schema/buffer.js
+index 91a59e0..6e18f25 100644
+--- a/lib/schema/buffer.js
++++ b/lib/schema/buffer.js
+@@ -112,6 +112,9 @@ SchemaBuffer.prototype.cast = function (value, doc, init) {
+ 
+   var type = typeof value;
+   if ('string' == type || 'number' == type || Array.isArray(value)) {
++    if (type === 'number') {
++      value = [value];
++    }
+     var ret = new MongooseBuffer(value, [this.path, doc]);
+     return ret;
+   }

--- a/packages/snyk-protect/patches/20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch
+++ b/packages/snyk-protect/patches/20160116_0_4_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch
@@ -1,0 +1,29 @@
+// code derived from https://github.com/Automattic/mongoose
+// reference: 
+//  https://github.com/Automattic/mongoose/commit/2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f
+//  https://github.com/Automattic/mongoose/commit/8066b145c07984c8b7e56dbb51721c0a3d48e18a 
+
+// https://github.com/Automattic/mongoose#license
+/*
+Copyright (c) 2010 LearnBoost <dev@learnboost.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/lib/schema/buffer.js b/lib/schema/buffer.js
+index 91a59e0..6e18f25 100644
+--- a/lib/schema/buffer.js
++++ b/lib/schema/buffer.js
+@@ -105,6 +105,9 @@
+
+   var type = typeof value;
+   if ('string' == type || 'number' == type || Array.isArray(value)) {
++    if (type === 'number') {
++      value = [value];
++    }
+     return new MongooseBuffer(value, [this.path, doc]);
+   }

--- a/packages/snyk-protect/patches/20160116_0_5_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch
+++ b/packages/snyk-protect/patches/20160116_0_5_mongoose_2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f.patch
@@ -1,0 +1,30 @@
+// code derived from https://github.com/Automattic/mongoose
+// reference: 
+//  https://github.com/Automattic/mongoose/commit/2ff7d36c5e52270211b17f3a84c8a47c6f4d8c1f
+//  https://github.com/Automattic/mongoose/commit/8066b145c07984c8b7e56dbb51721c0a3d48e18a 
+
+// https://github.com/Automattic/mongoose#license
+/*
+Copyright (c) 2010 LearnBoost <dev@learnboost.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/lib/schema/buffer.js b/lib/schema/buffer.js
+index 91a59e0..6e18f25 100644
+--- a/lib/schema/buffer.js
++++ b/lib/schema/buffer.js
+@@ -120,6 +120,9 @@
+
+   var type = typeof value;
+   if ('string' == type || 'number' == type || Array.isArray(value)) {
++    if (type === 'number') {
++      value = [value];
++    }
+     var ret = new MongooseBuffer(value, [this.path, doc]);
+     return ret;
+   }

--- a/packages/snyk-protect/patches/20180130_0_0_lodash_d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a.patch
+++ b/packages/snyk-protect/patches/20180130_0_0_lodash_d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a.patch
@@ -1,0 +1,62 @@
+// code derived from https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a
+
+// lodash license:
+/**
+ * @license
+ * Lodash <https://lodash.com/>
+ * Copyright JS Foundation and other contributors <https://js.foundation/>
+ * Released under MIT license <https://lodash.com/license>
+ * Based on Underscore.js 1.8.3 <http://underscorejs.org/LICENSE>
+ * Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+ */
+
+--- a/index.js
++++ b/index.js
+@@ -589,6 +589,20 @@
+   }
+ 
+   /**
++   * Gets the value at `key`, unless `key` is "__proto__".
++   *
++   * @private
++   * @param {Object} object The object to query.
++   * @param {string} key The key of the property to get.
++   * @returns {*} Returns the property value.
++   */
++  function safeGet(object, key) {
++    return key == '__proto__'
++      ? undefined
++      : object[key];
++  }
++
++  /**
+    * An implementation of `_.uniq` optimized for sorted arrays without support
+    * for callback shorthands and `this` binding.
+    *
+@@ -2366,7 +2380,7 @@
+           baseMergeDeep(object, source, key, baseMerge, customizer, stackA, stackB);
+         }
+         else {
+-          var value = object[key],
++          var value = safeGet(object, key),
+               result = customizer ? customizer(value, srcValue, key, object, source) : undefined,
+               isCommon = result === undefined;
+ 
+@@ -2399,7 +2413,7 @@
+      */
+     function baseMergeDeep(object, source, key, mergeFunc, customizer, stackA, stackB) {
+       var length = stackA.length,
+-          srcValue = source[key];
++          srcValue = safeGet(source, key);
+ 
+       while (length--) {
+         if (stackA[length] == srcValue) {
+@@ -2407,7 +2421,7 @@
+           return;
+         }
+       }
+-      var value = object[key],
++      var value = safeGet(object, key),
+           result = customizer ? customizer(value, srcValue, key, object, source) : undefined,
+           isCommon = result === undefined;
+ 

--- a/packages/snyk-protect/patches/20180212_0_0_hoek_5aed1a8c4a3d55722d1c799f2368857bf418d6df.patch
+++ b/packages/snyk-protect/patches/20180212_0_0_hoek_5aed1a8c4a3d55722d1c799f2368857bf418d6df.patch
@@ -1,0 +1,49 @@
+// code derived from https://github.com/hapijs/hoek/commit/32ed5c9413321fbc37da5ca81a7cbab693786dee
+/*
+Copyright (c) 2011-2017, Project contributors
+Copyright (c) 2011-2014, Walmart
+Copyright (c) 2011, Yahoo Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at: https://github.com/hapijs/hapi/graphs/contributors
+Portions of this project were initially based on the Yahoo! Inc. Postmile project,
+published at https://github.com/yahoo/postmile.
+
+*/
+
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -114,6 +114,9 @@ exports.merge = function (target, source, isNullOverride /* = true */, isMergeAr
+     const keys = Object.keys(source);
+     for (let i = 0; i < keys.length; ++i) {
+         const key = keys[i];
++        if (key === '__proto__') {
++            continue;
++        }        
+         const value = source[key];
+         if (value &&
+             typeof value === 'object') {

--- a/packages/snyk-protect/patches/20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch
+++ b/packages/snyk-protect/patches/20180212_0_1_hoek_32ed5c9413321fbc37da5ca81a7cbab693786dee.patch
@@ -1,0 +1,49 @@
+// code derived from https://github.com/hapijs/hoek/commit/32ed5c9413321fbc37da5ca81a7cbab693786dee
+/*
+Copyright (c) 2011-2017, Project contributors
+Copyright (c) 2011-2014, Walmart
+Copyright (c) 2011, Yahoo Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at: https://github.com/hapijs/hapi/graphs/contributors
+Portions of this project were initially based on the Yahoo! Inc. Postmile project,
+published at https://github.com/yahoo/postmile.
+
+*/
+
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -110,6 +110,9 @@ exports.merge = function (target, source, isNullOverride /* = true */, isMergeAr
+     var keys = Object.keys(source);
+     for (var k = 0, kl = keys.length; k < kl; ++k) {
+         var key = keys[k];
++        if (key === '__proto__') {
++            continue;
++        }
+         var value = source[key];
+         if (value &&
+             typeof value === 'object') {

--- a/packages/snyk-protect/patches/20180511_0_0_stringstream_afbc7442220358419e330618e47f3a65fc265b1b.patch
+++ b/packages/snyk-protect/patches/20180511_0_0_stringstream_afbc7442220358419e330618e47f3a65fc265b1b.patch
@@ -1,0 +1,38 @@
+// derived from https://github.com/mhart/StringStream/commit/afbc7442220358419e330618e47f3a65fc265b1b
+
+// license:
+/*
+* Copyright (c) 2012 Michael Hart (michael.hart.au@gmail.com)
+* 
+* Permission is hereby granted, free of charge, to any person
+* obtaining a copy of this software and associated documentation
+* files (the "Software"), to deal in the Software without
+* restriction, including without limitation the rights to use,
+* copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following
+* conditions:
+* 
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+* 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+* OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+* HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*/
+--- a/stringstream.js
++++ b/stringstream.js
+@@ -28,7 +28,7 @@ StringStream.prototype.write = function(data) {
+     return false
+   }
+   if (this.fromEncoding) {
+-    if (Buffer.isBuffer(data)) data = data.toString()
++    if (Buffer.isBuffer(data) || typeof data === 'number') data = data.toString()
+     data = new Buffer(data, this.fromEncoding)
+   }
+   var string = this.decoder.write(data)

--- a/packages/snyk-protect/patches/220_221.patch
+++ b/packages/snyk-protect/patches/220_221.patch
@@ -1,0 +1,48 @@
+// Code derived from https://github.com/salesforce/tough-cookie/commit/f1ed420a6a92ea7a5418df6e39e676556bc0c71d
+
+// https://github.com/salesforce/tough-cookie/blob/master/LICENSE
+/*
+Copyright (c) 2015, Salesforce.com, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===
+
+The following exceptions apply:
+
+===
+
+`public_suffix_list.dat` was obtained from
+<https://publicsuffix.org/list/public_suffix_list.dat> via
+<http://publicsuffix.org>. The license for this file is MPL/2.0.  The header of
+that file reads as follows:
+
+  // This Source Code Form is subject to the terms of the Mozilla Public
+  // License, v. 2.0. If a copy of the MPL was not distributed with this
+  // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+--- a/lib/cookie.js	2017-09-24 13:55:08.000000000 +0300
++++ b/lib/cookie.js	2017-09-24 13:55:44.000000000 +0300
+@@ -58,11 +58,11 @@
+ // (see: https://github.com/ChromiumWebApps/chromium/blob/b3d3b4da8bb94c1b2e061600df106d590fda3620/net/cookies/parsed_cookie.cc#L60)
+ // '=' and ';' are attribute/values separators
+ // (see: https://github.com/ChromiumWebApps/chromium/blob/b3d3b4da8bb94c1b2e061600df106d590fda3620/net/cookies/parsed_cookie.cc#L64)
+-var COOKIE_PAIR = /^(([^=;]+))\s*=\s*(("?)[^\n\r\0]*\3)/
++var COOKIE_PAIR = /^(([^=;]+))\s{0,256}=\s*(("?)[^\n\r\0]*\3)/
+ 
+ // Used to parse non-RFC-compliant cookies like '=abc' when given the `loose`
+ // option in Cookie.parse:
+-var LOOSE_COOKIE_PAIR = /^((?:=)?([^=;]*)\s*=\s*)?(("?)[^\n\r\0]*\3)/;
++var LOOSE_COOKIE_PAIR = /^((?:=)?([^=;]*)\s{0,256}=\s*)?(("?)[^\n\r\0]*\3)/;
+ 
+ // RFC6265 S4.1.1 defines path value as 'any CHAR except CTLs or ";"'
+ // Note ';' is \x3B

--- a/packages/snyk-protect/patches/222.patch
+++ b/packages/snyk-protect/patches/222.patch
@@ -1,0 +1,48 @@
+// Code derived from https://github.com/salesforce/tough-cookie/commit/f1ed420a6a92ea7a5418df6e39e676556bc0c71d
+
+// https://github.com/salesforce/tough-cookie/blob/master/LICENSE
+/*
+Copyright (c) 2015, Salesforce.com, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===
+
+The following exceptions apply:
+
+===
+
+`public_suffix_list.dat` was obtained from
+<https://publicsuffix.org/list/public_suffix_list.dat> via
+<http://publicsuffix.org>. The license for this file is MPL/2.0.  The header of
+that file reads as follows:
+
+  // This Source Code Form is subject to the terms of the Mozilla Public
+  // License, v. 2.0. If a copy of the MPL was not distributed with this
+  // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+--- a/lib/cookie.js	2017-09-24 13:55:08.000000000 +0300
++++ b/lib/cookie.js	2017-09-24 13:55:44.000000000 +0300
+@@ -58,11 +58,11 @@
+ // (see: https://github.com/ChromiumWebApps/chromium/blob/b3d3b4da8bb94c1b2e061600df106d590fda3620/net/cookies/parsed_cookie.cc#L60)
+ // '=' and ';' are attribute/values separators
+ // (see: https://github.com/ChromiumWebApps/chromium/blob/b3d3b4da8bb94c1b2e061600df106d590fda3620/net/cookies/parsed_cookie.cc#L64)
+-var COOKIE_PAIR = /^(([^=;]+))\s*=\s*([^\n\r\0]*)/;
++var COOKIE_PAIR = /^(([^=;]+))\s{0,256}=\s*([^\n\r\0]*)/;
+ 
+ // Used to parse non-RFC-compliant cookies like '=abc' when given the `loose`
+ // option in Cookie.parse:
+-var LOOSE_COOKIE_PAIR = /^((?:=)?([^=;]*)\s*=\s*)?([^\n\r\0]*)/;
++var LOOSE_COOKIE_PAIR = /^((?:=)?([^=;]*)\s{0,256}=\s*)?([^\n\r\0]*)/;
+ 
+ // RFC6265 S4.1.1 defines path value as 'any CHAR except CTLs or ";"'
+ // Note ';' is \x3B

--- a/packages/snyk-protect/patches/230_232.patch
+++ b/packages/snyk-protect/patches/230_232.patch
@@ -1,0 +1,50 @@
+// Code derived from https://github.com/salesforce/tough-cookie/commit/f1ed420a6a92ea7a5418df6e39e676556bc0c71d
+
+// https://github.com/salesforce/tough-cookie/blob/master/LICENSE
+/*
+Copyright (c) 2015, Salesforce.com, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===
+
+The following exceptions apply:
+
+===
+
+`public_suffix_list.dat` was obtained from
+<https://publicsuffix.org/list/public_suffix_list.dat> via
+<http://publicsuffix.org>. The license for this file is MPL/2.0.  The header of
+that file reads as follows:
+
+  // This Source Code Form is subject to the terms of the Mozilla Public
+  // License, v. 2.0. If a copy of the MPL was not distributed with this
+  // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+diff --git a/lib/cookie.js b/lib/cookie.js
+index 32e49ad..18e1afe 100644
+--- a/lib/cookie.js
++++ b/lib/cookie.js
+@@ -58,11 +58,11 @@ var CONTROL_CHARS = /[\x00-\x1F]/;
+ // (see: https://github.com/ChromiumWebApps/chromium/blob/b3d3b4da8bb94c1b2e061600df106d590fda3620/net/cookies/parsed_cookie.cc#L60)
+ // '=' and ';' are attribute/values separators
+ // (see: https://github.com/ChromiumWebApps/chromium/blob/b3d3b4da8bb94c1b2e061600df106d590fda3620/net/cookies/parsed_cookie.cc#L64)
+-var COOKIE_PAIR = /^(([^=;]+))\s*=\s*([^\n\r\0]*)/;
++var COOKIE_PAIR = /^(([^=;]+))\s{0,256}=\s*([^\n\r\0]*)/;
+ 
+ // Used to parse non-RFC-compliant cookies like '=abc' when given the `loose`
+ // option in Cookie.parse:
+-var LOOSE_COOKIE_PAIR = /^((?:=)?([^=;]*)\s*=\s*)?([^\n\r\0]*)/;
++var LOOSE_COOKIE_PAIR = /^((?:=)?([^=;]*)\s{0,256}=\s*)?([^\n\r\0]*)/;
+ 
+ // RFC6265 S4.1.1 defines path value as 'any CHAR except CTLs or ";"'
+ // Note ';' is \x3B

--- a/packages/snyk-protect/patches/602_604.patch
+++ b/packages/snyk-protect/patches/602_604.patch
@@ -1,0 +1,147 @@
+// code derived from https://github.com/ljharb/qs
+// based on the following commits:
+// '6.0.3', fixed https://github.com/ljharb/qs/commit/ca844c59f3180e2089a66f30c3b26848b9def123
+// '6.1.1', fixed https://github.com/ljharb/qs/commit/55de6600895b41f6726c39208fd0407da43604ae
+// '6.2.2', fixed https://github.com/ljharb/qs/commit/27bbdb2ba5723944dda50f8de72d8900348e3bba
+// '6.3.1'  fixed https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d
+
+// https://github.com/ljharb/qs/blob/master/LICENSE
+/*
+Copyright (c) 2014 Nathan LaFreniere and other contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at: https://github.com/hapijs/qs/graphs/contributors
+*/
+
+diff -Naur a/lib/parse.js a/lib/parse.js
+--- a/lib/parse.js	2017-03-09 19:34:30.000000000 +0200
++++ a/lib/parse.js	2017-03-06 18:50:46.000000000 +0200
+@@ -13,6 +13,8 @@
+     allowDots: false
+ };
+ 
++var has = Object.prototype.hasOwnProperty;
++
+ internals.parseValues = function (str, options) {
+     var obj = {};
+     var parts = str.split(options.delimiter, options.parameterLimit === Infinity ? undefined : options.parameterLimit);
+@@ -31,7 +33,7 @@
+             var key = Utils.decode(part.slice(0, pos));
+             var val = Utils.decode(part.slice(pos + 1));
+ 
+-            if (Object.prototype.hasOwnProperty.call(obj, key)) {
++            if (has.call(obj, key)) {
+                 obj[key] = [].concat(obj[key]).concat(val);
+             } else {
+                 obj[key] = val;
+@@ -55,7 +57,7 @@
+         obj = obj.concat(internals.parseObject(chain, val, options));
+     } else {
+         obj = options.plainObjects ? Object.create(null) : {};
+-        var cleanRoot = root[0] === '[' && root[root.length - 1] === ']' ? root.slice(1, root.length - 1) : root;
++        var cleanRoot = root.charAt(0) === '[' && root.charAt(root.length - 1) === ']' ? root.slice(1, -1) : root;
+         var index = parseInt(cleanRoot, 10);
+         if (
+             !isNaN(index) &&
+@@ -84,26 +86,27 @@
+ 
+     // The regex chunks
+ 
+-    var parent = /^([^\[\]]*)/;
+-    var child = /(\[[^\[\]]*\])/g;
++    var brackets = /(\[[^[\]]*])/;
++    var child = /(\[[^[\]]*])/g;
+ 
+     // Get the parent
+ 
+-    var segment = parent.exec(key);
++    var segment = brackets.exec(key);
++    var parent = segment ? key.slice(0, segment.index) : key;
+ 
+     // Stash the parent if it exists
+ 
+     var keys = [];
+-    if (segment[1]) {
++    if (parent) {
+         // If we aren't using plain objects, optionally prefix keys
+         // that would overwrite object prototype properties
+-        if (!options.plainObjects && Object.prototype.hasOwnProperty(segment[1])) {
++        if (!options.plainObjects && has.call(Object.prototype, parent)) {
+             if (!options.allowPrototypes) {
+                 return;
+             }
+         }
+ 
+-        keys.push(segment[1]);
++        keys.push(parent);
+     }
+ 
+     // Loop through children appending to the array until we hit depth
+@@ -111,9 +114,9 @@
+     var i = 0;
+     while ((segment = child.exec(key)) !== null && i < options.depth) {
+         i += 1;
+-        if (!options.plainObjects && Object.prototype.hasOwnProperty(segment[1].replace(/\[|\]/g, ''))) {
++        if (!options.plainObjects && has.call(Object.prototype, segment[1].slice(1, -1))) {
+             if (!options.allowPrototypes) {
+-                continue;
++                return;
+             }
+         }
+         keys.push(segment[1]);
+diff -Naur a/lib/utils.js a/lib/utils.js
+--- a/lib/utils.js	2017-03-09 19:34:30.000000000 +0200
++++ a/lib/utils.js	2017-03-06 18:50:46.000000000 +0200
+@@ -9,6 +9,8 @@
+     return array;
+ }());
+ 
++var has = Object.prototype.hasOwnProperty;
++
+ exports.arrayToObject = function (source, options) {
+     var obj = options.plainObjects ? Object.create(null) : {};
+     for (var i = 0; i < source.length; ++i) {
+@@ -29,7 +31,9 @@
+         if (Array.isArray(target)) {
+             target.push(source);
+         } else if (typeof target === 'object') {
+-            target[source] = true;
++            if (options.plainObjects || options.allowPrototypes || !has.call(Object.prototype, source)) {
++                target[source] = true;
++            }
+         } else {
+             return [target, source];
+         }
+@@ -49,7 +53,7 @@
+ 	return Object.keys(source).reduce(function (acc, key) {
+         var value = source[key];
+ 
+-        if (Object.prototype.hasOwnProperty.call(acc, key)) {
++        if (has.call(acc, key)) {
+             acc[key] = exports.merge(acc[key], value, options);
+         } else {
+             acc[key] = value;

--- a/packages/snyk-protect/patches/603_604.patch
+++ b/packages/snyk-protect/patches/603_604.patch
@@ -1,0 +1,134 @@
+// code derived from https://github.com/ljharb/qs
+// based on the following commits:
+// '6.0.3', fixed https://github.com/ljharb/qs/commit/ca844c59f3180e2089a66f30c3b26848b9def123
+// '6.1.1', fixed https://github.com/ljharb/qs/commit/55de6600895b41f6726c39208fd0407da43604ae
+// '6.2.2', fixed https://github.com/ljharb/qs/commit/27bbdb2ba5723944dda50f8de72d8900348e3bba
+// '6.3.1'  fixed https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d
+
+// https://github.com/ljharb/qs/blob/master/LICENSE
+/*
+Copyright (c) 2014 Nathan LaFreniere and other contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at: https://github.com/hapijs/qs/graphs/contributors
+*/
+
+diff -Naur a/lib/parse.js a/lib/parse.js
+--- a/lib/parse.js	2017-03-09 19:35:00.000000000 +0200
++++ a/lib/parse.js	2017-03-06 18:50:46.000000000 +0200
+@@ -13,6 +13,8 @@
+     allowDots: false
+ };
+ 
++var has = Object.prototype.hasOwnProperty;
++
+ internals.parseValues = function (str, options) {
+     var obj = {};
+     var parts = str.split(options.delimiter, options.parameterLimit === Infinity ? undefined : options.parameterLimit);
+@@ -31,7 +33,7 @@
+             var key = Utils.decode(part.slice(0, pos));
+             var val = Utils.decode(part.slice(pos + 1));
+ 
+-            if (Object.prototype.hasOwnProperty.call(obj, key)) {
++            if (has.call(obj, key)) {
+                 obj[key] = [].concat(obj[key]).concat(val);
+             } else {
+                 obj[key] = val;
+@@ -84,26 +86,27 @@
+ 
+     // The regex chunks
+ 
+-    var parent = /^([^[]*)/;
++    var brackets = /(\[[^[\]]*])/;
+     var child = /(\[[^[\]]*])/g;
+ 
+     // Get the parent
+ 
+-    var segment = parent.exec(key);
++    var segment = brackets.exec(key);
++    var parent = segment ? key.slice(0, segment.index) : key;
+ 
+     // Stash the parent if it exists
+ 
+     var keys = [];
+-    if (segment[1]) {
++    if (parent) {
+         // If we aren't using plain objects, optionally prefix keys
+         // that would overwrite object prototype properties
+-        if (!options.plainObjects && Object.prototype.hasOwnProperty(segment[1])) {
++        if (!options.plainObjects && has.call(Object.prototype, parent)) {
+             if (!options.allowPrototypes) {
+                 return;
+             }
+         }
+ 
+-        keys.push(segment[1]);
++        keys.push(parent);
+     }
+ 
+     // Loop through children appending to the array until we hit depth
+@@ -111,7 +114,7 @@
+     var i = 0;
+     while ((segment = child.exec(key)) !== null && i < options.depth) {
+         i += 1;
+-        if (!options.plainObjects && Object.prototype.hasOwnProperty.call(Object.prototype, segment[1].slice(1, -1))) {
++        if (!options.plainObjects && has.call(Object.prototype, segment[1].slice(1, -1))) {
+             if (!options.allowPrototypes) {
+                 return;
+             }
+diff -Naur a/lib/utils.js a/lib/utils.js
+--- a/lib/utils.js	2017-03-09 19:35:00.000000000 +0200
++++ a/lib/utils.js	2017-03-06 18:50:46.000000000 +0200
+@@ -9,6 +9,8 @@
+     return array;
+ }());
+ 
++var has = Object.prototype.hasOwnProperty;
++
+ exports.arrayToObject = function (source, options) {
+     var obj = options.plainObjects ? Object.create(null) : {};
+     for (var i = 0; i < source.length; ++i) {
+@@ -29,7 +31,9 @@
+         if (Array.isArray(target)) {
+             target.push(source);
+         } else if (typeof target === 'object') {
+-            target[source] = true;
++            if (options.plainObjects || options.allowPrototypes || !has.call(Object.prototype, source)) {
++                target[source] = true;
++            }
+         } else {
+             return [target, source];
+         }
+@@ -49,7 +53,7 @@
+ 	return Object.keys(source).reduce(function (acc, key) {
+         var value = source[key];
+ 
+-        if (Object.prototype.hasOwnProperty.call(acc, key)) {
++        if (has.call(acc, key)) {
+             acc[key] = exports.merge(acc[key], value, options);
+         } else {
+             acc[key] = value;

--- a/packages/snyk-protect/patches/610_612.patch
+++ b/packages/snyk-protect/patches/610_612.patch
@@ -1,0 +1,147 @@
+// code derived from https://github.com/ljharb/qs
+// based on the following commits:
+// '6.0.3', fixed https://github.com/ljharb/qs/commit/ca844c59f3180e2089a66f30c3b26848b9def123
+// '6.1.1', fixed https://github.com/ljharb/qs/commit/55de6600895b41f6726c39208fd0407da43604ae
+// '6.2.2', fixed https://github.com/ljharb/qs/commit/27bbdb2ba5723944dda50f8de72d8900348e3bba
+// '6.3.1'  fixed https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d
+
+// https://github.com/ljharb/qs/blob/master/LICENSE
+/*
+Copyright (c) 2014 Nathan LaFreniere and other contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at: https://github.com/hapijs/qs/graphs/contributors
+*/
+
+diff -Naur a/lib/parse.js a/lib/parse.js
+--- a/lib/parse.js	2017-03-09 19:34:19.000000000 +0200
++++ a/lib/parse.js	2017-03-06 18:50:46.000000000 +0200
+@@ -13,6 +13,8 @@
+     allowDots: false
+ };
+ 
++var has = Object.prototype.hasOwnProperty;
++
+ internals.parseValues = function (str, options) {
+     var obj = {};
+     var parts = str.split(options.delimiter, options.parameterLimit === Infinity ? undefined : options.parameterLimit);
+@@ -31,7 +33,7 @@
+             var key = Utils.decode(part.slice(0, pos));
+             var val = Utils.decode(part.slice(pos + 1));
+ 
+-            if (Object.prototype.hasOwnProperty.call(obj, key)) {
++            if (has.call(obj, key)) {
+                 obj[key] = [].concat(obj[key]).concat(val);
+             } else {
+                 obj[key] = val;
+@@ -55,7 +57,7 @@
+         obj = obj.concat(internals.parseObject(chain, val, options));
+     } else {
+         obj = options.plainObjects ? Object.create(null) : {};
+-        var cleanRoot = root[0] === '[' && root[root.length - 1] === ']' ? root.slice(1, root.length - 1) : root;
++        var cleanRoot = root.charAt(0) === '[' && root.charAt(root.length - 1) === ']' ? root.slice(1, -1) : root;
+         var index = parseInt(cleanRoot, 10);
+         if (
+             !isNaN(index) &&
+@@ -84,26 +86,27 @@
+ 
+     // The regex chunks
+ 
+-    var parent = /^([^\[\]]*)/;
+-    var child = /(\[[^\[\]]*\])/g;
++    var brackets = /(\[[^[\]]*])/;
++    var child = /(\[[^[\]]*])/g;
+ 
+     // Get the parent
+ 
+-    var segment = parent.exec(key);
++    var segment = brackets.exec(key);
++    var parent = segment ? key.slice(0, segment.index) : key;
+ 
+     // Stash the parent if it exists
+ 
+     var keys = [];
+-    if (segment[1]) {
++    if (parent) {
+         // If we aren't using plain objects, optionally prefix keys
+         // that would overwrite object prototype properties
+-        if (!options.plainObjects && Object.prototype.hasOwnProperty(segment[1])) {
++        if (!options.plainObjects && has.call(Object.prototype, parent)) {
+             if (!options.allowPrototypes) {
+                 return;
+             }
+         }
+ 
+-        keys.push(segment[1]);
++        keys.push(parent);
+     }
+ 
+     // Loop through children appending to the array until we hit depth
+@@ -111,9 +114,9 @@
+     var i = 0;
+     while ((segment = child.exec(key)) !== null && i < options.depth) {
+         i += 1;
+-        if (!options.plainObjects && Object.prototype.hasOwnProperty(segment[1].replace(/\[|\]/g, ''))) {
++        if (!options.plainObjects && has.call(Object.prototype, segment[1].slice(1, -1))) {
+             if (!options.allowPrototypes) {
+-                continue;
++                return;
+             }
+         }
+         keys.push(segment[1]);
+diff -Naur a/lib/utils.js a/lib/utils.js
+--- a/lib/utils.js	2017-03-09 19:34:19.000000000 +0200
++++ a/lib/utils.js	2017-03-06 18:50:46.000000000 +0200
+@@ -9,6 +9,8 @@
+     return array;
+ }());
+ 
++var has = Object.prototype.hasOwnProperty;
++
+ exports.arrayToObject = function (source, options) {
+     var obj = options.plainObjects ? Object.create(null) : {};
+     for (var i = 0; i < source.length; ++i) {
+@@ -29,7 +31,9 @@
+         if (Array.isArray(target)) {
+             target.push(source);
+         } else if (typeof target === 'object') {
+-            target[source] = true;
++            if (options.plainObjects || options.allowPrototypes || !has.call(Object.prototype, source)) {
++                target[source] = true;
++            }
+         } else {
+             return [target, source];
+         }
+@@ -49,7 +53,7 @@
+ 	return Object.keys(source).reduce(function (acc, key) {
+         var value = source[key];
+ 
+-        if (Object.prototype.hasOwnProperty.call(acc, key)) {
++        if (has.call(acc, key)) {
+             acc[key] = exports.merge(acc[key], value, options);
+         } else {
+             acc[key] = value;

--- a/packages/snyk-protect/patches/611_612.patch
+++ b/packages/snyk-protect/patches/611_612.patch
@@ -1,0 +1,134 @@
+// code derived from https://github.com/ljharb/qs
+// based on the following commits:
+// '6.0.3', fixed https://github.com/ljharb/qs/commit/ca844c59f3180e2089a66f30c3b26848b9def123
+// '6.1.1', fixed https://github.com/ljharb/qs/commit/55de6600895b41f6726c39208fd0407da43604ae
+// '6.2.2', fixed https://github.com/ljharb/qs/commit/27bbdb2ba5723944dda50f8de72d8900348e3bba
+// '6.3.1'  fixed https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d
+
+// https://github.com/ljharb/qs/blob/master/LICENSE
+/*
+Copyright (c) 2014 Nathan LaFreniere and other contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at: https://github.com/hapijs/qs/graphs/contributors
+*/
+
+diff -Naur a/lib/parse.js a/lib/parse.js
+--- a/lib/parse.js	2017-03-09 19:34:44.000000000 +0200
++++ a/lib/parse.js	2017-03-06 18:50:46.000000000 +0200
+@@ -13,6 +13,8 @@
+     allowDots: false
+ };
+ 
++var has = Object.prototype.hasOwnProperty;
++
+ internals.parseValues = function (str, options) {
+     var obj = {};
+     var parts = str.split(options.delimiter, options.parameterLimit === Infinity ? undefined : options.parameterLimit);
+@@ -31,7 +33,7 @@
+             var key = Utils.decode(part.slice(0, pos));
+             var val = Utils.decode(part.slice(pos + 1));
+ 
+-            if (Object.prototype.hasOwnProperty.call(obj, key)) {
++            if (has.call(obj, key)) {
+                 obj[key] = [].concat(obj[key]).concat(val);
+             } else {
+                 obj[key] = val;
+@@ -84,26 +86,27 @@
+ 
+     // The regex chunks
+ 
+-    var parent = /^([^[]*)/;
++    var brackets = /(\[[^[\]]*])/;
+     var child = /(\[[^[\]]*])/g;
+ 
+     // Get the parent
+ 
+-    var segment = parent.exec(key);
++    var segment = brackets.exec(key);
++    var parent = segment ? key.slice(0, segment.index) : key;
+ 
+     // Stash the parent if it exists
+ 
+     var keys = [];
+-    if (segment[1]) {
++    if (parent) {
+         // If we aren't using plain objects, optionally prefix keys
+         // that would overwrite object prototype properties
+-        if (!options.plainObjects && Object.prototype.hasOwnProperty(segment[1])) {
++        if (!options.plainObjects && has.call(Object.prototype, parent)) {
+             if (!options.allowPrototypes) {
+                 return;
+             }
+         }
+ 
+-        keys.push(segment[1]);
++        keys.push(parent);
+     }
+ 
+     // Loop through children appending to the array until we hit depth
+@@ -111,7 +114,7 @@
+     var i = 0;
+     while ((segment = child.exec(key)) !== null && i < options.depth) {
+         i += 1;
+-        if (!options.plainObjects && Object.prototype.hasOwnProperty.call(Object.prototype, segment[1].slice(1, -1))) {
++        if (!options.plainObjects && has.call(Object.prototype, segment[1].slice(1, -1))) {
+             if (!options.allowPrototypes) {
+                 return;
+             }
+diff -Naur a/lib/utils.js a/lib/utils.js
+--- a/lib/utils.js	2017-03-09 19:34:44.000000000 +0200
++++ a/lib/utils.js	2017-03-06 18:50:46.000000000 +0200
+@@ -9,6 +9,8 @@
+     return array;
+ }());
+ 
++var has = Object.prototype.hasOwnProperty;
++
+ exports.arrayToObject = function (source, options) {
+     var obj = options.plainObjects ? Object.create(null) : {};
+     for (var i = 0; i < source.length; ++i) {
+@@ -29,7 +31,9 @@
+         if (Array.isArray(target)) {
+             target.push(source);
+         } else if (typeof target === 'object') {
+-            target[source] = true;
++            if (options.plainObjects || options.allowPrototypes || !has.call(Object.prototype, source)) {
++                target[source] = true;
++            }
+         } else {
+             return [target, source];
+         }
+@@ -49,7 +53,7 @@
+ 	return Object.keys(source).reduce(function (acc, key) {
+         var value = source[key];
+ 
+-        if (Object.prototype.hasOwnProperty.call(acc, key)) {
++        if (has.call(acc, key)) {
+             acc[key] = exports.merge(acc[key], value, options);
+         } else {
+             acc[key] = value;

--- a/packages/snyk-protect/patches/621_623.patch
+++ b/packages/snyk-protect/patches/621_623.patch
@@ -1,0 +1,134 @@
+// code derived from https://github.com/ljharb/qs
+// based on the following commits:
+// '6.0.3', fixed https://github.com/ljharb/qs/commit/ca844c59f3180e2089a66f30c3b26848b9def123
+// '6.1.1', fixed https://github.com/ljharb/qs/commit/55de6600895b41f6726c39208fd0407da43604ae
+// '6.2.2', fixed https://github.com/ljharb/qs/commit/27bbdb2ba5723944dda50f8de72d8900348e3bba
+// '6.3.1'  fixed https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d
+
+// https://github.com/ljharb/qs/blob/master/LICENSE
+/*
+Copyright (c) 2014 Nathan LaFreniere and other contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at: https://github.com/hapijs/qs/graphs/contributors
+*/
+
+diff -Naur a/lib/parse.js a/lib/parse.js
+--- a/lib/parse.js	2017-03-09 19:33:52.000000000 +0200
++++ a/lib/parse.js	2017-03-06 11:02:34.000000000 +0200
+@@ -55,7 +55,7 @@
+         obj = obj.concat(parseObject(chain, val, options));
+     } else {
+         obj = options.plainObjects ? Object.create(null) : {};
+-        var cleanRoot = root[0] === '[' && root[root.length - 1] === ']' ? root.slice(1, root.length - 1) : root;
++        var cleanRoot = root.charAt(0) === '[' && root.charAt(root.length - 1) === ']' ? root.slice(1, -1) : root;
+         var index = parseInt(cleanRoot, 10);
+         if (
+             !isNaN(index) &&
+@@ -80,30 +80,31 @@
+     }
+ 
+     // Transform dot notation to bracket notation
+-    var key = options.allowDots ? givenKey.replace(/\.([^\.\[]+)/g, '[$1]') : givenKey;
++    var key = options.allowDots ? givenKey.replace(/\.([^.[]+)/g, '[$1]') : givenKey;
+ 
+     // The regex chunks
+ 
+-    var parent = /^([^\[\]]*)/;
+-    var child = /(\[[^\[\]]*\])/g;
++    var brackets = /(\[[^[\]]*])/;
++    var child = /(\[[^[\]]*])/g;
+ 
+     // Get the parent
+ 
+-    var segment = parent.exec(key);
++    var segment = brackets.exec(key);
++    var parent = segment ? key.slice(0, segment.index) : key;
+ 
+     // Stash the parent if it exists
+ 
+     var keys = [];
+-    if (segment[1]) {
++    if (parent) {
+         // If we aren't using plain objects, optionally prefix keys
+         // that would overwrite object prototype properties
+-        if (!options.plainObjects && has.call(Object.prototype, segment[1])) {
++        if (!options.plainObjects && has.call(Object.prototype, parent)) {
+             if (!options.allowPrototypes) {
+                 return;
+             }
+         }
+ 
+-        keys.push(segment[1]);
++        keys.push(parent);
+     }
+ 
+     // Loop through children appending to the array until we hit depth
+@@ -111,9 +112,9 @@
+     var i = 0;
+     while ((segment = child.exec(key)) !== null && i < options.depth) {
+         i += 1;
+-        if (!options.plainObjects && has.call(Object.prototype, segment[1].replace(/\[|\]/g, ''))) {
++        if (!options.plainObjects && has.call(Object.prototype, segment[1].slice(1, -1))) {
+             if (!options.allowPrototypes) {
+-                continue;
++                return;
+             }
+         }
+         keys.push(segment[1]);
+diff -Naur a/lib/utils.js a/lib/utils.js
+--- a/lib/utils.js	2017-03-09 19:33:52.000000000 +0200
++++ a/lib/utils.js	2017-03-06 11:02:34.000000000 +0200
+@@ -9,6 +9,8 @@
+     return array;
+ }());
+ 
++var has = Object.prototype.hasOwnProperty;
++
+ exports.arrayToObject = function (source, options) {
+     var obj = options.plainObjects ? Object.create(null) : {};
+     for (var i = 0; i < source.length; ++i) {
+@@ -29,7 +31,9 @@
+         if (Array.isArray(target)) {
+             target.push(source);
+         } else if (typeof target === 'object') {
+-            target[source] = true;
++            if (options.plainObjects || options.allowPrototypes || !has.call(Object.prototype, source)) {
++                target[source] = true;
++            }
+         } else {
+             return [target, source];
+         }
+@@ -49,7 +53,7 @@
+     return Object.keys(source).reduce(function (acc, key) {
+         var value = source[key];
+ 
+-        if (Object.prototype.hasOwnProperty.call(acc, key)) {
++        if (has.call(acc, key)) {
+             acc[key] = exports.merge(acc[key], value, options);
+         } else {
+             acc[key] = value;

--- a/packages/snyk-protect/patches/622_623.patch
+++ b/packages/snyk-protect/patches/622_623.patch
@@ -1,0 +1,107 @@
+// code derived from https://github.com/ljharb/qs
+// based on the following commits:
+// '6.0.3', fixed https://github.com/ljharb/qs/commit/ca844c59f3180e2089a66f30c3b26848b9def123
+// '6.1.1', fixed https://github.com/ljharb/qs/commit/55de6600895b41f6726c39208fd0407da43604ae
+// '6.2.2', fixed https://github.com/ljharb/qs/commit/27bbdb2ba5723944dda50f8de72d8900348e3bba
+// '6.3.1'  fixed https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d
+
+// https://github.com/ljharb/qs/blob/master/LICENSE
+/*
+Copyright (c) 2014 Nathan LaFreniere and other contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at: https://github.com/hapijs/qs/graphs/contributors
+*/
+
+diff -Naur a/lib/parse.js a/lib/parse.js
+--- a/lib/parse.js	2017-03-09 19:34:30.000000000 +0200
++++ a/lib/parse.js	2017-03-06 11:02:34.000000000 +0200
+@@ -84,26 +84,27 @@
+ 
+     // The regex chunks
+ 
+-    var parent = /^([^[]*)/;
++    var brackets = /(\[[^[\]]*])/;
+     var child = /(\[[^[\]]*])/g;
+ 
+     // Get the parent
+ 
+-    var segment = parent.exec(key);
++    var segment = brackets.exec(key);
++    var parent = segment ? key.slice(0, segment.index) : key;
+ 
+     // Stash the parent if it exists
+ 
+     var keys = [];
+-    if (segment[1]) {
++    if (parent) {
+         // If we aren't using plain objects, optionally prefix keys
+         // that would overwrite object prototype properties
+-        if (!options.plainObjects && has.call(Object.prototype, segment[1])) {
++        if (!options.plainObjects && has.call(Object.prototype, parent)) {
+             if (!options.allowPrototypes) {
+                 return;
+             }
+         }
+ 
+-        keys.push(segment[1]);
++        keys.push(parent);
+     }
+ 
+     // Loop through children appending to the array until we hit depth
+diff -Naur a/lib/utils.js a/lib/utils.js
+--- a/lib/utils.js	2017-03-09 19:34:30.000000000 +0200
++++ a/lib/utils.js	2017-03-06 11:02:34.000000000 +0200
+@@ -9,6 +9,8 @@
+     return array;
+ }());
+ 
++var has = Object.prototype.hasOwnProperty;
++
+ exports.arrayToObject = function (source, options) {
+     var obj = options.plainObjects ? Object.create(null) : {};
+     for (var i = 0; i < source.length; ++i) {
+@@ -29,7 +31,9 @@
+         if (Array.isArray(target)) {
+             target.push(source);
+         } else if (typeof target === 'object') {
+-            target[source] = true;
++            if (options.plainObjects || options.allowPrototypes || !has.call(Object.prototype, source)) {
++                target[source] = true;
++            }
+         } else {
+             return [target, source];
+         }
+@@ -49,7 +53,7 @@
+     return Object.keys(source).reduce(function (acc, key) {
+         var value = source[key];
+ 
+-        if (Object.prototype.hasOwnProperty.call(acc, key)) {
++        if (has.call(acc, key)) {
+             acc[key] = exports.merge(acc[key], value, options);
+         } else {
+             acc[key] = value;

--- a/packages/snyk-protect/patches/630_632.patch
+++ b/packages/snyk-protect/patches/630_632.patch
@@ -1,0 +1,222 @@
+// code derived from https://github.com/ljharb/qs
+// based on the following commits:
+// '6.0.3', fixed https://github.com/ljharb/qs/commit/ca844c59f3180e2089a66f30c3b26848b9def123
+// '6.1.1', fixed https://github.com/ljharb/qs/commit/55de6600895b41f6726c39208fd0407da43604ae
+// '6.2.2', fixed https://github.com/ljharb/qs/commit/27bbdb2ba5723944dda50f8de72d8900348e3bba
+// '6.3.1'  fixed https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d
+
+// https://github.com/ljharb/qs/blob/master/LICENSE
+/*
+Copyright (c) 2014 Nathan LaFreniere and other contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at: https://github.com/hapijs/qs/graphs/contributors
+*/
+
+diff -Naur a/lib/parse.js a/lib/parse.js
+--- a/lib/parse.js	2017-03-09 19:34:30.000000000 +0200
++++ a/lib/parse.js	2017-03-06 11:02:34.000000000 +0200
+@@ -16,7 +16,7 @@
+     strictNullHandling: false
+ };
+ 
+-var parseValues = function parseValues(str, options) {
++var parseValues = function parseQueryStringValues(str, options) {
+     var obj = {};
+     var parts = str.split(options.delimiter, options.parameterLimit === Infinity ? undefined : options.parameterLimit);
+ 
+@@ -42,7 +42,7 @@
+     return obj;
+ };
+ 
+-var parseObject = function parseObject(chain, val, options) {
++var parseObject = function parseObjectRecursive(chain, val, options) {
+     if (!chain.length) {
+         return val;
+     }
+@@ -55,7 +55,7 @@
+         obj = obj.concat(parseObject(chain, val, options));
+     } else {
+         obj = options.plainObjects ? Object.create(null) : {};
+-        var cleanRoot = root[0] === '[' && root[root.length - 1] === ']' ? root.slice(1, root.length - 1) : root;
++        var cleanRoot = root.charAt(0) === '[' && root.charAt(root.length - 1) === ']' ? root.slice(1, -1) : root;
+         var index = parseInt(cleanRoot, 10);
+         if (
+             !isNaN(index) &&
+@@ -74,36 +74,37 @@
+     return obj;
+ };
+ 
+-var parseKeys = function parseKeys(givenKey, val, options) {
++var parseKeys = function parseQueryStringKeys(givenKey, val, options) {
+     if (!givenKey) {
+         return;
+     }
+ 
+     // Transform dot notation to bracket notation
+-    var key = options.allowDots ? givenKey.replace(/\.([^\.\[]+)/g, '[$1]') : givenKey;
++    var key = options.allowDots ? givenKey.replace(/\.([^.[]+)/g, '[$1]') : givenKey;
+ 
+     // The regex chunks
+ 
+-    var parent = /^([^\[\]]*)/;
+-    var child = /(\[[^\[\]]*\])/g;
++    var brackets = /(\[[^[\]]*])/;
++    var child = /(\[[^[\]]*])/g;
+ 
+     // Get the parent
+ 
+-    var segment = parent.exec(key);
++    var segment = brackets.exec(key);
++    var parent = segment ? key.slice(0, segment.index) : key;
+ 
+     // Stash the parent if it exists
+ 
+     var keys = [];
+-    if (segment[1]) {
++    if (parent) {
+         // If we aren't using plain objects, optionally prefix keys
+         // that would overwrite object prototype properties
+-        if (!options.plainObjects && has.call(Object.prototype, segment[1])) {
++        if (!options.plainObjects && has.call(Object.prototype, parent)) {
+             if (!options.allowPrototypes) {
+                 return;
+             }
+         }
+ 
+-        keys.push(segment[1]);
++        keys.push(parent);
+     }
+ 
+     // Loop through children appending to the array until we hit depth
+@@ -111,9 +112,9 @@
+     var i = 0;
+     while ((segment = child.exec(key)) !== null && i < options.depth) {
+         i += 1;
+-        if (!options.plainObjects && has.call(Object.prototype, segment[1].replace(/\[|\]/g, ''))) {
++        if (!options.plainObjects && has.call(Object.prototype, segment[1].slice(1, -1))) {
+             if (!options.allowPrototypes) {
+-                continue;
++                return;
+             }
+         }
+         keys.push(segment[1]);
+diff -Naur 6.3.0/node_modules/qs/lib/stringify.js 6.3.2/node_modules/qs/lib/stringify.js
+--- a/lib/stringify.js	2017-03-09 19:33:52.000000000 +0200
++++ b/lib/stringify.js	2017-03-06 11:02:06.000000000 +0200
+@@ -4,13 +4,13 @@
+ var formats = require('./formats');
+ 
+ var arrayPrefixGenerators = {
+-    brackets: function brackets(prefix) {
++    brackets: function brackets(prefix) { // eslint-disable-line func-name-matching
+         return prefix + '[]';
+     },
+-    indices: function indices(prefix, key) {
++    indices: function indices(prefix, key) { // eslint-disable-line func-name-matching
+         return prefix + '[' + key + ']';
+     },
+-    repeat: function repeat(prefix) {
++    repeat: function repeat(prefix) { // eslint-disable-line func-name-matching
+         return prefix;
+     }
+ };
+@@ -21,14 +21,26 @@
+     delimiter: '&',
+     encode: true,
+     encoder: utils.encode,
+-    serializeDate: function serializeDate(date) {
++    serializeDate: function serializeDate(date) { // eslint-disable-line func-name-matching
+         return toISO.call(date);
+     },
+     skipNulls: false,
+     strictNullHandling: false
+ };
+ 
+-var stringify = function stringify(object, prefix, generateArrayPrefix, strictNullHandling, skipNulls, encoder, filter, sort, allowDots, serializeDate, formatter) {
++var stringify = function stringify( // eslint-disable-line func-name-matching
++    object,
++    prefix,
++    generateArrayPrefix,
++    strictNullHandling,
++    skipNulls,
++    encoder,
++    filter,
++    sort,
++    allowDots,
++    serializeDate,
++    formatter
++) {
+     var obj = object;
+     if (typeof filter === 'function') {
+         obj = filter(prefix, obj);
+@@ -107,6 +119,11 @@
+ module.exports = function (object, opts) {
+     var obj = object;
+     var options = opts || {};
++
++    if (options.encoder !== null && options.encoder !== undefined && typeof options.encoder !== 'function') {
++        throw new TypeError('Encoder has to be a function.');
++    }
++
+     var delimiter = typeof options.delimiter === 'undefined' ? defaults.delimiter : options.delimiter;
+     var strictNullHandling = typeof options.strictNullHandling === 'boolean' ? options.strictNullHandling : defaults.strictNullHandling;
+     var skipNulls = typeof options.skipNulls === 'boolean' ? options.skipNulls : defaults.skipNulls;
+@@ -124,10 +141,6 @@
+     var objKeys;
+     var filter;
+ 
+-    if (options.encoder !== null && options.encoder !== undefined && typeof options.encoder !== 'function') {
+-        throw new TypeError('Encoder has to be a function.');
+-    }
+-
+     if (typeof options.filter === 'function') {
+         filter = options.filter;
+         obj = filter('', obj);
+diff -Naur 6.3.0/node_modules/qs/lib/utils.js 6.3.2/node_modules/qs/lib/utils.js
+--- a/lib/utils.js	2017-03-09 19:33:52.000000000 +0200
++++ b/lib/utils.js	2017-03-06 11:02:06.000000000 +0200
+@@ -31,7 +31,9 @@
+         if (Array.isArray(target)) {
+             target.push(source);
+         } else if (typeof target === 'object') {
+-            target[source] = true;
++            if (options.plainObjects || options.allowPrototypes || !has.call(Object.prototype, source)) {
++                target[source] = true;
++            }
+         } else {
+             return [target, source];
+         }
+@@ -126,7 +128,7 @@
+ 
+         i += 1;
+         c = 0x10000 + (((c & 0x3FF) << 10) | (string.charCodeAt(i) & 0x3FF));
+-        out += hexTable[0xF0 | (c >> 18)] + hexTable[0x80 | ((c >> 12) & 0x3F)] + hexTable[0x80 | ((c >> 6) & 0x3F)] + hexTable[0x80 | (c & 0x3F)];
++        out += hexTable[0xF0 | (c >> 18)] + hexTable[0x80 | ((c >> 12) & 0x3F)] + hexTable[0x80 | ((c >> 6) & 0x3F)] + hexTable[0x80 | (c & 0x3F)]; // eslint-disable-line max-len
+     }
+ 
+     return out;

--- a/packages/snyk-protect/patches/631_632.patch
+++ b/packages/snyk-protect/patches/631_632.patch
@@ -1,0 +1,89 @@
+// code derived from https://github.com/ljharb/qs
+// based on the following commits:
+// '6.0.3', fixed https://github.com/ljharb/qs/commit/ca844c59f3180e2089a66f30c3b26848b9def123
+// '6.1.1', fixed https://github.com/ljharb/qs/commit/55de6600895b41f6726c39208fd0407da43604ae
+// '6.2.2', fixed https://github.com/ljharb/qs/commit/27bbdb2ba5723944dda50f8de72d8900348e3bba
+// '6.3.1'  fixed https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d
+
+// https://github.com/ljharb/qs/blob/master/LICENSE
+/*
+Copyright (c) 2014 Nathan LaFreniere and other contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at: https://github.com/hapijs/qs/graphs/contributors
+*/
+
+diff -Naur a/lib/parse.js a/lib/parse.js
+--- a/lib/parse.js	2017-03-09 19:34:06.000000000 +0200
++++ a/lib/parse.js	2017-03-06 11:02:06.000000000 +0200
+@@ -84,26 +84,27 @@
+ 
+     // The regex chunks
+ 
+-    var parent = /^([^[]*)/;
++    var brackets = /(\[[^[\]]*])/;
+     var child = /(\[[^[\]]*])/g;
+ 
+     // Get the parent
+ 
+-    var segment = parent.exec(key);
++    var segment = brackets.exec(key);
++    var parent = segment ? key.slice(0, segment.index) : key;
+ 
+     // Stash the parent if it exists
+ 
+     var keys = [];
+-    if (segment[1]) {
++    if (parent) {
+         // If we aren't using plain objects, optionally prefix keys
+         // that would overwrite object prototype properties
+-        if (!options.plainObjects && has.call(Object.prototype, segment[1])) {
++        if (!options.plainObjects && has.call(Object.prototype, parent)) {
+             if (!options.allowPrototypes) {
+                 return;
+             }
+         }
+ 
+-        keys.push(segment[1]);
++        keys.push(parent);
+     }
+ 
+     // Loop through children appending to the array until we hit depth
+diff -Naur a/lib/utils.js a/lib/utils.js
+--- a/lib/utils.js	2017-03-09 19:34:06.000000000 +0200
++++ a/lib/utils.js	2017-03-06 11:02:06.000000000 +0200
+@@ -31,7 +31,9 @@
+         if (Array.isArray(target)) {
+             target.push(source);
+         } else if (typeof target === 'object') {
+-            target[source] = true;
++            if (options.plainObjects || options.allowPrototypes || !has.call(Object.prototype, source)) {
++                target[source] = true;
++            }
+         } else {
+             return [target, source];
+         }

--- a/packages/snyk-protect/patches/debug_20170905_0_0_c38a0166c266a679c8de012d4eaccec3f944e685.patch
+++ b/packages/snyk-protect/patches/debug_20170905_0_0_c38a0166c266a679c8de012d4eaccec3f944e685.patch
@@ -1,0 +1,40 @@
+// https://github.com/visionmedia/debug/commit/c38a0166c266a679c8de012d4eaccec3f944e685
+
+// https://github.com/visionmedia/debug/blob/master/LICENSE
+/*
+(The MIT License)
+
+Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the 'Software'), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+
+diff --git a/src/node.js b/src/node.js
+index b85ec7e..2bc7571 100644
+--- a/src/node.js
++++ b/src/node.js
+@@ -83,7 +83,9 @@ function useColors() {
+ exports.formatters.o = function(v) {
+   this.inspectOpts.colors = this.useColors;
+   return util.inspect(v, this.inspectOpts)
+-    .replace(/\s*\n\s*/g, ' ');
++    .split('\n').map(function(str) {
++      return str.trim()
++    }).join(' ');
+ };
+
+ /**

--- a/packages/snyk-protect/patches/debug_20170905_0_1_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch
+++ b/packages/snyk-protect/patches/debug_20170905_0_1_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch
@@ -1,0 +1,39 @@
+// https://github.com/visionmedia/debug/commit/f53962e944a87e6ca9bb622a2a12dffc22a9bb5a
+
+// https://github.com/visionmedia/debug/blob/master/LICENSE
+/*
+(The MIT License)
+
+Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the 'Software'), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/src/node.js b/src/node.js
+index af61297..b15109c 100644
+--- a/src/node.js
++++ b/src/node.js
+@@ -85,7 +85,9 @@ function useColors() {
+ exports.formatters.o = function(v) {
+   this.inspectOpts.colors = this.useColors;
+   return util.inspect(v, this.inspectOpts)
+-    .replace(/\s*\n\s*/g, ' ');
++    .split('\n').map(function(str) {
++      return str.trim()
++    }).join(' ');
+ };
+
+ /**

--- a/packages/snyk-protect/patches/debug_20170905_0_2_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch
+++ b/packages/snyk-protect/patches/debug_20170905_0_2_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch
@@ -1,0 +1,38 @@
+// https://github.com/visionmedia/debug/commit/f53962e944a87e6ca9bb622a2a12dffc22a9bb5a
+
+// https://github.com/visionmedia/debug/blob/master/LICENSE
+/*
+(The MIT License)
+
+Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the 'Software'), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/node.js b/node.js
+--- a/node.js
++++ b/node.js
+@@ -83,7 +83,9 @@ function useColors() {
+ exports.formatters.o = function(v) {
+   this.inspectOpts.colors = this.useColors;
+   return util.inspect(v, this.inspectOpts)
+-    .replace(/\s*\n\s*/g, ' ');
++    .split('\n').map(function(str) {
++      return str.trim()
++    }).join(' ');
+ };
+
+ /**

--- a/packages/snyk-protect/patches/debug_20170905_0_3_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch
+++ b/packages/snyk-protect/patches/debug_20170905_0_3_f53962e944a87e6ca9bb622a2a12dffc22a9bb5a.patch
@@ -1,0 +1,36 @@
+// https://github.com/visionmedia/debug/commit/f53962e944a87e6ca9bb622a2a12dffc22a9bb5a
+
+// https://github.com/visionmedia/debug/blob/master/LICENSE
+/*
+(The MIT License)
+
+Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the 'Software'), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/node.js b/node.js
+--- a/node.js
++++ b/node.js
+@@ -70,7 +70,9 @@ var inspect = (4 === util.inspect.length ?
+
+ exports.formatters.o = exports.formatters.O = function(v) {
+   return inspect(v, this.useColors)
+-    .replace(/\s*\n\s*/g, ' ');
++    .split('\n').map(function(str) {
++      return str.trim()
++    }).join(' ');
+ };

--- a/packages/snyk-protect/patches/ejs_20161128_0_0_3d447c5a335844b25faec04b1132dbc721f9c8f6.patch
+++ b/packages/snyk-protect/patches/ejs_20161128_0_0_3d447c5a335844b25faec04b1132dbc721f9c8f6.patch
@@ -1,0 +1,225 @@
+// Code derived from https://github.com/mde/ejs/commit/3d447c5a335844b25faec04b1132dbc721f9c8f6
+
+// https://github.com/mde/ejs/blob/master/LICENSE
+/*
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+diff --git a/lib/ejs.js b/lib/ejs.js
+index 1511416..45042da 100644
+--- a/lib/ejs.js
++++ b/lib/ejs.js
+@@ -269,6 +269,13 @@ function rethrow(err, str, filename, lineno){
+ function cpOptsInData(data, opts) {
+   _OPTS.forEach(function (p) {
+     if (typeof data[p] != 'undefined') {
++      // Disallow setting the root opt for includes via a passed data obj
++      // Unsanitized, parameterized use of `render` could allow the
++      // include directory to be reset, opening up the possibility of
++      // remote code execution
++      if (p == 'root') {
++        return;
++      }
+       opts[p] = data[p];
+     }
+   });

--- a/packages/snyk-protect/patches/electron-packager_20160422_ebea1d8c177f2a2816687c4a445998cc35375a18.patch
+++ b/packages/snyk-protect/patches/electron-packager_20160422_ebea1d8c177f2a2816687c4a445998cc35375a18.patch
@@ -1,0 +1,45 @@
+// Code derived from https://github.com/electron-userland/electron-packager
+// Based on:
+// https://github.com/electron-userland/electron-packager/commit/ebea1d8c177f2a2816687c4a445998cc35375a18
+// https://github.com/electron-userland/electron-packager/commit/cd3f4886a1e7bd942a5737c931dad7983dc5c069
+// https://github.com/electron-userland/electron-packager/blob/master/LICENSE
+/*
+Copyright (c) 2015 Max Ogden and other contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+diff --git a/cli.js b/cli.js
+index 1c8dfcf..c6ba1e4 100755
+--- a/cli.js
++++ b/cli.js
+@@ -1,6 +1,9 @@
+ #!/usr/bin/env node
+ var fs = require('fs')
+-var args = require('minimist')(process.argv.slice(2), {boolean: ['prune', 'asar', 'all', 'overwrite', 'strict-ssl']})
++var args = require('minimist')(process.argv.slice(2), {boolean: ['prune', 'asar', 'all', 'overwrite', 'strict-ssl'],
++  default: {
++    'strict-ssl': true
++  }})
+ var packager = require('./')
+ var path = require('path')
+ var usage = fs.readFileSync(path.join(__dirname, 'usage.txt')).toString()

--- a/packages/snyk-protect/patches/engine.io-client_20160426_0_0_2a7a011932094d4970dc68abd32e78265495a621.patch
+++ b/packages/snyk-protect/patches/engine.io-client_20160426_0_0_2a7a011932094d4970dc68abd32e78265495a621.patch
@@ -1,0 +1,13 @@
+diff --git a/engine.io.js b/engine.io.js
+index 165333a..eeefaa9 100644
+--- a/engine.io.js
++++ b/engine.io.js
+@@ -116,7 +116,7 @@ function Socket(uri, opts){
+   this.cert = opts.cert || null;
+   this.ca = opts.ca || null;
+   this.ciphers = opts.ciphers || null;
+-  this.rejectUnauthorized = opts.rejectUnauthorized === undefined ? null : opts.rejectUnauthorized;
++  this.rejectUnauthorized = opts.rejectUnauthorized === undefined ? true : opts.rejectUnauthorized;
+ 
+   // other options for Node.js client
+   var freeGlobal = typeof global == 'object' && global;

--- a/packages/snyk-protect/patches/engine.io-client_20160426_0_1_2a7a011932094d4970dc68abd32e78265495a621.patch
+++ b/packages/snyk-protect/patches/engine.io-client_20160426_0_1_2a7a011932094d4970dc68abd32e78265495a621.patch
@@ -1,0 +1,13 @@
+diff --git a/engine.io.js b/engine.io.js
+index 165333a..eeefaa9 100644
+--- a/engine.io.js
++++ b/engine.io.js
+@@ -115,7 +115,7 @@
+   this.cert = opts.cert || null;
+   this.ca = opts.ca || null;
+   this.ciphers = opts.ciphers || null;
+-  this.rejectUnauthorized = opts.rejectUnauthorized || null;
++  this.rejectUnauthorized = opts.rejectUnauthorized || true;
+
+   this.open();
+ }

--- a/packages/snyk-protect/patches/extend_20180424_0_0_0e68e71d93507fcc391e398bc84abd0666b28190.patch
+++ b/packages/snyk-protect/patches/extend_20180424_0_0_0e68e71d93507fcc391e398bc84abd0666b28190.patch
@@ -1,0 +1,101 @@
+// This code derived from: https://github.com/justmoon/node-extend/commit/0e68e71d93507fcc391e398bc84abd0666b28190
+/*
+The MIT License (MIT)
+
+Copyright (c) 2014 Stefan Thomas
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/index.js b/index.js
+index bbe53f6..2aa3faa 100644
+--- a/index.js
++++ b/index.js
+@@ -2,6 +2,8 @@
+ 
+ var hasOwn = Object.prototype.hasOwnProperty;
+ var toStr = Object.prototype.toString;
++var defineProperty = Object.defineProperty;
++var gOPD = Object.getOwnPropertyDescriptor;
+ 
+ var isArray = function isArray(arr) {
+ 	if (typeof Array.isArray === 'function') {
+@@ -31,6 +33,35 @@ var isPlainObject = function isPlainObject(obj) {
+ 	return typeof key === 'undefined' || hasOwn.call(obj, key);
+ };
+ 
++// If name is '__proto__', and Object.defineProperty is available, define __proto__ as an own property on target
++var setProperty = function setProperty(target, options) {
++	if (defineProperty && options.name === '__proto__') {
++		defineProperty(target, options.name, {
++			enumerable: true,
++			configurable: true,
++			value: options.newValue,
++			writable: true
++		});
++	} else {
++		target[options.name] = options.newValue;
++	}
++};
++
++// Return undefined instead of __proto__ if '__proto__' is not an own property
++var getProperty = function getProperty(obj, name) {
++	if (name === '__proto__') {
++		if (!hasOwn.call(obj, name)) {
++			return void 0;
++		} else if (gOPD) {
++			// In early versions of node, obj['__proto__'] is buggy when obj has
++			// __proto__ as an own property. Object.getOwnPropertyDescriptor() works.
++			return gOPD(obj, name).value;
++		}
++	}
++
++	return obj[name];
++};
++
+ module.exports = function extend() {
+ 	var options, name, src, copy, copyIsArray, clone;
+ 	var target = arguments[0];
+@@ -55,8 +86,8 @@ module.exports = function extend() {
+ 		if (options != null) {
+ 			// Extend the base object
+ 			for (name in options) {
+-				src = target[name];
+-				copy = options[name];
++				src = getProperty(target, name);
++				copy = getProperty(options, name);
+ 
+ 				// Prevent never-ending loop
+ 				if (target !== copy) {
+@@ -70,11 +101,11 @@ module.exports = function extend() {
+ 						}
+ 
+ 						// Never move original objects, clone them
+-						target[name] = extend(deep, clone, copy);
++						setProperty(target, { name: name, newValue: extend(deep, clone, copy) });
+ 
+ 					// Don't bring in undefined values
+ 					} else if (typeof copy !== 'undefined') {
+-						target[name] = copy;
++						setProperty(target, { name: name, newValue: copy });
+ 					}
+ 				}
+ 			}
+

--- a/packages/snyk-protect/patches/geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch
+++ b/packages/snyk-protect/patches/geddy_20150727_0_0_3f1bacd7cfda6556f35563f3e79c60c62aa9d286.patch
@@ -1,0 +1,31 @@
+// Code derived from: https://github.com/geddy/geddy
+// reference: https://github.com/geddy/geddy/commit/3f1bacd7cfda6556f35563f3e79c60c62aa9d286
+
+// https://github.com/geddy/geddy#license
+/*
+Apache License, Version 2
+
+Geddy Web-app development framework copyright 2112 mde@fleegix.org.
+*/
+
+
+diff --git a/lib/app/index.js b/lib/app/index.js
+index 856fa73..148813f 100644
+--- a/lib/app/index.js
++++ b/lib/app/index.js
+@@ -176,7 +176,14 @@ var App = function () {
+ 
+ 
+     // Get the path to the file, decoding the request URI
+-    staticPath = this.config.staticFilePath + decodeURIComponent(reqUrl);
++    staticPath = path.resolve(path.join(this.config.staticFilePath, decodeURIComponent(reqUrl)));
++
++    // Prevent directory traversal
++    if (staticPath.indexOf(this.config.staticFilePath) !== 0) {
++      this.handleNotFound(reqUrl, params, reqObj, respObj);
++      return;
++    }
++
+     // Ignore querystring
+     staticPath = staticPath.split('?')[0];
+ 

--- a/packages/snyk-protect/patches/gm_20151026_0_0_5f5c77490aa84ed313405c88905eb4566135be31_snyk.patch
+++ b/packages/snyk-protect/patches/gm_20151026_0_0_5f5c77490aa84ed313405c88905eb4566135be31_snyk.patch
@@ -1,0 +1,123 @@
+// Code derived from https://github.com/aheckmann/gm
+
+// https://github.com/aheckmann/gm#license
+/*
+(The MIT License)
+
+Copyright (c) 2010 Aaron Heckmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+--- a/lib/compare.js
++++ b/lib/compare.js
+@@ -1,7 +1,6 @@
+ // compare
+
+-var exec = require('child_process').exec;
+-var utils = require('./utils');
++var spawn = require('child_process').spawn;
+
+ /**
+  * Compare two images uses graphicsmagicks `compare` command.
+@@ -20,13 +19,11 @@ var utils = require('./utils');
+
+ module.exports = exports = function (proto) {
+   function compare(orig, compareTo, options, cb) {
+-    orig = utils.escape(orig);
+-    compareTo = utils.escape(compareTo);
+
+     var isImageMagick = this._options && this._options.imageMagick;
+     // compare binary for IM is `compare`, for GM it's `gm compare`
+     var bin = isImageMagick ? '' : 'gm ';
+-    var execCmd = bin + 'compare -metric mse ' + orig + ' ' + compareTo;
++    var args = ['compare', '-metric', 'mse', orig, compareTo]
+     var tolerance = 0.4;
+     // outputting the diff image
+     if (typeof options === 'object') {
+@@ -40,16 +37,19 @@ module.exports = exports = function (proto) {
+           throw new TypeError('The path for the diff output is invalid');
+         }
+          // graphicsmagick defaults to red
+-        var highlightColorOption = options.highlightColor
+-          ? ' -highlight-color ' + options.highlightColor + ' '
+-          : ' ';
+-        var highlightStyleOption = options.highlightStyle
+-          ? ' -highlight-style ' + options.highlightStyle + ' '
+-          : ' ';
+-        var diffFilename = utils.escape(options.file);
++        if (options.highlightColour) {
++            args.push('-highlight-color');
++            args.push(options.highlightColor);
++        }
++        if (options.highlightStyle) {
++            args.push('-highlight-style')
++            args.push(options.highlightStyle)
++        }
+         // For IM, filename is the last argument. For GM it's `-file <filename>`
+-        var diffOpt = isImageMagick ? diffFilename : ('-file ' + diffFilename);
+-        execCmd += highlightColorOption + highlightStyleOption  + ' ' + diffOpt;
++        if (isImageMagick) {
++            args.push('-file');
++        }
++        args.push(options.file);
+       }
+
+       if (typeof options.tolerance != 'undefined') {
+@@ -60,7 +60,9 @@ module.exports = exports = function (proto) {
+       }
+     } else {
+       // For ImageMagick diff file is required but we don't care about it, so null it out
+-      isImageMagick && (execCmd += ' null:');
++      if (isImageMagick) {
++        args.push('null:');
++      }
+
+       if (typeof options == 'function') {
+         cb = options; // tolerance value not provided, flip the cb place
+@@ -69,19 +71,27 @@ module.exports = exports = function (proto) {
+       }
+     }
+
+-    exec(execCmd, function (err, stdout, stderr) {
++    var proc = spawn('/usr/bin/gm', args);
++    var stdout = '';
++    var stderr = '';
++    proc.stdout.on('data',function(data) { stdout+=data });
++    proc.stderr.on('data',function(data) { stderr+=data });
++    proc.on('close', function (code) {
+       // ImageMagick returns err code 2 if err, 0 if similar, 1 if dissimilar
+       if (isImageMagick) {
+-        if (!err) {
++        if (code === 0) {
+           return cb(null, 0 <= tolerance, 0, stdout);
+         }
+-        if (err.code === 1) {
++        else if (code === 1) {
+           err = null;
+           stdout = stderr;
++        } else {
++        return cb(stderr);
++        }
++      } else {
++        if(code !== 0) {
++          return cb(stderr);
+         }
+-      }
+-      if (err) {
+-        return cb(err);
+       }
+       // Since ImageMagick similar gives err code 0 and no stdout, there's really no matching
+       // Otherwise, output format for IM is `12.00 (0.123)` and for GM it's `Total: 0.123`
+@@ -93,7 +103,7 @@ module.exports = exports = function (proto) {
+       }
+
+       var equality = parseFloat(match[1]);
+-      cb(null, equality <= tolerance, equality, stdout, utils.unescape(orig), utils.unescape(compareTo));
++      cb(null, equality <= tolerance, equality, stdout, orig, compareTo);
+     });
+   }

--- a/packages/snyk-protect/patches/gm_20151026_1_0_5f5c77490aa84ed313405c88905eb4566135be31_snyk_c1.patch
+++ b/packages/snyk-protect/patches/gm_20151026_1_0_5f5c77490aa84ed313405c88905eb4566135be31_snyk_c1.patch
@@ -1,0 +1,138 @@
+// Code derived from https://github.com/aheckmann/gm
+
+// https://github.com/aheckmann/gm#license
+/*
+(The MIT License)
+
+Copyright (c) 2010 Aaron Heckmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+--- a/lib/compare.js	2015-11-06 17:41:26.000000000 +0200
++++ b/lib/compare.js	2015-11-06 17:49:30.000000000 +0200
+@@ -1,7 +1,6 @@
+ // compare
+ 
+-var exec = require('child_process').exec;
+-var utils = require('./utils');
++var spawn = require('child_process').spawn;
+ 
+ /**
+  * Compare two images uses graphicsmagicks `compare` command.
+@@ -20,13 +19,11 @@
+ 
+ module.exports = exports = function (proto) {
+   function compare(orig, compareTo, options, cb) {
+-    orig = utils.escape(orig);
+-    compareTo = utils.escape(compareTo);
+ 
+     var isImageMagick = this._options && this._options.imageMagick;
+     // compare binary for IM is `compare`, for GM it's `gm compare`
+     var bin = isImageMagick ? '' : 'gm ';
+-    var execCmd = bin + 'compare -metric mse ' + orig + ' ' + compareTo;
++    var args = ['compare', '-metric', 'mse', orig, compareTo]
+     var tolerance = 0.4
+     // outputting the diff image
+     if (typeof options === 'object') {
+@@ -34,28 +31,33 @@
+         if (typeof options.file !== 'string') {
+           throw new TypeError('The path for the diff output is invalid');
+         }
+-         // graphicsmagick defaults to red
+-        var highlightColorOption = options.highlightColor
+-          ? ' -highlight-color ' + options.highlightColor + ' '
+-          : ' ';
+-        var highlightStyleOption = options.highlightStyle
+-          ? ' -highlight-style ' + options.highlightStyle + ' '
+-          : ' ';
+-        var diffFilename = utils.escape(options.file);
++        // graphicsmagick defaults to red
++        if (options.highlightColour) {
++          args.push('-highlight-color');
++          args.push(options.highlightColor);
++        }
++        if (options.highlightStyle) {
++          args.push('-highlight-style')
++          args.push(options.highlightStyle)
++        }
+         // For IM, filename is the last argument. For GM it's `-file <filename>`
+-        var diffOpt = isImageMagick ? diffFilename : ('-file ' + diffFilename);
+-        execCmd += highlightColorOption + highlightStyleOption  + ' ' + diffOpt;
++        if (isImageMagick) {
++          args.push('-file');
++        }
++        args.push(options.file);
+       }
+-      
++
+       if (options.tolerance) {
+         if (typeof options.tolerance !== 'number') {
+           throw new TypeError('The tolerance value should be a number');
+         }
+         tolerance = options.tolerance;
+-      } 
++      }
+     } else {
+       // For ImageMagick diff file is required but we don't care about it, so null it out
+-      isImageMagick && (execCmd += ' null:');
++      if (isImageMagick) {
++        args.push('null:');
++      }
+ 
+       if (typeof options == 'function') {
+         cb = options; // tolerance value not provided, flip the cb place
+@@ -64,20 +66,29 @@
+       }
+     }
+ 
+-    exec(execCmd, function (err, stdout, stderr) {
++    var proc = spawn('/usr/bin/gm', args);
++    var stdout = '';
++    var stderr = '';
++    proc.stdout.on('data',function(data) { stdout+=data });
++    proc.stderr.on('data',function(data) { stderr+=data });
++    proc.on('close', function (code) {
+       // ImageMagick returns err code 2 if err, 0 if similar, 1 if dissimilar
+       if (isImageMagick) {
+-        if (!err) {
++        if (code === 0) {
+           return cb(null, 0 <= tolerance, 0, stdout);
+         }
+-        if (err.code === 1) {
++        else if (code === 1) {
+           err = null;
+           stdout = stderr;
++        } else {
++        return cb(stderr);
++        }
++      } else {
++        if(code !== 0) {
++          return cb(stderr);
+         }
+       }
+-      if (err) {
+-        return cb(err);
+-      }
++      
+       // Since ImageMagick similar gives err code 0 and no stdout, there's really no matching
+       // Otherwise, output format for IM is `12.00 (0.123)` and for GM it's `Total: 0.123`
+       var regex = isImageMagick ? /\((\d+\.?[\d\-\+e]*)\)/m : /Total: (\d+\.?\d*)/m;
+@@ -88,7 +99,7 @@
+       }
+ 
+       var equality = parseFloat(match[1]);
+-      cb(null, equality <= tolerance, equality, stdout);
++      cb(null, equality <= tolerance, equality, stdout, orig, compareTo);
+     });
+   }
+ 
+@@ -97,4 +108,3 @@
+   }
+   return compare;
+ };
+-

--- a/packages/snyk-protect/patches/gm_20151026_2_0_5f5c77490aa84ed313405c88905eb4566135be31_snyk_c2.patch
+++ b/packages/snyk-protect/patches/gm_20151026_2_0_5f5c77490aa84ed313405c88905eb4566135be31_snyk_c2.patch
@@ -1,0 +1,124 @@
+// Code derived from https://github.com/aheckmann/gm
+
+// https://github.com/aheckmann/gm#license
+/*
+(The MIT License)
+
+Copyright (c) 2010 Aaron Heckmann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+--- a/lib/compare.js	2014-05-03 19:28:00.000000000 +0300
++++ b/lib/compare.js	2015-11-06 18:27:58.000000000 +0200
+@@ -1,7 +1,6 @@
+ // compare
+ 
+-var exec = require('child_process').exec;
+-var utils = require('./utils');
++var spawn = require('child_process').spawn;
+ 
+ /**
+  * Compare two images uses graphicsmagicks `compare` command.
+@@ -20,13 +19,11 @@
+ 
+ module.exports = exports = function (proto) {
+   function compare(orig, compareTo, options, cb) {
+-    orig = utils.escape(orig);
+-    compareTo = utils.escape(compareTo);
+ 
+     var isImageMagick = this._options && this._options.imageMagick;
+     // compare binary for IM is `compare`, for GM it's `gm compare`
+     var bin = isImageMagick ? '' : 'gm ';
+-    var execCmd = bin + 'compare -metric mse ' + orig + ' ' + compareTo;
++    var args = ['compare', '-metric', 'mse', orig, compareTo]
+     var tolerance = 0.4
+     // outputting the diff image
+     if (typeof options === 'object') {
+@@ -35,21 +32,23 @@
+           throw new TypeError('The path for the diff output is invalid');
+         }
+          // graphicsmagick defaults to red
+-        var highlightColorOption = options.highlightColor
+-          ? ' -highlight-color ' + options.highlightColor + ' '
+-          : ' ';
+-        var diffFilename = utils.escape(options.file);
+-        // For IM, filename is the last argument. For GM it's `-file <filename>`
+-        var diffOpt = isImageMagick ? diffFilename : ('-file ' + diffFilename);
+-        execCmd += highlightColorOption + ' ' + diffOpt;
++          if (options.highlightColour) {
++              args.push('-highlight-color');
++              args.push(options.highlightColor);
++          }
++         // For IM, filename is the last argument. For GM it's `-file <filename>`
++         if (isImageMagick) {
++             args.push('-file');
++         }
++         args.push(options.file);
+       }
+-      
++
+       if (options.tolerance) {
+         if (typeof options.tolerance !== 'number') {
+           throw new TypeError('The tolerance value should be a number');
+         }
+         tolerance = options.tolerance;
+-      } 
++      }
+     } else {
+       // For ImageMagick diff file is required but we don't care about it, so null it out
+       isImageMagick && (execCmd += ' null:');
+@@ -61,20 +60,29 @@
+       }
+     }
+ 
+-    exec(execCmd, function (err, stdout, stderr) {
++    var proc = spawn('/usr/bin/gm', args);
++    var stdout = '';
++    var stderr = '';
++    proc.stdout.on('data',function(data) { stdout+=data });
++    proc.stderr.on('data',function(data) { stderr+=data });
++    proc.on('close', function (code) {
+       // ImageMagick returns err code 2 if err, 0 if similar, 1 if dissimilar
+       if (isImageMagick) {
+-        if (!err) {
++        if (code === 0) {
+           return cb(null, 0 <= tolerance, 0, stdout);
+         }
+-        if (err.code === 1) {
++        else if (code === 1) {
+           err = null;
+           stdout = stderr;
++        } else {
++        return cb(stderr);
++        }
++      } else {
++        if(code !== 0) {
++          return cb(stderr);
+         }
+       }
+-      if (err) {
+-        return cb(err);
+-      }
++
+       // Since ImageMagick similar gives err code 0 and no stdout, there's really no matching
+       // Otherwise, output format for IM is `12.00 (0.123)` and for GM it's `Total: 0.123`
+       var regex = isImageMagick ? /\((\d+\.?[\d\-\+e]*)\)/m : /Total: (\d+\.?\d*)/m;
+@@ -85,7 +93,7 @@
+       }
+ 
+       var equality = parseFloat(match[1]);
+-      cb(null, equality <= tolerance, equality, stdout);
++      cb(null, equality <= tolerance, equality, stdout, orig, compareTo);
+     });
+   }
+ 
+@@ -94,4 +102,3 @@
+   }
+   return compare;
+ };
+-

--- a/packages/snyk-protect/patches/handlebars_0.patch
+++ b/packages/snyk-protect/patches/handlebars_0.patch
@@ -1,0 +1,22 @@
+// code derived from https://github.com/wycats/handlebars.js
+// https://github.com/wycats/handlebars.js/commit/83b8e846a3569bd366cf0b6bdc1e4604d1a2077e
+diff --git a/lib/handlebars/utils.js b/lib/handlebars/utils.js
+index 81050f9..d34646b 100644
+--- a/lib/handlebars/utils.js
++++ b/lib/handlebars/utils.js
+@@ -4,11 +4,12 @@ const escape = {
+   '>': '&gt;',
+   '"': '&quot;',
+   "'": '&#x27;',
+-  '`': '&#x60;'
++  '`': '&#x60;',
++  '=': '&#x3D;'
+ };
+ 
+-const badChars = /[&<>"'`]/g,
+-      possible = /[&<>"'`]/;
++const badChars = /[&<>"'`=]/g,
++      possible = /[&<>"'`=]/;
+ 
+ function escapeChar(chr) {
+   return escape[chr];

--- a/packages/snyk-protect/patches/hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch
+++ b/packages/snyk-protect/patches/hapi_20140708-1_0_0_94c6f0f223c3c2c915ba80adec58b153f435b2d1.patch
@@ -1,0 +1,52 @@
+// code derived from https://github.com/hapijs/hapi.git
+// reference: https://github.com/patrickkettner/hapi/commit/94c6f0f223c3c2c915ba80adec58b153f435b2d1
+
+// https://github.com/hapijs/hapi/blob/master/LICENSE
+/*
+Copyright (c) 2011-2016, Eran Hammer and other contributors.
+Copyright (c) 2011-2014, Walmart.
+Copyright (c) 2011, Yahoo Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at: https://github.com/hapijs/hapi/graphs/contributors
+Portions of this project were initially based on the Yahoo! Inc. Postmile project,
+published at https://github.com/yahoo/postmile.
+*/
+
+diff --git a/lib/response/payload.js b/lib/response/payload.js
+index d49d86c..4ac2033 100755
+--- a/lib/response/payload.js
++++ b/lib/response/payload.js
+@@ -53,7 +53,7 @@ internals.Payload.prototype.size = function () {
+ internals.Payload.prototype.jsonp = function (variable) {
+
+     this._sizeOffset += variable.length + 3;
+-    this._prefix = variable + '(';
++    this._prefix = '/**/' + variable + '(';
+     this._data = Buffer.isBuffer(this._data) ? this._data : this._data.replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029');
+     this._suffix = ');';
+ };

--- a/packages/snyk-protect/patches/hawk_20160119_0_0_0833f99ba64558525995a7e21d4093da1f3e15fa.patch
+++ b/packages/snyk-protect/patches/hawk_20160119_0_0_0833f99ba64558525995a7e21d4093da1f3e15fa.patch
@@ -1,0 +1,128 @@
+// Code derived from https://github.com/hueniverse/hawk
+// Reference: https://github.com/hueniverse/hawk/commit/0833f99ba64558525995a7e21d4093da1f3e15fa
+
+// https://github.com/hueniverse/hawk/blob/master/LICENSE
+/*
+Copyright (c) 2012-2014, Eran Hammer and other contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at: https://github.com/hueniverse/hawk/graphs/contributors
+*/
+
+diff --git a/lib/server.js b/lib/server.js
+index e42c884..0486805 100755
+--- a/lib/server.js
++++ b/lib/server.js
+@@ -310,6 +310,11 @@ exports.header = function (credentials, artifacts, options) {
+  * 'hostHeaderName', 'localtimeOffsetMsec', 'host', 'port'
+  */
+ 
++
++//                       1     2             3           4
++internals.bewitRegex = /^(\/.*)([\?&])bewit\=([^&$]*)(?:&(.+))?$/;
++
++
+ exports.authenticateBewit = function (req, credentialsFunc, options, callback) {
+ 
+     callback = Hoek.nextTick(callback);
+@@ -327,8 +332,11 @@ exports.authenticateBewit = function (req, credentialsFunc, options, callback) {
+ 
+     // Extract bewit
+ 
+-    //                                 1     2             3           4
+-    const resource = request.url.match(/^(\/.*)([\?&])bewit\=([^&$]*)(?:&(.+))?$/);
++    if (request.url.length > Utils.limits.maxMatchLength) {
++        return callback(Boom.badRequest('Resource path exceeds max length'));
++    }
++
++    const resource = request.url.match(internals.bewitRegex);
+     if (!resource) {
+         return callback(Utils.unauthorized());
+     }
+diff --git a/lib/utils.js b/lib/utils.js
+index 29c8a22..ecb64d3 100755
+--- a/lib/utils.js
++++ b/lib/utils.js
+@@ -17,6 +17,11 @@ exports.version = function () {
+ };
+ 
+ 
++exports.limits = {
++    maxMatchLength: 4096            // Limit the length of uris and headers to avoid a DoS attack on string matching
++};
++
++
+ // Extract host and port from request
+ 
+ //                                            $1                            $2
+@@ -31,6 +36,10 @@ exports.parseHost = function (req, hostHeaderName) {
+         return null;
+     }
+ 
++    if (hostHeader.length > exports.limits.maxMatchLength) {
++        return null;
++    }
++
+     const hostParts = hostHeader.match(internals.hostHeaderRegex);
+     if (!hostParts) {
+         return null;
+@@ -100,6 +109,10 @@ exports.nowSecs = function (localtimeOffsetMsec) {
+ };
+ 
+ 
++internals.authHeaderRegex = /^(\w+)(?:\s+(.*))?$/;                                      // Header: scheme[ something]
++internals.attributeRegex = /^[ \w\!#\$%&'\(\)\*\+,\-\.\/\:;<\=>\?@\[\]\^`\{\|\}~]+$/;   // !#$%&'()*+,-./:;<=>?@[]^_`{|}~ and space, a-z, A-Z, 0-9
++
++
+ // Parse Hawk HTTP Authorization header
+ 
+ exports.parseAuthorizationHeader = function (header, keys) {
+@@ -110,7 +123,11 @@ exports.parseAuthorizationHeader = function (header, keys) {
+         return Boom.unauthorized(null, 'Hawk');
+     }
+ 
+-    const headerParts = header.match(/^(\w+)(?:\s+(.*))?$/);       // Header: scheme[ something]
++    if (header.length > exports.limits.maxMatchLength) {
++        return Boom.badRequest('Header length too long');
++    }
++
++    const headerParts = header.match(internals.authHeaderRegex);
+     if (!headerParts) {
+         return Boom.badRequest('Invalid header syntax');
+     }
+@@ -136,9 +153,9 @@ exports.parseAuthorizationHeader = function (header, keys) {
+             return;
+         }
+ 
+-        // Allowed attribute value characters: !#$%&'()*+,-./:;<=>?@[]^_`{|}~ and space, a-z, A-Z, 0-9
++        // Allowed attribute value characters
+ 
+-        if ($2.match(/^[ \w\!#\$%&'\(\)\*\+,\-\.\/\:;<\=>\?@\[\]\^`\{\|\}~]+$/) === null) {
++        if ($2.match(internals.attributeRegex) === null) {
+             errorMessage = 'Bad attribute value: ' + $1;
+             return;
+         }

--- a/packages/snyk-protect/patches/hawk_20160119_0_1_0833f99ba64558525995a7e21d4093da1f3e15fa.patch
+++ b/packages/snyk-protect/patches/hawk_20160119_0_1_0833f99ba64558525995a7e21d4093da1f3e15fa.patch
@@ -1,0 +1,142 @@
+// Code derived from https://github.com/hueniverse/hawk
+// Reference: https://github.com/hueniverse/hawk/commit/0833f99ba64558525995a7e21d4093da1f3e15fa
+
+// https://github.com/hueniverse/hawk/blob/master/LICENSE
+/*
+Copyright (c) 2012-2014, Eran Hammer and other contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at: https://github.com/hueniverse/hawk/graphs/contributors
+*/
+
+diff --git a/lib/server.js b/lib/server.js
+index a325d56..2f76372 100755
+--- a/lib/server.js
++++ b/lib/server.js
+@@ -308,6 +308,11 @@ exports.header = function (credentials, artifacts, options) {
+  * 'hostHeaderName', 'localtimeOffsetMsec', 'host', 'port'
+  */
+ 
++
++//                       1     2             3           4
++internals.bewitRegex = /^(\/.*)([\?&])bewit\=([^&$]*)(?:&(.+))?$/;
++
++
+ exports.authenticateBewit = function (req, credentialsFunc, options, callback) {
+ 
+     callback = Hoek.nextTick(callback);
+@@ -325,8 +330,11 @@ exports.authenticateBewit = function (req, credentialsFunc, options, callback) {
+ 
+     // Extract bewit
+ 
+-    //                                 1     2             3           4
+-    var resource = request.url.match(/^(\/.*)([\?&])bewit\=([^&$]*)(?:&(.+))?$/);
++    if (request.url.length > Utils.limits.maxMatchLength) {
++        return callback(Boom.badRequest('Resource path exceeds max length'));
++    }
++
++    var resource = request.url.match(internals.bewitRegex);
+     if (!resource) {
+         return callback(Boom.unauthorized(null, 'Hawk'));
+     }
+diff --git a/lib/utils.js b/lib/utils.js
+index 8d2719a..28a3511 100755
+--- a/lib/utils.js
++++ b/lib/utils.js
+@@ -15,6 +15,11 @@ exports.version = function () {
+ };
+ 
+ 
++exports.limits = {
++    maxMatchLength: 4096            // Limit the length of uris and headers to avoid a DoS attack on string matching
++};
++
++
+ // Extract host and port from request
+ 
+ //                                            $1                            $2
+@@ -29,6 +34,10 @@ exports.parseHost = function (req, hostHeaderName) {
+         return null;
+     }
+ 
++    if (hostHeader.length > exports.limits.maxMatchLength) {
++        return null;
++    }
++
+     var hostParts = hostHeader.match(internals.hostHeaderRegex);
+     if (!hostParts) {
+         return null;
+@@ -63,8 +72,11 @@ exports.parseRequest = function (req, options) {
+ 
+     // Obtain host and port information
+ 
+-    if (!options.host || !options.port) {
+-        var host = exports.parseHost(req, options.hostHeaderName);
++    var host;
++    if (!options.host ||
++        !options.port) {
++
++        host = exports.parseHost(req, options.hostHeaderName);
+         if (!host) {
+             return new Error('Invalid Host header');
+         }
+@@ -95,6 +107,10 @@ exports.nowSecs = function (localtimeOffsetMsec) {
+ };
+ 
+ 
++internals.authHeaderRegex = /^(\w+)(?:\s+(.*))?$/;                                      // Header: scheme[ something]
++internals.attributeRegex = /^[ \w\!#\$%&'\(\)\*\+,\-\.\/\:;<\=>\?@\[\]\^`\{\|\}~]+$/;   // !#$%&'()*+,-./:;<=>?@[]^_`{|}~ and space, a-z, A-Z, 0-9
++
++
+ // Parse Hawk HTTP Authorization header
+ 
+ exports.parseAuthorizationHeader = function (header, keys) {
+@@ -105,7 +121,11 @@ exports.parseAuthorizationHeader = function (header, keys) {
+         return Boom.unauthorized(null, 'Hawk');
+     }
+ 
+-    var headerParts = header.match(/^(\w+)(?:\s+(.*))?$/);       // Header: scheme[ something]
++    if (header.length > exports.limits.maxMatchLength) {
++        return Boom.badRequest('Header length too long');
++    }
++
++    var headerParts = header.match(internals.authHeaderRegex);
+     if (!headerParts) {
+         return Boom.badRequest('Invalid header syntax');
+     }
+@@ -131,9 +151,9 @@ exports.parseAuthorizationHeader = function (header, keys) {
+             return;
+         }
+ 
+-        // Allowed attribute value characters: !#$%&'()*+,-./:;<=>?@[]^_`{|}~ and space, a-z, A-Z, 0-9
++        // Allowed attribute value characters
+ 
+-        if ($2.match(/^[ \w\!#\$%&'\(\)\*\+,\-\.\/\:;<\=>\?@\[\]\^`\{\|\}~]+$/) === null) {
++        if ($2.match(internals.attributeRegex) === null) {
+             errorMessage = 'Bad attribute value: ' + $1;
+             return;
+         }

--- a/packages/snyk-protect/patches/hawk_20160119_0_2_0833f99ba64558525995a7e21d4093da1f3e15fa.patch
+++ b/packages/snyk-protect/patches/hawk_20160119_0_2_0833f99ba64558525995a7e21d4093da1f3e15fa.patch
@@ -1,0 +1,118 @@
+// Code derived from https://github.com/hueniverse/hawk
+// Reference: https://github.com/hueniverse/hawk/commit/0833f99ba64558525995a7e21d4093da1f3e15fa
+
+// https://github.com/hueniverse/hawk/blob/master/LICENSE
+/*
+Copyright (c) 2012-2014, Eran Hammer and other contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at: https://github.com/hueniverse/hawk/graphs/contributors
+*/
+
+--- a/lib/server.js
++++ b/lib/server.js
+@@ -308,6 +308,8 @@
+  * 'hostHeaderName', 'localtimeOffsetMsec', 'host', 'port'
+  */
+ 
++internals.bewitRegex = /^(\/.*)([\?&])bewit\=([^&$]*)(?:&(.+))?$/;
++
+ exports.authenticateBewit = function (req, credentialsFunc, options, callback) {
+ 
+     callback = Hoek.nextTick(callback);
+@@ -325,8 +327,11 @@
+ 
+     // Extract bewit
+ 
+-    //                                 1     2             3           4     
+-    var resource = request.url.match(/^(\/.*)([\?&])bewit\=([^&$]*)(?:&(.+))?$/);
++    if (request.url.length > Utils.limits.maxMatchLength) {
++        return callback(Boom.badRequest('Resource path exceeds max length'));
++    }
++
++    var resource = request.url.match(internals.bewitRegex);
+     if (!resource) {
+         return callback(Boom.unauthorized(null, 'Hawk'));
+     }
+
+--- a/lib/utils.js
++++ b/lib/utils.js
+@@ -14,6 +14,9 @@
+     return require('../package.json').version;
+ };
+ 
++exports.limits = {
++   maxMatchLength: 4096            // Limit the length of uris and headers to avoid a DoS attack on string matching
++};
+ 
+ // Extract host and port from request
+ 
+@@ -29,6 +32,10 @@
+         return null;
+     }
+ 
++    if (hostHeader.length > exports.limits.maxMatchLength) {
++        return null;
++    }
++
+     var hostParts = hostHeader.match(internals.hostHeaderRegex);
+     if (!hostParts) {
+         return null;
+@@ -94,6 +101,8 @@
+     return Math.floor(exports.now(localtimeOffsetMsec) / 1000);
+ };
+ 
++internals.authHeaderRegex = /^(\w+)(?:\s+(.*))?$/;                                      // Header: scheme[ something]
++internals.attributeRegex = /^[ \w\!#\$%&'\(\)\*\+,\-\.\/\:;<\=>\?@\[\]\^`\{\|\}~]+$/;   // !#$%&'()*+,-./:;<=>?@[]^_`{|}~ and space, a-z, A-Z, 0-9
+ 
+ // Parse Hawk HTTP Authorization header
+ 
+@@ -105,7 +114,11 @@
+         return Boom.unauthorized(null, 'Hawk');
+     }
+ 
+-    var headerParts = header.match(/^(\w+)(?:\s+(.*))?$/);       // Header: scheme[ something]
++    if (header.length > exports.limits.maxMatchLength) {
++        return Boom.badRequest('Header length too long');
++    }
++
++    var headerParts = header.match(internals.authHeaderRegex);
+     if (!headerParts) {
+         return Boom.badRequest('Invalid header syntax');
+     }
+@@ -131,9 +144,9 @@
+             return;
+         }
+ 
+-        // Allowed attribute value characters: !#$%&'()*+,-./:;<=>?@[]^_`{|}~ and space, a-z, A-Z, 0-9
++        // Allowed attribute value characters:
+ 
+-        if ($2.match(/^[ \w\!#\$%&'\(\)\*\+,\-\.\/\:;<\=>\?@\[\]\^`\{\|\}~]+$/) === null) {
++        if ($2.match(internals.attributeRegex) === null) {
+             errorMessage = 'Bad attribute value: ' + $1;
+             return;
+         }

--- a/packages/snyk-protect/patches/hawk_20160119_0_3_0833f99ba64558525995a7e21d4093da1f3e15fa.patch
+++ b/packages/snyk-protect/patches/hawk_20160119_0_3_0833f99ba64558525995a7e21d4093da1f3e15fa.patch
@@ -1,0 +1,121 @@
+// Code derived from https://github.com/hueniverse/hawk
+// Reference: https://github.com/hueniverse/hawk/commit/0833f99ba64558525995a7e21d4093da1f3e15fa
+
+// https://github.com/hueniverse/hawk/blob/master/LICENSE
+/*
+Copyright (c) 2012-2014, Eran Hammer and other contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at: https://github.com/hueniverse/hawk/graphs/contributors
+*/
+
+--- a/lib/server.js
++++ b/lib/server.js
+@@ -295,6 +295,9 @@
+  * 'hostHeaderName', 'localtimeOffsetMsec', 'host', 'port'
+  */
+ 
++//                       1     2             3           4
++internals.bewitRegex = /^(\/.*)([\?&])bewit\=([^&$]*)(?:&(.+))?$/;
++
+ exports.authenticateBewit = function (req, credentialsFunc, options, callback) {
+ 
+     callback = Utils.nextTick(callback);
+@@ -312,8 +315,11 @@
+ 
+     // Extract bewit
+ 
+-    //                                 1     2             3           4     
+-    var resource = request.url.match(/^(\/.*)([\?&])bewit\=([^&$]*)(?:&(.+))?$/);
++    if (request.url.length > Utils.limits.maxMatchLength) {
++          return callback(Boom.badRequest('Resource path exceeds max length'));
++    }
++
++    var resource = request.url.match(internals.bewitRegex);
+     if (!resource) {
+         return callback(Boom.unauthorized(null, 'Hawk'));
+     }
+
+--- a/lib/utils.js
++++ b/lib/utils.js
+@@ -31,6 +31,9 @@
+     return exports.loadPackage(__dirname + '/..').version;
+ };
+ 
++exports.limits = {
++   maxMatchLength: 4096            // Limit the length of uris and headers to avoid a DoS attack on string matching
++};
+ 
+ // Extract host and port from request
+ 
+@@ -42,6 +45,10 @@
+         return null;
+     }
+ 
++    if (hostHeader.length > exports.limits.maxMatchLength) {
++        return null;
++    }
++
+     var hostHeaderRegex;
+     if (hostHeader[0] === '[') {
+         hostHeaderRegex = /^(?:(?:\r\n)?\s)*(\[[^\]]+\])(?::(\d+))?(?:(?:\r\n)?\s)*$/;      // IPv6
+@@ -113,7 +120,10 @@
+     return Sntp.now();
+ };
+ 
++internals.authHeaderRegex = /^(\w+)(?:\s+(.*))?$/;                                      // Header: scheme[ something]
++internals.attributeRegex = /^[ \w\!#\$%&'\(\)\*\+,\-\.\/\:;<\=>\?@\[\]\^`\{\|\}~]+$/;   // !#$%&'()*+,-./:;<=>?@[]^_`{|}~ and space, a-z, A-Z, 0-9
+ 
++
+ // Parse Hawk HTTP Authorization header
+ 
+ exports.parseAuthorizationHeader = function (header, keys) {
+@@ -124,7 +134,11 @@
+         return Boom.unauthorized(null, 'Hawk');
+     }
+ 
+-    var headerParts = header.match(/^(\w+)(?:\s+(.*))?$/);       // Header: scheme[ something]
++    if (header.length > exports.limits.maxMatchLength) {
++        return Boom.badRequest('Header length too long');
++    }
++
++    var headerParts = header.match(internals.authHeaderRegex);
+     if (!headerParts) {
+         return Boom.badRequest('Invalid header syntax');
+     }
+@@ -150,9 +164,9 @@
+             return;
+         }
+ 
+-        // Allowed attribute value characters: !#$%&'()*+,-./:;<=>?@[]^_`{|}~ and space, a-z, A-Z, 0-9
++        // Allowed attribute value characters
+ 
+-        if ($2.match(/^[ \w\!#\$%&'\(\)\*\+,\-\.\/\:;<\=>\?@\[\]\^`\{\|\}~]+$/) === null) {
++        if ($2.match(internals.attributeRegex) === null) {
+             errorMessage = 'Bad attribute value: ' + $1;
+             return;
+         }

--- a/packages/snyk-protect/patches/https-proxy-agent_0_0_20190929.patch
+++ b/packages/snyk-protect/patches/https-proxy-agent_0_0_20190929.patch
@@ -1,0 +1,85 @@
+# Derived from https://github.com/TooTallNate/node-https-proxy-agent/pull/76
+# License
+# -------
+
+# (The MIT License)
+
+# Copyright (c) 2013 Nathan Rajlich &lt;nathan@tootallnate.net&gt;
+
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# 'Software'), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+diff --git a/index.js b/index.js
+index 0a2fdab..4008fdc 100644
+--- a/index.js
++++ b/index.js
+@@ -157,17 +157,16 @@ HttpsProxyAgent.prototype.callback = function connect(req, opts, fn) {
+       cleanup();
+       fn(null, sock);
+     } else {
+-      // some other status code that's not 200... need to re-play the HTTP header
+-      // "data" events onto the socket once the HTTP machinery is attached so that
+-      // the user can parse and handle the error status code
++      // We got a bad response to the CONNECT request. Destroy the socket and
++      // return an error.
++      //
++      // If a secure endpoint is targeted, returning a socket without upgrading
++      // it to a TLS connection could result in plaintext secrets leaking to a
++      // network firewall or remote server.
++      buffers = buffered = null;
++      socket.destroy();
+       cleanup();
+-
+-      // save a reference to the concat'd Buffer for the `onsocket` callback
+-      buffers = buffered;
+-
+-      // need to wait for the "socket" event to re-play the "data" events
+-      req.once('socket', onsocket);
+-      fn(null, socket);
++      fn(new Error(`Could not establish connection to proxy server. Status code: ${statusCode}`));
+     }
+   }
+ 
+diff --git a/test/test.js b/test/test.js
+index b368495..a68c7d9 100644
+--- a/test/test.js
++++ b/test/test.js
+@@ -189,7 +189,7 @@ describe('HttpsProxyAgent', function () {
+         });
+       });
+     });
+-    it('should receive the 407 authorization code on the `http.ClientResponse`', function (done) {
++    it('should emit an "error" event on `http.ClientRequest` on proxy 407 authentication required response', function (done) {
+       // set a proxy authentication function for this test
+       proxy.authenticate = function (req, fn) {
+         // reject all requests
+@@ -206,8 +206,11 @@ describe('HttpsProxyAgent', function () {
+       opts.agent = agent;
+ 
+       var req = http.get(opts, function (res) {
+-        assert.equal(407, res.statusCode);
+-        assert('proxy-authenticate' in res.headers);
++        assert.fail('Got an unexpected response with status ' + res.statusCode);
++      });
++      req.once('error', function (err) {
++        assert.equal('Could not establish connection to proxy server. Status code: 407', err.message);
++        req.abort();
+         done();
+       });
+     });

--- a/packages/snyk-protect/patches/https-proxy-agent_0_1_20190929.patch
+++ b/packages/snyk-protect/patches/https-proxy-agent_0_1_20190929.patch
@@ -1,0 +1,57 @@
+# Derived from https://github.com/TooTallNate/node-https-proxy-agent/pull/76
+# License
+# -------
+
+# (The MIT License)
+
+# Copyright (c) 2013 Nathan Rajlich &lt;nathan@tootallnate.net&gt;
+
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# 'Software'), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+diff --git a/index.js b/index.js
+index 0a2fdab..4008fdc 100644
+--- a/index.js
++++ b/index.js
+@@ -157,17 +157,16 @@ HttpsProxyAgent.prototype.callback = function connect(req, opts, fn) {
+       cleanup();
+       fn(null, sock);
+     } else {
+-      // some other status code that's not 200... need to re-play the HTTP header
+-      // "data" events onto the socket once the HTTP machinery is attached so that
+-      // the user can parse and handle the error status code
++      // We got a bad response to the CONNECT request. Destroy the socket and
++      // return an error.
++      //
++      // If a secure endpoint is targeted, returning a socket without upgrading
++      // it to a TLS connection could result in plaintext secrets leaking to a
++      // network firewall or remote server.
++      buffers = buffered = null;
++      socket.destroy();
+       cleanup();
+-
+-      // save a reference to the concat'd Buffer for the `onsocket` callback
+-      buffers = buffered;
+-
+-      // need to wait for the "socket" event to re-play the "data" events
+-      req.once('socket', onsocket);
+-      fn(null, socket);
++      fn(new Error(`Could not establish connection to proxy server. Status code: ${statusCode}`));
+     }
+   }

--- a/packages/snyk-protect/patches/i1n-20160125_0_0_877720d2d9bb90dc8233706e81ffa03f99fc9dc8.patch
+++ b/packages/snyk-protect/patches/i1n-20160125_0_0_877720d2d9bb90dc8233706e81ffa03f99fc9dc8.patch
@@ -1,0 +1,43 @@
+// Code derived from https://github.com/oliversalzburg/i18n-node-angular/
+// Reference: https://github.com/oliversalzburg/i18n-node-angular/commit/877720d2d9bb90dc8233706e81ffa03f99fc9dc8.patch
+
+// https://github.com/oliversalzburg/i18n-node-angular/blob/master/LICENSE
+/*
+The MIT License (MIT)
+
+Copyright (c) 2013 Oliver Salzburg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/i18n-node-routes.js b/i18n-node-routes.js
+index 0083412..cfe0b1a 100644
+--- a/i18n-node-routes.js
++++ b/i18n-node-routes.js
+@@ -49,7 +49,10 @@ var configure = function( app, configObject ) {
+ 
+ 	// Register routes
+ 	app.get( "/i18n/:locale", i18nRoutes.i18n );
+-	app.get( "/i18n/:locale/:phrase", i18nRoutes.translate );
++
++	if( process.env.NODE_ENV === "development" ) {
++		app.get( "/i18n/:locale/:phrase", i18nRoutes.translate );
++	}
+ };
+ 
+ /**

--- a/packages/snyk-protect/patches/imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch
+++ b/packages/snyk-protect/patches/imjv_20160118_0_0_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch
@@ -1,0 +1,38 @@
+// Code derived from https://github.com/mafintosh/is-my-json-valid/
+// Reference: https://github.com/mafintosh/is-my-json-valid/commit/eca4beb21e61877d76fdf6bea771f72f39544d9b
+
+// https://github.com/mafintosh/is-my-json-valid/blob/master/LICENSE
+/*
+The MIT License (MIT)
+
+Copyright (c) 2014 Mathias Buus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+diff --git a/formats.js b/formats.js
+index 3038dae..9cb8380 100644
+--- a/formats.js
++++ b/formats.js
+@@ -11,4 +11,4 @@ exports['alpha'] = /^[a-zA-Z]+$/
+ exports['alphanumeric'] = /^[a-zA-Z0-9]+$/
+ exports['style'] = /\s*(.+?):\s*([^;]+);?/g
+ exports['phone'] = /^\+(?:[0-9] ?){6,14}[0-9]$/
+-exports['utc-millisec'] = /^[0-9]+(\.?[0-9]+)?$/
++exports['utc-millisec'] = /^[0-9]{1,15}\.?[0-9]{0,15}$/

--- a/packages/snyk-protect/patches/imjv_20160118_0_1_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch
+++ b/packages/snyk-protect/patches/imjv_20160118_0_1_eca4beb21e61877d76fdf6bea771f72f39544d9b.patch
@@ -1,0 +1,38 @@
+// Code derived from https://github.com/mafintosh/is-my-json-valid/
+// Reference: https://github.com/mafintosh/is-my-json-valid/commit/eca4beb21e61877d76fdf6bea771f72f39544d9b
+
+// https://github.com/mafintosh/is-my-json-valid/blob/master/LICENSE
+/*
+The MIT License (MIT)
+
+Copyright (c) 2014 Mathias Buus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+diff --git a/formats.js b/formats.js
+index 3038dae..9cb8380 100644
+--- a/formats.js
++++ b/formats.js
+@@ -11,4 +11,4 @@
+ exports['alphanumeric'] = /^[a-zA-Z0-9]+$/,
+ exports['style'] = /\s*(.+?):\s*([^;]+);?/g,
+ exports['phone'] = /^\+(?:[0-9] ?){6,14}[0-9]$/,
+-exports['utc-millisec'] = /^[0-9]+(\.?[0-9]+)?$/
++exports['utc-millisec'] = /^[0-9]{1,15}\.?[0-9]{0,15}$/

--- a/packages/snyk-protect/patches/inert_20141215_0_0_e8f99f94da4cb08e8032eda984761c3f111e3e82_snyk.patch
+++ b/packages/snyk-protect/patches/inert_20141215_0_0_e8f99f94da4cb08e8032eda984761c3f111e3e82_snyk.patch
@@ -1,0 +1,48 @@
+// code derived from https://github.com/hapijs/inert
+
+// https://github.com/hapijs/inert/blob/master/LICENSE
+/*
+Copyright (c) 2012-2015, Gil Pedersen and other contributors.
+Copyright (c) 2012-2014, Walmart.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at: https://github.com/hapijs/inert/graphs/contributors
+*/
+
+diff --git a/lib/directory.js b/lib/directory.js
+index 8880676..e15c78c 100755
+--- a/lib/directory.js
++++ b/lib/directory.js
+@@ -229,7 +229,7 @@ internals.generateListing = function (path, resource, selection, hasTrailingSlas
+
+ internals.isFileHidden = function (path) {
+
+-    return /^\./.test(Path.basename(path));
++    return /(^|[\\\/])\.([^\\\/]|[\\\/]?$)/.test(path);           // Starts with a '.' or contains '/.' or '\.', and not followed by a '/' or '\' or end
+ };
+
+ 

--- a/packages/snyk-protect/patches/jsonwebtoken_20150331_0_0_1bb584bc382295eeb7ee8c4452a673a77a68b687_snyk.patch
+++ b/packages/snyk-protect/patches/jsonwebtoken_20150331_0_0_1bb584bc382295eeb7ee8c4452a673a77a68b687_snyk.patch
@@ -1,0 +1,56 @@
+// code derived from https://github.com/auth0/node-jsonwebtoken.git
+
+// https://github.com/auth0/node-jsonwebtoken/blob/master/LICENSE
+/*
+The MIT License (MIT)
+ 
+Copyright (c) 2015 Auth0, Inc. <support@auth0.com> (http://auth0.com)
+ 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+ 
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+ 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+diff --git a/index.js b/index.js
+index 442fd50..7bd3d2d 100644
+--- a/index.js
++++ b/index.js
+@@ -107,6 +107,12 @@ module.exports.verify = function(jwtString, secretOrPublicKey, options, callback
+     return done(new JsonWebTokenError('jwt signature is required'));
+   }
+
++  if (!options.algorithms) {
++    options.algorithms = ~secretOrPublicKey.toString().indexOf('BEGIN CERTIFICATE') ?
++                        [ 'RS256','RS384','RS512','ES256','ES384','ES512' ] :
++                        [ 'HS256','HS384','HS512' ];
++  }
++
+   var valid;
+
+   try {
+@@ -126,6 +132,11 @@ module.exports.verify = function(jwtString, secretOrPublicKey, options, callback
+     return done(err);
+   }
+
++  var header = jws.decode(jwtString).header;
++  if (!~options.algorithms.indexOf(header.alg)) {
++    return done(new JsonWebTokenError('invalid signature'));
++  }
++
+   if (typeof payload.exp !== 'undefined' && !options.ignoreExpiration) {
+     if (typeof payload.exp !== 'number') {
+       return done(new JsonWebTokenError('invalid exp value'));

--- a/packages/snyk-protect/patches/ldapauth-fork_20150918_0_0_3feea43e243698bcaeffa904a7324f4d96df60e4.patch
+++ b/packages/snyk-protect/patches/ldapauth-fork_20150918_0_0_3feea43e243698bcaeffa904a7324f4d96df60e4.patch
@@ -1,0 +1,62 @@
+// code derived from https://github.com/vesse/node-ldapauth-fork
+// reference: https://github.com/vesse/node-ldapauth-fork/commit/3feea43e243698bcaeffa904a7324f4d96df60e4.patch
+
+// https://github.com/vesse/node-ldapauth-fork/blob/master/LICENSE
+/*
+Modified Work Copyright 2013 Vesa Poikajärvi.
+Original Work Copyright 2011 Trent Mick.
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/lib/ldapauth.js b/lib/ldapauth.js
+index 5bfafe9..103d619 100644
+--- a/lib/ldapauth.js
++++ b/lib/ldapauth.js
+@@ -219,6 +219,17 @@ LdapAuth.prototype._search = function (searchBase, options, callback) {
+   });
+ };
+
++// https://tools.ietf.org/search/rfc4515#section-3
++var sanitizeInput = function (username) {
++  return username
++    .replace(/\*/g, '\\2a')
++    .replace(/\(/g, '\\28')
++    .replace(/\)/g, '\\29')
++    .replace(/\\/g, '\\5c')
++    .replace(/\0/g, '\\00')
++    .replace(/\//g, '\\2f');
++};
++
+ /**
+  * Find the user record for the given username.
+  *
+@@ -233,7 +244,7 @@ LdapAuth.prototype._findUser = function (username, callback) {
+     return callback("empty username");
+   }
+
+-  var searchFilter = self.opts.searchFilter.replace(/{{username}}/g, username);
++  var searchFilter = self.opts.searchFilter.replace(/{{username}}/g, sanitizeInput(username));
+   var opts = {filter: searchFilter, scope: self.opts.searchScope};
+   if (self.opts.searchAttributes) {
+     opts.attributes = self.opts.searchAttributes;

--- a/packages/snyk-protect/patches/libnotify_20130515_0_0_8e2e7306088624503ba5eec592b502c4f97d8846.patch
+++ b/packages/snyk-protect/patches/libnotify_20130515_0_0_8e2e7306088624503ba5eec592b502c4f97d8846.patch
@@ -1,0 +1,43 @@
+// code derived from https://github.com/mytrile/node-libnotify
+// reference: https://github.com/mytrile/node-libnotify/commit/8e2e7306088624503ba5eec592b502c4f97d8846.patch
+
+// https://github.com/mytrile/node-libnotify#license
+/*
+(The MIT License)
+
+Copyright (c) 2010 Mitko Kostov mitko.kostov@gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/lib/libnotify.js b/lib/libnotify.js
+index 2c1567b..7e59267 100644
+--- a/lib/libnotify.js
++++ b/lib/libnotify.js
+@@ -55,18 +55,17 @@ exports.binVersion = function(callback) {
+ 
+ exports.notify = function(msg, options, callback) {
+   var image,
+-      args = ['notify-send','"' + msg + '"'],
++      args = [msg],
+       options = options || {}
+   this.binVersion(function(err, version){
+     if (err) return callback(err)
+-    if (image = options.image) args.push('-i ' + image)
++    if (image = options.image) args.push('-i', image)
+     if (options.time) args.push('-t', options.time)
+     if (options.category) args.push('-c', options.category)
+     if (options.urgency) args.push('-u', options.urgency)
+     if (options.title) {
+-      args.shift()
+-      args.unshift('notify-send', '"'+ options.title +'"')
++      args.unshift(options.title)
+     }
+-    child_process.exec(args.join(' '), callback)
++    child_process.execFile('notify-send', args, {}, callback)
+   })
+ }

--- a/packages/snyk-protect/patches/lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch
+++ b/packages/snyk-protect/patches/lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch
@@ -1,0 +1,68 @@
+# Licence
+# ---------
+# The MIT License
+
+# Copyright JS Foundation and other contributors <https://js.foundation/>
+
+# Based on Underscore.js, copyright Jeremy Ashkenas,
+# DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+# This software consists of voluntary contributions made by many
+# individuals. For exact contribution history, see the revision history
+# available at https://github.com/lodash/lodash
+
+# The following license applies to all parts of this software except as
+# documented below:
+
+# ====
+
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# ====
+
+# Copyright and related rights for sample code are waived via CC0. Sample
+# code is defined as all source code displayed within the prose of the
+# documentation.
+
+# CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+# ====
+
+# Files located in the node_modules and vendor directories are externally
+# maintained libraries used by this software which have their own
+# licenses; we recommend you read them, as their terms may differ from the
+# terms above.
+diff --git a/lodash.js b/lodash.js
+index 9b95dfef..43e71ffb 100644
+--- a/lodash.js
++++ b/lodash.js
+@@ -3977,6 +3977,10 @@
+         var key = toKey(path[index]),
+             newValue = value;
+ 
++        if ((key === '__proto__' || key === 'constructor' || key === 'prototype')) {
++          return object;
++        }
++
+         if (index != lastIndex) {
+           var objValue = nested[key];
+           newValue = customizer ? customizer(objValue, key, nested) : undefined;
+
+ 

--- a/packages/snyk-protect/patches/lodash_20190702_0_0_1f8ea07746963a535385a5befc19fa687a627d2b.patch
+++ b/packages/snyk-protect/patches/lodash_20190702_0_0_1f8ea07746963a535385a5befc19fa687a627d2b.patch
@@ -1,0 +1,93 @@
+# Derived from: https://github.com/lodash/lodash/commit/1f8ea07746963a535385a5befc19fa687a627d2b
+# Copyright JS Foundation and other contributors <https://js.foundation/>
+
+# Based on Underscore.js, copyright Jeremy Ashkenas,
+# DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+# This software consists of voluntary contributions made by many
+# individuals. For exact contribution history, see the revision history
+# available at https://github.com/lodash/lodash
+
+# The following license applies to all parts of this software except as
+# documented below:
+
+# ====
+
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# ====
+
+# Copyright and related rights for sample code are waived via CC0. Sample
+# code is defined as all source code displayed within the prose of the
+# documentation.
+
+# CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+# ====
+
+# Files located in the node_modules and vendor directories are externally
+# maintained libraries used by this software which have their own
+# licenses; we recommend you read them, as their terms may differ from the
+# terms above.
+
+diff --git a/lodash.js b/lodash.js
+index 92c566ac9..5c308f605 100644
+--- a/lodash.js
++++ b/lodash.js
+@@ -6605,7 +6605,7 @@
+     }
+
+     /**
+-     * Gets the value at `key`, unless `key` is "__proto__".
++     * Gets the value at `key`, unless `key` is "__proto__" or "constructor".
+      *
+      * @private
+      * @param {Object} object The object to query.
+@@ -6613,6 +6613,10 @@
+      * @returns {*} Returns the property value.
+      */
+     function safeGet(object, key) {
++      if (key === 'constructor' && typeof object[key] === 'function') {
++        return;
++      }
++
+       if (key == '__proto__') {
+         return;
+       }
+--- a/_safeGet.js
++++ b/_safeGet.js
+@@ -1,5 +1,5 @@
+ /**
+- * Gets the value at `key`, unless `key` is "__proto__".
++ * Gets the value at `key`, unless `key` is "__proto__" or "constructor".
+  *
+  * @private
+  * @param {Object} object The object to query.
+@@ -7,6 +7,10 @@
+  * @returns {*} Returns the property value.
+  */
+ function safeGet(object, key) {
++  if (key === 'constructor' && typeof object[key] === 'function') {
++    return;
++  }
++
+   if (key == '__proto__') {
+     return;
+   }

--- a/packages/snyk-protect/patches/mapbox.js_20151024_0_0_538d229ab6767bb4c3f3969c417f9884189c1512.patch
+++ b/packages/snyk-protect/patches/mapbox.js_20151024_0_0_538d229ab6767bb4c3f3969c417f9884189c1512.patch
@@ -1,0 +1,103 @@
+// code derived from: https://github.com/mapbox/mapbox.js
+
+// https://github.com/mapbox/mapbox.js/blob/mb-pages/LICENSE.md
+/* 
+# Mapbox.js
+
+Copyright (c), Mapbox
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+- Neither the name "Mapbox" nor the names of its contributors may be
+  used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Contains parts of L.UTFGrid
+
+Copyright 2012 David Leaver
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/src/map.js b/src/map.js
+index 93e7de6..c5e6098 100644
+--- a/src/map.js
++++ b/src/map.js
+@@ -27,7 +27,8 @@ var LMap = L.Map.extend({
+         legendControl: {},
+         gridControl: {},
+         infoControl: false,
+-        shareControl: false
++        shareControl: false,
++        sanitizer: require('sanitize-caja')
+     },
+
+     _tilejson: {},
+@@ -143,7 +144,7 @@ var LMap = L.Map.extend({
+         }
+
+         if (this.infoControl && json.attribution) {
+-            this.infoControl.addInfo(json.attribution);
++            this.infoControl.addInfo(this.options.sanitizer(json.attribution));
+             this._updateMapFeedbackLink();
+         }
+
+diff --git a/src/tile_layer.js b/src/tile_layer.js
+index 1cb1e42..3417318 100644
+--- a/src/tile_layer.js
++++ b/src/tile_layer.js
+@@ -6,6 +6,10 @@ var formatPattern = /\.((?:png|jpg)\d*)(?=$|\?)/;
+ var TileLayer = L.TileLayer.extend({
+     includes: [require('./load_tilejson')],
+
++    options: {
++        sanitizer: require('sanitize-caja')
++    },
++
+     // http://mapbox.com/developers/api/#image_quality
+     formats: [
+         'png', 'jpg',
+@@ -46,7 +50,7 @@ var TileLayer = L.TileLayer.extend({
+
+         L.extend(this.options, {
+             tiles: json.tiles,
+-            attribution: json.attribution,
++            attribution: this.options.sanitizer(json.attribution),
+             minZoom: json.minzoom || 0,
+             maxZoom: json.maxzoom || 18,
+             tms: json.scheme === 'tms',

--- a/packages/snyk-protect/patches/markdown-it_20160912_0_0_f76d3beb46abd121892a2e2e5c78376354c214e3.patch
+++ b/packages/snyk-protect/patches/markdown-it_20160912_0_0_f76d3beb46abd121892a2e2e5c78376354c214e3.patch
@@ -1,0 +1,83 @@
+// code derived form: https://github.com/markdown-it/markdown-it
+// reference:
+//  https://github.com/markdown-it/markdown-it/commit/f76d3beb46abd121892a2e2e5c78376354c214e3
+
+// https://raw.githubusercontent.com/markdown-it/markdown-it/master/LICENSE
+/*
+
+Copyright (c) 2014 Vitaly Puzrin, Alex Kocharin.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+diff --git a/lib/index.js b/lib/index.js
+index abc1525..320b983 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -20,20 +20,41 @@ var config = {
+   commonmark: require('./presets/commonmark')
+ };
+
+-
+-var BAD_PROTOCOLS    = [ 'vbscript', 'javascript', 'file' ];
++////////////////////////////////////////////////////////////////////////////////
++//
++// This validator does not pretent to functionality of full weight sanitizers.
++// It's a tradeoff between default security, simplicity and usability.
++// If you need different setup - override validator method as you wish. Or
++// replace it with dummy function and use external sanitizer.
++//
++
++var BAD_PROTOCOLS      = [ 'vbscript', 'javascript', 'file', 'data' ];
++var ALLOWED_DATA_MIMES = [
++  'data:image/gif',
++  'data:image/png',
++  'data:image/jpeg',
++  'data:image/webp'
++];
+
+ function validateLink(url) {
+   // url should be normalized at this point, and existing entities are decoded
+-  //
+-  var str = url.trim().toLowerCase();
+
+-  if (str.indexOf(':') >= 0 && BAD_PROTOCOLS.indexOf(str.split(':')[0]) >= 0) {
++  var str      = url.trim().toLowerCase(),
++      protocol = str.split(':')[0];
++
++  if (str.indexOf(':') >= 0 && BAD_PROTOCOLS.indexOf(protocol) >= 0) {
++    if (protocol === 'data' && ALLOWED_DATA_MIMES.indexOf(str.split(';')[0]) >= 0) {
++      return true;
++    }
+     return false;
+   }
++
+   return true;
+ }
+
++////////////////////////////////////////////////////////////////////////////////
++
++
+ var RECODE_HOSTNAME_FOR = [ 'http:', 'https:', 'mailto:' ];
+
+ function normalizeLink(url) {

--- a/packages/snyk-protect/patches/marked_20140131-1_0_0_a37bd643f05bf95ff18cafa2b06e7d741d2e2157.patch
+++ b/packages/snyk-protect/patches/marked_20140131-1_0_0_a37bd643f05bf95ff18cafa2b06e7d741d2e2157.patch
@@ -1,0 +1,14 @@
+// code derived from https://github.com/chjj/marked
+diff --git a/lib/marked.js b/lib/marked.js
+index 0c2ac4b..97f18cd 100644
+--- a/lib/marked.js
++++ b/lib/marked.js
+@@ -456,7 +456,7 @@ var inline = {
+   reflink: /^!?\[(inside)\]\s*\[([^\]]*)\]/,
+   nolink: /^!?\[((?:\[[^\]]*\]|[^\[\]])*)\]/,
+   strong: /^__([\s\S]+?)__(?!_)|^\*\*([\s\S]+?)\*\*(?!\*)/,
+-  em: /^\b_((?:__|[\s\S])+?)_\b|^\*((?:\*\*|[\s\S])+?)\*(?!\*)/,
++  em: /^\b_((?:[^_]|__)+?)_\b|^\*((?:\*\*|[\s\S])+?)\*(?!\*)/,
+   code: /^(`+)\s*([\s\S]*?[^`])\s*\1(?!`)/,
+   br: /^ {2,}\n(?!\s*$)/,
+   del: noop,

--- a/packages/snyk-protect/patches/marked_20140131-2_0_0_3c191144939107c45a7fa11ab6cb88be6694a1ba.patch
+++ b/packages/snyk-protect/patches/marked_20140131-2_0_0_3c191144939107c45a7fa11ab6cb88be6694a1ba.patch
@@ -1,0 +1,14 @@
+// code derived from https://github.com/chjj/marked
+diff --git a/lib/marked.js b/lib/marked.js
+index 142eccf..0b7180f 100644
+--- a/lib/marked.js
++++ b/lib/marked.js
+@@ -868,7 +868,7 @@ Renderer.prototype.link = function(href, title, text) {
+     } catch (e) {
+       return '';
+     }
+-    if (prot.indexOf('javascript:') === 0) {
++    if (prot.indexOf('javascript:') === 0 || prot.indexOf('vbscript:') === 0) {
+       return '';
+     }
+   }

--- a/packages/snyk-protect/patches/marked_20150520_0_0_2cff85979be8e7a026a9aca35542c470cf5da523.patch
+++ b/packages/snyk-protect/patches/marked_20150520_0_0_2cff85979be8e7a026a9aca35542c470cf5da523.patch
@@ -1,0 +1,41 @@
+// code derived form: https://github.com/chjj/marked
+// reference:
+//  https://github.com/chjj/marked/commit/2cff85979be8e7a026a9aca35542c470cf5da523
+
+// https://raw.githubusercontent.com/chjj/marked/master/LICENSE
+/*
+Copyright (c) 2011-2014, Christopher Jeffrey (https://github.com/chjj/)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+diff --git a/lib/marked.js b/lib/marked.js
+index 0c2ac4b..089369f 100644
+--- a/lib/marked.js
++++ b/lib/marked.js
+@@ -1094,7 +1094,8 @@ function escape(html, encode) {
+ }
+ 
+ function unescape(html) {
+-  return html.replace(/&([#\w]+);/g, function(_, n) {
++	// explicitly match decimal, hex, and named HTML entities 
++  return html.replace(/&(#(?:\d+)|(?:#x[0-9A-Fa-f]+)|(?:\w+));?/g, function(_, n) {
+     n = n.toLowerCase();
+     if (n === 'colon') return ':';
+     if (n.charAt(0) === '#') {

--- a/packages/snyk-protect/patches/marked_20150520_0_1_2cff85979be8e7a026a9aca35542c470cf5da523_20140131-1.patch
+++ b/packages/snyk-protect/patches/marked_20150520_0_1_2cff85979be8e7a026a9aca35542c470cf5da523_20140131-1.patch
@@ -1,0 +1,55 @@
+// code derived form: https://github.com/chjj/marked
+// reference:
+//  https://github.com/chjj/marked/commit/2cff85979be8e7a026a9aca35542c470cf5da523
+
+// https://raw.githubusercontent.com/chjj/marked/master/LICENSE
+/*
+Copyright (c) 2011-2014, Christopher Jeffrey (https://github.com/chjj/)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+diff --git a/lib/marked.js b/lib/marked.js
+index 0c2ac4b..089369f 100644
+--- a/lib/marked.js
++++ b/lib/marked.js
+@@ -1094,7 +1094,8 @@ function escape(html, encode) {
+ }
+ 
+ function unescape(html) {
+-  return html.replace(/&([#\w]+);/g, function(_, n) {
++	// explicitly match decimal, hex, and named HTML entities 
++  return html.replace(/&(#(?:\d+)|(?:#x[0-9A-Fa-f]+)|(\w+))/g, function(_, n) {
+     n = n.toLowerCase();
+     if (n === 'colon') return ':';
+     if (n.charAt(0) === '#') {
+// 20140131-1
+diff --git a/lib/marked.js b/lib/marked.js
+index 0c2ac4b..97f18cd 100644
+--- a/lib/marked.js
++++ b/lib/marked.js
+@@ -456,7 +456,7 @@ var inline = {
+   reflink: /^!?\[(inside)\]\s*\[([^\]]*)\]/,
+   nolink: /^!?\[((?:\[[^\]]*\]|[^\[\]])*)\]/,
+   strong: /^__([\s\S]+?)__(?!_)|^\*\*([\s\S]+?)\*\*(?!\*)/,
+-  em: /^\b_((?:__|[\s\S])+?)_\b|^\*((?:\*\*|[\s\S])+?)\*(?!\*)/,
++  em: /^\b_((?:[^_]|__)+?)_\b|^\*((?:\*\*|[\s\S])+?)\*(?!\*)/,
+   code: /^(`+)\s*([\s\S]*?[^`])\s*\1(?!`)/,
+   br: /^ {2,}\n(?!\s*$)/,
+   del: noop,

--- a/packages/snyk-protect/patches/marked_20150520_0_2_2cff85979be8e7a026a9aca35542c470cf5da523_20140131-1-2.patch
+++ b/packages/snyk-protect/patches/marked_20150520_0_2_2cff85979be8e7a026a9aca35542c470cf5da523_20140131-1-2.patch
@@ -1,0 +1,69 @@
+// code derived form: https://github.com/chjj/marked
+// reference:
+//  https://github.com/chjj/marked/commit/2cff85979be8e7a026a9aca35542c470cf5da523
+
+// https://raw.githubusercontent.com/chjj/marked/master/LICENSE
+/*
+Copyright (c) 2011-2014, Christopher Jeffrey (https://github.com/chjj/)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+diff --git a/lib/marked.js b/lib/marked.js
+index 0c2ac4b..089369f 100644
+--- a/lib/marked.js
++++ b/lib/marked.js
+@@ -1094,7 +1094,8 @@ function escape(html, encode) {
+ }
+ 
+ function unescape(html) {
+-  return html.replace(/&([#\w]+);/g, function(_, n) {
++	// explicitly match decimal, hex, and named HTML entities 
++  return html.replace(/&(#(?:\d+)|(?:#x[0-9A-Fa-f]+)|(\w+))/g, function(_, n) {
+     n = n.toLowerCase();
+     if (n === 'colon') return ':';
+     if (n.charAt(0) === '#') {
+// 20140131-2
+diff --git a/lib/marked.js b/lib/marked.js
+index 142eccf..0b7180f 100644
+--- a/lib/marked.js
++++ b/lib/marked.js
+@@ -868,7 +868,7 @@ Renderer.prototype.link = function(href, title, text) {
+     } catch (e) {
+       return '';
+     }
+-    if (prot.indexOf('javascript:') === 0) {
++    if (prot.indexOf('javascript:') === 0 || prot.indexOf('vbscript:') === 0) {
+       return '';
+     }
+   }
+// 20140131-1
+diff --git a/lib/marked.js b/lib/marked.js
+index 0c2ac4b..97f18cd 100644
+--- a/lib/marked.js
++++ b/lib/marked.js
+@@ -456,7 +456,7 @@ var inline = {
+   reflink: /^!?\[(inside)\]\s*\[([^\]]*)\]/,
+   nolink: /^!?\[((?:\[[^\]]*\]|[^\[\]])*)\]/,
+   strong: /^__([\s\S]+?)__(?!_)|^\*\*([\s\S]+?)\*\*(?!\*)/,
+-  em: /^\b_((?:__|[\s\S])+?)_\b|^\*((?:\*\*|[\s\S])+?)\*(?!\*)/,
++  em: /^\b_((?:[^_]|__)+?)_\b|^\*((?:\*\*|[\s\S])+?)\*(?!\*)/,
+   code: /^(`+)\s*([\s\S]*?[^`])\s*\1(?!`)/,
+   br: /^ {2,}\n(?!\s*$)/,
+   del: noop,

--- a/packages/snyk-protect/patches/marked_20170112_0_0_cd2f6f5b7091154c5526e79b5f3bfb4d15995a51.patch
+++ b/packages/snyk-protect/patches/marked_20170112_0_0_cd2f6f5b7091154c5526e79b5f3bfb4d15995a51.patch
@@ -1,0 +1,40 @@
+// code derived form: https://github.com/chjj/marked
+// reference:
+//  https://github.com/chjj/marked/commit/cd2f6f5b7091154c5526e79b5f3bfb4d15995a51.patch
+
+// https://raw.githubusercontent.com/chjj/marked/master/LICENSE
+/*
+Copyright (c) 2011-2014, Christopher Jeffrey (https://github.com/chjj/)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+diff --git a/lib/marked.js b/lib/marked.js
+index 9f1584b..2696019 100644
+--- a/lib/marked.js
++++ b/lib/marked.js
+@@ -875,7 +875,7 @@ Renderer.prototype.link = function(href, title, text) {
+     } catch (e) {
+       return '';
+     }
+-    if (prot.indexOf('javascript:') === 0 || prot.indexOf('vbscript:') === 0) {
++    if (prot.indexOf('javascript:') === 0 || prot.indexOf('vbscript:') === 0 || prot.indexOf('data:') === 0) {
+       return '';
+     }
+   }

--- a/packages/snyk-protect/patches/marked_20170907_0_0_4afb8ce135a1e020e48f7084340333dd0c18229f.patch
+++ b/packages/snyk-protect/patches/marked_20170907_0_0_4afb8ce135a1e020e48f7084340333dd0c18229f.patch
@@ -1,0 +1,52 @@
+// Based on a commit written by UziTech https://github.com/UziTech
+// reference:
+//  https://github.com/chjj/marked/commit/4afb8ce135a1e020e48f7084340333dd0c18229f.patch
+=======
+// code derived form: https://github.com/chjj/marked
+// reference:
+//  https://github.com/chjj/marked/commit/cd2f6f5b7091154c5526e79b5f3bfb4d15995a51.patch
+
+// https://raw.githubusercontent.com/chjj/marked/master/LICENSE
+/*
+Copyright (c) 2011-2014, Christopher Jeffrey (https://github.com/chjj/)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+diff --git a/lib/marked.js b/lib/marked.js
+index 2696019c..1faab722 100644
+--- a/lib/marked.js
++++ b/lib/marked.js
+@@ -457,7 +457,7 @@ var inline = {
+   nolink: /^!?\[((?:\[[^\]]*\]|[^\[\]])*)\]/,
+   strong: /^__([\s\S]+?)__(?!_)|^\*\*([\s\S]+?)\*\*(?!\*)/,
+   em: /^\b_((?:[^_]|__)+?)_\b|^\*((?:\*\*|[\s\S])+?)\*(?!\*)/,
+-  code: /^(`+)\s*([\s\S]*?[^`])\s*\1(?!`)/,
++  code: /^(`+)([\s\S]*?[^`])\1(?!`)/,
+   br: /^ {2,}\n(?!\s*$)/,
+   del: noop,
+   text: /^[\s\S]+?(?=[\\<!\[_*`]| {2,}\n|$)/
+@@ -661,7 +661,7 @@ InlineLexer.prototype.output = function(src) {
+     // code
+     if (cap = this.rules.code.exec(src)) {
+       src = src.substring(cap[0].length);
+-      out += this.renderer.codespan(escape(cap[2], true));
++      out += this.renderer.codespan(escape(cap[2].trim(), true));
+       continue;
+     }

--- a/packages/snyk-protect/patches/millisecond_20151120_0_0_d3e03f8cd2089806b522e867505e14444fbac838.patch
+++ b/packages/snyk-protect/patches/millisecond_20151120_0_0_d3e03f8cd2089806b522e867505e14444fbac838.patch
@@ -1,0 +1,56 @@
+// code derived from https://github.com/unshiftio/millisecond
+
+// https://github.com/unshiftio/millisecond/blob/master/LICENSE
+/*
+The MIT License (MIT)
+
+Copyright (c) 2015 Unshift.io, Arnout Kazemier,  the Contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+diff --git a/index.js b/index.js
+index f353600..4abe7c6 100644
+--- a/index.js
++++ b/index.js
+@@ -38,12 +38,20 @@ var second = 1000
+  * @api private
+  */
+ module.exports = function millisecond(ms) {
+-  if ('string' !== typeof ms || '0' === ms || +ms) return +ms;
++  var type = typeof ms
++    , amount
++    , match;
+
+-  var match = regex.exec(ms)
+-    , amount;
++  if ('number' === type) return ms;
++  else if ('string' !== type || '0' === ms || !ms) return 0;
++  else if (+ms) return +ms;
+
+-  if (!match) return 0;
++  //
++  // We are vulnerable to the regular expression denial of service (ReDoS).
++  // In order to mitigate this we don't parse the input string if it is too long.
++  // See https://nodesecurity.io/advisories/46.
++  //
++  if (ms.length > 10000 || !(match = regex.exec(ms))) return 0;
+
+   amount = parseFloat(match[1]);
+

--- a/packages/snyk-protect/patches/mime_20170907_0_0_855d0c4b8b22e4a80b9401a81f2872058eae274d.patch
+++ b/packages/snyk-protect/patches/mime_20170907_0_0_855d0c4b8b22e4a80b9401a81f2872058eae274d.patch
@@ -1,0 +1,39 @@
+// code derived from https://github.com/broofa/node-mime
+// https://github.com/broofa/node-mime/blob/master/LICENSE
+/*
+The MIT License (MIT)
+
+Copyright (c) 2010 Benjamin Thomas, Robert Kieffer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+diff --git a/mime.js b/mime.js
+index d9a46a8..d7efbde 100644
+--- a/mime.js
++++ b/mime.js
+@@ -67,7 +67,7 @@ Mime.prototype.load = function(file) {
+  * Lookup a mime type based on extension
+  */
+ Mime.prototype.lookup = function(path, fallback) {
+-  var ext = path.replace(/.*[\.\/\\]/, '').toLowerCase();
++  var ext = path.replace(/^.*[\.\/\\]/, '').toLowerCase();
+ 
+   return this.types[ext] || fallback || this.default_type;
+ };

--- a/packages/snyk-protect/patches/minimatch_20160620_0_0_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch
+++ b/packages/snyk-protect/patches/minimatch_20160620_0_0_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch
@@ -1,0 +1,78 @@
+// Code derived from https://github.com/isaacs/minimatch/
+// Reference: https://github.com/isaacs/minimatch/commit/6944abf9e0694bd22fd9dad293faa40c2bc8a955
+
+// https://github.com/isaacs/minimatch/blob/master/LICENSE
+/*
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+diff --git a/minimatch.js b/minimatch.js
+index ec4c05c..830a272 100644
+--- a/minimatch.js
++++ b/minimatch.js
+@@ -235,7 +235,7 @@ function braceExpand (pattern, options) {
+     ? this.pattern : pattern
+ 
+   if (typeof pattern === 'undefined') {
+-    throw new Error('undefined pattern')
++    throw new TypeError('undefined pattern')
+   }
+ 
+   if (options.nobrace ||
+--- a/minimatch.js
++++ b/minimatch.js
+@@ -261,6 +261,10 @@ function braceExpand (pattern, options) {
+ Minimatch.prototype.parse = parse
+ var SUBPARSE = {}
+ function parse (pattern, isSub) {
++  if (pattern.length > 1024 * 64) {
++    throw new TypeError('pattern is too long')
++  }
++
+   var options = this.options
+ 
+   // shortcuts
+--- a/minimatch.js
++++ b/minimatch.js
+@@ -518,7 +522,7 @@ function parse (pattern, isSub) {
+   for (pl = patternListStack.pop(); pl; pl = patternListStack.pop()) {
+     var tail = re.slice(pl.reStart + 3)
+     // maybe some even number of \, then maybe 1 \, followed by a |
+-    tail = tail.replace(/((?:\\{2})*)(\\?)\|/g, function (_, $1, $2) {
++    tail = tail.replace(/((?:\\{2}){0,64})(\\?)\|/g, function (_, $1, $2) {
+       if (!$2) {
+         // the | isn't already escaped, so escape it.
+         $2 = '\\'
+--- a/minimatch.js
++++ b/minimatch.js
+@@ -615,7 +619,15 @@ function parse (pattern, isSub) {
+   }
+ 
+   var flags = options.nocase ? 'i' : ''
+-  var regExp = new RegExp('^' + re + '$', flags)
++  try {
++    var regExp = new RegExp('^' + re + '$', flags)
++  } catch (er) {
++    // If it was an invalid regular expression, then it can't match
++    // anything.  This trick looks for a character after the end of
++    // the string, which is of course impossible, except in multi-line
++    // mode, but it's not a /m regex.
++    return new RegExp('$.')
++  }
+ 
+   regExp._glob = pattern
+   regExp._src = re

--- a/packages/snyk-protect/patches/minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch
+++ b/packages/snyk-protect/patches/minimatch_20160620_0_1_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch
@@ -1,0 +1,69 @@
+// Code derived from https://github.com/isaacs/minimatch/
+// Reference: https://github.com/isaacs/minimatch/commit/6944abf9e0694bd22fd9dad293faa40c2bc8a955
+
+// https://github.com/isaacs/minimatch/blob/master/LICENSE
+/*
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+diff --git a/minimatch.js b/minimatch.js
+--- a/minimatch.js
++++ b/minimatch.js
+@@ -467,6 +467,10 @@
+ Minimatch.prototype.parse = parse
+ var SUBPARSE = {}
+ function parse (pattern, isSub) {
++  if (pattern.length > 1024 * 64) {
++    throw new TypeError('pattern is too long')
++  }
++
+   var options = this.options
+
+   // shortcuts
+--- a/minimatch.js
++++ b/minimatch.js
+@@ -696,7 +700,7 @@
+   while (pl = patternListStack.pop()) {
+     var tail = re.slice(pl.reStart + 3)
+     // maybe some even number of \, then maybe 1 \, followed by a |
+-    tail = tail.replace(/((?:\\{2})*)(\\?)\|/g, function (_, $1, $2) {
++    tail = tail.replace(/((?:\\{2}){0,64})(\\?)\|/g, function (_, $1, $2) {
+       if (!$2) {
+         // the | isn't already escaped, so escape it.
+         $2 = "\\"
+--- a/minimatch.js
++++ b/minimatch.js
+@@ -757,9 +761,17 @@
+     return globUnescape(pattern)
+   }
+
+-  var flags = options.nocase ? "i" : ""
+-    , regExp = new RegExp("^" + re + "$", flags)
+-
++  var flags = options.nocase ? "i" : "";
++  try {
++    var regExp = new RegExp('^' + re + '$', flags)
++  } catch (er) {
++    // If it was an invalid regular expression, then it can't match
++    // anything.  This trick looks for a character after the end of
++    // the string, which is of course impossible, except in multi-line
++    // mode, but it's not a /m regex.
++    return new RegExp('$.')
++  }
++
+   regExp._glob = pattern
+   regExp._src = re

--- a/packages/snyk-protect/patches/moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch
+++ b/packages/snyk-protect/patches/moment_0_0_69ed9d44957fa6ab12b73d2ae29d286a857b80eb.patch
@@ -1,0 +1,65 @@
+// code derived from https://github.com/moment/moment/commit/69ed9d44957fa6ab12b73d2ae29d286a857b80eb
+/*
+Copyright (c) JS Foundation and other contributors
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/min/moment-with-locales.js b/min/moment-with-locales.js
+index 5a3c3dbb4..f5a2a8bff 100644
+--- a/min/moment-with-locales.js
++++ b/min/moment-with-locales.js
+@@ -653,7 +653,7 @@ var matchTimestamp = /[+-]?\d+(\.\d{1,3})?/; // 123456789 123456789.123
+
+ // any word (or two) characters or numbers including two/three word month in arabic.
+ // includes scottish gaelic two word and hyphenated months
+-var matchWord = /[0-9]*['a-z\u00A0-\u05FF\u0700-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+|[\u0600-\u06FF\/]+(\s*?[\u0600-\u06FF]+){1,2}/i;
++var matchWord = /[0-9]{0,256}['a-z\u00A0-\u05FF\u0700-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]{1,256}|[\u0600-\u06FF\/]{1,256}(\s*?[\u0600-\u06FF]{1,256}){1,2}/i;
+
+
+ var regexes = {};
+diff --git a/moment.js b/moment.js
+index f806995fb..6feb4964d 100644
+--- a/moment.js
++++ b/moment.js
+@@ -659,7 +659,7 @@ var matchTimestamp = /[+-]?\d+(\.\d{1,3})?/; // 123456789 123456789.123
+
+ // any word (or two) characters or numbers including two/three word month in arabic.
+ // includes scottish gaelic two word and hyphenated months
+-var matchWord = /[0-9]*['a-z\u00A0-\u05FF\u0700-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+|[\u0600-\u06FF\/]+(\s*?[\u0600-\u06FF]+){1,2}/i;
++var matchWord = /[0-9]{0,256}['a-z\u00A0-\u05FF\u0700-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]{1,256}|[\u0600-\u06FF\/]{1,256}(\s*?[\u0600-\u06FF]{1,256}){1,2}/i;
+
+
+ var regexes = {};
+diff --git a/src/lib/parse/regex.js b/src/lib/parse/regex.js
+index b1dc7529e..5076548ed 100644
+--- a/src/lib/parse/regex.js
++++ b/src/lib/parse/regex.js
+@@ -20,7 +20,7 @@ export var matchTimestamp = /[+-]?\d+(\.\d{1,3})?/; // 123456789 123456789.123
+
+ // any word (or two) characters or numbers including two/three word month in arabic.
+ // includes scottish gaelic two word and hyphenated months
+-export var matchWord = /[0-9]*['a-z\u00A0-\u05FF\u0700-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]+|[\u0600-\u06FF\/]+(\s*?[\u0600-\u06FF]+){1,2}/i;
++export var matchWord = /[0-9]{0,256}['a-z\u00A0-\u05FF\u0700-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]{1,256}|[\u0600-\u06FF\/]{1,256}(\s*?[\u0600-\u06FF]{1,256}){1,2}/i;
+
+
+ import hasOwnProp from '../utils/has-own-prop';

--- a/packages/snyk-protect/patches/moment_20160126_0_0_34af63b8b21208a949dfaf42d228502c73d20ec0.patch
+++ b/packages/snyk-protect/patches/moment_20160126_0_0_34af63b8b21208a949dfaf42d228502c73d20ec0.patch
@@ -1,0 +1,42 @@
+// code derived from https://github.com/rvagg/moment
+// reference: https://github.com/rvagg/moment/commit/34af63b8b21208a949dfaf42d228502c73d20ec0
+
+// https://github.com/rvagg/moment/blob/develop/LICENSE
+/*
+Copyright (c) 2011-2016 Tim Wood, Iskren Chernev, Moment.js contributors
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/src/lib/duration/create.js b/src/lib/duration/create.js
+index a79feea..d465cee 100644
+--- a/moment.js
++++ b/moment.js
+@@ -1816,7 +1816,7 @@
+     }
+
+     // ASP.NET json date format regex
+-    var aspNetRegex = /(\-)?(?:(\d*)[. ])?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?)?/;
++    var aspNetRegex = /^(\-)?(?:(\d*)[. ])?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?\d*)?$/;
+
+     // from http://docs.closure-library.googlecode.com/git/closure_goog_date_date.js.source.html
+     // somewhat more in line with 4.4.3.2 2004 spec, but allows decimal anywhere

--- a/packages/snyk-protect/patches/moment_20160126_0_1_34af63b8b21208a949dfaf42d228502c73d20ec0.patch
+++ b/packages/snyk-protect/patches/moment_20160126_0_1_34af63b8b21208a949dfaf42d228502c73d20ec0.patch
@@ -1,0 +1,42 @@
+// code derived from https://github.com/rvagg/moment
+// reference: https://github.com/rvagg/moment/commit/34af63b8b21208a949dfaf42d228502c73d20ec0
+
+// https://github.com/rvagg/moment/blob/develop/LICENSE
+/*
+Copyright (c) 2011-2016 Tim Wood, Iskren Chernev, Moment.js contributors
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/src/lib/duration/create.js b/src/lib/duration/create.js
+index a79feea..d465cee 100644
+--- a/moment.js
++++ b/moment.js
+@@ -1648,7 +1648,7 @@
+         return this._isUTC && this._offset === 0;
+     }
+
+-    var aspNetRegex = /(\-)?(?:(\d*)\.)?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?)?/;
++    var aspNetRegex = /^(\-)?(?:(\d*)[. ])?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?\d*)?$/;
+
+     // from http://docs.closure-library.googlecode.com/git/closure_goog_date_date.js.source.html
+     // somewhat more in line with 4.4.3.2 2004 spec, but allows decimal anywhere

--- a/packages/snyk-protect/patches/moment_20160126_0_2_34af63b8b21208a949dfaf42d228502c73d20ec0.patch
+++ b/packages/snyk-protect/patches/moment_20160126_0_2_34af63b8b21208a949dfaf42d228502c73d20ec0.patch
@@ -1,0 +1,42 @@
+// code derived from https://github.com/rvagg/moment
+// reference: https://github.com/rvagg/moment/commit/34af63b8b21208a949dfaf42d228502c73d20ec0
+
+// https://github.com/rvagg/moment/blob/develop/LICENSE
+/*
+Copyright (c) 2011-2016 Tim Wood, Iskren Chernev, Moment.js contributors
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/src/lib/duration/create.js b/src/lib/duration/create.js
+index a79feea..d465cee 100644
+--- a/moment.js
++++ b/moment.js
+@@ -37,7 +37,7 @@
+
+         // ASP.NET json date format regex
+         aspNetJsonRegex = /^\/?Date\((\-?\d+)/i,
+-        aspNetTimeSpanJsonRegex = /(\-)?(?:(\d*)\.)?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?)?/,
++        aspNetTimeSpanJsonRegex = /^(\-)?(?:(\d*)[. ])?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?\d*)?$/;
+
+         // from http://docs.closure-library.googlecode.com/git/closure_goog_date_date.js.source.html
+         // somewhat more in line with 4.4.3.2 2004 spec, but allows decimal anywhere

--- a/packages/snyk-protect/patches/moment_20160126_0_3_34af63b8b21208a949dfaf42d228502c73d20ec0.patch
+++ b/packages/snyk-protect/patches/moment_20160126_0_3_34af63b8b21208a949dfaf42d228502c73d20ec0.patch
@@ -1,0 +1,41 @@
+// code derived from https://github.com/rvagg/moment
+// reference: https://github.com/rvagg/moment/commit/34af63b8b21208a949dfaf42d228502c73d20ec0
+
+// https://github.com/rvagg/moment/blob/develop/LICENSE
+/*
+Copyright (c) 2011-2016 Tim Wood, Iskren Chernev, Moment.js contributors
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/src/lib/duration/create.js b/src/lib/duration/create.js
+index a79feea..d465cee 100644
+--- a/moment.js
++++ b/moment.js
+@@ -21,6 +21,6 @@
+
+         // ASP.NET json date format regex
+         aspNetJsonRegex = /^\/?Date\((\-?\d+)/i,
+-        aspNetTimeSpanJsonRegex = /(\-)?(?:(\d*)\.)?(\d+)\:(\d+)\:(\d+)\.?(\d{3})?/,
++        aspNetTimeSpanJsonRegex = /^(\-)?(?:(\d*)[. ])?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?\d*)?$/,
+
+         // format tokens

--- a/packages/snyk-protect/patches/moment_20160126_0_4_34af63b8b21208a949dfaf42d228502c73d20ec0.patch
+++ b/packages/snyk-protect/patches/moment_20160126_0_4_34af63b8b21208a949dfaf42d228502c73d20ec0.patch
@@ -1,0 +1,42 @@
+// code derived from https://github.com/rvagg/moment
+// reference: https://github.com/rvagg/moment/commit/34af63b8b21208a949dfaf42d228502c73d20ec0
+
+// https://github.com/rvagg/moment/blob/develop/LICENSE
+/*
+Copyright (c) 2011-2016 Tim Wood, Iskren Chernev, Moment.js contributors
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/src/lib/duration/create.js b/src/lib/duration/create.js
+index a79feea..d465cee 100644
+--- a/moment.js
++++ b/moment.js
+@@ -21,7 +21,7 @@
+
+         // ASP.NET json date format regex
+         aspNetJsonRegex = /^\/?Date\((\-?\d+)/i,
+-        aspNetTimeSpanJsonRegex = /(\-)?(\d*)?\.?(\d+)\:(\d+)\:(\d+)\.?(\d{3})?/,
++        aspNetTimeSpanJsonRegex = /^(\-)?(?:(\d*)[. ])?(\d+)\:(\d+)(?:\:(\d+)\.?(\d{3})?\d*)?$/,
+
+         // format tokens
+         formattingTokens = /(\[[^\[]*\])|(\\)?(Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|YYYYY|YYYY|YY|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|mm?|ss?|SS?S?|X|zz?|ZZ?|.)/g,

--- a/packages/snyk-protect/patches/moment_20161019_0_0.patch
+++ b/packages/snyk-protect/patches/moment_20161019_0_0.patch
@@ -1,0 +1,40 @@
+// code derived from https://github.com/moment/moment
+// https://github.com/moment/moment/commit/663f33e333212b3800b63592cd8e237ac8fabdb9.patch
+
+// https://github.com/moment/moment/blob/develop/LICENSE
+/*
+Copyright (c) 2011-2016 Tim Wood, Iskren Chernev, Moment.js contributors
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+--- a/src/lib/units/month.js
++++ b/src/lib/units/month.js
+@@ -66,7 +66,7 @@
+
+ // LOCALES
+
+-var MONTHS_IN_FORMAT = /D[oD]?(\[[^\[\]]*\]|\s+)+MMMM?/;
++var MONTHS_IN_FORMAT = /D[oD]?(\[[^\[\]]*\]|\s)+MMMM?/;
+ export var defaultLocaleMonths = 'January_February_March_April_May_June_July_August_September_October_November_December'.split('_');
+ export function localeMonths (m, format) {
+     return isArray(this._months) ? this._months[m.month()] :

--- a/packages/snyk-protect/patches/moment_20161019_0_1.patch
+++ b/packages/snyk-protect/patches/moment_20161019_0_1.patch
@@ -1,0 +1,52 @@
+// code derived from https://github.com/moment/moment
+// https://github.com/moment/moment/commit/663f33e333212b3800b63592cd8e237ac8fabdb9.patch
+
+// https://github.com/moment/moment/blob/develop/LICENSE
+/*
+Copyright (c) 2011-2016 Tim Wood, Iskren Chernev, Moment.js contributors
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+--- a/src/lib/units/month.js
++++ b/src/lib/units/month.js
+@@ -66,7 +66,7 @@ addParseToken(['MMM', 'MMMM'], function (input, array, config, token) {
+ 
+ // LOCALES
+ 
+-var MONTHS_IN_FORMAT = /D[oD]?(\[[^\[\]]*\]|\s+)+MMMM?/;
++var MONTHS_IN_FORMAT = /D[oD]?(\[[^\[\]]*\]|\s)+MMMM?/;
+ export var defaultLocaleMonths = 'January_February_March_April_May_June_July_August_September_October_November_December'.split('_');
+ export function localeMonths (m, format) {
+     if (!m) {
+
+--- a/src/locale/lt.js
++++ b/src/locale/lt.js
+@@ -50,7 +50,7 @@ export default moment.defineLocale('lt', {
+     months : {
+         format: 'sausio_vasario_kovo_balandžio_gegužės_birželio_liepos_rugpjūčio_rugsėjo_spalio_lapkričio_gruodžio'.split('_'),
+         standalone: 'sausis_vasaris_kovas_balandis_gegužė_birželis_liepa_rugpjūtis_rugsėjis_spalis_lapkritis_gruodis'.split('_'),
+-        isFormat: /D[oD]?(\[[^\[\]]*\]|\s+)+MMMM?|MMMM?(\[[^\[\]]*\]|\s+)+D[oD]?/
++        isFormat: /D[oD]?(\[[^\[\]]*\]|\s)+MMMM?|MMMM?(\[[^\[\]]*\]|\s)+D[oD]?/
+     },
+     monthsShort : 'sau_vas_kov_bal_geg_bir_lie_rgp_rgs_spa_lap_grd'.split('_'),
+     weekdays : {

--- a/packages/snyk-protect/patches/ms_071.patch
+++ b/packages/snyk-protect/patches/ms_071.patch
@@ -1,0 +1,40 @@
+// Code derived from https://github.com/zeit/ms/pull/89/commits/305f2ddcd4eff7cc7c518aca6bb2b2d2daad8fef
+
+// https://github.com/zeit/ms/blob/master/license.md
+/*
+The MIT License (MIT)
+
+Copyright (c) 2016 Zeit, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+diff --git a/index.js b/index.js
+--- a/index.js
++++ b/index.js
+@@ -39,7 +39,7 @@
+ 
+ function parse(str) {
+   str = '' + str;
+-  if (str.length > 10000) return;
++  if (str.length > 100) return;
+   var match = /^((?:\d+)?\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|years?|yrs?|y)?$/i.exec(str);
+   if (!match) return;
+   var n = parseFloat(match[1]);

--- a/packages/snyk-protect/patches/ms_072-073.patch
+++ b/packages/snyk-protect/patches/ms_072-073.patch
@@ -1,0 +1,40 @@
+// Code derived from https://github.com/zeit/ms/pull/89/commits/305f2ddcd4eff7cc7c518aca6bb2b2d2daad8fef
+
+// https://github.com/zeit/ms/blob/master/license.md
+/*
+The MIT License (MIT)
+
+Copyright (c) 2016 Zeit, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+diff --git a/index.js b/index.js
+--- a/index.js
++++ b/index.js
+@@ -45,7 +45,7 @@
+
+ function parse(str) {
+   str = String(str)
+-  if (str.length > 10000) {
++  if (str.length > 100) {
+     return
+   }
+   var match = /^((?:\d+)?\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|years?|yrs?|y)?$/i.exec(str)

--- a/packages/snyk-protect/patches/ms_100.patch
+++ b/packages/snyk-protect/patches/ms_100.patch
@@ -1,0 +1,39 @@
+// Code derived from https://github.com/zeit/ms/pull/89/commits/305f2ddcd4eff7cc7c518aca6bb2b2d2daad8fef
+
+// https://github.com/zeit/ms/blob/master/license.md
+/*
+The MIT License (MIT)
+
+Copyright (c) 2016 Zeit, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+diff --git a/index.js b/index.js
+--- a/index.js
++++ b/index.js
+@@ -46,7 +46,7 @@ module.exports = function(val, options) {
+ function parse(str) {
+   str = String(str);
+-  if (str.length > 10000) {
++  if (str.length > 100) {
+     return;
+   }
+   var match = /^((?:\d+)?\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|years?|yrs?|y)?$/i.exec(

--- a/packages/snyk-protect/patches/ms_20151024_0_0_48701f029417faf65e6f5e0b61a3cebe5436b07b.patch
+++ b/packages/snyk-protect/patches/ms_20151024_0_0_48701f029417faf65e6f5e0b61a3cebe5436b07b.patch
@@ -1,0 +1,38 @@
+// code derived from https://github.com/guille/ms.js
+// reference: https://github.com/rauchg/ms.js/commit/48701f029417faf65e6f5e0b61a3cebe5436b07b
+
+// https://github.com/rauchg/ms.js/blob/master/LICENSE
+/*
+(The MIT License)
+
+Copyright (c) 2014 Guillermo Rauch <rauchg@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+--- a/index.js
++++ b/index.js
+@@ -38,6 +38,8 @@ module.exports = function(val, options){
+  */
+ 
+ function parse(str) {
++  str = '' + str;
++  if (str.length > 10000) return;
+   var match = /^((?:\d+)?\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|years?|yrs?|y)?$/i.exec(str);
+   if (!match) return;
+   var n = parseFloat(match[1]);

--- a/packages/snyk-protect/patches/ms_20151024_1_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk.patch
+++ b/packages/snyk-protect/patches/ms_20151024_1_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk.patch
@@ -1,0 +1,38 @@
+// code derived from https://github.com/guille/ms.js
+// reference: https://github.com/rauchg/ms.js/commit/48701f029417faf65e6f5e0b61a3cebe5436b07b
+
+// https://github.com/rauchg/ms.js/blob/master/LICENSE
+/*
+(The MIT License)
+
+Copyright (c) 2014 Guillermo Rauch <rauchg@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+--- a/index.js
++++ b/index.js
+@@ -38,6 +38,8 @@
+  */
+
+ function parse(str) {
++  str = '' + str;
++  if (str.length > 10000) return;
+   var match = /^((?:\d+)?\.?\d+) *(ms|seconds?|s|minutes?|m|hours?|h|days?|d|years?|y)?$/i.exec(str);
+   if (!match) return;
+   var n = parseFloat(match[1]);

--- a/packages/snyk-protect/patches/ms_20151024_2_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk2.patch
+++ b/packages/snyk-protect/patches/ms_20151024_2_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk2.patch
@@ -1,0 +1,38 @@
+// code derived from https://github.com/guille/ms.js
+// reference: https://github.com/rauchg/ms.js/commit/48701f029417faf65e6f5e0b61a3cebe5436b07b
+
+// https://github.com/rauchg/ms.js/blob/master/LICENSE
+/*
+(The MIT License)
+
+Copyright (c) 2014 Guillermo Rauch <rauchg@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+--- a/index.js
++++ b/index.js
+@@ -38,6 +38,8 @@
+  */
+
+ function parse(str) {
++  str = '' + str;
++  if (str.length > 10000) return;
+   var m = /^((?:\d+)?\.?\d+) *(ms|seconds?|s|minutes?|m|hours?|h|days?|d|years?|y)?$/i.exec(str);
+   if (!m) return;
+   var n = parseFloat(m[1]);

--- a/packages/snyk-protect/patches/ms_20151024_3_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk3.patch
+++ b/packages/snyk-protect/patches/ms_20151024_3_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk3.patch
@@ -1,0 +1,38 @@
+// code derived from https://github.com/guille/ms.js
+// reference: https://github.com/rauchg/ms.js/commit/48701f029417faf65e6f5e0b61a3cebe5436b07b
+
+// https://github.com/rauchg/ms.js/blob/master/LICENSE
+/*
+(The MIT License)
+
+Copyright (c) 2014 Guillermo Rauch <rauchg@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+--- a/ms.js
++++ b/ms.js
+@@ -38,6 +38,8 @@
+  */
+
+ function parse(str) {
++  str = '' + str;
++  if (str.length > 10000) return;
+   var m = /^((?:\d+)?\.?\d+) *(ms|seconds?|s|minutes?|m|hours?|h|days?|d|years?|y)?$/i.exec(str);
+   if (!m) return;
+   var n = parseFloat(m[1]);

--- a/packages/snyk-protect/patches/ms_20151024_4_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk4.patch
+++ b/packages/snyk-protect/patches/ms_20151024_4_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk4.patch
@@ -1,0 +1,38 @@
+// code derived from https://github.com/guille/ms.js
+// reference: https://github.com/rauchg/ms.js/commit/48701f029417faf65e6f5e0b61a3cebe5436b07b
+
+// https://github.com/rauchg/ms.js/blob/master/LICENSE
+/*
+(The MIT License)
+
+Copyright (c) 2014 Guillermo Rauch <rauchg@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+--- a/ms.js
++++ b/ms.js
+@@ -30,6 +30,8 @@
+  */
+
+ function parse(str) {
++  str = '' + str;
++  if (str.length > 10000) return;
+   var m = /^((?:\d+)?\.?\d+) *(ms|seconds?|s|minutes?|m|hours?|h|days?|d|years?|y)$/i.exec(str);
+   if (!m) return;
+   var n = parseFloat(m[1]);

--- a/packages/snyk-protect/patches/ms_20151024_5_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk5.patch
+++ b/packages/snyk-protect/patches/ms_20151024_5_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk5.patch
@@ -1,0 +1,38 @@
+// code derived from https://github.com/guille/ms.js
+// reference: https://github.com/rauchg/ms.js/commit/48701f029417faf65e6f5e0b61a3cebe5436b07b
+
+// https://github.com/rauchg/ms.js/blob/master/LICENSE
+/*
+(The MIT License)
+
+Copyright (c) 2014 Guillermo Rauch <rauchg@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+--- a/ms.js
++++ b/ms.js
+@@ -26,6 +26,8 @@
+   _.d = _.h * 24;
+
+   function ms (s) {
++    s = '' + s;
++    if (s.length > 10000) return;
+     if (s == Number(s)) return Number(s);
+     r.exec(s.toLowerCase());
+     return RegExp.$1 * _[RegExp.$2];

--- a/packages/snyk-protect/patches/mustache_0.patch
+++ b/packages/snyk-protect/patches/mustache_0.patch
@@ -1,0 +1,36 @@
+// Code derived from https://github.com/janl/mustache.js
+// https://github.com/janl/mustache.js/commit/378bcca8a5cfe4058f294a3dbb78e8755e8e0da5
+
+// https://github.com/janl/mustache.js/blob/master/LICENSE
+/*
+The MIT License
+
+Copyright (c) 2009 Chris Wanstrath (Ruby)
+Copyright (c) 2010-2014 Jan Lehnardt (JavaScript)
+Copyright (c) 2010-2015 The mustache.js community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+--- a/mustache.js
++++ b/mustache.js
+@@ -63,11 +63,13 @@
+     '>': '&gt;',
+     '"': '&quot;',
+     "'": '&#39;',
+-    '/': '&#x2F;'
++    '/': '&#x2F;',
++    '`': '&#x60;',
++    '=': '&#x3D;'
+   };
+ 
+   function escapeHtml (string) {
+-    return String(string).replace(/[&<>"'\/]/g, function fromEntityMap (s) {
++    return String(string).replace(/[&<>"'`=\/]/g, function fromEntityMap (s) {
+       return entityMap[s];
+     });
+   }

--- a/packages/snyk-protect/patches/negotiator_20160616_0_0_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch
+++ b/packages/snyk-protect/patches/negotiator_20160616_0_0_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch
@@ -1,0 +1,42 @@
+// Code derived from: https://github.com/jshttp/negotiator/
+// Reference: https://github.com/jshttp/negotiator/commit/26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c
+
+// https://github.com/jshttp/negotiator/blob/master/LICENSE
+/*
+(The MIT License)
+
+Copyright (c) 2012-2014 Federico Romero
+Copyright (c) 2012-2014 Isaac Z. Schlueter
+Copyright (c) 2014-2015 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+--- a/lib/language.js
++++ b/lib/language.js
+@@ -21,7 +21,7 @@
+  * @private
+  */
+ 
+-var simpleLanguageRegExp = /^\s*(\S+?)(?:-(\S+?))?\s*(?:;(.*))?$/;
++var simpleLanguageRegExp = /^\s*([^\s\-;]+)(?:-([^\s;]+))?\s*(?:;(.*))?$/;
+ 
+ /**
+  * Parse the Accept-Language header.

--- a/packages/snyk-protect/patches/negotiator_20160616_0_1_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch
+++ b/packages/snyk-protect/patches/negotiator_20160616_0_1_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch
@@ -1,0 +1,42 @@
+// Code derived from: https://github.com/jshttp/negotiator/
+// Reference: https://github.com/jshttp/negotiator/commit/26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c
+
+// https://github.com/jshttp/negotiator/blob/master/LICENSE
+/*
+(The MIT License)
+
+Copyright (c) 2012-2014 Federico Romero
+Copyright (c) 2012-2014 Isaac Z. Schlueter
+Copyright (c) 2014-2015 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+  
+--- a/lib/language.js
++++ b/lib/language.js
+@@ -19,7 +19,7 @@
+ }
+ 
+ function parseLanguage(s, i) {
+-  var match = s.match(/^\s*(\S+?)(?:-(\S+?))?\s*(?:;(.*))?$/);
++  var match = s.match(/^\s*([^\s\-;]+)(?:-([^\s;]+))?\s*(?:;(.*))?$/);
+   if (!match) return null;
+ 
+   var prefix = match[1],

--- a/packages/snyk-protect/patches/negotiator_20160616_0_2_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch
+++ b/packages/snyk-protect/patches/negotiator_20160616_0_2_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch
@@ -1,0 +1,42 @@
+// Code derived from: https://github.com/jshttp/negotiator/
+// Reference: https://github.com/jshttp/negotiator/commit/26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c
+
+// https://github.com/jshttp/negotiator/blob/master/LICENSE
+/*
+(The MIT License)
+
+Copyright (c) 2012-2014 Federico Romero
+Copyright (c) 2012-2014 Isaac Z. Schlueter
+Copyright (c) 2014-2015 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+  
+--- a/lib/language.js
++++ b/lib/language.js
+@@ -19,7 +19,7 @@
+ }
+ 
+ function parseLanguage(s) {
+-  var match = s.match(/^\s*(\S+?)(?:-(\S+?))?\s*(?:;(.*))?$/);
++  var match = s.match(/^\s*([^\s\-;]+)(?:-([^\s;]+))?\s*(?:;(.*))?$/);
+   if (!match) return null;
+ 
+   var prefix = match[1],

--- a/packages/snyk-protect/patches/negotiator_20160616_0_3_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch
+++ b/packages/snyk-protect/patches/negotiator_20160616_0_3_26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c.patch
@@ -1,0 +1,42 @@
+// Code derived from: https://github.com/jshttp/negotiator/
+// Reference: https://github.com/jshttp/negotiator/commit/26a05ec15cf7d1fa56000d66ebe9c9a1a62cb75c
+
+// https://github.com/jshttp/negotiator/blob/master/LICENSE
+/*
+(The MIT License)
+
+Copyright (c) 2012-2014 Federico Romero
+Copyright (c) 2012-2014 Isaac Z. Schlueter
+Copyright (c) 2014-2015 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+--- a/lib/language.coffee
++++ b/lib/language.coffee
+@@ -5,7 +5,7 @@
+   _.select(acceptableLanguages, (e) -> e && e.q > 0)
+ 
+ parseLanguage = (s) ->
+-  match = /^\s*(\S+?)(?:-(\S+?))?\s*(?:;(.*))?$/.exec(s)
++  match = /^\s*([^\s\-;]+)(?:-([^\s;]+))?\s*(?:;(.*))?$/.exec(s)
+   if !match
+     null
+   else

--- a/packages/snyk-protect/patches/node-uuid_20160328_0_0_616ad3800f35cf58089215f420db9654801a5a02.patch
+++ b/packages/snyk-protect/patches/node-uuid_20160328_0_0_616ad3800f35cf58089215f420db9654801a5a02.patch
@@ -1,0 +1,36 @@
+// Code derived from https://github.com/broofa/node-uuid
+// Reference: https://github.com/broofa/node-uuid/commit/616ad3800f35cf58089215f420db9654801a5a02
+
+// https://github.com/broofa/node-uuid/blob/master/LICENSE.md
+/*
+
+The MIT License (MIT)
+
+Copyright (c) 2010-2012 Robert Kieffer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+diff --git a/uuid.js b/uuid.js
+index 0b596fc..8c1a26b 100644
+--- a/uuid.js
++++ b/uuid.js
+@@ -17,7 +17,7 @@
+   // Node.js crypto-based RNG - http://nodejs.org/docs/v0.6.2/api/crypto.html
+   //
+   // Moderately fast, high quality
+-  if (typeof(_global.require) == 'function') {
++  if ('function' === typeof require) {
+     try {
+       var _rb = _global.require('crypto').randomBytes;
+       _rng = _rb && function() {return _rb(16);};

--- a/packages/snyk-protect/patches/printer_20140306_0_0_e001e38738c17219a1d9dd8c31f7d82b9c0013c7.patch
+++ b/packages/snyk-protect/patches/printer_20140306_0_0_e001e38738c17219a1d9dd8c31f7d82b9c0013c7.patch
@@ -1,0 +1,27 @@
+// code derived from http://github.com/tojocky/node-printer
+// reference: https://github.com/tojocky/node-printer/commit/e001e38738c17219a1d9dd8c31f7d82b9c0013c7.patch
+
+// https://github.com/tojocky/node-printer#license
+/*
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/lib/printer.js b/lib/printer.js
+index a184034..6cb06da 100644
+--- a/lib/printer.js
++++ b/lib/printer.js
+@@ -93,7 +93,7 @@ function printDirect(parameters){
+     }else if (!printer_helper.printDirect){// should be POSIX
+         var temp_file_name = path.join(os.tmpDir(),"printing");
+         fs.writeFileSync(temp_file_name, data);
+-        child_process.exec('lpr -P'+printer+' -oraw -r'+' '+temp_file_name, function(err, stdout, stderr){
++        child_process.execFile('lpr', ['-P' + printer, '-oraw', '-r', temp_file_name], function(err, stdout, stderr){
+             if (err !== null) {
+                 error('ERROR: ' + err);
+                 return;

--- a/packages/snyk-protect/patches/qs_20140806-1_0_0_snyk.patch
+++ b/packages/snyk-protect/patches/qs_20140806-1_0_0_snyk.patch
@@ -1,0 +1,90 @@
+// code derived from https://github.com/hapijs/qs
+
+// https://github.com/ljharb/qs/blob/master/LICENSE
+/*
+Copyright (c) 2014 Nathan LaFreniere and other contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at: https://github.com/hapijs/qs/graphs/contributors
+*/
+
+diff --git a/index.js b/index.js
+index b05938a..33fe69f 100644
+--- a/index.js
++++ b/index.js
+@@ -1,3 +1,7 @@
++const patchInternals = {
++    depth: 50
++};
++
+ /**
+  * Object#toString() ref for stringify().
+  */
+@@ -84,7 +88,7 @@ function promote(parent, key) {
+   return t;
+ }
+
+-function parse(parts, parent, key, val) {
++function parse(parts, parent, key, val, depth) {
+   var part = parts.shift();
+
+   // illegal
+@@ -91,7 +95,7 @@ function parse(parts, parent, key, val) {
+   if (Object.getOwnPropertyDescriptor(Object.prototype, key)) return;
+
+   // end
+-  if (!part) {
++  if (!part || depth == 0) {
+     if (isArray(parent[key])) {
+       parent[key].push(val);
+     } else if ('object' == typeof parent[key]) {
+@@ -116,11 +120,14 @@
+     } else if (~indexOf(part, ']')) {
+       part = part.substr(0, part.length - 1);
+       if (!isint.test(part) && isArray(obj)) obj = promote(parent, key);
+-      parse(parts, obj, part, val);
++      if (depth) {
++        depth--;
++      }
++      parse(parts, obj, part, val, depth);
+       // key
+     } else {
+       if (!isint.test(part) && isArray(obj)) obj = promote(parent, key);
+-      parse(parts, obj, part, val);
++      parse(parts, obj, part, val, depth);
+     }
+   }
+ }
+@@ -134,7 +141,7 @@
+     var parts = key.split('[')
+       , len = parts.length
+       , last = len - 1;
+-    parse(parts, parent, 'base', val);
++    parse(parts, parent, 'base', val, patchInternals.depth);
+     // optimize
+   } else {
+     if (!isint.test(key) && isArray(parent.base)) {

--- a/packages/snyk-protect/patches/qs_20140806-1_0_1_snyk.patch
+++ b/packages/snyk-protect/patches/qs_20140806-1_0_1_snyk.patch
@@ -1,0 +1,84 @@
+// code derived from https://github.com/hapijs/qs
+
+// https://github.com/ljharb/qs/blob/master/LICENSE
+/*
+Copyright (c) 2014 Nathan LaFreniere and other contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at: https://github.com/hapijs/qs/graphs/contributors
+*/
+
+diff --git a/index.js b/index.js
+index 2c76fb1..5c8cd83 100644
+--- a/index.js
++++ b/index.js
+@@ -1,3 +1,6 @@
++const patchInternals = {
++    depth: 10
++};
+ 
+ /**
+  * Object#toString() ref for stringify().
+@@ -19,10 +22,10 @@ function promote(parent, key) {
+   return t;
+ }
+ 
+-function parse(parts, parent, key, val) {
++function parse(parts, parent, key, val, depth) {
+   var part = parts.shift();
+   // end
+-  if (!part) {
++  if (!part || depth == 0) {
+     if (Array.isArray(parent[key])) {
+       parent[key].push(val);
+     } else if ('object' == typeof parent[key]) {
+@@ -47,11 +50,14 @@ function parse(parts, parent, key, val) {
+     } else if (~part.indexOf(']')) {
+       part = part.substr(0, part.length - 1);
+       if (!isint.test(part) && Array.isArray(obj)) obj = promote(parent, key);
+-      parse(parts, obj, part, val);
++      if (depth) {
++        depth--;
++      }
++      parse(parts, obj, part, val, depth);
+       // key
+     } else {
+       if (!isint.test(part) && Array.isArray(obj)) obj = promote(parent, key);
+-      parse(parts, obj, part, val);
++      parse(parts, obj, part, val, depth);
+     }
+   }
+ }
+@@ -65,7 +71,7 @@ function merge(parent, key, val){
+     var parts = key.split('[')
+       , len = parts.length
+       , last = len - 1;
+-    parse(parts, parent, 'base', val);
++    parse(parts, parent, 'base', val, patchInternals.depth);
+     // optimize
+   } else {
+     if (!isint.test(key) && Array.isArray(parent.base)) {

--- a/packages/snyk-protect/patches/qs_20140806_0_0_43a604b7847e56bba49d0ce3e222fe89569354d8_snyk.patch
+++ b/packages/snyk-protect/patches/qs_20140806_0_0_43a604b7847e56bba49d0ce3e222fe89569354d8_snyk.patch
@@ -1,0 +1,48 @@
+// code derived from https://github.com/hapijs/qs
+
+// https://github.com/ljharb/qs/blob/master/LICENSE
+/*
+Copyright (c) 2014 Nathan LaFreniere and other contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at: https://github.com/hapijs/qs/graphs/contributors
+*/
+
+diff --git a/index.js b/index.js
+index 426017b..311ce62 100644
+--- a/index.js
++++ b/index.js
+@@ -160,7 +160,9 @@ function compact(obj) {
+
+     for (var i in obj) {
+       if (hasOwnProperty.call(obj, i)) {
+-        ret.push(obj[i]);
++        // We need to compact the nesting array too
++        // See https://github.com/visionmedia/node-querystring/issues/104
++        ret.push(compact(obj[i]));
+       }
+     }

--- a/packages/snyk-protect/patches/qs_20140806_0_1_snyk_npm.patch
+++ b/packages/snyk-protect/patches/qs_20140806_0_1_snyk_npm.patch
@@ -1,0 +1,299 @@
+// code derived from https://github.com/hapijs/qs
+
+// https://github.com/ljharb/qs/blob/master/LICENSE
+/*
+Copyright (c) 2014 Nathan LaFreniere and other contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of any contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                  *   *   *
+
+The complete list of contributors can be found at: https://github.com/hapijs/qs/graphs/contributors
+*/
+
+diff --git a/index.js b/index.js
+index 426017b..311ce62 100644
+--- a/index.js
++++ b/index.js
+@@ -1,4 +1,3 @@
+-
+ /**
+  * Object#toString() ref for stringify().
+  */
+@@ -6,24 +5,94 @@
+ var toString = Object.prototype.toString;
+
+ /**
++ * Object#hasOwnProperty ref
++ */
++
++var hasOwnProperty = Object.prototype.hasOwnProperty;
++
++/**
++ * Array#indexOf shim.
++ */
++
++var indexOf = typeof Array.prototype.indexOf === 'function'
++  ? function(arr, el) { return arr.indexOf(el); }
++  : function(arr, el) {
++      for (var i = 0; i < arr.length; i++) {
++        if (arr[i] === el) return i;
++      }
++      return -1;
++    };
++
++/**
++ * Array.isArray shim.
++ */
++
++var isArray = Array.isArray || function(arr) {
++  return toString.call(arr) == '[object Array]';
++};
++
++/**
++ * Object.keys shim.
++ */
++
++var objectKeys = Object.keys || function(obj) {
++  var ret = [];
++  for (var key in obj) {
++    if (obj.hasOwnProperty(key)) {
++      ret.push(key);
++    }
++  }
++  return ret;
++};
++
++/**
++ * Array#forEach shim.
++ */
++
++var forEach = typeof Array.prototype.forEach === 'function'
++  ? function(arr, fn) { return arr.forEach(fn); }
++  : function(arr, fn) {
++      for (var i = 0; i < arr.length; i++) fn(arr[i]);
++    };
++
++/**
++ * Array#reduce shim.
++ */
++
++var reduce = function(arr, fn, initial) {
++  if (typeof arr.reduce === 'function') return arr.reduce(fn, initial);
++  var res = initial;
++  for (var i = 0; i < arr.length; i++) res = fn(res, arr[i]);
++  return res;
++};
++
++/**
+  * Cache non-integer test regexp.
+  */
+
+ var isint = /^[0-9]+$/;
+
+ function promote(parent, key) {
+-  if (parent[key].length == 0) return parent[key] = {};
++  if (parent[key].length == 0) return parent[key] = {}
+   var t = {};
+-  for (var i in parent[key]) t[i] = parent[key][i];
++  for (var i in parent[key]) {
++    if (hasOwnProperty.call(parent[key], i)) {
++      t[i] = parent[key][i];
++    }
++  }
+   parent[key] = t;
+   return t;
+ }
+
+ function parse(parts, parent, key, val) {
+   var part = parts.shift();
++
++  // illegal
++  if (Object.getOwnPropertyDescriptor(Object.prototype, key)) return;
++
+   // end
+   if (!part) {
+-    if (Array.isArray(parent[key])) {
++    if (isArray(parent[key])) {
+       parent[key].push(val);
+     } else if ('object' == typeof parent[key]) {
+       parent[key] = val;
+@@ -36,21 +105,21 @@
+   } else {
+     var obj = parent[key] = parent[key] || [];
+     if (']' == part) {
+-      if (Array.isArray(obj)) {
++      if (isArray(obj)) {
+         if ('' != val) obj.push(val);
+       } else if ('object' == typeof obj) {
+-        obj[Object.keys(obj).length] = val;
++        obj[objectKeys(obj).length] = val;
+       } else {
+         obj = parent[key] = [parent[key], val];
+       }
+       // prop
+-    } else if (~part.indexOf(']')) {
++    } else if (~indexOf(part, ']')) {
+       part = part.substr(0, part.length - 1);
+-      if (!isint.test(part) && Array.isArray(obj)) obj = promote(parent, key);
++      if (!isint.test(part) && isArray(obj)) obj = promote(parent, key);
+       parse(parts, obj, part, val);
+       // key
+     } else {
+-      if (!isint.test(part) && Array.isArray(obj)) obj = promote(parent, key);
++      if (!isint.test(part) && isArray(obj)) obj = promote(parent, key);
+       parse(parts, obj, part, val);
+     }
+   }
+@@ -61,14 +130,14 @@
+  */
+
+ function merge(parent, key, val){
+-  if (~key.indexOf(']')) {
++  if (~indexOf(key, ']')) {
+     var parts = key.split('[')
+       , len = parts.length
+       , last = len - 1;
+     parse(parts, parent, 'base', val);
+     // optimize
+   } else {
+-    if (!isint.test(key) && Array.isArray(parent.base)) {
++    if (!isint.test(key) && isArray(parent.base)) {
+       var t = {};
+       for (var k in parent.base) t[k] = parent.base[k];
+       parent.base = t;
+@@ -80,15 +149,45 @@
+ }
+
+ /**
++ * Compact sparse arrays.
++ */
++
++function compact(obj) {
++  if ('object' != typeof obj) return obj;
++
++  if (isArray(obj)) {
++    var ret = [];
++
++    for (var i in obj) {
++      if (hasOwnProperty.call(obj, i)) {
++        // We need to compact the nesting array too
++        // See https://github.com/visionmedia/node-querystring/issues/104
++        ret.push(compact(obj[i]));
++      }
++    }
++
++    return ret;
++  }
++
++  for (var key in obj) {
++    obj[key] = compact(obj[key]);
++  }
++
++  return obj;
++}
++
++/**
+  * Parse the given obj.
+  */
+
+ function parseObject(obj){
+   var ret = { base: {} };
+-  Object.keys(obj).forEach(function(name){
++
++  forEach(objectKeys(obj), function(name){
+     merge(ret, name, obj[name]);
+   });
+-  return ret.base;
++
++  return compact(ret.base);
+ }
+
+ /**
+@@ -96,21 +195,21 @@
+  */
+
+ function parseString(str){
+-  return String(str)
+-    .split('&')
+-    .reduce(function(ret, pair){
+-      var eql = pair.indexOf('=')
+-        , brace = lastBraceInKey(pair)
+-        , key = pair.substr(0, brace || eql)
+-        , val = pair.substr(brace || eql, pair.length)
+-        , val = val.substr(val.indexOf('=') + 1, val.length);
+-
+-      // ?foo
+-      if ('' == key) key = pair, val = '';
+-      if ('' == key) return ret;
++  var ret = reduce(String(str).split('&'), function(ret, pair){
++    var eql = indexOf(pair, '=')
++      , brace = lastBraceInKey(pair)
++      , key = pair.substr(0, brace || eql)
++      , val = pair.substr(brace || eql, pair.length)
++      , val = val.substr(indexOf(val, '=') + 1, val.length);
++
++    // ?foo
++    if ('' == key) key = pair, val = '';
++    if ('' == key) return ret;
++
++    return merge(ret, decode(key), decode(val));
++  }, { base: {} }).base;
+
+-      return merge(ret, decode(key), decode(val));
+-    }, { base: {} }).base;
++  return compact(ret);
+ }
+
+ /**
+@@ -137,7 +236,7 @@
+  */
+
+ var stringify = exports.stringify = function(obj, prefix) {
+-  if (Array.isArray(obj)) {
++  if (isArray(obj)) {
+     return stringifyArray(obj, prefix);
+   } else if ('[object Object]' == toString.call(obj)) {
+     return stringifyObject(obj, prefix);
+@@ -191,7 +290,7 @@
+
+ function stringifyObject(obj, prefix) {
+   var ret = []
+-    , keys = Object.keys(obj)
++    , keys = objectKeys(obj)
+     , key;
+
+   for (var i = 0, len = keys.length; i < len; ++i) {
+@@ -221,9 +321,10 @@
+
+ function set(obj, key, val) {
+   var v = obj[key];
++  if (Object.getOwnPropertyDescriptor(Object.prototype, key)) return;
+   if (undefined === v) {
+     obj[key] = val;
+-  } else if (Array.isArray(v)) {
++  } else if (isArray(v)) {
+     v.push(val);
+   } else {
+     obj[key] = [v, val];

--- a/packages/snyk-protect/patches/request_20160119_0_0_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch
+++ b/packages/snyk-protect/patches/request_20160119_0_0_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch
@@ -1,0 +1,54 @@
+// code derived form: https://github.com/request/request
+// reference:
+//  https://github.com/request/request/commit/3d31d4526fa4d4e4f59b89cabe194fb671063cdb
+
+// https://raw.githubusercontent.com/request/request/master/LICENSE
+/*
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+END OF TERMS AND CONDITIONS
+*/
+
+diff --git a/lib/multipart.js b/lib/multipart.js
+index 0361858..c128172 100644
+--- a/lib/multipart.js
++++ b/lib/multipart.js
+@@ -68,6 +68,9 @@ Multipart.prototype.build = function (parts, chunked) {
+   var body = chunked ? new CombinedStream() : []
+ 
+   function add (part) {
++    if (typeof part === 'number') {
++      part = part.toString()
++    }
+     return chunked ? body.append(part) : body.push(new Buffer(part))
+   }
+ 

--- a/packages/snyk-protect/patches/request_20160119_0_1_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch
+++ b/packages/snyk-protect/patches/request_20160119_0_1_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch
@@ -1,0 +1,51 @@
+// code derived form: https://github.com/request/request
+// reference:
+//  https://github.com/request/request/commit/3d31d4526fa4d4e4f59b89cabe194fb671063cdb
+
+// https://raw.githubusercontent.com/request/request/master/LICENSE
+/*
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+END OF TERMS AND CONDITIONS
+*/
+
+--- a/request.js
++++ b/request.js
+@@ -1388,6 +1388,9 @@
+
+   var parts = chunked ? new CombinedStream() : []
+   function add (part) {
++    if (typeof part === 'number') {
++      part = part.toString()
++    }
+     return chunked ? parts.append(part) : parts.push(new Buffer(part))
+   }

--- a/packages/snyk-protect/patches/request_20160119_0_2_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch
+++ b/packages/snyk-protect/patches/request_20160119_0_2_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch
@@ -1,0 +1,51 @@
+// code derived form: https://github.com/request/request
+// reference:
+//  https://github.com/request/request/commit/3d31d4526fa4d4e4f59b89cabe194fb671063cdb
+
+// https://raw.githubusercontent.com/request/request/master/LICENSE
+/*
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+END OF TERMS AND CONDITIONS
+*/
+
+--- a/request.js
++++ b/request.js
+@@ -1427,6 +1427,9 @@
+
+   var items = chunked ? new CombinedStream() : []
+   function add (part) {
++    if (typeof part === 'number') {
++      part = part.toString()
++    }
+     return chunked ? items.append(part) : items.push(new Buffer(part))
+   }

--- a/packages/snyk-protect/patches/request_20160119_0_3_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch
+++ b/packages/snyk-protect/patches/request_20160119_0_3_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch
@@ -1,0 +1,52 @@
+// code derived form: https://github.com/request/request
+// reference:
+//  https://github.com/request/request/commit/3d31d4526fa4d4e4f59b89cabe194fb671063cdb
+
+// https://raw.githubusercontent.com/request/request/master/LICENSE
+/*
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+END OF TERMS AND CONDITIONS
+*/
+
+--- a/request.js
++++ b/request.js
+@@ -1442,6 +1442,9 @@
+     })
+     preamble += '\r\n'
+     self._multipart.append(preamble)
++    if (typeof body === 'number') {
++      body = body.toString()
++    }
+     self._multipart.append(body)
+     self._multipart.append('\r\n')
+   })

--- a/packages/snyk-protect/patches/request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch
+++ b/packages/snyk-protect/patches/request_20160119_0_4_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch
@@ -1,0 +1,52 @@
+// code derived form: https://github.com/request/request
+// reference:
+//  https://github.com/request/request/commit/3d31d4526fa4d4e4f59b89cabe194fb671063cdb
+
+// https://raw.githubusercontent.com/request/request/master/LICENSE
+/*
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+END OF TERMS AND CONDITIONS
+*/
+
+--- a/request.js
++++ b/request.js
+@@ -1450,6 +1450,9 @@
+     })
+     preamble += '\r\n'
+     self.body.push(new Buffer(preamble))
++    if (typeof body === 'number') {
++      body = body.toString()
++    }
+     self.body.push(new Buffer(body))
+     self.body.push(new Buffer('\r\n'))
+   })

--- a/packages/snyk-protect/patches/request_20160119_0_5_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch
+++ b/packages/snyk-protect/patches/request_20160119_0_5_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch
@@ -1,0 +1,52 @@
+// code derived form: https://github.com/request/request
+// reference:
+//  https://github.com/request/request/commit/3d31d4526fa4d4e4f59b89cabe194fb671063cdb
+
+// https://raw.githubusercontent.com/request/request/master/LICENSE
+/*
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+END OF TERMS AND CONDITIONS
+*/
+
+--- a/index.js
++++ b/index.js
+@@ -1023,6 +1023,9 @@
+     })
+     preamble += '\r\n'
+     self.body.push(new Buffer(preamble))
++    if (typeof body === 'number') {
++      body = body.toString()
++    }
+     self.body.push(new Buffer(body))
+     self.body.push(new Buffer('\r\n'))
+   })

--- a/packages/snyk-protect/patches/request_20160119_0_6_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch
+++ b/packages/snyk-protect/patches/request_20160119_0_6_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch
@@ -1,0 +1,52 @@
+// code derived form: https://github.com/request/request
+// reference:
+//  https://github.com/request/request/commit/3d31d4526fa4d4e4f59b89cabe194fb671063cdb
+
+// https://raw.githubusercontent.com/request/request/master/LICENSE
+/*
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+END OF TERMS AND CONDITIONS
+*/
+
+--- a/main.js
++++ b/main.js
+@@ -894,6 +894,9 @@
+     })
+     preamble += '\r\n'
+     self.body.push(new Buffer(preamble))
++    if (typeof body === 'number') {
++      body = body.toString()
++    }
+     self.body.push(new Buffer(body))
+     self.body.push(new Buffer('\r\n'))
+   })

--- a/packages/snyk-protect/patches/request_20160119_0_7_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch
+++ b/packages/snyk-protect/patches/request_20160119_0_7_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch
@@ -1,0 +1,52 @@
+// code derived form: https://github.com/request/request
+// reference:
+//  https://github.com/request/request/commit/3d31d4526fa4d4e4f59b89cabe194fb671063cdb
+
+// https://raw.githubusercontent.com/request/request/master/LICENSE
+/*
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+END OF TERMS AND CONDITIONS
+*/
+
+--- a/main.js
++++ b/main.js
+@@ -290,6 +290,9 @@
+       })
+       preamble += '\r\n'
+       self.body.push(new Buffer(preamble))
++      if (typeof body === 'number') {
++        body = body.toString()
++      }
+       self.body.push(new Buffer(body))
+       self.body.push(new Buffer('\r\n'))
+     })

--- a/packages/snyk-protect/patches/request_20160119_0_8_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch
+++ b/packages/snyk-protect/patches/request_20160119_0_8_3d31d4526fa4d4e4f59b89cabe194fb671063cdb.patch
@@ -1,0 +1,52 @@
+// code derived form: https://github.com/request/request
+// reference:
+//  https://github.com/request/request/commit/3d31d4526fa4d4e4f59b89cabe194fb671063cdb
+
+// https://raw.githubusercontent.com/request/request/master/LICENSE
+/*
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+END OF TERMS AND CONDITIONS
+*/
+
+--- a/main.js
++++ b/main.js
+@@ -277,6 +277,9 @@
+       })
+       preamble += '\r\n';
+       self.body.push(new Buffer(preamble));
++      if (typeof body === 'number') {
++        body = body.toString()
++      }
+       self.body.push(new Buffer(body));
+       self.body.push(new Buffer('\r\n'));
+     })

--- a/packages/snyk-protect/patches/semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch
+++ b/packages/snyk-protect/patches/semver_20150403_0_0_c80180d8341a8ada0236815c29a2be59864afd70.patch
@@ -1,0 +1,79 @@
+// code derived from https://github.com/npm/node-semver
+
+// https://github.com/npm/node-semver/blob/master/LICENSE
+/*
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+--- a/semver.js
++++ b/semver.js
+@@ -20,6 +20,9 @@ if (typeof module === 'object' && module.exports === exports)
+ // Not necessarily the package version of this code.
+ exports.SEMVER_SPEC_VERSION = '2.0.0';
+
++var MAX_LENGTH = 256;
++var MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER || 9007199254740991;
++
+ // The actual regexps go on exports.re
+ var re = exports.re = [];
+ var src = exports.src = [];
+@@ -233,8 +236,18 @@ for (var i = 0; i < R; i++) {
+
+ exports.parse = parse;
+ function parse(version, loose) {
++  if (version.length > MAX_LENGTH)
++    return null;
++
+   var r = loose ? re[LOOSE] : re[FULL];
+-  return (r.test(version)) ? new SemVer(version, loose) : null;
++  if (!r.test(version))
++    return null;
++
++  try {
++    return new SemVer(version, loose);
++  } catch (er) {
++    return null;
++  }
+ }
+
+ exports.valid = valid;
+@@ -262,6 +275,9 @@ function SemVer(version, loose) {
+     throw new TypeError('Invalid Version: ' + version);
+   }
+
++  if (version.length > MAX_LENGTH)
++    throw new TypeError('version is longer than ' + MAX_LENGTH + ' characters')
++
+   if (!(this instanceof SemVer))
+     return new SemVer(version, loose);
+
+@@ -279,6 +295,15 @@ function SemVer(version, loose) {
+   this.minor = +m[2];
+   this.patch = +m[3];
+
++  if (this.major > MAX_SAFE_INTEGER || this.major < 0)
++    throw new TypeError('Invalid major version')
++
++  if (this.minor > MAX_SAFE_INTEGER || this.minor < 0)
++    throw new TypeError('Invalid minor version')
++
++  if (this.patch > MAX_SAFE_INTEGER || this.patch < 0)
++    throw new TypeError('Invalid patch version')
++
+   // numberify any prerelease numeric ids
+   if (!m[4])
+     this.prerelease = [];

--- a/packages/snyk-protect/patches/send_20140912_0_0_9c6ca9b2c0b880afd3ff91ce0d211213c5fa_snyk.patch
+++ b/packages/snyk-protect/patches/send_20140912_0_0_9c6ca9b2c0b880afd3ff91ce0d211213c5fa_snyk.patch
@@ -1,0 +1,51 @@
+// code derived from https://github.com/pillarjs/send
+
+// https://github.com/pillarjs/send/blob/master/LICENSE
+/*
+(The MIT License)
+
+Copyright (c) 2012 TJ Holowaychuk
+Copyright (c) 2014-2015 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/lib/send.js b/lib/send.js
+index 2ea9319..e172fe3 100644
+--- a/lib/send.js
++++ b/lib/send.js
+@@ -412,7 +412,7 @@ SendStream.prototype.pipe = function(res){
+   if (root !== null) {
+     // join / normalize from optional root dir
+     path = normalize(join(root, path))
+-    root = normalize(root)
++    root = normalize(root + sep)
+
+     // malicious path
+     if (path.substr(0, root.length) !== root) {
+@@ -421,7 +421,7 @@ SendStream.prototype.pipe = function(res){
+     }
+
+     // explode path parts
+-    parts = path.substr(root.length + 1).split(sep)
++    parts = path.substr(root.length).split(sep)
+   } else {
+     // ".." is malicious without "root"
+     if (upPathRegexp.test(path)) {

--- a/packages/snyk-protect/patches/send_20151103_0_1_98a5b89982b38e79db684177cf94730ce7fc7aed.patch
+++ b/packages/snyk-protect/patches/send_20151103_0_1_98a5b89982b38e79db684177cf94730ce7fc7aed.patch
@@ -1,0 +1,55 @@
+// code derived from https://github.com/pillarjs/send
+
+// https://github.com/pillarjs/send/blob/master/LICENSE
+/*
+(The MIT License)
+
+Copyright (c) 2012 TJ Holowaychuk
+Copyright (c) 2014-2015 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/index.js b/index.js
+index 64b6d64..f63081d 100644
+--- a/index.js
++++ b/index.js
+@@ -415,16 +415,16 @@ SendStream.prototype.pipe = function(res){
+
+   var parts
+   if (root !== null) {
+-    // join / normalize from optional root dir
+-    path = normalize(join(root, path))
+-    root = normalize(root + sep)
+-
+     // malicious path
+-    if ((path + sep).substr(0, root.length) !== root) {
++    if (upPathRegexp.test(normalize('.' + sep + path))) {
+       debug('malicious path "%s"', path)
+       return this.error(403)
+     }
+
++    // join / normalize from optional root dir
++    path = normalize(join(root, path))
++    root = normalize(root + sep)
++
+     // explode path parts
+     parts = path.substr(root.length).split(sep)
+   } else {

--- a/packages/snyk-protect/patches/sequelize_20150118_0_0_f6ff86f7af6e2d15906ad1511b234d19adcccb07_snyk.patch
+++ b/packages/snyk-protect/patches/sequelize_20150118_0_0_f6ff86f7af6e2d15906ad1511b234d19adcccb07_snyk.patch
@@ -1,0 +1,30 @@
+// Code derived from https://github.com/sequelize/sequelize
+
+// https://github.com/sequelize/sequelize/blob/master/LICENSE
+/*
+Copyright (c) 2014-2015 Sequelize contributors
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+
+diff --git a/lib/dialects/abstract/query-generator.js b/lib/dialects/abstract/query-generator.js
+index 480239f..4dfd830 100644
+--- a/lib/dialects/abstract/query-generator.js
++++ b/lib/dialects/abstract/query-generator.js
+@@ -1232,6 +1232,14 @@ module.exports = (function() {
+ 
+         if (Array.isArray(options.order)) {
+           options.order.forEach(function(t) {
++            if (Array.isArray(t)) {
++              var order = _.last(t);
++
++              if (!_.contains(['ASC', 'DESC'], order.toUpperCase())) {
++                throw new Error(util.format('Order must be \'ASC\' or \'DESC\', \'%s\' given', order));
++              }
++            }
++
+             if (subQuery && (Array.isArray(t) && !(t[0] instanceof Model) && !(t[0].model instanceof Model))) {
+               subQueryOrder.push(this.quote(t, model));
+             }

--- a/packages/snyk-protect/patches/sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch
+++ b/packages/snyk-protect/patches/sequelize_20160106_d198d78182cbf1ea3ef1706740b35813a6aa0838.patch
@@ -1,0 +1,82 @@
+// Code derived from https://github.com/sequelize/sequelize
+// Based on:
+//  https://github.com/sequelize/sequelize/commit/d198d78182cbf1ea3ef1706740b35813a6aa0838
+// https://github.com/sequelize/sequelize/blob/master/LICENSE
+/*
+Copyright (c) 2014-2016 Sequelize contributors
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+diff --git a/lib/dialects/abstract/query-generator.js b/lib/dialects/abstract/query-generator.js
+index 568b219..aec1245 100644
+--- a/lib/dialects/abstract/query-generator.js
++++ b/lib/dialects/abstract/query-generator.js
+@@ -1765,12 +1765,12 @@ var QueryGenerator = {
+   addLimitAndOffset: function(options, model) {
+     var fragment = '';
+     if (options.offset && !options.limit) {
+-      fragment += ' LIMIT ' + options.offset + ', ' + 18440000000000000000;
++      fragment += ' LIMIT ' + this.escape(options.offset) + ', ' + 18440000000000000000;
+     } else if (options.limit) {
+       if (options.offset) {
+-        fragment += ' LIMIT ' + options.offset + ', ' + options.limit;
++        fragment += ' LIMIT ' + this.escape(options.offset) + ', ' + this.escape(options.limit);
+       } else {
+-        fragment += ' LIMIT ' + options.limit;
++        fragment += ' LIMIT ' + this.escape(options.limit);
+       }
+     }
+ 
+diff --git a/lib/dialects/mssql/query-generator.js b/lib/dialects/mssql/query-generator.js
+index e634159..9497125 100644
+--- a/lib/dialects/mssql/query-generator.js
++++ b/lib/dialects/mssql/query-generator.js
+@@ -590,11 +590,11 @@ var QueryGenerator = {
+       }
+ 
+       if (options.offset || options.limit) {
+-        fragment += ' OFFSET ' + offset + ' ROWS';
++        fragment += ' OFFSET ' + this.escape(offset) + ' ROWS';
+       }
+ 
+       if (options.limit) {
+-        fragment += ' FETCH NEXT ' + options.limit + ' ROWS ONLY';
++        fragment += ' FETCH NEXT ' + this.escape(options.limit) + ' ROWS ONLY';
+       }
+     }
+ 
+diff --git a/lib/dialects/postgres/query-generator.js b/lib/dialects/postgres/query-generator.js
+index 7ff65d1..8974dcc 100644
+--- a/lib/dialects/postgres/query-generator.js
++++ b/lib/dialects/postgres/query-generator.js
+@@ -423,8 +423,8 @@ var QueryGenerator = {
+ 
+   addLimitAndOffset: function(options) {
+     var fragment = '';
+-    if (options.limit) fragment += ' LIMIT ' + options.limit;
+-    if (options.offset) fragment += ' OFFSET ' + options.offset;
++    if (options.limit) fragment += ' LIMIT ' + this.escape(options.limit);
++    if (options.offset) fragment += ' OFFSET ' + this.escape(options.offset);
+ 
+     return fragment;
+   },
+diff --git a/lib/dialects/sqlite/query-generator.js b/lib/dialects/sqlite/query-generator.js
+index ab73ac0..5d343f2 100644
+--- a/lib/dialects/sqlite/query-generator.js
++++ b/lib/dialects/sqlite/query-generator.js
+@@ -91,12 +91,12 @@
+   addLimitAndOffset: function(options){
+     var fragment = '';
+     if (options.offset && !options.limit) {
+-      fragment += ' LIMIT ' + options.offset + ', ' + 10000000000000;
++      fragment += ' LIMIT ' + this.escape(options.offset) + ', ' + 10000000000000;
+     } else if (options.limit) {
+       if (options.offset) {
+-        fragment += ' LIMIT ' + options.offset + ', ' + options.limit;
++        fragment += ' LIMIT ' + this.escape(options.offset) + ', ' + this.escape(options.limit);
+       } else {
+-        fragment += ' LIMIT ' + options.limit;
++        fragment += ' LIMIT ' + this.escape(options.limit);
+       }
+     }

--- a/packages/snyk-protect/patches/sequelize_20160115_0_0_b85f78a318e6f7112a3374498171a3e148cdc4da.patch
+++ b/packages/snyk-protect/patches/sequelize_20160115_0_0_b85f78a318e6f7112a3374498171a3e148cdc4da.patch
@@ -1,0 +1,28 @@
+// Code derived from https://github.com/sequelize/sequelize
+// Based on:
+//  https://github.com/sequelize/sequelize/commit/cbfaa4f0a135cfc55874c9bfc39ead2d85c417e9
+//  https://github.com/sequelize/sequelize/commit/b85f78a318e6f7112a3374498171a3e148cdc4da
+// https://github.com/sequelize/sequelize/blob/master/LICENSE
+/*
+Copyright (c) 2014-2016 Sequelize contributors
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+diff --git a/lib/data-types.js b/lib/data-types.js
+index 9d32661..961c0cc 100644
+--- a/lib/data-types.js
++++ b/lib/data-types.js
+@@ -578,7 +578,11 @@ BLOB.prototype.validate = function(value) {
+ BLOB.prototype.escape = false;
+ BLOB.prototype.$stringify = function (value) {
+   if (!Buffer.isBuffer(value)) {
+-    value = new Buffer(value);
++    if (Array.isArray(value)) {
++      value = new Buffer(value);
++    } else {
++      value = new Buffer(value.toString());
++    }
+   }
+   var hex = value.toString('hex');
+ 

--- a/packages/snyk-protect/patches/sequelize_20160115_0_0_b85f78a318e6f7112a3374498171a3e148cdc4da_w_20160106.patch
+++ b/packages/snyk-protect/patches/sequelize_20160115_0_0_b85f78a318e6f7112a3374498171a3e148cdc4da_w_20160106.patch
@@ -1,0 +1,106 @@
+// Code derived from https://github.com/sequelize/sequelize
+// Based on:
+//  https://github.com/sequelize/sequelize/commit/cbfaa4f0a135cfc55874c9bfc39ead2d85c417e9
+//  https://github.com/sequelize/sequelize/commit/b85f78a318e6f7112a3374498171a3e148cdc4da
+// https://github.com/sequelize/sequelize/blob/master/LICENSE
+/*
+Copyright (c) 2014-2016 Sequelize contributors
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+// carries patches for:
+//  * npm:sequelize:20160106
+//  * npm:sequelize:20160115
+//
+// fix npm:sequelize:20160106 vulnerability
+diff --git a/lib/dialects/abstract/query-generator.js b/lib/dialects/abstract/query-generator.js
+index 568b219..aec1245 100644
+--- a/lib/dialects/abstract/query-generator.js
++++ b/lib/dialects/abstract/query-generator.js
+@@ -1765,12 +1765,12 @@ var QueryGenerator = {
+   addLimitAndOffset: function(options, model) {
+     var fragment = '';
+     if (options.offset && !options.limit) {
+-      fragment += ' LIMIT ' + options.offset + ', ' + 18440000000000000000;
++      fragment += ' LIMIT ' + this.escape(options.offset) + ', ' + 18440000000000000000;
+     } else if (options.limit) {
+       if (options.offset) {
+-        fragment += ' LIMIT ' + options.offset + ', ' + options.limit;
++        fragment += ' LIMIT ' + this.escape(options.offset) + ', ' + this.escape(options.limit);
+       } else {
+-        fragment += ' LIMIT ' + options.limit;
++        fragment += ' LIMIT ' + this.escape(options.limit);
+       }
+     }
+ 
+diff --git a/lib/dialects/mssql/query-generator.js b/lib/dialects/mssql/query-generator.js
+index e634159..9497125 100644
+--- a/lib/dialects/mssql/query-generator.js
++++ b/lib/dialects/mssql/query-generator.js
+@@ -590,11 +590,11 @@ var QueryGenerator = {
+       }
+ 
+       if (options.offset || options.limit) {
+-        fragment += ' OFFSET ' + offset + ' ROWS';
++        fragment += ' OFFSET ' + this.escape(offset) + ' ROWS';
+       }
+ 
+       if (options.limit) {
+-        fragment += ' FETCH NEXT ' + options.limit + ' ROWS ONLY';
++        fragment += ' FETCH NEXT ' + this.escape(options.limit) + ' ROWS ONLY';
+       }
+     }
+ 
+diff --git a/lib/dialects/postgres/query-generator.js b/lib/dialects/postgres/query-generator.js
+index 7ff65d1..8974dcc 100644
+--- a/lib/dialects/postgres/query-generator.js
++++ b/lib/dialects/postgres/query-generator.js
+@@ -423,8 +423,8 @@ var QueryGenerator = {
+ 
+   addLimitAndOffset: function(options) {
+     var fragment = '';
+-    if (options.limit) fragment += ' LIMIT ' + options.limit;
+-    if (options.offset) fragment += ' OFFSET ' + options.offset;
++    if (options.limit) fragment += ' LIMIT ' + this.escape(options.limit);
++    if (options.offset) fragment += ' OFFSET ' + this.escape(options.offset);
+ 
+     return fragment;
+   },
+diff --git a/lib/dialects/sqlite/query-generator.js b/lib/dialects/sqlite/query-generator.js
+index ab73ac0..5d343f2 100644
+--- a/lib/dialects/sqlite/query-generator.js
++++ b/lib/dialects/sqlite/query-generator.js
+@@ -91,12 +91,12 @@
+   addLimitAndOffset: function(options){
+     var fragment = '';
+     if (options.offset && !options.limit) {
+-      fragment += ' LIMIT ' + options.offset + ', ' + 10000000000000;
++      fragment += ' LIMIT ' + this.escape(options.offset) + ', ' + 10000000000000;
+     } else if (options.limit) {
+       if (options.offset) {
+-        fragment += ' LIMIT ' + options.offset + ', ' + options.limit;
++        fragment += ' LIMIT ' + this.escape(options.offset) + ', ' + this.escape(options.limit);
+       } else {
+-        fragment += ' LIMIT ' + options.limit;
++        fragment += ' LIMIT ' + this.escape(options.limit);
+       }
+     }
+
+diff --git a/lib/data-types.js b/lib/data-types.js
+index 9d32661..961c0cc 100644
+--- a/lib/data-types.js
++++ b/lib/data-types.js
+@@ -578,7 +578,11 @@ BLOB.prototype.validate = function(value) {
+ BLOB.prototype.escape = false;
+ BLOB.prototype.$stringify = function (value) {
+   if (!Buffer.isBuffer(value)) {
+-    value = new Buffer(value);
++    if (Array.isArray(value)) {
++      value = new Buffer(value);
++    } else {
++      value = new Buffer(value.toString());
++    }
+   }
+   var hex = value.toString('hex');
+ 

--- a/packages/snyk-protect/patches/sequelize_20160329_0_0_23952a2b020cc3571f090e67dae7feb084e1be71.patch
+++ b/packages/snyk-protect/patches/sequelize_20160329_0_0_23952a2b020cc3571f090e67dae7feb084e1be71.patch
@@ -1,0 +1,25 @@
+// Code derived from https://github.com/sequelize/sequelize
+// Based on https://github.com/sequelize/sequelize/commit/23952a2b020cc3571f090e67dae7feb084e1be71
+// https://github.com/sequelize/sequelize/blob/master/LICENSE
+/*
+Copyright (c) 2014-2016 Sequelize contributors
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+// carries patch for:
+//  * npm:sequelize:20160329
+//
+diff --git a/lib/sql-string.js b/lib/sql-string.js
+index d9916ea..e3c6206 100644
+--- a/lib/sql-string.js
++++ b/lib/sql-string.js
+@@ -48,7 +48,7 @@ SqlString.escape = function(val, timeZone, dialect, format) {
+   }
+ 
+   if (Array.isArray(val)) {
+-    var escape = _.partialRight(SqlString.escape, timeZone, dialect);
++    var escape = _.partial(SqlString.escape, _, timeZone, dialect, format);
+     if (dialect === 'postgres' && !format) {
+       return dataTypes.ARRAY.prototype.stringify(val, {escape: escape});
+     }

--- a/packages/snyk-protect/patches/sequelize_20160329_0_0_23952a2b020cc3571f090e67dae7feb084e1be71_w_20160115.patch
+++ b/packages/snyk-protect/patches/sequelize_20160329_0_0_23952a2b020cc3571f090e67dae7feb084e1be71_w_20160115.patch
@@ -1,0 +1,42 @@
+// Code derived from https://github.com/sequelize/sequelize
+// Based on https://github.com/sequelize/sequelize/commit/23952a2b020cc3571f090e67dae7feb084e1be71
+// https://github.com/sequelize/sequelize/blob/master/LICENSE
+/*
+Copyright (c) 2014-2016 Sequelize contributors
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+// carries patches for:
+//  * npm:sequelize:20160115
+//  * npm:sequelize:20160329
+//
+// fix for npm:sequelize:20160115 vulnerability
+--- a/lib/data-types.js
++++ b/lib/data-types.js
+@@ -578,7 +578,11 @@ BLOB.prototype.validate = function(value) {
+ BLOB.prototype.escape = false;
+ BLOB.prototype.$stringify = function (value) {
+   if (!Buffer.isBuffer(value)) {
+-    value = new Buffer(value);
++    if (Array.isArray(value)) {
++      value = new Buffer(value);
++    } else {
++      value = new Buffer(value.toString());
++    }
+   }
+   var hex = value.toString('hex');
+ 
+diff --git a/lib/sql-string.js b/lib/sql-string.js
+index d9916ea..e3c6206 100644
+--- a/lib/sql-string.js
++++ b/lib/sql-string.js
+@@ -48,7 +48,7 @@ SqlString.escape = function(val, timeZone, dialect, format) {
+   }
+ 
+   if (Array.isArray(val)) {
+-    var escape = _.partialRight(SqlString.escape, timeZone, dialect);
++    var escape = _.partial(SqlString.escape, _, timeZone, dialect, format);
+     if (dialect === 'postgres' && !format) {
+       return dataTypes.ARRAY.prototype.stringify(val, {escape: escape});
+     }

--- a/packages/snyk-protect/patches/sequelize_20160329_0_0_23952a2b020cc3571f090e67dae7feb084e1be71_w_20160115_w_20160106.patch
+++ b/packages/snyk-protect/patches/sequelize_20160329_0_0_23952a2b020cc3571f090e67dae7feb084e1be71_w_20160115_w_20160106.patch
@@ -1,0 +1,118 @@
+// Code derived from https://github.com/sequelize/sequelize
+// Based on https://github.com/sequelize/sequelize/commit/23952a2b020cc3571f090e67dae7feb084e1be71
+// https://github.com/sequelize/sequelize/blob/master/LICENSE
+/*
+Copyright (c) 2014-2016 Sequelize contributors
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+// carries patches for:
+//  * npm:sequelize:20160106
+//  * npm:sequelize:20160115
+//  * npm:sequelize:20160329
+//
+// fix npm:sequelize:20160106 vulnerability
+diff --git a/lib/dialects/abstract/query-generator.js b/lib/dialects/abstract/query-generator.js
+index 568b219..aec1245 100644
+--- a/lib/dialects/abstract/query-generator.js
++++ b/lib/dialects/abstract/query-generator.js
+@@ -1765,12 +1765,12 @@ var QueryGenerator = {
+   addLimitAndOffset: function(options, model) {
+     var fragment = '';
+     if (options.offset && !options.limit) {
+-      fragment += ' LIMIT ' + options.offset + ', ' + 18440000000000000000;
++      fragment += ' LIMIT ' + this.escape(options.offset) + ', ' + 18440000000000000000;
+     } else if (options.limit) {
+       if (options.offset) {
+-        fragment += ' LIMIT ' + options.offset + ', ' + options.limit;
++        fragment += ' LIMIT ' + this.escape(options.offset) + ', ' + this.escape(options.limit);
+       } else {
+-        fragment += ' LIMIT ' + options.limit;
++        fragment += ' LIMIT ' + this.escape(options.limit);
+       }
+     }
+ 
+diff --git a/lib/dialects/mssql/query-generator.js b/lib/dialects/mssql/query-generator.js
+index e634159..9497125 100644
+--- a/lib/dialects/mssql/query-generator.js
++++ b/lib/dialects/mssql/query-generator.js
+@@ -590,11 +590,11 @@ var QueryGenerator = {
+       }
+ 
+       if (options.offset || options.limit) {
+-        fragment += ' OFFSET ' + offset + ' ROWS';
++        fragment += ' OFFSET ' + this.escape(offset) + ' ROWS';
+       }
+ 
+       if (options.limit) {
+-        fragment += ' FETCH NEXT ' + options.limit + ' ROWS ONLY';
++        fragment += ' FETCH NEXT ' + this.escape(options.limit) + ' ROWS ONLY';
+       }
+     }
+ 
+diff --git a/lib/dialects/postgres/query-generator.js b/lib/dialects/postgres/query-generator.js
+index 7ff65d1..8974dcc 100644
+--- a/lib/dialects/postgres/query-generator.js
++++ b/lib/dialects/postgres/query-generator.js
+@@ -423,8 +423,8 @@ var QueryGenerator = {
+ 
+   addLimitAndOffset: function(options) {
+     var fragment = '';
+-    if (options.limit) fragment += ' LIMIT ' + options.limit;
+-    if (options.offset) fragment += ' OFFSET ' + options.offset;
++    if (options.limit) fragment += ' LIMIT ' + this.escape(options.limit);
++    if (options.offset) fragment += ' OFFSET ' + this.escape(options.offset);
+ 
+     return fragment;
+   },
+diff --git a/lib/dialects/sqlite/query-generator.js b/lib/dialects/sqlite/query-generator.js
+index ab73ac0..5d343f2 100644
+--- a/lib/dialects/sqlite/query-generator.js
++++ b/lib/dialects/sqlite/query-generator.js
+@@ -91,12 +91,12 @@
+   addLimitAndOffset: function(options){
+     var fragment = '';
+     if (options.offset && !options.limit) {
+-      fragment += ' LIMIT ' + options.offset + ', ' + 10000000000000;
++      fragment += ' LIMIT ' + this.escape(options.offset) + ', ' + 10000000000000;
+     } else if (options.limit) {
+       if (options.offset) {
+-        fragment += ' LIMIT ' + options.offset + ', ' + options.limit;
++        fragment += ' LIMIT ' + this.escape(options.offset) + ', ' + this.escape(options.limit);
+       } else {
+-        fragment += ' LIMIT ' + options.limit;
++        fragment += ' LIMIT ' + this.escape(options.limit);
+       }
+     }
+
+// fix for npm:sequelize:20160115 vulnerability
+--- a/lib/data-types.js
++++ b/lib/data-types.js
+@@ -578,7 +578,11 @@ BLOB.prototype.validate = function(value) {
+ BLOB.prototype.escape = false;
+ BLOB.prototype.$stringify = function (value) {
+   if (!Buffer.isBuffer(value)) {
+-    value = new Buffer(value);
++    if (Array.isArray(value)) {
++      value = new Buffer(value);
++    } else {
++      value = new Buffer(value.toString());
++    }
+   }
+   var hex = value.toString('hex');
+ 
+// fix npm:sequelize:20160329 vulnerability
+diff --git a/lib/sql-string.js b/lib/sql-string.js
+index d9916ea..e3c6206 100644
+--- a/lib/sql-string.js
++++ b/lib/sql-string.js
+@@ -48,7 +48,7 @@ SqlString.escape = function(val, timeZone, dialect, format) {
+   }
+ 
+   if (Array.isArray(val)) {
+-    var escape = _.partialRight(SqlString.escape, timeZone, dialect);
++    var escape = _.partial(SqlString.escape, _, timeZone, dialect, format);
+     if (dialect === 'postgres' && !format) {
+       return dataTypes.ARRAY.prototype.stringify(val, {escape: escape});
+     }

--- a/packages/snyk-protect/patches/sequelize_20160718_0_0_f93af43a1d86400487f5e3d9762f1a4b7cf6b1e1.patch
+++ b/packages/snyk-protect/patches/sequelize_20160718_0_0_f93af43a1d86400487f5e3d9762f1a4b7cf6b1e1.patch
@@ -1,0 +1,67 @@
+// Code derived from: https://github.com/sequelize/sequelize
+// Reference: https://github.com/sequelize/sequelize/compare/v3.23.4...v3.23.6
+
+// https://github.com/sequelize/sequelize/blob/master/LICENSE
+/*
+Copyright (c) 2014-2016 Sequelize contributors
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/lib/data-types.js b/lib/data-types.js
+index 82bd5ec..cadf299 100644
+--- a/lib/data-types.js
++++ b/lib/data-types.js
+@@ -900,8 +900,8 @@ var GEOMETRY = ABSTRACT.inherits(function(type, srid) {
+ GEOMETRY.prototype.key = GEOMETRY.key = 'GEOMETRY';
+ 
+ GEOMETRY.prototype.escape = false;
+-GEOMETRY.prototype.$stringify = function (value) {
+-  return 'GeomFromText(\'' + Wkt.convert(value) + '\')';
++GEOMETRY.prototype.$stringify = function (value, options) {
++  return 'GeomFromText(' + options.escape(Wkt.convert(value)) + ')';
+ };
+ 
+ /**
+@@ -925,8 +925,8 @@ var GEOGRAPHY = ABSTRACT.inherits(function(type, srid) {
+ GEOGRAPHY.prototype.key = GEOGRAPHY.key = 'GEOGRAPHY';
+ 
+ GEOGRAPHY.prototype.escape = false;
+-GEOGRAPHY.prototype.$stringify = function (value) {
+-  return 'GeomFromText(\'' + Wkt.convert(value) + '\')';
++GEOGRAPHY.prototype.$stringify = function (value, options) {
++  return 'GeomFromText(' + options.escape(Wkt.convert(value)) + ')';
+ };
+ 
+ Object.keys(helpers).forEach(function (helper) {
+diff --git a/lib/dialects/postgres/data-types.js b/lib/dialects/postgres/data-types.js
+index 5a53ecb..aa9baf8 100644
+--- a/lib/dialects/postgres/data-types.js
++++ b/lib/dialects/postgres/data-types.js
+@@ -266,8 +266,8 @@ module.exports = function (BaseTypes) {
+     return wkx.Geometry.parse(b).toGeoJSON();
+   };
+ 
+-  GEOMETRY.prototype.$stringify = function (value) {
+-    return 'ST_GeomFromGeoJSON(\'' + JSON.stringify(value) + '\')';
++  GEOMETRY.prototype.$stringify = function (value, options) {
++    return 'ST_GeomFromGeoJSON(' + options.escape(JSON.stringify(value)) + ')';
+   };
+ 
+   var GEOGRAPHY = BaseTypes.GEOGRAPHY.inherits();
+@@ -298,8 +298,8 @@ module.exports = function (BaseTypes) {
+     return wkx.Geometry.parse(b).toGeoJSON();
+   };
+ 
+-  GEOGRAPHY.prototype.$stringify = function (value) {
+-    return 'ST_GeomFromGeoJSON(\'' + JSON.stringify(value) + '\')';
++  GEOGRAPHY.prototype.$stringify = function (value, options) {
++    return 'ST_GeomFromGeoJSON(' + options.escape(JSON.stringify(value)) + ')';
+   };
+ 
+   var hstore;

--- a/packages/snyk-protect/patches/sequelize_20160718_0_1_f93af43a1d86400487f5e3d9762f1a4b7cf6b1e1.patch
+++ b/packages/snyk-protect/patches/sequelize_20160718_0_1_f93af43a1d86400487f5e3d9762f1a4b7cf6b1e1.patch
@@ -1,0 +1,63 @@
+// Code derived from: https://github.com/sequelize/sequelize
+// Reference: https://github.com/sequelize/sequelize/compare/v3.23.4...v3.23.6
+
+// https://github.com/sequelize/sequelize/blob/master/LICENSE
+/*
+Copyright (c) 2014-2016 Sequelize contributors
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+--- a/lib/dialects/postgres/data-types.js	
++++ b/lib/dialects/postgres/data-types.js
+@@ -266,8 +266,8 @@
+     return wkx.Geometry.parse(b).toGeoJSON();
+   };
+ 
+-  GEOMETRY.prototype.$stringify = function (value) {
+-    return 'ST_GeomFromGeoJSON(\'' + JSON.stringify(value) + '\')';
++  GEOMETRY.prototype.$stringify = function (value, options) {
++    return 'ST_GeomFromGeoJSON(' + options.escape(JSON.stringify(value)) + ')';
+   };
+ 
+   var GEOGRAPHY = BaseTypes.GEOGRAPHY.inherits();
+@@ -298,8 +298,8 @@
+     return wkx.Geometry.parse(b).toGeoJSON();
+   };
+ 
+-  GEOGRAPHY.prototype.$stringify = function (value) {
+-    return 'ST_GeomFromGeoJSON(\'' + JSON.stringify(value) + '\')';
++  GEOGRAPHY.prototype.$stringify = function (value, options) {
++    return 'ST_GeomFromGeoJSON(' + options.escape(JSON.stringify(value)) + ')';
+   };
+ 
+   var hstore;
+--- a/lib/data-types.js	
++++ b/lib/data-types.js	
+@@ -897,8 +897,8 @@
+ GEOMETRY.prototype.key = GEOMETRY.key = 'GEOMETRY';
+ 
+ GEOMETRY.prototype.escape = false;
+-GEOMETRY.prototype.$stringify = function (value) {
+-  return 'GeomFromText(\'' + Wkt.stringify(value) + '\')';
++GEOMETRY.prototype.$stringify = function (value, options) {
++  return 'GeomFromText(' + options.escape(Wkt.convert(value)) + ')';
+ };
+ 
+ /**
+@@ -922,8 +922,8 @@
+ GEOGRAPHY.prototype.key = GEOGRAPHY.key = 'GEOGRAPHY';
+ 
+ GEOGRAPHY.prototype.escape = false;
+-GEOGRAPHY.prototype.$stringify = function (value) {
+-  return 'GeomFromText(\'' + Wkt.stringify(value) + '\')';
++GEOGRAPHY.prototype.$stringify = function (value, options) {
++  return 'GeomFromText(' + options.escape(Wkt.convert(value)) + ')';
+ };
+ 
+ Object.keys(helpers).forEach(function (helper) {

--- a/packages/snyk-protect/patches/sequelize_20160718_0_1_f93af43a1d86400487f5e3d9762f1a4b7cf6b1e1_w_20160329.patch
+++ b/packages/snyk-protect/patches/sequelize_20160718_0_1_f93af43a1d86400487f5e3d9762f1a4b7cf6b1e1_w_20160329.patch
@@ -1,0 +1,77 @@
+// Code derived from: https://github.com/sequelize/sequelize
+// Reference: https://github.com/sequelize/sequelize/compare/v3.23.4...v3.23.6
+
+// https://github.com/sequelize/sequelize/blob/master/LICENSE
+/*
+Copyright (c) 2014-2016 Sequelize contributors
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+--- a/lib/dialects/postgres/data-types.js	
++++ b/lib/dialects/postgres/data-types.js
+@@ -266,8 +266,8 @@
+     return wkx.Geometry.parse(b).toGeoJSON();
+   };
+ 
+-  GEOMETRY.prototype.$stringify = function (value) {
+-    return 'ST_GeomFromGeoJSON(\'' + JSON.stringify(value) + '\')';
++  GEOMETRY.prototype.$stringify = function (value, options) {
++    return 'ST_GeomFromGeoJSON(' + options.escape(JSON.stringify(value)) + ')';
+   };
+ 
+   var GEOGRAPHY = BaseTypes.GEOGRAPHY.inherits();
+@@ -298,8 +298,8 @@
+     return wkx.Geometry.parse(b).toGeoJSON();
+   };
+ 
+-  GEOGRAPHY.prototype.$stringify = function (value) {
+-    return 'ST_GeomFromGeoJSON(\'' + JSON.stringify(value) + '\')';
++  GEOGRAPHY.prototype.$stringify = function (value, options) {
++    return 'ST_GeomFromGeoJSON(' + options.escape(JSON.stringify(value)) + ')';
+   };
+ 
+   var hstore;
+--- a/lib/data-types.js	
++++ b/lib/data-types.js	
+@@ -897,8 +897,8 @@
+ GEOMETRY.prototype.key = GEOMETRY.key = 'GEOMETRY';
+ 
+ GEOMETRY.prototype.escape = false;
+-GEOMETRY.prototype.$stringify = function (value) {
+-  return 'GeomFromText(\'' + Wkt.stringify(value) + '\')';
++GEOMETRY.prototype.$stringify = function (value, options) {
++  return 'GeomFromText(' + options.escape(Wkt.convert(value)) + ')';
+ };
+ 
+ /**
+@@ -922,8 +922,8 @@
+ GEOGRAPHY.prototype.key = GEOGRAPHY.key = 'GEOGRAPHY';
+ 
+ GEOGRAPHY.prototype.escape = false;
+-GEOGRAPHY.prototype.$stringify = function (value) {
+-  return 'GeomFromText(\'' + Wkt.stringify(value) + '\')';
++GEOGRAPHY.prototype.$stringify = function (value, options) {
++  return 'GeomFromText(' + options.escape(Wkt.convert(value)) + ')';
+ };
+ 
+ Object.keys(helpers).forEach(function (helper) {
+
+ diff --git a/lib/sql-string.js b/lib/sql-string.js
+ index d9916ea..e3c6206 100644
+ --- a/lib/sql-string.js
+ +++ b/lib/sql-string.js
+ @@ -48,7 +48,7 @@ SqlString.escape = function(val, timeZone, dialect, format) {
+    }
+  
+    if (Array.isArray(val)) {
+ -    var escape = _.partialRight(SqlString.escape, timeZone, dialect);
+ +    var escape = _.partial(SqlString.escape, _, timeZone, dialect, format);
+      if (dialect === 'postgres' && !format) {
+        return dataTypes.ARRAY.prototype.stringify(val, {escape: escape});
+      }

--- a/packages/snyk-protect/patches/serve-index_20150314_0_0_0d135e710d717d7d9a3a3994f611214fb42e2191_snyk.patch
+++ b/packages/snyk-protect/patches/serve-index_20150314_0_0_0d135e710d717d7d9a3a3994f611214fb42e2191_snyk.patch
@@ -1,0 +1,75 @@
+// Code derived from https://github.com/expressjs/serve-index
+
+// https://github.com/expressjs/serve-index/blob/master/LICENSE
+/*
+(The MIT License)
+
+Copyright (c) 2010 Sencha Inc.
+Copyright (c) 2011 LearnBoost
+Copyright (c) 2011 TJ Holowaychuk
+Copyright (c) 2014-2015 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/index.js b/index.js
+index 1fec6fd..5cb6a51 100644
+--- a/index.js
++++ b/index.js
+@@ -11,11 +11,13 @@
+
+ /**
+  * Module dependencies.
++ * @private
+  */
+
+ var accepts = require('accepts');
+ var createError = require('http-errors');
+ var debug = require('debug')('serve-index');
++var escapeHtml = require('escape-html');
+ var fs = require('fs')
+   , path = require('path')
+   , normalize = path.normalize
+@@ -383,12 +385,11 @@ function html(files, dir, useIcons, view) {
+
+     return '<li><a href="'
+       + normalizeSlashes(normalize(path.join('/')))
+-      + '" class="'
+-      + classes.join(' ') + '"'
+-      + ' title="' + file.name + '">'
+-      + '<span class="name">'+file.name+'</span>'
+-      + '<span class="size">'+size+'</span>'
+-      + '<span class="date">'+date+'</span>'
++      + '" class="' + escapeHtml(classes.join(' ')) + '"'
++      + ' title="' + escapeHtml(file.name) + '">'
++      + '<span class="name">' + escapeHtml(file.name) + '</span>'
++      + '<span class="size">' + escapeHtml(size) + '</span>'
++      + '<span class="date">' + escapeHtml(date) + '</span>'
+       + '</a></li>';
+
+   }).join('\n') + '</ul>';
+diff --git a/package.json b/package.json
+index 0ba7dae..15486f6 100644
+--- a/package.json
++++ b/package.json
+@@ -12,2 +12,3 @@
+   },
+   "dependencies": {
++    "escape-html": "1.0.1",

--- a/packages/snyk-protect/patches/serve-static_20150113_0_0_0399e399935bab99530d6926094b4451438c2d50_snyk.patch
+++ b/packages/snyk-protect/patches/serve-static_20150113_0_0_0399e399935bab99530d6926094b4451438c2d50_snyk.patch
@@ -1,0 +1,70 @@
+// Code derived from https://github.com/expressjs/serve-static
+
+// https://github.com/expressjs/serve-static/blob/master/LICENSE
+/*
+(The MIT License)
+
+Copyright (c) 2010 Sencha Inc.
+Copyright (c) 2011 LearnBoost
+Copyright (c) 2011 TJ Holowaychuk
+Copyright (c) 2014-2015 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/index.js b/index.js
+index 12ea659..fbe044c 100644
+--- a/index.js
++++ b/index.js
+@@ -79,10 +79,13 @@ exports = module.exports = function serveStatic(root, options) {
+           return next()
+         }
+
+-        originalUrl.pathname += '/'
++        // append trailing slash
++        originalUrl.pathname = collapseLeadingSlashes(originalUrl.pathname + '/')
+
++        // reformat the URL
+         var target = url.format(originalUrl)
+
++        // send redirect response
+         res.statusCode = 303
+         res.setHeader('Content-Type', 'text/html; charset=utf-8')
+         res.setHeader('Location', target)
+@@ -116,3 +119,19 @@ exports = module.exports = function serveStatic(root, options) {
+  */
+
+ exports.mime = send.mime
++
++/**
++ * Collapse all leading slashes into a single slash
++ * @private
++ */
++function collapseLeadingSlashes(str) {
++  for (var i = 0; i < str.length; i++) {
++    if (str[i] !== '/') {
++      break
++    }
++  }
++
++  return i > 1
++    ? '/' + str.substr(i)
++    : str
++}

--- a/packages/snyk-protect/patches/shell-quote_20160621_0_0.patch
+++ b/packages/snyk-protect/patches/shell-quote_20160621_0_0.patch
@@ -1,0 +1,44 @@
+// code derived from https://github.com/substack/node-shell-quote/
+// based on https://github.com/substack/node-shell-quote/compare/1.6.0...1.6.1.patch
+
+// https://github.com/substack/node-shell-quote/blob/master/LICENSE
+/*
+The MIT License
+
+Copyright (c) 2013 James Halliday (mail@substack.net)
+
+Permission is hereby granted, free of charge, 
+to any person obtaining a copy of this software and 
+associated documentation files (the "Software"), to 
+deal in the Software without restriction, including 
+without limitation the rights to use, copy, modify, 
+merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom 
+the Software is furnished to do so, 
+subject to the following conditions:
+
+The above copyright notice and this permission notice 
+shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/index.js b/index.js
+index 473b3d2..e3811e8 100644
+--- a/index.js
++++ b/index.js
+@@ -15,7 +15,7 @@ exports.quote = function (xs) {
+             return '"' + s.replace(/(["\\$`!])/g, '\\$1') + '"';
+         }
+         else {
+-            return String(s).replace(/([\\$`()!#&*|])/g, '\\$1');
++            return String(s).replace(/([#!"$&'()*,:;<=>?@\[\\\]^`{|}])/g, '\\$1'); 
+         }
+     }).join(' ');
+ };

--- a/packages/snyk-protect/patches/shout_20160913_0_0_7ef2da0c832175cea1776a651a3c14051468fdc2.patch
+++ b/packages/snyk-protect/patches/shout_20160913_0_0_7ef2da0c832175cea1776a651a3c14051468fdc2.patch
@@ -1,0 +1,42 @@
+// code derived form: https://github.com/erming/shout/
+// reference:
+//  https://github.com/erming/shout/commit/7ef2da0c832175cea1776a651a3c14051468fdc2
+
+// https://github.com/erming/shout/blob/master/LICENSE
+/*
+The MIT License (MIT)
+
+Copyright (c) 2014 Mattias Erming and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+diff --git a/client/views/toggle.tpl b/client/views/toggle.tpl
+index 08de2b5..629d821 100644
+--- a/client/views/toggle.tpl
++++ b/client/views/toggle.tpl
+@@ -9,7 +9,7 @@
+ 			{{#if thumb}}
+ 				<img src="{{thumb}}" class="thumb">
+ 			{{/if}}
+-			<div class="head">{{{head}}}</div>
++			<div class="head">{{{parse head}}}</div>
+ 			<div class="body">
+ 				{{body}}
+ 			</div>

--- a/packages/snyk-protect/patches/st-20140206_0_0_6b54ce2d2fb912eadd31e2c25c65456d2c8666e1.patch
+++ b/packages/snyk-protect/patches/st-20140206_0_0_6b54ce2d2fb912eadd31e2c25c65456d2c8666e1.patch
@@ -1,0 +1,19 @@
+--- a/st.js
++++ b/st.js
+@@ -156,7 +156,15 @@ Mount.prototype.getCacheOptions = function (opt) {
+ 
+ // get a path from a url
+ Mount.prototype.getPath = function (u) {
+-  u = path.normalize(url.parse(u).pathname.replace(/^[\/\\]?/, '/')).replace(/\\/g, '/')
++  var p = url.parse(u).pathname
++
++  p = p.replace(/%2e/ig, '.')
++  p = p.replace(/%2f/ig, '/')
++  p = p.replace(/%5c/ig, '\\')
++  p = p.replace(/^[\/\\]?/g, '/')
++  p = p.replace(/[\/\\]\.\.[\/\\]/g, '/')
++
++  u = path.normalize(p).replace(/\\/g, '/')
+   if (u.indexOf(this.url) !== 0) return false
+ 
+   try {

--- a/packages/snyk-protect/patches/tar_20151103_0_0_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch
+++ b/packages/snyk-protect/patches/tar_20151103_0_0_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch
@@ -1,0 +1,62 @@
+// Code derived from https://github.com/isaacs/node-tar
+// Reference: https://github.com/npm/node-tar/commit/a5337a6cd58a2d800fc03b3781a25751cf459f28.patch
+
+// https://github.com/npm/node-tar/blob/master/LICENSE
+/*
+The ISC License
+Copyright (c) Isaac Z. Schlueter and Contributors
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+--- a/lib/extract.js
++++ b/lib/extract.js
+@@ -11,16 +11,13 @@ function Extract (opts) {
+   if (!(this instanceof Extract)) return new Extract(opts)
+   tar.Parse.apply(this)
+
+-  // have to dump into a directory
+-  opts.type = "Directory"
+-  opts.Directory = true
+-
+   if (typeof opts !== "object") {
+     opts = { path: opts }
+   }
+
+   // better to drop in cwd? seems more standard.
+   opts.path = opts.path || path.resolve("node-tar-extract")
++  // have to dump into a directory
+   opts.type = "Directory"
+   opts.Directory = true
+
+@@ -47,9 +44,20 @@ function Extract (opts) {
+         entry.linkpath = entry.props.linkpath = lp
+       }
+     }
+-    if (entry.type !== "Link") return
+-    entry.linkpath = entry.props.linkpath =
+-      path.join(opts.path, path.join("/", entry.props.linkpath))
++
++    if (entry.type === "Link") {
++      entry.linkpath = entry.props.linkpath = path.join(
++        opts.path, path.join("/", entry.props.linkpath)
++      )
++    }
++
++    if (entry.props && entry.props.linkpath) {
++      var linkpath = entry.props.linkpath
++      // normalize paths that point outside the extraction root
++      if (path.resolve(opts.path, linkpath).indexOf(opts.path) !== 0) {
++        entry.props.linkpath = path.join(opts.path, path.join("/", linkpath))
++      }
++    }
+   })
+
+   this._fst.on("ready", function () {

--- a/packages/snyk-protect/patches/tar_20151103_0_1_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch
+++ b/packages/snyk-protect/patches/tar_20151103_0_1_a5337a6cd58a2d800fc03b3781a25751cf459f28_snyk.patch
@@ -1,0 +1,62 @@
+// Code derived from https://github.com/isaacs/node-tar
+// Reference: https://github.com/npm/node-tar/commit/a5337a6cd58a2d800fc03b3781a25751cf459f28.patch
+
+// https://github.com/npm/node-tar/blob/master/LICENSE
+/*
+The ISC License
+Copyright (c) Isaac Z. Schlueter and Contributors
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+--- a/lib/extract.js
++++ b/lib/extract.js
+@@ -11,16 +11,13 @@ function Extract (opts) {
+   if (!(this instanceof Extract)) return new Extract(opts)
+   tar.Parse.apply(this)
+
+-  // have to dump into a directory
+-  opts.type = "Directory"
+-  opts.Directory = true
+-
+   if (typeof opts !== "object") {
+     opts = { path: opts }
+   }
+
+   // better to drop in cwd? seems more standard.
+   opts.path = opts.path || path.resolve("node-tar-extract")
++  // have to dump into a directory
+   opts.type = "Directory"
+   opts.Directory = true
+
+@@ -33,9 +30,19 @@
+   // of the tarball.  So, they need to be resolved against
+   // the target directory in order to be created properly.
+   me.on("entry", function (entry) {
+-    if (entry.type !== "Link") return
+-    entry.linkpath = entry.props.linkpath =
+-      path.join(opts.path, path.join("/", entry.props.linkpath))
++    if (entry.type === "Link") {
++      entry.linkpath = entry.props.linkpath = path.join(
++        opts.path, path.join("/", entry.props.linkpath)
++      )
++    }
++
++    if (entry.props && entry.props.linkpath) {
++      var linkpath = entry.props.linkpath
++      // normalize paths that point outside the extraction root
++      if (path.resolve(opts.path, linkpath).indexOf(opts.path) !== 0) {
++        entry.props.linkpath = path.join(opts.path, path.join("/", linkpath))
++      }
++    }
+   })
+
+   this._fst.on("ready", function () {

--- a/packages/snyk-protect/patches/tomato_20130307_0_0_9e427d524e04a905312a3294c85e939ed7d57b8c.patch
+++ b/packages/snyk-protect/patches/tomato_20130307_0_0_9e427d524e04a905312a3294c85e939ed7d57b8c.patch
@@ -1,0 +1,64 @@
+// Code derived from: https://github.com/leizongmin/tomato
+
+// https://github.com/leizongmin/tomato/blob/master/MIT-License
+/*
+Copyright (c) 2012 Lei Zongmin(雷宗民) <leizongmin@gmail.com>
+http://ucdok.com
+
+The MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/lib/api.js b/lib/api.js
+index ea0c86f..b56578e 100644
+--- a/lib/api.js
++++ b/lib/api.js
+@@ -69,17 +69,20 @@ var configureInit = function () {
+    * 顺序 headers > GET > POST > Cookie
+    */
+   app.use('/api', function (req, res, next) {
+-    var access_key = req.headers['access-key'] ||
+-                     (req.query && req.query.access_key) ||
+-                     (req.body && req.body.access_key) ||
+-                     (req.cookies && req.cookies.access_key);
+-    if (access_key && config.master.api.access_key.indexOf(access_key) !== -1) {
+-      logger.info({event: 'verify-success', access_key: access_key, url: req.url});
+-      req.access_key = access_key;
+-      next();
++    var access_key = req.headers['access-key'] || (req.query && req.query.access_key) ||
++                     (req.body && req.body.access_key) || (req.cookies && req.cookies.access_key);
++    if (Array.isArray(config.master.api.access_key)) {
++      if (access_key && config.master.api.access_key.indexOf(access_key) !== -1) {
++        logger.info({event: 'verify-success', access_key: access_key, url: req.url});
++        req.access_key = access_key;
++        next();
++      } else {
++        logger.warn({event: 'verify-fail', access_key: access_key, url: req.url});
++        res.json({error: 'Permission denied.', access_key: access_key});
++      }
+     } else {
+-      logger.warn({event: 'verify-fail', access_key: access_key, url: req.url});
+-      res.json({error: 'Permission denied.', access_key: access_key});
++      logger.warn({event: 'verify-fail', message: 'Config error: master.api.access_key must be an Array!'});
++      res.json({error: 'Config error: master.api.access_key must be an Array!'});
+     }
+   });
+

--- a/packages/snyk-protect/patches/tough-cookie_20160722_0_0_e4fc2e0f9ee1b7a818d68f0ac7ea696f377b1534.patch
+++ b/packages/snyk-protect/patches/tough-cookie_20160722_0_0_e4fc2e0f9ee1b7a818d68f0ac7ea696f377b1534.patch
@@ -1,0 +1,85 @@
+// Code derived from https://github.com/SalesforceEng/tough-cookie
+// Reference: https://github.com/SalesforceEng/tough-cookie/commit/e4fc2e0f9ee1b7a818d68f0ac7ea696f377b1534
+
+// https://github.com/SalesforceEng/tough-cookie/blob/master/LICENSE
+/*
+Copyright (c) 2015, Salesforce.com, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===
+
+The following exceptions apply:
+
+===
+
+`public_suffix_list.dat` was obtained from
+<https://publicsuffix.org/list/public_suffix_list.dat> via
+<http://publicsuffix.org>. The license for this file is MPL/2.0.  The header of
+that file reads as follows:
+
+  // This Source Code Form is subject to the terms of the Mozilla Public
+  // License, v. 2.0. If a copy of the MPL was not distributed with this
+  // file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+diff --git a/lib/cookie.js b/lib/cookie.js
+index 12da297..c3dacfe 100644
+--- a/lib/cookie.js
++++ b/lib/cookie.js
+@@ -68,9 +68,6 @@ var LOOSE_COOKIE_PAIR = /^((?:=)?([^=;]*)\s*=\s*)?([^\n\r\0]*)/;
+ // Note ';' is \x3B
+ var PATH_VALUE = /[\x20-\x3A\x3C-\x7E]+/;
+ 
+-// Used for checking whether or not there is a trailing semi-colon
+-var TRAILING_SEMICOLON = /;+$/;
+-
+ var DAY_OF_MONTH = /^(\d{1,2})[^\d]*$/;
+ var TIME = /^(\d{1,2})[^\d]*:(\d{1,2})[^\d]*:(\d{1,2})[^\d]*$/;
+ var MONTH = /^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)/i;
+@@ -327,12 +324,6 @@ function parse(str, options) {
+   }
+   str = str.trim();
+ 
+-  // S4.1.1 Trailing semi-colons are not part of the specification.
+-  var semiColonCheck = TRAILING_SEMICOLON.exec(str);
+-  if (semiColonCheck) {
+-    str = str.slice(0, semiColonCheck.index);
+-  }
+-
+   // We use a regex to parse the "name-value-pair" part of S5.2
+   var firstSemi = str.indexOf(';'); // S5.2 step 1
+   var pairRe = options.loose ? LOOSE_COOKIE_PAIR : COOKIE_PAIR;
+@@ -362,7 +353,7 @@ function parse(str, options) {
+   // S5.2.3 "unparsed-attributes consist of the remainder of the set-cookie-string
+   // (including the %x3B (";") in question)." plus later on in the same section
+   // "discard the first ";" and trim".
+-  var unparsed = str.slice(firstSemi).replace(/^\s*;\s*/,'').trim();
++  var unparsed = str.slice(firstSemi + 1).trim();
+ 
+   // "If the unparsed-attributes string is empty, skip the rest of these
+   // steps."
+@@ -378,9 +369,12 @@ function parse(str, options) {
+    * cookie-attribute-list".  Therefore, in this implementation, we overwrite
+    * the previous value.
+    */
+-  var cookie_avs = unparsed.split(/\s*;\s*/);
++  var cookie_avs = unparsed.split(';');
+   while (cookie_avs.length) {
+-    var av = cookie_avs.shift();
++    var av = cookie_avs.shift().trim();
++    if (av.length === 0) { // happens if ";;" appears
++      continue;
++    }
+     var av_sep = av.indexOf('=');
+     var av_key, av_value;
+ 

--- a/packages/snyk-protect/patches/tree-kill_0_0_20191210_e5d66d1fbd4b392294512d4644ac22bdc888573c.patch
+++ b/packages/snyk-protect/patches/tree-kill_0_0_20191210_e5d66d1fbd4b392294512d4644ac22bdc888573c.patch
@@ -1,0 +1,38 @@
+# Based off https://github.com/pkrumins/node-tree-kill/pull/31
+# MIT License
+
+# Copyright (c) 2018 Peter Krumins
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+diff --git a/index.js b/index.js
+index 125afdc..8348b4b 100755
+--- a/index.js
++++ b/index.js
+@@ -5,6 +5,10 @@ var spawn = childProcess.spawn;
+ var exec = childProcess.exec;
+ 
+ module.exports = function (pid, signal, callback) {
++    if (typeof pid !== "number") {
++        throw new Error("pid must be a number");
++    }
++
+     var tree = {};
+     var pidsToProcess = {};
+     tree[pid] = [];

--- a/packages/snyk-protect/patches/tunnel-agent_20170305_0_0_9ca95ec7219daface8a6fc2674000653de0922c0.patch
+++ b/packages/snyk-protect/patches/tunnel-agent_20170305_0_0_9ca95ec7219daface8a6fc2674000653de0922c0.patch
@@ -1,0 +1,76 @@
+// Code derived from https://github.com/request/tunnel-agent/
+// Reference: https://github.com/request/tunnel-agent/commit/9ca95ec7219daface8a6fc2674000653de0922c0.patch
+
+// https://github.com/request/tunnel-agent/blob/master/LICENSE
+/*
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+*/
+---
+
+diff --git a/index.js b/index.js
+index cb63452..3ee9abc 100644
+--- a/index.js
++++ b/index.js
+@@ -128,7 +128,7 @@ TunnelingAgent.prototype.createSocket = function createSocket(options, cb) {
+   if (connectOptions.proxyAuth) {
+     connectOptions.headers = connectOptions.headers || {}
+     connectOptions.headers['Proxy-Authorization'] = 'Basic ' +
+-        new Buffer(connectOptions.proxyAuth).toString('base64')
++        Buffer.from(connectOptions.proxyAuth).toString('base64')
+   }
+ 
+   debug('making CONNECT request')

--- a/packages/snyk-protect/patches/uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch
+++ b/packages/snyk-protect/patches/uglify-js_20150824_0_0_905b6011784ca60d41919ac1a499962b7c1d4b02_snyk.patch
@@ -1,0 +1,49 @@
+// Code derived from: https://github.com/mishoo/UglifyJS2.git
+// Reference: https://github.com/mishoo/UglifyJS2/commit/905b6011784ca60d41919ac1a499962b7c1d4b02
+
+// https://github.com/mishoo/UglifyJS2/blob/master/LICENSE
+/*
+UglifyJS is released under the BSD license:
+
+Copyright 2012-2013 (c) Mihai Bazon <mihai.bazon@gmail.com>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the following
+      disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials
+      provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER “AS IS” AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+*/
+
+diff --git a/lib/compress.js b/lib/compress.js
+index 54873f0..4c4cf97 100644
+--- a/lib/compress.js
++++ b/lib/compress.js
+@@ -2183,7 +2183,7 @@ merge(Compressor.prototype, {
+             }
+             break;
+         }
+-        if (compressor.option("comparisons")) {
++        if (compressor.option("comparisons") && self.is_boolean()) {
+             if (!(compressor.parent() instanceof AST_Binary)
+                 || compressor.parent() instanceof AST_Assign) {
+                 var negated = make_node(AST_UnaryPrefix, self, {

--- a/packages/snyk-protect/patches/uglify-js_20151024_0_0_63d35f8_snyk.patch
+++ b/packages/snyk-protect/patches/uglify-js_20151024_0_0_63d35f8_snyk.patch
@@ -1,0 +1,57 @@
+// Code derived from: https://github.com/mishoo/UglifyJS2.git
+// Reference: https://github.com/mishoo/UglifyJS2/commit/905b6011784ca60d41919ac1a499962b7c1d4b02
+
+// https://github.com/mishoo/UglifyJS2/blob/master/LICENSE
+/*
+UglifyJS is released under the BSD license:
+
+Copyright 2012-2013 (c) Mihai Bazon <mihai.bazon@gmail.com>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the following
+      disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials
+      provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER “AS IS” AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+*/
+
+diff --git a/lib/parse.js b/lib/parse.js
+index 1ab0358..4c548a2 100644
+--- a/lib/parse.js
++++ b/lib/parse.js
+@@ -59,7 +59,6 @@ var OPERATOR_CHARS = makePredicate(characters("+-*&%=<>!?|~^"));
+
+ var RE_HEX_NUMBER = /^0x[0-9a-f]+$/i;
+ var RE_OCT_NUMBER = /^0[0-7]+$/;
+-var RE_DEC_NUMBER = /^\d*\.?\d*(?:e[+-]?\d*(?:\d\.?|\.?\d)\d*)?$/i;
+
+ var OPERATORS = makePredicate([
+     "in",
+@@ -182,7 +181,7 @@ function parse_js_number(num) {
+         return parseInt(num.substr(2), 16);
+     } else if (RE_OCT_NUMBER.test(num)) {
+         return parseInt(num.substr(1), 8);
+-    } else if (RE_DEC_NUMBER.test(num)) {
++    } else {
+         return parseFloat(num);
+     }
+ };

--- a/packages/snyk-protect/patches/uglify-js_20151024_0_0_63d35f8_snyk_inc.patch
+++ b/packages/snyk-protect/patches/uglify-js_20151024_0_0_63d35f8_snyk_inc.patch
@@ -1,0 +1,70 @@
+// Code derived from: https://github.com/mishoo/UglifyJS2.git
+// Reference: https://github.com/mishoo/UglifyJS2/commit/905b6011784ca60d41919ac1a499962b7c1d4b02
+
+// https://github.com/mishoo/UglifyJS2/blob/master/LICENSE
+/*
+UglifyJS is released under the BSD license:
+
+Copyright 2012-2013 (c) Mihai Bazon <mihai.bazon@gmail.com>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the following
+      disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials
+      provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER “AS IS” AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+*/
+
+diff --git a/lib/compress.js b/lib/compress.js
+index 54873f0..4c4cf97 100644
+--- a/lib/compress.js
++++ b/lib/compress.js
+@@ -2183,7 +2183,7 @@ merge(Compressor.prototype, {
+             }
+             break;
+         }
+-        if (compressor.option("comparisons")) {
++        if (compressor.option("comparisons") && self.is_boolean()) {
+             if (!(compressor.parent() instanceof AST_Binary)
+                 || compressor.parent() instanceof AST_Assign) {
+                 var negated = make_node(AST_UnaryPrefix, self, {
+diff --git a/lib/parse.js b/lib/parse.js
+index 1ab0358..4c548a2 100644
+--- a/lib/parse.js
++++ b/lib/parse.js
+@@ -59,7 +59,6 @@ var OPERATOR_CHARS = makePredicate(characters("+-*&%=<>!?|~^"));
+
+ var RE_HEX_NUMBER = /^0x[0-9a-f]+$/i;
+ var RE_OCT_NUMBER = /^0[0-7]+$/;
+-var RE_DEC_NUMBER = /^\d*\.?\d*(?:e[+-]?\d*(?:\d\.?|\.?\d)\d*)?$/i;
+
+ var OPERATORS = makePredicate([
+     "in",
+@@ -182,7 +181,7 @@ function parse_js_number(num) {
+         return parseInt(num.substr(2), 16);
+     } else if (RE_OCT_NUMBER.test(num)) {
+         return parseInt(num.substr(1), 8);
+-    } else if (RE_DEC_NUMBER.test(num)) {
++    } else {
+         return parseFloat(num);
+     }
+ };

--- a/packages/snyk-protect/patches/v0.3.15.patch
+++ b/packages/snyk-protect/patches/v0.3.15.patch
@@ -1,0 +1,42 @@
+// code derived from https://github.com/keystonejs/keystone/
+
+// https://github.com/keystonejs/keystone/blob/master/LICENSE
+/*
+(The MIT License)
+
+Copyright (c) 2016 Jed Watson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff -Naur -r v0.3.15/node_modules/keystone/lib/session.js v0.3.16/node_modules/keystone/lib/session.js
+--- a/lib/session.js	2015-08-18 08:09:25.000000000 +0300
++++ b/lib/session.js	2015-12-04 04:14:53.000000000 +0200
+@@ -84,6 +84,10 @@
+ 	}
+ 	var User = keystone.list(keystone.get('user model'));
+ 	if ('string' === typeof lookup.email && 'string' === typeof lookup.password) {
++		// ensure that it is an email, we don't want people being able to sign in by just using "\." and a haphazardly correct password.
++		if (!utils.isEmail(lookup.email)) {
++			return onFail(new Error('Incorrect email or password'));
++		}
+ 		// create regex for email lookup with special characters escaped
+ 		var emailRegExp = new RegExp('^' + utils.escapeRegExp(lookup.email) + '$', 'i');
+ 		// match email address and password

--- a/packages/snyk-protect/patches/validator_20130705-1_0_0_2d5d6999541add350fb396ef02dc42ca3215049e_snyk.patch
+++ b/packages/snyk-protect/patches/validator_20130705-1_0_0_2d5d6999541add350fb396ef02dc42ca3215049e_snyk.patch
@@ -1,0 +1,524 @@
+// Code derived from https://github.com/chriso/validator.js
+
+// https://github.com/chriso/validator.js/blob/master/LICENSE
+/*
+Copyright (c) 2016 Chris O'Hara <cohara87@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/lib/filter.js b/lib/filter.js
+index f828c33..c739d84 100755
+--- a/lib/filter.js
++++ b/lib/filter.js
+@@ -1,5 +1,4 @@
+ var entities = require('./entities');
+-var xss = require('./xss');
+ 
+ var Filter = exports.Filter = function() {}
+ 
+@@ -28,11 +27,6 @@ Filter.prototype.convert = Filter.prototype.sanitize = function(str) {
+     return this;
+ }
+ 
+-Filter.prototype.xss = function(is_image) {
+-    this.modify(xss.clean(this.str, is_image));
+-    return this.wrap(this.str);
+-}
+-
+ Filter.prototype.entityDecode = function() {
+     this.modify(entities.decode(this.str));
+     return this.wrap(this.str);
+diff --git a/lib/xss.js b/lib/xss.js
+deleted file mode 100755
+index 4a2ed9e..0000000
+--- a/lib/xss.js
++++ /dev/null
+@@ -1,228 +0,0 @@
+-//This module is adapted from the CodeIgniter framework
+-//The license is available at http://codeigniter.com/
+-
+-var html_entity_decode = require('./entities').decode;
+-
+-var never_allowed_str = {
+-    'document.cookie':              '[removed]',
+-    'document.write':               '[removed]',
+-    '.parentNode':                  '[removed]',
+-    '.innerHTML':                   '[removed]',
+-    'window.location':              '[removed]',
+-    '-moz-binding':                 '[removed]',
+-    '<!--':                         '&lt;!--',
+-    '-->':                          '--&gt;',
+-    '(<!\\[CDATA\\[)':              '&lt;![CDATA[',
+-    '<comment>':                    '&lt;comment&gt;'
+-};
+-
+-var never_allowed_regex = {
+-    'javascript\\s*:':                                       '[removed]',
+-    'expression\\s*(\\(|&#40;)':                             '[removed]',
+-    'vbscript\\s*:':                                         '[removed]',
+-    'Redirect\\s+302':                                       '[removed]',
+-    "([\"'])?data\\s*:[^\\1]*?base64[^\\1]*?,[^\\1]*?\\1?":  '[removed]'
+-};
+-
+-var non_displayables = [
+-    /%0[0-8bcef]/g,           // url encoded 00-08, 11, 12, 14, 15
+-    /%1[0-9a-f]/g,            // url encoded 16-31
+-    /[\x00-\x08]/g,           // 00-08
+-    /\x0b/g, /\x0c/g,         // 11,12
+-    /[\x0e-\x1f]/g            // 14-31
+-];
+-
+-var compact_words = [
+-    'javascript', 'expression', 'vbscript',
+-    'script', 'base64', 'applet', 'alert',
+-    'document', 'write', 'cookie', 'window'
+-];
+-
+-exports.clean = function(str, is_image) {
+-
+-    //Remove invisible characters
+-    str = remove_invisible_characters(str);
+-
+-    //Protect query string variables in URLs => 901119URL5918AMP18930PROTECT8198
+-    var hash;
+-    do {
+-      // ensure str does not contain hash before inserting it
+-      hash = xss_hash();
+-    } while(str.indexOf(hash) >= 0)
+-    str = str.replace(/\&([a-z\_0-9\-]+)\=([a-z\_0-9\-]+)/ig, hash + '$1=$2');
+-
+-    //Validate standard character entities. Add a semicolon if missing.  We do this to enable
+-    //the conversion of entities to ASCII later.
+-    str = str.replace(/(&#?[0-9a-z]{2,})([\x00-\x20])*;?/ig, '$1;$2');
+-
+-    //Validate UTF16 two byte encoding (x00) - just as above, adds a semicolon if missing.
+-    str = str.replace(/(&#x?)([0-9A-F]+);?/ig, '$1$2;');
+-
+-    //Un-protect query string variables
+-    str = str.replace(new RegExp(hash, 'g'), '&');
+-
+-    //Decode just in case stuff like this is submitted:
+-    //<a href="http://%77%77%77%2E%67%6F%6F%67%6C%65%2E%63%6F%6D">Google</a>
+-    try{  
+-      str = decodeURIComponent(str);
+-    }
+-    catch(error){
+-      // str was not actually URI-encoded
+-    }
+-
+-    //Convert character entities to ASCII - this permits our tests below to work reliably.
+-    //We only convert entities that are within tags since these are the ones that will pose security problems.
+-    str = str.replace(/[a-z]+=([\'\"]).*?\1/gi, function(m, match) {
+-        return m.replace(match, convert_attribute(match));
+-    });
+-    str = str.replace(/<\w+.*/gi, function(m) {
+-        return m.replace(m, html_entity_decode(m));
+-    });
+-
+-    //Remove invisible characters again
+-    str = remove_invisible_characters(str);
+-
+-    //Convert tabs to spaces
+-    str = str.replace('\t', ' ');
+-
+-    //Captured the converted string for later comparison
+-    var converted_string = str;
+-
+-    //Remove strings that are never allowed
+-    for (var i in never_allowed_str) {
+-        str = str.replace(new RegExp(i, "gi"), never_allowed_str[i]);
+-    }
+-
+-    //Remove regex patterns that are never allowed
+-    for (var i in never_allowed_regex) {
+-        str = str.replace(new RegExp(i, 'gi'), never_allowed_regex[i]);
+-    }
+-
+-    //Compact any exploded words like:  j a v a s c r i p t
+-    // We only want to do this when it is followed by a non-word character
+-    for (var i = 0, l = compact_words.length; i < l; i++) {
+-        var spacified = compact_words[i].split('').join('\\s*')+'\\s*';
+-
+-        str = str.replace(new RegExp('('+spacified+')(\\W)', 'ig'), function(m, compat, after) {
+-            return compat.replace(/\s+/g, '') + after;
+-        });
+-    }
+-
+-    //Remove disallowed Javascript in links or img tags
+-    do {
+-        var original = str;
+-
+-        if (str.match(/<a/i)) {
+-            str = str.replace(/<a\s+([^>]*?)(>|$)/gi, function(m, attributes, end_tag) {
+-                var filtered_attributes = filter_attributes(attributes.replace('<','').replace('>',''));
+-                filtered_attributes = filtered_attributes.replace(/href=.*?(?:alert\(|alert&#40;|javascript:|livescript:|mocha:|charset=|window\.|document\.|\.cookie|<script|<xss|data\s*:)/gi, '');
+-                return m.replace(attributes, filtered_attributes);
+-            });
+-        }
+-
+-        if (str.match(/<img/i)) {
+-            str = str.replace(/<img\s+([^>]*?)(\s?\/?>|$)/gi, function(m, attributes, end_tag) {
+-                var filtered_attributes = filter_attributes(attributes.replace('<','').replace('>',''));
+-                filtered_attributes = filtered_attributes.replace(/src=.*?(?:alert\(|alert&#40;|javascript:|livescript:|mocha:|charset=|window\.|document\.|\.cookie|<script|<xss|base64\s*,)/gi, '');
+-                return m.replace(attributes, filtered_attributes);
+-            });
+-        }
+-
+-        if (str.match(/script/i) || str.match(/xss/i)) {
+-            str = str.replace(/<(\/*)(script|xss)(.*?)\>/gi, '[removed]');
+-        }
+-
+-    } while(original !== str);
+-
+-    // Remove Evil HTML Attributes (like event handlers and style)
+-    var event_handlers = ['\\bon\\w*', '\\bstyle', '\\bformaction'];
+-
+-    //Adobe Photoshop puts XML metadata into JFIF images, including namespacing,
+-    //so we have to allow this for images
+-    if (!is_image) {
+-        event_handlers.push('xmlns');
+-    }
+-
+-    do {
+-        var attribs = [];
+-        var count = 0;
+-
+-        attribs = attribs.concat(str.match(new RegExp("("+event_handlers.join('|')+")\\s*=\\s*(\\x22|\\x27)([^\\2]*?)(\\2)", 'ig')));
+-        attribs = attribs.concat(str.match(new RegExp("("+event_handlers.join('|')+")\\s*=\\s*([^\\s>]*)", 'ig')));
+-        attribs = attribs.filter(function(element) { return element !== null; });
+-
+-        if (attribs.length > 0) {
+-            for (var i = 0; i < attribs.length; ++i) {
+-                attribs[i] = attribs[i].replace(new RegExp('[.\\\\+*?\\[\\^\\]$(){}=!<>|:\\-]', 'g'), '\\$&')
+-            }
+-
+-            str = str.replace(new RegExp("(<?)(\/?[^><]+?)([^A-Za-z<>\\-])(.*?)("+attribs.join('|')+")(.*?)([\\s><]?)([><]*)", 'i'), function(m, a, b, c, d, e, f, g, h) {
+-                ++count;
+-                return a + b + ' ' + d + f + g + h;
+-            });
+-        }
+-    } while (count > 0);
+-
+-    //Sanitize naughty HTML elements
+-    //If a tag containing any of the words in the list
+-    //below is found, the tag gets converted to entities.
+-    //So this: <blink>
+-    //Becomes: &lt;blink&gt;
+-    var naughty = 'alert|applet|audio|basefont|base|behavior|bgsound|blink|body|embed|expression|form|frameset|frame|head|html|ilayer|iframe|input|isindex|layer|link|meta|object|plaintext|style|script|textarea|title|video|xml|xss';
+-    str = str.replace(new RegExp('<(/*\\s*)('+naughty+')([^><]*)([><]*)', 'gi'), function(m, a, b, c, d) {
+-        return '&lt;' + a + b + c + d.replace('>','&gt;').replace('<','&lt;');
+-    });
+-
+-    //Sanitize naughty scripting elements Similar to above, only instead of looking for
+-    //tags it looks for PHP and JavaScript commands that are disallowed.  Rather than removing the
+-    //code, it simply converts the parenthesis to entities rendering the code un-executable.
+-    //For example:    eval('some code')
+-    //Becomes:        eval&#40;'some code'&#41;
+-    str = str.replace(/(alert|cmd|passthru|eval|exec|expression|system|fopen|fsockopen|file|file_get_contents|readfile|unlink)(\s*)\((.*?)\)/gi, '$1$2&#40;$3&#41;');
+-
+-    //This adds a bit of extra precaution in case something got through the above filters
+-    for (var i in never_allowed_str) {
+-        str = str.replace(new RegExp(i, "gi"), never_allowed_str[i]);
+-    }
+-    for (var i in never_allowed_regex) {
+-        str = str.replace(new RegExp(i, 'gi'), never_allowed_regex[i]);
+-    }
+-
+-    //Images are handled in a special way
+-    if (is_image && str !== converted_string) {
+-        throw new Error('Image may contain XSS');
+-    }
+-
+-    return str;
+-}
+-
+-function remove_invisible_characters(str) {
+-    for (var i = 0, l = non_displayables.length; i < l; i++) {
+-        str = str.replace(non_displayables[i], '');
+-    }
+-    return str;
+-}
+-
+-function xss_hash() {
+-    var str = '', num = 10;
+-    while (num--) str += String.fromCharCode(Math.random() * 25 | 97);
+-    return str;
+-}
+-
+-function convert_attribute(str) {
+-    return str.replace('>','&gt;').replace('<','&lt;').replace('\\','\\\\');
+-}
+-
+-function filter_attributes(str) {
+-    var result = "";
+-
+-    var match = str.match(/\s*[a-z-]+\s*=\s*(\x22|\x27)([^\1]*?)\1/ig);
+-    if (match) {
+-        for (var i = 0; i < match.length; ++i) {
+-            result += match[i].replace(/\*.*?\*/g, '');
+-        }
+-    }
+-
+-    return result;
+-}
+-
+diff --git a/validator-min.js b/validator-min.js
+index 9b39281..5cf9bef 100644
+--- a/validator-min.js
++++ b/validator-min.js
+@@ -20,4 +20,4 @@
+  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  */
+-(function(root,factory){if(typeof define === 'function' && define.amd){define(['exports'],factory);}else if(typeof exports === 'object'){factory(exports);}else{factory(root);}}(this,function(t){var r={"&nbsp;":" ","&iexcl;":"¡","&cent;":"¢","&pound;":"£","&curren;":"€","&yen;":"¥","&brvbar;":"Š","&sect;":"§","&uml;":"š","&copy;":"©","&ordf;":"ª","&laquo;":"«","&not;":"¬","&shy;":"­","&reg;":"®","&macr;":"¯","&deg;":"°","&plusmn;":"±","&sup2;":"²","&sup3;":"³","&acute;":"Ž","&micro;":"µ","&para;":"¶","&middot;":"·","&cedil;":"ž","&sup1;":"¹","&ordm;":"º","&raquo;":"»","&frac14;":"Œ","&frac12;":"œ","&frac34;":"Ÿ","&iquest;":"¿","&Agrave;":"À","&Aacute;":"Á","&Acirc;":"Â","&Atilde;":"Ã","&Auml;":"Ä","&Aring;":"Å","&AElig;":"Æ","&Ccedil;":"Ç","&Egrave;":"È","&Eacute;":"É","&Ecirc;":"Ê","&Euml;":"Ë","&Igrave;":"Ì","&Iacute;":"Í","&Icirc;":"Î","&Iuml;":"Ï","&ETH;":"Ð","&Ntilde;":"Ñ","&Ograve;":"Ò","&Oacute;":"Ó","&Ocirc;":"Ô","&Otilde;":"Õ","&Ouml;":"Ö","&times;":"×","&Oslash;":"Ø","&Ugrave;":"Ù","&Uacute;":"Ú","&Ucirc;":"Û","&Uuml;":"Ü","&Yacute;":"Ý","&THORN;":"Þ","&szlig;":"ß","&agrave;":"à","&aacute;":"á","&acirc;":"â","&atilde;":"ã","&auml;":"ä","&aring;":"å","&aelig;":"æ","&ccedil;":"ç","&egrave;":"è","&eacute;":"é","&ecirc;":"ê","&euml;":"ë","&igrave;":"ì","&iacute;":"í","&icirc;":"î","&iuml;":"ï","&eth;":"ð","&ntilde;":"ñ","&ograve;":"ò","&oacute;":"ó","&ocirc;":"ô","&otilde;":"õ","&ouml;":"ö","&divide;":"÷","&oslash;":"ø","&ugrave;":"ù","&uacute;":"ú","&ucirc;":"û","&uuml;":"ü","&yacute;":"ý","&thorn;":"þ","&yuml;":"ÿ","&quot;":'"',"&lt;":"<","&gt;":">","&apos;":"'","&minus;":"−","&circ;":"ˆ","&tilde;":"˜","&Scaron;":"Š","&lsaquo;":"‹","&OElig;":"Œ","&lsquo;":"‘","&rsquo;":"’","&ldquo;":"“","&rdquo;":"”","&bull;":"•","&ndash;":"–","&mdash;":"—","&trade;":"™","&scaron;":"š","&rsaquo;":"›","&oelig;":"œ","&Yuml;":"Ÿ","&fnof;":"ƒ","&Alpha;":"Α","&Beta;":"Β","&Gamma;":"Γ","&Delta;":"Δ","&Epsilon;":"Ε","&Zeta;":"Ζ","&Eta;":"Η","&Theta;":"Θ","&Iota;":"Ι","&Kappa;":"Κ","&Lambda;":"Λ","&Mu;":"Μ","&Nu;":"Ν","&Xi;":"Ξ","&Omicron;":"Ο","&Pi;":"Π","&Rho;":"Ρ","&Sigma;":"Σ","&Tau;":"Τ","&Upsilon;":"Υ","&Phi;":"Φ","&Chi;":"Χ","&Psi;":"Ψ","&Omega;":"Ω","&alpha;":"α","&beta;":"β","&gamma;":"γ","&delta;":"δ","&epsilon;":"ε","&zeta;":"ζ","&eta;":"η","&theta;":"θ","&iota;":"ι","&kappa;":"κ","&lambda;":"λ","&mu;":"μ","&nu;":"ν","&xi;":"ξ","&omicron;":"ο","&pi;":"π","&rho;":"ρ","&sigmaf;":"ς","&sigma;":"σ","&tau;":"τ","&upsilon;":"υ","&phi;":"φ","&chi;":"χ","&psi;":"ψ","&omega;":"ω","&thetasym;":"ϑ","&upsih;":"ϒ","&piv;":"ϖ","&ensp;":" ","&emsp;":" ","&thinsp;":" ","&zwnj;":"‌","&zwj;":"‍","&lrm;":"‎","&rlm;":"‏","&sbquo;":"‚","&bdquo;":"„","&dagger;":"†","&Dagger;":"‡","&hellip;":"…","&permil;":"‰","&prime;":"′","&Prime;":"″","&oline;":"‾","&frasl;":"⁄","&euro;":"€","&image;":"ℑ","&weierp;":"℘","&real;":"ℜ","&alefsym;":"ℵ","&larr;":"←","&uarr;":"↑","&rarr;":"→","&darr;":"↓","&harr;":"↔","&crarr;":"↵","&lArr;":"⇐","&uArr;":"⇑","&rArr;":"⇒","&dArr;":"⇓","&hArr;":"⇔","&forall;":"∀","&part;":"∂","&exist;":"∃","&empty;":"∅","&nabla;":"∇","&isin;":"∈","&notin;":"∉","&ni;":"∋","&prod;":"∏","&sum;":"∑","&lowast;":"∗","&radic;":"√","&prop;":"∝","&infin;":"∞","&ang;":"∠","&and;":"∧","&or;":"∨","&cap;":"∩","&cup;":"∪","&int;":"∫","&there4;":"∴","&sim;":"∼","&cong;":"≅","&asymp;":"≈","&ne;":"≠","&equiv;":"≡","&le;":"≤","&ge;":"≥","&sub;":"⊂","&sup;":"⊃","&nsub;":"⊄","&sube;":"⊆","&supe;":"⊇","&oplus;":"⊕","&otimes;":"⊗","&perp;":"⊥","&sdot;":"⋅","&lceil;":"⌈","&rceil;":"⌉","&lfloor;":"⌊","&rfloor;":"⌋","&lang;":"〈","&rang;":"〉","&loz;":"◊","&spades;":"♠","&clubs;":"♣","&hearts;":"♥","&diams;":"♦"};var e=function(t){if(!~t.indexOf("&"))return t;for(var e in r){t=t.replace(new RegExp(e,"g"),r[e])}t=t.replace(/&#x(0*[0-9a-f]{2,5});?/gi,function(t,r){return String.fromCharCode(parseInt(+r,16))});t=t.replace(/&#([0-9]{2,4});?/gi,function(t,r){return String.fromCharCode(+r)});t=t.replace(/&amp;/g,"&");return t};var i=function(t){t=t.replace(/&/g,"&amp;");t=t.replace(/'/g,"&#39;");for(var e in r){t=t.replace(new RegExp(r[e],"g"),e)}return t};t.entities={encode:i,decode:e};var s={"document.cookie":"","document.write":"",".parentNode":"",".innerHTML":"","window.location":"","-moz-binding":"","<!--":"&lt;!--","-->":"--&gt;","<![CDATA[":"&lt;![CDATA["};var n={"javascript\\s*:":"","expression\\s*(\\(|&\\#40;)":"","vbscript\\s*:":"","Redirect\\s+302":""};var a=[/%0[0-8bcef]/g,/%1[0-9a-f]/g,/[\x00-\x08]/g,/\x0b/g,/\x0c/g,/[\x0e-\x1f]/g];var o=["javascript","expression","vbscript","script","applet","alert","document","write","cookie","window"];t.xssClean=function(r,e){if(typeof r==="object"){for(var i in r){r[i]=t.xssClean(r[i])}return r}r=c(r);r=r.replace(/\&([a-z\_0-9]+)\=([a-z\_0-9]+)/i,u()+"$1=$2");r=r.replace(/(&\#?[0-9a-z]{2,})([\x00-\x20])*;?/i,"$1;$2");r=r.replace(/(&\#x?)([0-9A-F]+);?/i,"$1;$2");r=r.replace(u(),"&");try{r=decodeURIComponent(r)}catch(a){}r=r.replace(/[a-z]+=([\'\"]).*?\1/gi,function(t,r){return t.replace(r,p(r))});r=c(r);r=r.replace("	"," ");var l=r;for(var i in s){r=r.replace(i,s[i])}for(var i in n){r=r.replace(new RegExp(i,"i"),n[i])}for(var i in o){var f=o[i].split("").join("\\s*")+"\\s*";r=r.replace(new RegExp("("+f+")(\\W)","ig"),function(t,r,e){return r.replace(/\s+/g,"")+e})}do{var m=r;if(r.match(/<a/i)){r=r.replace(/<a\s+([^>]*?)(>|$)/gi,function(t,r,e){r=h(r.replace("<","").replace(">",""));return t.replace(r,r.replace(/href=.*?(alert\(|alert&\#40;|javascript\:|charset\=|window\.|document\.|\.cookie|<script|<xss|base64\s*,)/gi,""))})}if(r.match(/<img/i)){r=r.replace(/<img\s+([^>]*?)(\s?\/?>|$)/gi,function(t,r,e){r=h(r.replace("<","").replace(">",""));return t.replace(r,r.replace(/src=.*?(alert\(|alert&\#40;|javascript\:|charset\=|window\.|document\.|\.cookie|<script|<xss|base64\s*,)/gi,""))})}if(r.match(/script/i)||r.match(/xss/i)){r=r.replace(/<(\/*)(script|xss)(.*?)\>/gi,"")}}while(m!=r);event_handlers=["[^a-z_-]on\\w*"];if(!e){event_handlers.push("xmlns")}r=r.replace(new RegExp("<([^><]+?)("+event_handlers.join("|")+")(\\s*=\\s*[^><]*)([><]*)","i"),"<$1$4");naughty="alert|applet|audio|basefont|base|behavior|bgsound|blink|body|embed|expression|form|frameset|frame|head|html|ilayer|iframe|input|isindex|layer|link|meta|object|plaintext|style|script|textarea|title|video|xml|xss";r=r.replace(new RegExp("<(/*\\s*)("+naughty+")([^><]*)([><]*)","gi"),function(t,r,e,i,s){return"&lt;"+r+e+i+s.replace(">","&gt;").replace("<","&lt;")});r=r.replace(/(alert|cmd|passthru|eval|exec|expression|system|fopen|fsockopen|file|file_get_contents|readfile|unlink)(\s*)\((.*?)\)/gi,"$1$2&#40;$3&#41;");for(var i in s){r=r.replace(i,s[i])}for(var i in n){r=r.replace(new RegExp(i,"i"),n[i])}if(e&&r!==l){throw new Error("Image may contain XSS")}return r};function c(t){for(var r in a){t=t.replace(a[r],"")}return t}function u(){return"!*$^#(@*#&"}function p(t){return t.replace(">","&gt;").replace("<","&lt;").replace("\\","\\\\")}function h(t){var r=/\/\*.*?\*\//g;return t.replace(/\s*[a-z-]+\s*=\s*'[^']*'/gi,function(t){return t.replace(r,"")}).replace(/\s*[a-z-]+\s*=\s*"[^"]*"/gi,function(t){return t.replace(r,"")}).replace(/\s*[a-z-]+\s*=\s*[^\s]+/gi,function(t){return t.replace(r,"")})}var l=t.Validator=function(){};l.prototype.check=function(t,r){this.str=typeof t==="undefined"||t===null||isNaN(t)&&t.length===undefined?"":t+"";this.msg=r;this._errors=this._errors||[];return this};l.prototype.validate=l.prototype.check;l.prototype.assert=l.prototype.check;l.prototype.error=function(t){throw new Error(t)};function f(t){if(t instanceof Date){return t}var r=Date.parse(t);if(isNaN(r)){return null}return new Date(r)}l.prototype.isAfter=function(t){t=t||new Date;var r=f(this.str),e=f(t);if(!(r&&e&&r>=e)){return this.error(this.msg||"Invalid date")}return this};l.prototype.isBefore=function(t){t=t||new Date;var r=f(this.str),e=f(t);if(!(r&&e&&r<=e)){return this.error(this.msg||"Invalid date")}return this};l.prototype.isEmail=function(){if(!this.str.match(/^(?:[\w\!\#\$\%\&\'\*\+\-\/\=\?\^\`\{\|\}\~]+\.)*[\w\!\#\$\%\&\'\*\+\-\/\=\?\^\`\{\|\}\~]+@(?:(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9\-](?!\.)){0,61}[a-zA-Z0-9]?\.)+[a-zA-Z0-9](?:[a-zA-Z0-9\-](?!$)){0,61}[a-zA-Z0-9]?)|(?:\[(?:(?:[01]?\d{1,2}|2[0-4]\d|25[0-5])\.){3}(?:[01]?\d{1,2}|2[0-4]\d|25[0-5])\]))$/)){return this.error(this.msg||"Invalid email")}return this};l.prototype.isCreditCard=function(){this.str=this.str.replace(/[^0-9]+/g,"");if(!this.str.match(/^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11})$/)){return this.error(this.msg||"Invalid credit card")}var t=0;var r;var e;var i=false;for(var s=this.length-1;s>=0;s--){r=this.substring(s,s+1);e=parseInt(r,10);if(i){e*=2;if(e>=10){t+=e%10+1}else{t+=e}}else{t+=e}if(i){i=false}else{i=true}}if(t%10!==0){return this.error(this.msg||"Invalid credit card")}return this};l.prototype.isUrl=function(){if(!this.str.match(/^(?!mailto:)(?:(?:https?|ftp):\/\/)?(?:\S+(?::\S*)?@)?(?:(?:(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))|localhost)(?::\d{2,5})?(?:\/[^\s]*)?$/i)||this.str.length>2083){return this.error(this.msg||"Invalid URL")}return this};l.prototype.isIP=function(){if(!this.str.match(/^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/)){return this.error(this.msg||"Invalid IP")}return this};l.prototype.isAlpha=function(){if(!this.str.match(/^[a-zA-Z]+$/)){return this.error(this.msg||"Invalid characters")}return this};l.prototype.isAlphanumeric=function(){if(!this.str.match(/^[a-zA-Z0-9]+$/)){return this.error(this.msg||"Invalid characters")}return this};l.prototype.isNumeric=function(){if(!this.str.match(/^-?[0-9]+$/)){return this.error(this.msg||"Invalid number")}return this};l.prototype.isLowercase=function(){if(!this.str.match(/^[a-z0-9]+$/)){return this.error(this.msg||"Invalid characters")}return this};l.prototype.isUppercase=function(){if(!this.str.match(/^[A-Z0-9]+$/)){return this.error(this.msg||"Invalid characters")}return this};l.prototype.isInt=function(){if(!this.str.match(/^(?:-?(?:0|[1-9][0-9]*))$/)){return this.error(this.msg||"Invalid integer")}return this};l.prototype.isDecimal=function(){if(!this.str.match(/^(?:-?(?:0|[1-9][0-9]*))?(?:\.[0-9]*)?$/)){return this.error(this.msg||"Invalid decimal")}return this};l.prototype.isFloat=function(){return this.isDecimal()};l.prototype.notNull=function(){if(this.str===""){return this.error(this.msg||"Invalid characters")}return this};l.prototype.isNull=function(){if(this.str!==""){return this.error(this.msg||"Invalid characters")}return this};l.prototype.notEmpty=function(){if(this.str.match(/^[\s\t\r\n]*$/)){return this.error(this.msg||"String is whitespace")}return this};l.prototype.equals=function(t){if(this.str!=t){return this.error(this.msg||"Not equal")}return this};l.prototype.contains=function(t){if(this.str.indexOf(t)===-1){return this.error(this.msg||"Invalid characters")}return this};l.prototype.notContains=function(t){if(this.str.indexOf(t)>=0){return this.error(this.msg||"Invalid characters")}return this};l.prototype.regex=l.prototype.is=function(t,r){if(Object.prototype.toString.call(t).slice(8,-1)!=="RegExp"){t=new RegExp(t,r)}if(!this.str.match(t)){return this.error(this.msg||"Invalid characters")}return this};l.prototype.notRegex=l.prototype.not=function(t,r){if(Object.prototype.toString.call(t).slice(8,-1)!=="RegExp"){t=new RegExp(t,r)}if(this.str.match(t)){this.error(this.msg||"Invalid characters")}return this};l.prototype.len=function(t,r){if(this.str.length<t){return this.error(this.msg||"String is too small")}if(typeof r!==undefined&&this.str.length>r){return this.error(this.msg||"String is too large")}return this};l.prototype.isUUID=function(t){var r;if(t==3||t=="v3"){r=/[0-9A-F]{8}-[0-9A-F]{4}-3[0-9A-F]{3}-[0-9A-F]{4}-[0-9A-F]{12}$/i}else if(t==4||t=="v4"){r=/[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i}else{r=/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i}if(!this.str.match(r)){return this.error(this.msg||"Not a UUID")}return this};l.prototype.isDate=function(){var t=Date.parse(this.str);if(isNaN(t)){return this.error(this.msg||"Not a date")}return this};l.prototype.isIn=function(t){if(t&&typeof t.indexOf==="function"){if(!~t.indexOf(this.str)){return this.error(this.msg||"Unexpected value")}return this}else{return this.error(this.msg||"Invalid in() argument")}};l.prototype.notIn=function(t){if(t&&typeof t.indexOf==="function"){if(t.indexOf(this.str)!==-1){return this.error(this.msg||"Unexpected value")}return this}else{return this.error(this.msg||"Invalid notIn() argument")}};l.prototype.min=function(t){var r=parseFloat(this.str);if(!isNaN(r)&&r<t){return this.error(this.msg||"Invalid number")}return this};l.prototype.max=function(t){var r=parseFloat(this.str);if(!isNaN(r)&&r>t){return this.error(this.msg||"Invalid number")}return this};l.prototype.isArray=function(){if(!Array.isArray(this.str)){return this.error(this.msg||"Not an array")}return this};var m=t.Filter=function(){};var d="\\r\\n\\t\\s";m.prototype.modify=function(t){this.str=t};m.prototype.convert=m.prototype.sanitize=function(t){this.str=t==null?"":t+"";return this};m.prototype.xss=function(r){this.modify(t.xssClean(this.str,r));return this.str};m.prototype.entityDecode=function(){this.modify(e(this.str));return this.str};m.prototype.entityEncode=function(){this.modify(i(this.str));return this.str};m.prototype.escape=function(){this.modify(this.str.replace(/&/g,"&amp;").replace(/"/g,"&quot;").replace(/</g,"&lt;").replace(/>/g,"&gt;"));return this.str};m.prototype.ltrim=function(t){t=t||d;this.modify(this.str.replace(new RegExp("^["+t+"]+","g"),""));return this.str};m.prototype.rtrim=function(t){t=t||d;this.modify(this.str.replace(new RegExp("["+t+"]+$","g"),""));return this.str};m.prototype.trim=function(t){t=t||d;this.modify(this.str.replace(new RegExp("^["+t+"]+|["+t+"]+$","g"),""));return this.str};m.prototype.ifNull=function(t){if(!this.str||this.str===""){this.modify(t)}return this.str};m.prototype.toFloat=function(){this.modify(parseFloat(this.str));return this.str};m.prototype.toInt=function(t){t=t||10;this.modify(parseInt(this.str,t));return this.str};m.prototype.toBoolean=function(){if(!this.str||this.str=="0"||this.str=="false"||this.str==""){this.modify(false)}else{this.modify(true)}return this.str};m.prototype.toBooleanStrict=function(){if(this.str=="1"||this.str=="true"){this.modify(true)}else{this.modify(false)}return this.str};t.sanitize=t.convert=function(r){var e=new t.Filter;return e.sanitize(r)};t.check=t.validate=t.assert=function(r,e){var i=new t.Validator;return i.check(r,e)};return t;}));
++(function(e,t){typeof define=="function"&&define.amd?define(["exports"],t):typeof exports=="object"?t(exports):t(e)})(this,function(e){function s(e){if(/^(\d?\d?\d)\.(\d?\d?\d)\.(\d?\d?\d)\.(\d?\d?\d)$/.test(e)){var t=e.split(".").sort();return t[3]>255?!1:!0}return!1}function o(e){return/^::|^::1|^([a-fA-F0-9]{1,4}::?){1,7}([a-fA-F0-9]{1,4})$/.test(e)?!0:!1}function u(e){if(e instanceof Date)return e;var t=Date.parse(e);return isNaN(t)?null:new Date(t)}var t={"&nbsp;":"\u00a0","&iexcl;":"\u00a1","&cent;":"\u00a2","&pound;":"\u00a3","&curren;":"\u20ac","&yen;":"\u00a5","&brvbar;":"\u0160","&sect;":"\u00a7","&uml;":"\u0161","&copy;":"\u00a9","&ordf;":"\u00aa","&laquo;":"\u00ab","&not;":"\u00ac","&shy;":"\u00ad","&reg;":"\u00ae","&macr;":"\u00af","&deg;":"\u00b0","&plusmn;":"\u00b1","&sup2;":"\u00b2","&sup3;":"\u00b3","&acute;":"\u017d","&micro;":"\u00b5","&para;":"\u00b6","&middot;":"\u00b7","&cedil;":"\u017e","&sup1;":"\u00b9","&ordm;":"\u00ba","&raquo;":"\u00bb","&frac14;":"\u0152","&frac12;":"\u0153","&frac34;":"\u0178","&iquest;":"\u00bf","&Agrave;":"\u00c0","&Aacute;":"\u00c1","&Acirc;":"\u00c2","&Atilde;":"\u00c3","&Auml;":"\u00c4","&Aring;":"\u00c5","&AElig;":"\u00c6","&Ccedil;":"\u00c7","&Egrave;":"\u00c8","&Eacute;":"\u00c9","&Ecirc;":"\u00ca","&Euml;":"\u00cb","&Igrave;":"\u00cc","&Iacute;":"\u00cd","&Icirc;":"\u00ce","&Iuml;":"\u00cf","&ETH;":"\u00d0","&Ntilde;":"\u00d1","&Ograve;":"\u00d2","&Oacute;":"\u00d3","&Ocirc;":"\u00d4","&Otilde;":"\u00d5","&Ouml;":"\u00d6","&times;":"\u00d7","&Oslash;":"\u00d8","&Ugrave;":"\u00d9","&Uacute;":"\u00da","&Ucirc;":"\u00db","&Uuml;":"\u00dc","&Yacute;":"\u00dd","&THORN;":"\u00de","&szlig;":"\u00df","&agrave;":"\u00e0","&aacute;":"\u00e1","&acirc;":"\u00e2","&atilde;":"\u00e3","&auml;":"\u00e4","&aring;":"\u00e5","&aelig;":"\u00e6","&ccedil;":"\u00e7","&egrave;":"\u00e8","&eacute;":"\u00e9","&ecirc;":"\u00ea","&euml;":"\u00eb","&igrave;":"\u00ec","&iacute;":"\u00ed","&icirc;":"\u00ee","&iuml;":"\u00ef","&eth;":"\u00f0","&ntilde;":"\u00f1","&ograve;":"\u00f2","&oacute;":"\u00f3","&ocirc;":"\u00f4","&otilde;":"\u00f5","&ouml;":"\u00f6","&divide;":"\u00f7","&oslash;":"\u00f8","&ugrave;":"\u00f9","&uacute;":"\u00fa","&ucirc;":"\u00fb","&uuml;":"\u00fc","&yacute;":"\u00fd","&thorn;":"\u00fe","&yuml;":"\u00ff","&quot;":'"',"&lt;":"<","&gt;":">","&apos;":"'","&minus;":"\u2212","&circ;":"\u02c6","&tilde;":"\u02dc","&Scaron;":"\u0160","&lsaquo;":"\u2039","&OElig;":"\u0152","&lsquo;":"\u2018","&rsquo;":"\u2019","&ldquo;":"\u201c","&rdquo;":"\u201d","&bull;":"\u2022","&ndash;":"\u2013","&mdash;":"\u2014","&trade;":"\u2122","&scaron;":"\u0161","&rsaquo;":"\u203a","&oelig;":"\u0153","&Yuml;":"\u0178","&fnof;":"\u0192","&Alpha;":"\u0391","&Beta;":"\u0392","&Gamma;":"\u0393","&Delta;":"\u0394","&Epsilon;":"\u0395","&Zeta;":"\u0396","&Eta;":"\u0397","&Theta;":"\u0398","&Iota;":"\u0399","&Kappa;":"\u039a","&Lambda;":"\u039b","&Mu;":"\u039c","&Nu;":"\u039d","&Xi;":"\u039e","&Omicron;":"\u039f","&Pi;":"\u03a0","&Rho;":"\u03a1","&Sigma;":"\u03a3","&Tau;":"\u03a4","&Upsilon;":"\u03a5","&Phi;":"\u03a6","&Chi;":"\u03a7","&Psi;":"\u03a8","&Omega;":"\u03a9","&alpha;":"\u03b1","&beta;":"\u03b2","&gamma;":"\u03b3","&delta;":"\u03b4","&epsilon;":"\u03b5","&zeta;":"\u03b6","&eta;":"\u03b7","&theta;":"\u03b8","&iota;":"\u03b9","&kappa;":"\u03ba","&lambda;":"\u03bb","&mu;":"\u03bc","&nu;":"\u03bd","&xi;":"\u03be","&omicron;":"\u03bf","&pi;":"\u03c0","&rho;":"\u03c1","&sigmaf;":"\u03c2","&sigma;":"\u03c3","&tau;":"\u03c4","&upsilon;":"\u03c5","&phi;":"\u03c6","&chi;":"\u03c7","&psi;":"\u03c8","&omega;":"\u03c9","&thetasym;":"\u03d1","&upsih;":"\u03d2","&piv;":"\u03d6","&ensp;":"\u2002","&emsp;":"\u2003","&thinsp;":"\u2009","&zwnj;":"\u200c","&zwj;":"\u200d","&lrm;":"\u200e","&rlm;":"\u200f","&sbquo;":"\u201a","&bdquo;":"\u201e","&dagger;":"\u2020","&Dagger;":"\u2021","&hellip;":"\u2026","&permil;":"\u2030","&prime;":"\u2032","&Prime;":"\u2033","&oline;":"\u203e","&frasl;":"\u2044","&euro;":"\u20ac","&image;":"\u2111","&weierp;":"\u2118","&real;":"\u211c","&alefsym;":"\u2135","&larr;":"\u2190","&uarr;":"\u2191","&rarr;":"\u2192","&darr;":"\u2193","&harr;":"\u2194","&crarr;":"\u21b5","&lArr;":"\u21d0","&uArr;":"\u21d1","&rArr;":"\u21d2","&dArr;":"\u21d3","&hArr;":"\u21d4","&forall;":"\u2200","&part;":"\u2202","&exist;":"\u2203","&empty;":"\u2205","&nabla;":"\u2207","&isin;":"\u2208","&notin;":"\u2209","&ni;":"\u220b","&prod;":"\u220f","&sum;":"\u2211","&lowast;":"\u2217","&radic;":"\u221a","&prop;":"\u221d","&infin;":"\u221e","&ang;":"\u2220","&and;":"\u2227","&or;":"\u2228","&cap;":"\u2229","&cup;":"\u222a","&int;":"\u222b","&there4;":"\u2234","&sim;":"\u223c","&cong;":"\u2245","&asymp;":"\u2248","&ne;":"\u2260","&equiv;":"\u2261","&le;":"\u2264","&ge;":"\u2265","&sub;":"\u2282","&sup;":"\u2283","&nsub;":"\u2284","&sube;":"\u2286","&supe;":"\u2287","&oplus;":"\u2295","&otimes;":"\u2297","&perp;":"\u22a5","&sdot;":"\u22c5","&lceil;":"\u2308","&rceil;":"\u2309","&lfloor;":"\u230a","&rfloor;":"\u230b","&lang;":"\u2329","&rang;":"\u232a","&loz;":"\u25ca","&spades;":"\u2660","&clubs;":"\u2663","&hearts;":"\u2665","&diams;":"\u2666"},n=function(e){if(!~e.indexOf("&"))return e;for(var n in t)e=e.replace(new RegExp(n,"g"),t[n]);return e=e.replace(/&#x(0*[0-9a-f]{2,5});?/gi,function(e,t){return String.fromCharCode(parseInt(+t,16))}),e=e.replace(/&#([0-9]{2,4});?/gi,function(e,t){return String.fromCharCode(+t)}),e=e.replace(/&amp;/g,"&"),e},r=function(e){e=e.replace(/&/g,"&amp;"),e=e.replace(/'/g,"&#39;");for(var n in t)e=e.replace(new RegExp(t[n],"g"),n);return e};e.entities={encode:r,decode:n};var i=e.Validator=function(){};i.prototype.check=function(e,t){return this.str=typeof e=="undefined"||e===null||isNaN(e)&&e.length===undefined?"":e+"",this.msg=t,this._errors=this._errors||[],this},i.prototype.validate=i.prototype.check,i.prototype.assert=i.prototype.check,i.prototype.error=function(e){throw new Error(e)},i.prototype.isAfter=function(e){e=e||new Date;var t=u(this.str),n=u(e);return t&&n&&t>=n?this:this.error(this.msg||"Invalid date")},i.prototype.isBefore=function(e){e=e||new Date;var t=u(this.str),n=u(e);return t&&n&&t<=n?this:this.error(this.msg||"Invalid date")},i.prototype.isEmail=function(){return this.str.match(/^(?:[\w\!\#\$\%\&\'\*\+\-\/\=\?\^\`\{\|\}\~]+\.)*[\w\!\#\$\%\&\'\*\+\-\/\=\?\^\`\{\|\}\~]+@(?:(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9\-](?!\.)){0,61}[a-zA-Z0-9]?\.)+[a-zA-Z0-9](?:[a-zA-Z0-9\-](?!$)){0,61}[a-zA-Z0-9]?)|(?:\[(?:(?:[01]?\d{1,2}|2[0-4]\d|25[0-5])\.){3}(?:[01]?\d{1,2}|2[0-4]\d|25[0-5])\]))$/)?this:this.error(this.msg||"Invalid email")},i.prototype.isCreditCard=function(){this.str=this.str.replace(/[^0-9]+/g,"");if(!this.str.match(/^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11})$/))return this.error(this.msg||"Invalid credit card");var e=0,t,n,r=!1;for(var i=this.length-1;i>=0;i--)t=this.substring(i,i+1),n=parseInt(t,10),r?(n*=2,n>=10?e+=n%10+1:e+=n):e+=n,r?r=!1:r=!0;return e%10!==0?this.error(this.msg||"Invalid credit card"):this},i.prototype.isUrl=function(){return!this.str.match(/^(?!mailto:)(?:(?:https?|ftp):\/\/)?(?:\S+(?::\S*)?@)?(?:(?:(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))|localhost)(?::\d{2,5})?(?:\/[^\s]*)?$/i)||this.str.length>2083?this.error(this.msg||"Invalid URL"):this},i.prototype.isIPv4=function(){return s(this.str)?this:this.error(this.msg||"Invalid IP")},i.prototype.isIPv6=function(){return o(this.str)?this:this.error(this.msg||"Invalid IP")},i.prototype.isIP=function(){return s(this.str)||o(this.str)?this:this.error(this.msg||"Invalid IP")},i.prototype.isAlpha=function(){return this.str.match(/^[a-zA-Z]+$/)?this:this.error(this.msg||"Invalid characters")},i.prototype.isAlphanumeric=function(){return this.str.match(/^[a-zA-Z0-9]+$/)?this:this.error(this.msg||"Invalid characters")},i.prototype.isNumeric=function(){return this.str.match(/^-?[0-9]+$/)?this:this.error(this.msg||"Invalid number")},i.prototype.isHexadecimal=function(){return this.str.match(/^[0-9a-fA-F]+$/)?this:this.error(this.msg||"Invalid hexadecimal")},i.prototype.isHexColor=function(){return this.str.match(/^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/)?this:this.error(this.msg||"Invalid hexcolor")},i.prototype.isLowercase=function(){return this.str!==this.str.toLowerCase()?this.error(this.msg||"Invalid characters"):this},i.prototype.isUppercase=function(){return this.str!==this.str.toUpperCase()?this.error(this.msg||"Invalid characters"):this},i.prototype.isInt=function(){return this.str.match(/^(?:-?(?:0|[1-9][0-9]*))$/)?this:this.error(this.msg||"Invalid integer")},i.prototype.isDecimal=function(){return this.str.match(/^(?:-?(?:0|[1-9][0-9]*))?(?:\.[0-9]*)?$/)?this:this.error(this.msg||"Invalid decimal")},i.prototype.isDivisibleBy=function(e){return parseFloat(this.str)%parseInt(e,10)===0},i.prototype.isFloat=function(){return this.isDecimal()},i.prototype.notNull=function(){return this.str===""?this.error(this.msg||"String is empty"):this},i.prototype.isNull=function(){return this.str!==""?this.error(this.msg||"String is not empty"):this},i.prototype.notEmpty=function(){return this.str.match(/^[\s\t\r\n]*$/)?this.error(this.msg||"String is whitespace"):this},i.prototype.equals=function(e){return this.str!=e?this.error(this.msg||"Not equal"):this},i.prototype.contains=function(e){return this.str.indexOf(e)===-1||!e?this.error(this.msg||"Invalid characters"):this},i.prototype.notContains=function(e){return this.str.indexOf(e)>=0?this.error(this.msg||"Invalid characters"):this},i.prototype.regex=i.prototype.is=function(e,t){return Object.prototype.toString.call(e).slice(8,-1)!=="RegExp"&&(e=new RegExp(e,t)),this.str.match(e)?this:this.error(this.msg||"Invalid characters")},i.prototype.notRegex=i.prototype.not=function(e,t){return Object.prototype.toString.call(e).slice(8,-1)!=="RegExp"&&(e=new RegExp(e,t)),this.str.match(e)&&this.error(this.msg||"Invalid characters"),this},i.prototype.len=function(e,t){return this.str.length<e?this.error(this.msg||"String is too small"):typeof t!==undefined&&this.str.length>t?this.error(this.msg||"String is too large"):this},i.prototype.isUUID=function(e){var t;return e==3||e=="v3"?t=/[0-9A-F]{8}-[0-9A-F]{4}-3[0-9A-F]{3}-[0-9A-F]{4}-[0-9A-F]{12}$/i:e==4||e=="v4"?t=/[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i:e==5||e=="v5"?t=/^[0-9A-F]{8}-[0-9A-F]{4}-5[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i:t=/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i,this.str.match(t)?this:this.error(this.msg||"Not a UUID")},i.prototype.isUUIDv3=function(){return this.isUUID(3)},i.prototype.isUUIDv4=function(){return this.isUUID(4)},i.prototype.isUUIDv5=function(){return this.isUUID(5)},i.prototype.isDate=function(){var e=Date.parse(this.str);return isNaN(e)?this.error(this.msg||"Not a date"):this},i.prototype.isIn=function(e){return e&&typeof e.indexOf=="function"?~e.indexOf(this.str)?this:this.error(this.msg||"Unexpected value"):this.error(this.msg||"Invalid in() argument")},i.prototype.notIn=function(e){return e&&typeof e.indexOf=="function"?e.indexOf(this.str)!==-1?this.error(this.msg||"Unexpected value"):this:this.error(this.msg||"Invalid notIn() argument")},i.prototype.min=function(e){var t=parseFloat(this.str);return!isNaN(t)&&t<e?this.error(this.msg||"Invalid number"):this},i.prototype.max=function(e){var t=parseFloat(this.str);return!isNaN(t)&&t>e?this.error(this.msg||"Invalid number"):this};var a=e.Filter=function(){},f="\\r\\n\\t\\s";return a.prototype.modify=function(e){this.str=e},a.prototype.convert=a.prototype.sanitize=function(e){return this.str=e==null?"":e+"",this},a.prototype.entityDecode=function(){return this.modify(n(this.str)),this.str},a.prototype.entityEncode=function(){return this.modify(r(this.str)),this.str},a.prototype.escape=function(){return this.modify(this.str.replace(/&/g,"&amp;").replace(/"/g,"&quot;").replace(/</g,"&lt;").replace(/>/g,"&gt;")),this.str},a.prototype.ltrim=function(e){return e=e||f,this.modify(this.str.replace(new RegExp("^["+e+"]+","g"),"")),this.str},a.prototype.rtrim=function(e){return e=e||f,this.modify(this.str.replace(new RegExp("["+e+"]+$","g"),"")),this.str},a.prototype.trim=function(e){return e=e||f,this.modify(this.str.replace(new RegExp("^["+e+"]+|["+e+"]+$","g"),"")),this.str},a.prototype.ifNull=function(e){return(!this.str||this.str==="")&&this.modify(e),this.str},a.prototype.toFloat=function(){return this.modify(parseFloat(this.str)),this.str},a.prototype.toInt=function(e){return e=e||10,this.modify(parseInt(this.str,e)),this.str},a.prototype.toBoolean=function(){return!this.str||this.str=="0"||this.str=="false"||this.str==""?this.modify(!1):this.modify(!0),this.str},a.prototype.toBooleanStrict=function(){return this.str=="1"||this.str=="true"?this.modify(!0):this.modify(!1),this.str},e.sanitize=e.convert=function(t){var n=new e.Filter;return n.sanitize(t)},e.check=e.validate=e.assert=function(t,n){var r=new e.Validator;return r.check(t,n)},e});
+diff --git a/validator.js b/validator.js
+index acf7c42..62eee2a 100644
+--- a/validator.js
++++ b/validator.js
+@@ -335,208 +335,6 @@
+         decode: decode
+     }
+ 
+-    //This module is adapted from the CodeIgniter framework
+-    //The license is available at http://codeigniter.com/
+-
+-    var never_allowed_str = {
+-        'document.cookie':              '',
+-        'document.write':               '',
+-        '.parentNode':                  '',
+-        '.innerHTML':                   '',
+-        'window.location':              '',
+-        '-moz-binding':                 '',
+-        '<!--':                         '&lt;!--',
+-        '-->':                          '--&gt;',
+-        '<![CDATA[':                    '&lt;![CDATA['
+-    };
+-
+-    var never_allowed_regex = {
+-        'javascript\\s*:':              '',
+-        'expression\\s*(\\(|&\\#40;)':  '',
+-        'vbscript\\s*:':                '',
+-        'Redirect\\s+302':              ''
+-    };
+-
+-    var non_displayables = [
+-        /%0[0-8bcef]/g,           // url encoded 00-08, 11, 12, 14, 15
+-        /%1[0-9a-f]/g,            // url encoded 16-31
+-        /[\x00-\x08]/g,           // 00-08
+-        /\x0b/g, /\x0c/g,         // 11,12
+-        /[\x0e-\x1f]/g            // 14-31
+-    ];
+-
+-    var compact_words = [
+-        'javascript', 'expression', 'vbscript',
+-        'script', 'applet', 'alert', 'document',
+-        'write', 'cookie', 'window'
+-    ];
+-
+-    exports.xssClean = function(str, is_image) {
+-
+-        //Recursively clean objects and arrays
+-        if (typeof str === 'object') {
+-            for (var i in str) {
+-                str[i] = exports.xssClean(str[i]);
+-            }
+-            return str;
+-        }
+-
+-        //Remove invisible characters
+-        str = remove_invisible_characters(str);
+-
+-        //Protect query string variables in URLs => 901119URL5918AMP18930PROTECT8198
+-        str = str.replace(/\&([a-z\_0-9]+)\=([a-z\_0-9]+)/i, xss_hash() + '$1=$2');
+-
+-        //Validate standard character entities - add a semicolon if missing.  We do this to enable
+-        //the conversion of entities to ASCII later.
+-        str = str.replace(/(&\#?[0-9a-z]{2,})([\x00-\x20])*;?/i, '$1;$2');
+-
+-        //Validate UTF16 two byte encoding (x00) - just as above, adds a semicolon if missing.
+-        str = str.replace(/(&\#x?)([0-9A-F]+);?/i, '$1;$2');
+-
+-        //Un-protect query string variables
+-        str = str.replace(xss_hash(), '&');
+-
+-        //Decode just in case stuff like this is submitted:
+-        //<a href="http://%77%77%77%2E%67%6F%6F%67%6C%65%2E%63%6F%6D">Google</a>
+-        try {
+-          str = decodeURIComponent(str);
+-        } catch (e) {
+-          // str was not actually URI-encoded
+-        }
+-
+-        //Convert character entities to ASCII - this permits our tests below to work reliably.
+-        //We only convert entities that are within tags since these are the ones that will pose security problems.
+-        str = str.replace(/[a-z]+=([\'\"]).*?\1/gi, function(m, match) {
+-            return m.replace(match, convert_attribute(match));
+-        });
+-
+-        //Remove invisible characters again
+-        str = remove_invisible_characters(str);
+-
+-        //Convert tabs to spaces
+-        str = str.replace('\t', ' ');
+-
+-        //Captured the converted string for later comparison
+-        var converted_string = str;
+-
+-        //Remove strings that are never allowed
+-        for (var i in never_allowed_str) {
+-            str = str.replace(i, never_allowed_str[i]);
+-        }
+-
+-        //Remove regex patterns that are never allowed
+-        for (var i in never_allowed_regex) {
+-            str = str.replace(new RegExp(i, 'i'), never_allowed_regex[i]);
+-        }
+-
+-        //Compact any exploded words like:  j a v a s c r i p t
+-        // We only want to do this when it is followed by a non-word character
+-        for (var i in compact_words) {
+-            var spacified = compact_words[i].split('').join('\\s*')+'\\s*';
+-
+-            str = str.replace(new RegExp('('+spacified+')(\\W)', 'ig'), function(m, compat, after) {
+-                return compat.replace(/\s+/g, '') + after;
+-            });
+-        }
+-
+-        //Remove disallowed Javascript in links or img tags
+-        do {
+-            var original = str;
+-
+-            if (str.match(/<a/i)) {
+-                str = str.replace(/<a\s+([^>]*?)(>|$)/gi, function(m, attributes, end_tag) {
+-                    attributes = filter_attributes(attributes.replace('<','').replace('>',''));
+-                    return m.replace(attributes, attributes.replace(/href=.*?(alert\(|alert&\#40;|javascript\:|charset\=|window\.|document\.|\.cookie|<script|<xss|base64\s*,)/gi, ''));
+-                });
+-            }
+-
+-            if (str.match(/<img/i)) {
+-                str = str.replace(/<img\s+([^>]*?)(\s?\/?>|$)/gi, function(m, attributes, end_tag) {
+-                    attributes = filter_attributes(attributes.replace('<','').replace('>',''));
+-                    return m.replace(attributes, attributes.replace(/src=.*?(alert\(|alert&\#40;|javascript\:|charset\=|window\.|document\.|\.cookie|<script|<xss|base64\s*,)/gi, ''));
+-                });
+-            }
+-
+-            if (str.match(/script/i) || str.match(/xss/i)) {
+-                str = str.replace(/<(\/*)(script|xss)(.*?)\>/gi, '');
+-            }
+-
+-        } while(original != str);
+-
+-        //Remove JavaScript Event Handlers - Note: This code is a little blunt.  It removes the event
+-        //handler and anything up to the closing >, but it's unlikely to be a problem.
+-        event_handlers = ['[^a-z_\-]on\\w*'];
+-
+-        //Adobe Photoshop puts XML metadata into JFIF images, including namespacing,
+-        //so we have to allow this for images
+-        if (!is_image) {
+-            event_handlers.push('xmlns');
+-        }
+-
+-        str = str.replace(new RegExp("<([^><]+?)("+event_handlers.join('|')+")(\\s*=\\s*[^><]*)([><]*)", 'i'), '<$1$4');
+-
+-        //Sanitize naughty HTML elements
+-        //If a tag containing any of the words in the list
+-        //below is found, the tag gets converted to entities.
+-        //So this: <blink>
+-        //Becomes: &lt;blink&gt;
+-        naughty = 'alert|applet|audio|basefont|base|behavior|bgsound|blink|body|embed|expression|form|frameset|frame|head|html|ilayer|iframe|input|isindex|layer|link|meta|object|plaintext|style|script|textarea|title|video|xml|xss';
+-        str = str.replace(new RegExp('<(/*\\s*)('+naughty+')([^><]*)([><]*)', 'gi'), function(m, a, b, c, d) {
+-            return '&lt;' + a + b + c + d.replace('>','&gt;').replace('<','&lt;');
+-        });
+-
+-        //Sanitize naughty scripting elements Similar to above, only instead of looking for
+-        //tags it looks for PHP and JavaScript commands that are disallowed.  Rather than removing the
+-        //code, it simply converts the parenthesis to entities rendering the code un-executable.
+-        //For example:    eval('some code')
+-        //Becomes:        eval&#40;'some code'&#41;
+-        str = str.replace(/(alert|cmd|passthru|eval|exec|expression|system|fopen|fsockopen|file|file_get_contents|readfile|unlink)(\s*)\((.*?)\)/gi, '$1$2&#40;$3&#41;');
+-
+-        //This adds a bit of extra precaution in case something got through the above filters
+-        for (var i in never_allowed_str) {
+-            str = str.replace(i, never_allowed_str[i]);
+-        }
+-        for (var i in never_allowed_regex) {
+-            str = str.replace(new RegExp(i, 'i'), never_allowed_regex[i]);
+-        }
+-
+-        //Images are handled in a special way
+-        if (is_image && str !== converted_string) {
+-            throw new Error('Image may contain XSS');
+-        }
+-
+-        return str;
+-    }
+-
+-    function remove_invisible_characters(str) {
+-        for (var i in non_displayables) {
+-            str = str.replace(non_displayables[i], '');
+-        }
+-        return str;
+-    }
+-
+-    function xss_hash() {
+-        //TODO: Create a random hash
+-        return '!*$^#(@*#&';
+-    }
+-
+-    function convert_attribute(str) {
+-        return str.replace('>','&gt;').replace('<','&lt;').replace('\\','\\\\');
+-    }
+-
+-    //Filter Attributes - filters tag attributes for consistency and safety
+-    function filter_attributes(str) {
+-        var comments = /\/\*.*?\*\//g;
+-        return str.replace(/\s*[a-z-]+\s*=\s*'[^']*'/gi, function (m) {
+-            return m.replace(comments, '');
+-        }).replace(/\s*[a-z-]+\s*=\s*"[^"]*"/gi, function (m) {
+-            return m.replace(comments, '');
+-        }).replace(/\s*[a-z-]+\s*=\s*[^\s]+/gi, function (m) {
+-            return m.replace(comments, '');
+-        });
+-    }
+-
+     var Validator = exports.Validator = function() {}
+ 
+     Validator.prototype.check = function(str, fail_msg) {
+@@ -913,11 +711,6 @@
+         return this;
+     }
+ 
+-    Filter.prototype.xss = function(is_image) {
+-        this.modify(exports.xssClean(this.str, is_image));
+-        return this.str;
+-    }
+-
+     Filter.prototype.entityDecode = function() {
+         this.modify(decode(this.str));
+         return this.str;
+@@ -1007,4 +800,4 @@
+ 
+     return exports;
+ 
+-}));
+\ No newline at end of file
++}));

--- a/packages/snyk-protect/patches/ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch
+++ b/packages/snyk-protect/patches/ws_20160104_0_0_29293ed11b679e0366fa0f6bb9310b330dafd795.patch
@@ -1,0 +1,34 @@
+// Code derived from https://github.com/websockets/ws
+
+// https://github.com/websockets/ws#license
+/*
+(The MIT License)
+
+Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/lib/Sender.js b/lib/Sender.js
+index 2f8f7c4..d34061e 100644
+--- a/lib/Sender.js
++++ b/lib/Sender.js
+@@ -155,6 +155,14 @@ Sender.prototype.frameAndSend = function(opcode, data, finalFragment, maskData,
+     if (data && (typeof data.byteLength !== 'undefined' || typeof data.buffer !== 'undefined')) {
+       data = getArrayBuffer(data);
+     } else {
++      //
++      // If people want to send a number, this would allocate the number in
++      // bytes as memory size instead of storing the number as buffer value. So
++      // we need to transform it to string in order to prevent possible
++      // vulnerabilities / memory attacks.
++      //
++      if (typeof data === 'number') data = data.toString();
++
+       data = new Buffer(data);
+     }
+   }

--- a/packages/snyk-protect/patches/ws_20160104_0_1_29293ed11b679e0366fa0f6bb9310b330dafd795.patch
+++ b/packages/snyk-protect/patches/ws_20160104_0_1_29293ed11b679e0366fa0f6bb9310b330dafd795.patch
@@ -1,0 +1,40 @@
+// Code derived from https://github.com/websockets/ws
+
+// https://github.com/websockets/ws#license
+/*
+(The MIT License)
+
+Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/lib/Sender.js b/lib/Sender.js
+index 2f8f7c4..d34061e 100644
+--- a/lib/Sender.js
++++ b/lib/Sender.js
+@@ -103,7 +103,19 @@
+
+   if (!Buffer.isBuffer(data)) {
+     canModifyData = true;
+-    data = (data && typeof data.buffer !== 'undefined') ? getArrayBuffer(data.buffer) : new Buffer(data);
++    if (data && (typeof data.byteLength !== 'undefined' || typeof data.buffer !== 'undefined')) {
++      data = getArrayBuffer(data);
++    } else {
++      //
++      // If people want to send a number, this would allocate the number in
++      // bytes as memory size instead of storing the number as buffer value. So
++      // we need to transform it to string in order to prevent possible
++      // vulnerabilities / memory attacks.
++      //
++      if (typeof data === 'number') data = data.toString();
++
++      data = new Buffer(data);
++    }
+   }
+
+   var dataLength = data.length

--- a/packages/snyk-protect/patches/ws_20160104_0_2_29293ed11b679e0366fa0f6bb9310b330dafd795.patch
+++ b/packages/snyk-protect/patches/ws_20160104_0_2_29293ed11b679e0366fa0f6bb9310b330dafd795.patch
@@ -1,0 +1,40 @@
+// Code derived from https://github.com/websockets/ws
+
+// https://github.com/websockets/ws#license
+/*
+(The MIT License)
+
+Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/lib/Sender.js b/lib/Sender.js
+index 2f8f7c4..d34061e 100644
+--- a/lib/Sender.js
++++ b/lib/Sender.js
+@@ -109,7 +109,19 @@
+   }
+   else if (!Buffer.isBuffer(data)) {
+     dontModifyData = false;
+-    data = (data && typeof data.buffer !== 'undefined') ? getArrayBuffer(data.buffer) : new Buffer(data);
++    if (data && (typeof data.byteLength !== 'undefined' || typeof data.buffer !== 'undefined')) {
++      data = getArrayBuffer(data);
++    } else {
++      //
++      // If people want to send a number, this would allocate the number in
++      // bytes as memory size instead of storing the number as buffer value. So
++      // we need to transform it to string in order to prevent possible
++      // vulnerabilities / memory attacks.
++      //
++      if (typeof data === 'number') data = data.toString();
++
++      data = new Buffer(data);
++    }
+   }
+   var dataLength = data.length
+     , dataOffset = maskData ? 6 : 2

--- a/packages/snyk-protect/patches/ws_20160104_0_3_29293ed11b679e0366fa0f6bb9310b330dafd795.patch
+++ b/packages/snyk-protect/patches/ws_20160104_0_3_29293ed11b679e0366fa0f6bb9310b330dafd795.patch
@@ -1,0 +1,39 @@
+// Code derived from https://github.com/websockets/ws
+
+// https://github.com/websockets/ws#license
+/*
+(The MIT License)
+
+Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/lib/Sender.js b/lib/Sender.js
+index 2f8f7c4..d34061e 100644
+--- a/lib/Sender.js
++++ b/lib/Sender.js
+@@ -109,6 +109,18 @@
+   }
+   else if (!Buffer.isBuffer(data)) {
+-    data = (data && typeof data.buffer !== 'undefined') ? getArrayBuffer(data.buffer) : new Buffer(data);
++    if (data && (typeof data.byteLength !== 'undefined' || typeof data.buffer !== 'undefined')) {
++      data = getArrayBuffer(data);
++    } else {
++      //
++      // If people want to send a number, this would allocate the number in
++      // bytes as memory size instead of storing the number as buffer value. So
++      // we need to transform it to string in order to prevent possible
++      // vulnerabilities / memory attacks.
++      //
++      if (typeof data === 'number') data = data.toString();
++
++      data = new Buffer(data);
++    }
+   }
+   var dataLength = data.length
+     , dataOffset = maskData ? 6 : 2

--- a/packages/snyk-protect/patches/ws_20160624_0_0_0328a8f49f004f98d2913016214e93b2fc2713bc.patch
+++ b/packages/snyk-protect/patches/ws_20160624_0_0_0328a8f49f004f98d2913016214e93b2fc2713bc.patch
@@ -1,0 +1,29 @@
+// Code derived from https://github.com/websockets/ws
+// https://github.com/websockets/ws/commit/0328a8f49f004f98d2913016214e93b2fc2713bc
+
+// https://github.com/websockets/ws#license
+/*
+(The MIT License)
+
+Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+diff --git a/lib/WebSocketServer.js b/lib/WebSocketServer.js
+index 476cf71..92077cd 100644
+--- a/lib/WebSocketServer.js
++++ b/lib/WebSocketServer.js
+@@ -37,7 +37,7 @@ function WebSocketServer(options, callback) {
+     disableHixie: false,
+     clientTracking: true,
+     perMessageDeflate: true,
+-    maxPayload: null
++    maxPayload: 100 * 1024 * 1024
+   }).merge(options);
+ 
+   if (!options.isDefinedAndNonNull('port') && !options.isDefinedAndNonNull('server') && !options.value.noServer) {

--- a/packages/snyk-protect/patches/ws_20160624_0_1_101_sio.patch
+++ b/packages/snyk-protect/patches/ws_20160624_0_1_101_sio.patch
@@ -1,0 +1,691 @@
+diff --git a/lib/BufferUtil.fallback.js b/lib/BufferUtil.fallback.js
+index 508542c..7abd0d8 100644
+--- a/lib/BufferUtil.fallback.js
++++ b/lib/BufferUtil.fallback.js
+@@ -4,7 +4,7 @@
+  * MIT Licensed
+  */
+ 
+-module.exports.BufferUtil = {
++exports.BufferUtil = {
+   merge: function(mergedBuffer, buffers) {
+     var offset = 0;
+     for (var i = 0, l = buffers.length; i < l; ++i) {
+diff --git a/lib/PerMessageDeflate.js b/lib/PerMessageDeflate.js
+index 5324bd8..00a6ea6 100644
+--- a/lib/PerMessageDeflate.js
++++ b/lib/PerMessageDeflate.js
+@@ -11,7 +11,7 @@ PerMessageDeflate.extensionName = 'permessage-deflate';
+  * Per-message Compression Extensions implementation
+  */
+ 
+-function PerMessageDeflate(options, isServer) {
++function PerMessageDeflate(options, isServer,maxPayload) {
+   if (this instanceof PerMessageDeflate === false) {
+     throw new TypeError("Classes can't be function-called");
+   }
+@@ -21,6 +21,7 @@ function PerMessageDeflate(options, isServer) {
+   this._inflate = null;
+   this._deflate = null;
+   this.params = null;
++  this._maxPayload = maxPayload || 0;
+ }
+ 
+ /**
+@@ -236,6 +237,7 @@ PerMessageDeflate.prototype.decompress = function (data, fin, callback) {
+ 
+   var self = this;
+   var buffers = [];
++  var cumulativeBufferLength=0;
+ 
+   this._inflate.on('error', onError).on('data', onData);
+   this._inflate.write(data);
+@@ -253,7 +255,17 @@ PerMessageDeflate.prototype.decompress = function (data, fin, callback) {
+   }
+ 
+   function onData(data) {
+-    buffers.push(data);
++      if(self._maxPayload!==undefined && self._maxPayload!==null && self._maxPayload>0){
++          cumulativeBufferLength+=data.length;
++          if(cumulativeBufferLength>self._maxPayload){
++            buffers=[];
++            cleanup();
++            var err={type:1009};
++            callback(err);
++            return;
++          }
++      }
++      buffers.push(data);
+   }
+ 
+   function cleanup() {
+diff --git a/lib/Receiver.hixie.js b/lib/Receiver.hixie.js
+index 66bc561..598ccbd 100644
+--- a/lib/Receiver.hixie.js
++++ b/lib/Receiver.hixie.js
+@@ -47,6 +47,7 @@ module.exports = Receiver;
+  */
+ 
+ Receiver.prototype.add = function(data) {
++  if (this.dead) return;
+   var self = this;
+   function doAdd() {
+     if (self.state === EMPTY) {
+@@ -153,8 +154,17 @@ Receiver.prototype.parse = function() {
+  */
+ 
+ Receiver.prototype.error = function (reason, terminate) {
++  if (this.dead) return;
+   this.reset();
+-  this.onerror(reason, terminate);
++  if(typeof reason == 'string'){
++    this.onerror(new Error(reason), terminate);
++  }
++  else if(reason.constructor == Error){
++    this.onerror(reason, terminate);
++  }
++  else{
++    this.onerror(new Error("An error occured"),terminate);
++  }
+   return this;
+ };
+ 
+diff --git a/lib/Receiver.js b/lib/Receiver.js
+index b3183bf..0bf29d8 100644
+--- a/lib/Receiver.js
++++ b/lib/Receiver.js
+@@ -15,10 +15,15 @@ var util = require('util')
+  * HyBi Receiver implementation
+  */
+ 
+-function Receiver (extensions) {
++function Receiver (extensions,maxPayload) {
+   if (this instanceof Receiver === false) {
+     throw new TypeError("Classes can't be function-called");
+   }
++  if(typeof extensions==='number'){
++    maxPayload=extensions;
++    extensions={};
++  }
++
+ 
+   // memory pool for fragmented messages
+   var fragmentedPoolPrevUsed = -1;
+@@ -39,8 +44,9 @@ function Receiver (extensions) {
+       Math.ceil((unfragmentedPoolPrevUsed + db.used) / 2) :
+       db.used;
+   });
+-
+   this.extensions = extensions || {};
++  this.maxPayload = maxPayload || 0;
++  this.currentPayloadLength = 0;
+   this.state = {
+     activeFragmentedOperation: null,
+     lastFragment: false,
+@@ -54,6 +60,7 @@ function Receiver (extensions) {
+   this.expectBuffer = null;
+   this.expectHandler = null;
+   this.currentMessage = [];
++  this.currentMessageLength = 0;
+   this.messageHandlers = [];
+   this.expectHeader(2, this.processPacket);
+   this.dead = false;
+@@ -76,6 +83,7 @@ module.exports = Receiver;
+  */
+ 
+ Receiver.prototype.add = function(data) {
++  if (this.dead) return;
+   var dataLength = data.length;
+   if (dataLength == 0) return;
+   if (this.expectBuffer == null) {
+@@ -244,6 +252,7 @@ Receiver.prototype.processPacket = function (data) {
+  */
+ 
+ Receiver.prototype.endPacket = function() {
++  if (this.dead) return;
+   if (!this.state.fragmentedOperation) this.unfragmentedBufferPool.reset(true);
+   else if (this.state.lastFragment) this.fragmentedBufferPool.reset(true);
+   this.expectOffset = 0;
+@@ -253,6 +262,7 @@ Receiver.prototype.endPacket = function() {
+     // end current fragmented operation
+     this.state.activeFragmentedOperation = null;
+   }
++  this.currentPayloadLength = 0;
+   this.state.lastFragment = false;
+   this.state.opcode = this.state.activeFragmentedOperation != null ? this.state.activeFragmentedOperation : 0;
+   this.state.masked = false;
+@@ -281,7 +291,9 @@ Receiver.prototype.reset = function() {
+   this.expectHandler = null;
+   this.overflow = [];
+   this.currentMessage = [];
++  this.currentMessageLength = 0;
+   this.messageHandlers = [];
++  this.currentPayloadLength = 0;
+ };
+ 
+ /**
+@@ -297,28 +309,23 @@ Receiver.prototype.unmask = function (mask, buf, binary) {
+ };
+ 
+ /**
+- * Concatenates a list of buffers.
+- *
+- * @api private
+- */
+-
+-Receiver.prototype.concatBuffers = function(buffers) {
+-  var length = 0;
+-  for (var i = 0, l = buffers.length; i < l; ++i) length += buffers[i].length;
+-  var mergedBuffer = new Buffer(length);
+-  bufferUtil.merge(mergedBuffer, buffers);
+-  return mergedBuffer;
+-};
+-
+-/**
+  * Handles an error
+  *
+  * @api private
+  */
+ 
+ Receiver.prototype.error = function (reason, protocolErrorCode) {
++  if (this.dead) return;
+   this.reset();
+-  this.onerror(reason, protocolErrorCode);
++  if(typeof reason == 'string'){
++    this.onerror(new Error(reason), protocolErrorCode);
++  }
++  else if(reason.constructor == Error){
++    this.onerror(reason, protocolErrorCode);
++  }
++  else{
++    this.onerror(new Error("An error occured"),protocolErrorCode);
++  }
+   return this;
+ };
+ 
+@@ -366,6 +373,27 @@ Receiver.prototype.applyExtensions = function(messageBuffer, fin, compressed, ca
+ };
+ 
+ /**
++* Checks payload size, disconnects socket when it exceeds maxPayload
++*
++* @api private
++*/
++Receiver.prototype.maxPayloadExceeded = function(length) {
++  if (this.maxPayload=== undefined || this.maxPayload === null || this.maxPayload < 1) {
++    return false;
++  }
++  var fullLength = this.currentPayloadLength + length;
++  if (fullLength < this.maxPayload) {
++    this.currentPayloadLength = fullLength;
++    return false;
++  }
++  this.error('payload cannot exceed ' + this.maxPayload + ' bytes', 1009);
++  this.messageBuffer=[];
++  this.cleanup();
++
++  return true;
++};
++
++/**
+  * Buffer utilities
+  */
+ 
+@@ -425,11 +453,20 @@ var opcodes = {
+       // decode length
+       var firstLength = data[1] & 0x7f;
+       if (firstLength < 126) {
++        if (self.maxPayloadExceeded(firstLength)){
++          self.error('Maximumpayload exceeded in compressed text message. Aborting...', 1009);
++          return;
++        }
+         opcodes['1'].getData.call(self, firstLength);
+       }
+       else if (firstLength == 126) {
+         self.expectHeader(2, function(data) {
+-          opcodes['1'].getData.call(self, readUInt16BE.call(data, 0));
++          var length = readUInt16BE.call(data, 0);
++          if (self.maxPayloadExceeded(length)){
++            self.error('Maximumpayload exceeded in compressed text message. Aborting...', 1009);
++            return;
++          }
++          opcodes['1'].getData.call(self, length);
+         });
+       }
+       else if (firstLength == 127) {
+@@ -438,6 +475,11 @@ var opcodes = {
+             self.error('packets with length spanning more than 32 bit is currently not supported', 1008);
+             return;
+           }
++          var length = readUInt32BE.call(data, 4);
++          if (self.maxPayloadExceeded(length)){
++            self.error('Maximumpayload exceeded in compressed text message. Aborting...', 1009);
++            return;
++          }
+           opcodes['1'].getData.call(self, readUInt32BE.call(data, 4));
+         });
+       }
+@@ -464,12 +506,29 @@ var opcodes = {
+       var state = clone(this.state);
+       this.messageHandlers.push(function(callback) {
+         self.applyExtensions(packet, state.lastFragment, state.compressed, function(err, buffer) {
+-          if (err) return self.error(err.message, 1007);
+-          if (buffer != null) self.currentMessage.push(buffer);
+-
++          if (err) {
++            if(err.type===1009){
++                return self.error('Maximumpayload exceeded in compressed text message. Aborting...', 1009);
++            }
++            return self.error(err.message, 1007);
++          }
++          if (buffer != null) {
++            if( self.maxPayload==0 || (self.maxPayload > 0 && (self.currentMessageLength + buffer.length) < self.maxPayload) ){
++              self.currentMessage.push(buffer);
++            }
++            else{
++                self.currentMessage=null;
++                self.currentMessage = [];
++                self.currentMessageLength = 0;
++                self.error(new Error('Maximum payload exceeded. maxPayload: '+self.maxPayload), 1009);
++                return;
++            }
++            self.currentMessageLength += buffer.length;
++          }
+           if (state.lastFragment) {
+-            var messageBuffer = self.concatBuffers(self.currentMessage);
++            var messageBuffer = Buffer.concat(self.currentMessage);
+             self.currentMessage = [];
++            self.currentMessageLength = 0;
+             if (!Validation.isValidUTF8(messageBuffer)) {
+               self.error('invalid utf8 sequence', 1007);
+               return;
+@@ -490,11 +549,20 @@ var opcodes = {
+       // decode length
+       var firstLength = data[1] & 0x7f;
+       if (firstLength < 126) {
++          if (self.maxPayloadExceeded(firstLength)){
++            self.error('Max payload exceeded in compressed text message. Aborting...', 1009);
++            return;
++          }
+         opcodes['2'].getData.call(self, firstLength);
+       }
+       else if (firstLength == 126) {
+         self.expectHeader(2, function(data) {
+-          opcodes['2'].getData.call(self, readUInt16BE.call(data, 0));
++          var length = readUInt16BE.call(data, 0);
++          if (self.maxPayloadExceeded(length)){
++            self.error('Max payload exceeded in compressed text message. Aborting...', 1009);
++            return;
++          }
++          opcodes['2'].getData.call(self, length);
+         });
+       }
+       else if (firstLength == 127) {
+@@ -503,7 +571,12 @@ var opcodes = {
+             self.error('packets with length spanning more than 32 bit is currently not supported', 1008);
+             return;
+           }
+-          opcodes['2'].getData.call(self, readUInt32BE.call(data, 4, true));
++          var length = readUInt32BE.call(data, 4, true);
++          if (self.maxPayloadExceeded(length)){
++            self.error('Max payload exceeded in compressed text message. Aborting...', 1009);
++            return;
++          }
++          opcodes['2'].getData.call(self, length);
+         });
+       }
+     },
+@@ -529,11 +602,29 @@ var opcodes = {
+       var state = clone(this.state);
+       this.messageHandlers.push(function(callback) {
+         self.applyExtensions(packet, state.lastFragment, state.compressed, function(err, buffer) {
+-          if (err) return self.error(err.message, 1007);
+-          if (buffer != null) self.currentMessage.push(buffer);
++          if (err) {
++            if(err.type===1009){
++                return self.error('Max payload exceeded in compressed binary message. Aborting...', 1009);
++            }
++            return self.error(err.message, 1007);
++          }
++          if (buffer != null) {
++            if( self.maxPayload==0 || (self.maxPayload > 0 && (self.currentMessageLength + buffer.length) < self.maxPayload) ){
++              self.currentMessage.push(buffer);
++            }
++            else{
++                self.currentMessage=null;
++                self.currentMessage = [];
++                self.currentMessageLength = 0;
++                self.error(new Error('Maximum payload exceeded'), 1009);
++                return;
++            }
++            self.currentMessageLength += buffer.length;
++          }
+           if (state.lastFragment) {
+-            var messageBuffer = self.concatBuffers(self.currentMessage);
++            var messageBuffer = Buffer.concat(self.currentMessage);
+             self.currentMessage = [];
++            self.currentMessageLength = 0;
+             self.onbinary(messageBuffer, {masked: state.masked, buffer: messageBuffer});
+           }
+           callback();
+diff --git a/lib/Sender.js b/lib/Sender.js
+index d34061e..6ef2ea2 100644
+--- a/lib/Sender.js
++++ b/lib/Sender.js
+@@ -197,7 +197,7 @@ Sender.prototype.frameAndSend = function(opcode, data, finalFragment, maskData,
+ 
+   if (maskData) {
+     outputBuffer[1] = secondByte | 0x80;
+-    var mask = this._randomMask || (this._randomMask = getRandomMask());
++    var mask = getRandomMask();
+     outputBuffer[dataOffset - 4] = mask[0];
+     outputBuffer[dataOffset - 3] = mask[1];
+     outputBuffer[dataOffset - 2] = mask[2];
+diff --git a/lib/Validation.fallback.js b/lib/Validation.fallback.js
+index 2c7c4fd..639b0d3 100644
+--- a/lib/Validation.fallback.js
++++ b/lib/Validation.fallback.js
+@@ -3,10 +3,9 @@
+  * Copyright(c) 2011 Einar Otto Stangvik <einaros@gmail.com>
+  * MIT Licensed
+  */
+- 
+-module.exports.Validation = {
++
++exports.Validation = {
+   isValidUTF8: function(buffer) {
+     return true;
+   }
+ };
+-
+diff --git a/lib/WebSocket.js b/lib/WebSocket.js
+index 4e06c80..bb09e85 100644
+--- a/lib/WebSocket.js
++++ b/lib/WebSocket.js
+@@ -71,6 +71,7 @@ function WebSocket(address, protocols, options) {
+   this.readyState = null;
+   this.supports = {};
+   this.extensions = {};
++  this._binaryType = 'nodebuffer';
+ 
+   if (Array.isArray(address)) {
+     initAsServerClient.apply(this, address.concat(options));
+@@ -372,6 +373,27 @@ Object.defineProperty(WebSocket.prototype, 'bufferedAmount', {
+ });
+ 
+ /**
++ * Expose binaryType
++ *
++ * This deviates from the W3C interface since ws doesn't support the required
++ * default "blob" type (instead we define a custom "nodebuffer" type).
++ *
++ * @see http://dev.w3.org/html5/websockets/#the-websocket-interface
++ * @api public
++ */
++Object.defineProperty(WebSocket.prototype, 'binaryType', {
++  get: function get() {
++    return this._binaryType;
++  },
++  set: function set(type) {
++    if (type === 'arraybuffer' || type === 'nodebuffer' || type === 'buffer')
++      this._binaryType = type;
++    else
++      throw new SyntaxError('unsupported binaryType: must be either "nodebuffer" or "arraybuffer"');
++  }
++});
++
++/**
+  * Emulates the W3C Browser based WebSocket interface using function members.
+  *
+  * @see http://dev.w3.org/html5/websockets/#the-websocket-interface
+@@ -415,6 +437,8 @@ WebSocket.prototype.addEventListener = function(method, listener) {
+   var target = this;
+ 
+   function onMessage (data, flags) {
++    if (flags.binary && this.binaryType === 'arraybuffer')
++        data = new Uint8Array(data).buffer;
+     listener.call(target, new MessageEvent(data, !!flags.binary, target));
+   }
+ 
+@@ -523,7 +547,8 @@ function initAsServerClient(req, socket, upgradeHead, options) {
+   options = new Options({
+     protocolVersion: protocolVersion,
+     protocol: null,
+-    extensions: {}
++    extensions: {},
++    maxPayload: 0
+   }).merge(options);
+ 
+   // expose state properties
+@@ -534,7 +559,7 @@ function initAsServerClient(req, socket, upgradeHead, options) {
+   this.upgradeReq = req;
+   this.readyState = WebSocket.CONNECTING;
+   this._isServer = true;
+-
++  this.maxPayload = options.value.maxPayload;
+   // establish connection
+   if (options.value.protocolVersion === 'hixie-76') {
+     establishConnection.call(this, ReceiverHixie, SenderHixie, socket, upgradeHead);
+@@ -770,7 +795,7 @@ function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
+   socket.setTimeout(0);
+   socket.setNoDelay(true);
+ 
+-  this._receiver = new ReceiverClass(this.extensions);
++  this._receiver = new ReceiverClass(this.extensions,this.maxPayload);
+   this._socket = socket;
+ 
+   // socket cleanup handlers
+@@ -848,7 +873,7 @@ function establishConnection(ReceiverClass, SenderClass, socket, upgradeHead) {
+   self._receiver.onerror = function onerror(reason, errorCode) {
+     // close the connection when the receiver reports a HyBi error code
+     self.close(typeof errorCode !== 'undefined' ? errorCode : 1002, '');
+-    self.emit('error', reason, errorCode);
++    self.emit('error', (reason instanceof Error) ? reason : (new Error(reason)));
+   };
+ 
+   // finalize the client
+@@ -911,21 +936,18 @@ function sendStream(instance, stream, options, cb) {
+ function cleanupWebsocketResources(error) {
+   if (this.readyState === WebSocket.CLOSED) return;
+ 
+-  var emitClose = this.readyState !== WebSocket.CONNECTING;
+   this.readyState = WebSocket.CLOSED;
+ 
+   clearTimeout(this._closeTimer);
+   this._closeTimer = null;
+ 
+-  if (emitClose) {
+-    // If the connection was closed abnormally (with an error), or if
+-    // the close control frame was not received then the close code
+-    // must default to 1006.
+-    if (error || !this._closeReceived) {
+-      this._closeCode = 1006;
+-    }
+-    this.emit('close', this._closeCode || 1000, this._closeMessage || '');
++  // If the connection was closed abnormally (with an error), or if
++  // the close control frame was not received then the close code
++  // must default to 1006.
++  if (error || !this._closeReceived) {
++    this._closeCode = 1006;
+   }
++  this.emit('close', this._closeCode || 1000, this._closeMessage || '');
+ 
+   if (this._socket) {
+     if (this._ultron) this._ultron.destroy();
+diff --git a/lib/WebSocketServer.js b/lib/WebSocketServer.js
+index ba0e4c0..92077cd 100644
+--- a/lib/WebSocketServer.js
++++ b/lib/WebSocketServer.js
+@@ -36,7 +36,8 @@ function WebSocketServer(options, callback) {
+     noServer: false,
+     disableHixie: false,
+     clientTracking: true,
+-    perMessageDeflate: true
++    perMessageDeflate: true,
++    maxPayload: 100 * 1024 * 1024
+   }).merge(options);
+ 
+   if (!options.isDefinedAndNonNull('port') && !options.isDefinedAndNonNull('server') && !options.value.noServer) {
+@@ -72,13 +73,15 @@ function WebSocketServer(options, callback) {
+       this._server._webSocketPaths[options.value.path] = 1;
+     }
+   }
+-  if (this._server) this._server.once('listening', function() { self.emit('listening'); });
++  if (this._server) {
++    this._onceServerListening = function() { self.emit('listening'); };
++    this._server.once('listening', this._onceServerListening);
++  }
+ 
+   if (typeof this._server != 'undefined') {
+-    this._server.on('error', function(error) {
+-      self.emit('error', error)
+-    });
+-    this._server.on('upgrade', function(req, socket, upgradeHead) {
++    this._onServerError = function(error) { self.emit('error', error) };
++    this._server.on('error', this._onServerError);
++    this._onServerUpgrade = function(req, socket, upgradeHead) {
+       //copy upgradeHead to avoid retention of large slab buffers used in node core
+       var head = new Buffer(upgradeHead.length);
+       upgradeHead.copy(head);
+@@ -87,7 +90,8 @@ function WebSocketServer(options, callback) {
+         self.emit('connection'+req.url, client);
+         self.emit('connection', client);
+       });
+-    });
++    };
++    this._server.on('upgrade', this._onServerUpgrade);
+   }
+ 
+   this.options = options.value;
+@@ -134,6 +138,11 @@ WebSocketServer.prototype.close = function(callback) {
+     }
+   }
+   finally {
++    if (this._server) {
++      this._server.removeListener('listening', this._onceServerListening);
++      this._server.removeListener('error', this._onServerError);
++      this._server.removeListener('upgrade', this._onServerUpgrade);
++    }
+     delete this._server;
+   }
+   if(callback)
+@@ -256,7 +265,8 @@ function handleHybiUpgrade(req, socket, upgradeHead, cb) {
+     var client = new WebSocket([req, socket, upgradeHead], {
+       protocolVersion: version,
+       protocol: protocol,
+-      extensions: extensions
++      extensions: extensions,
++      maxPayload: self.options.maxPayload
+     });
+ 
+     if (self.options.clientTracking) {
+@@ -359,8 +369,42 @@ function handleHixieUpgrade(req, socket, upgradeHead, cb) {
+     var location = ((req.headers['x-forwarded-proto'] === 'https' || socket.encrypted) ? 'wss' : 'ws') + '://' + wshost + req.url
+       , protocol = req.headers['sec-websocket-protocol'];
+ 
++    // build the response header and return a Buffer
++    var buildResponseHeader = function() {
++      var headers = [
++          'HTTP/1.1 101 Switching Protocols'
++        , 'Upgrade: WebSocket'
++        , 'Connection: Upgrade'
++        , 'Sec-WebSocket-Location: ' + location
++      ];
++      if (typeof protocol != 'undefined') headers.push('Sec-WebSocket-Protocol: ' + protocol);
++      if (typeof origin != 'undefined') headers.push('Sec-WebSocket-Origin: ' + origin);
++
++      return new Buffer(headers.concat('', '').join('\r\n'));
++    };
++
++    // send handshake response before receiving the nonce
++    var handshakeResponse = function() {
++
++      socket.setTimeout(0);
++      socket.setNoDelay(true);
++
++      var headerBuffer = buildResponseHeader();
++
++      try {
++        socket.write(headerBuffer, 'binary', function(err) {
++          // remove listener if there was an error
++          if (err) socket.removeListener('data', handler);
++          return;
++        });
++      } catch (e) {
++        try { socket.destroy(); } catch (e) {}
++        return;
++      };
++    };
++
+     // handshake completion code to run once nonce has been successfully retrieved
+-    var completeHandshake = function(nonce, rest) {
++    var completeHandshake = function(nonce, rest, headerBuffer) {
+       // calculate key
+       var k1 = req.headers['sec-websocket-key1']
+         , k2 = req.headers['sec-websocket-key2']
+@@ -382,20 +426,10 @@ function handleHixieUpgrade(req, socket, upgradeHead, cb) {
+       });
+       md5.update(nonce.toString('binary'));
+ 
+-      var headers = [
+-          'HTTP/1.1 101 Switching Protocols'
+-        , 'Upgrade: WebSocket'
+-        , 'Connection: Upgrade'
+-        , 'Sec-WebSocket-Location: ' + location
+-      ];
+-      if (typeof protocol != 'undefined') headers.push('Sec-WebSocket-Protocol: ' + protocol);
+-      if (typeof origin != 'undefined') headers.push('Sec-WebSocket-Origin: ' + origin);
+-
+       socket.setTimeout(0);
+       socket.setNoDelay(true);
++
+       try {
+-        // merge header and hash buffer
+-        var headerBuffer = new Buffer(headers.concat('', '').join('\r\n'));
+         var hashBuffer = new Buffer(md5.digest('binary'), 'binary');
+         var handshakeBuffer = new Buffer(headerBuffer.length + hashBuffer.length);
+         headerBuffer.copy(handshakeBuffer, 0);
+@@ -434,11 +468,10 @@ function handleHixieUpgrade(req, socket, upgradeHead, cb) {
+     if (upgradeHead && upgradeHead.length >= nonceLength) {
+       var nonce = upgradeHead.slice(0, nonceLength);
+       var rest = upgradeHead.length > nonceLength ? upgradeHead.slice(nonceLength) : null;
+-      completeHandshake.call(self, nonce, rest);
++      completeHandshake.call(self, nonce, rest, buildResponseHeader());
+     }
+     else {
+-      // nonce not present in upgradeHead, so we must wait for enough data
+-      // data to arrive before continuing
++      // nonce not present in upgradeHead
+       var nonce = new Buffer(nonceLength);
+       upgradeHead.copy(nonce, 0);
+       var received = upgradeHead.length;
+@@ -451,10 +484,17 @@ function handleHixieUpgrade(req, socket, upgradeHead, cb) {
+         if (received == nonceLength) {
+           socket.removeListener('data', handler);
+           if (toRead < data.length) rest = data.slice(toRead);
+-          completeHandshake.call(self, nonce, rest);
++
++          // complete the handshake but send empty buffer for headers since they have already been sent
++          completeHandshake.call(self, nonce, rest, new Buffer(0));
+         }
+       }
++
++      // handle additional data as we receive it
+       socket.on('data', handler);
++
++      // send header response before we have the nonce to fix haproxy buffering
++      handshakeResponse();
+     }
+   }
+ 
+@@ -489,8 +529,9 @@ function handleHixieUpgrade(req, socket, upgradeHead, cb) {
+ function acceptExtensions(offer) {
+   var extensions = {};
+   var options = this.options.perMessageDeflate;
++  var maxPayload = this.options.maxPayload;
+   if (options && offer[PerMessageDeflate.extensionName]) {
+-    var perMessageDeflate = new PerMessageDeflate(options !== true ? options : {}, true);
++    var perMessageDeflate = new PerMessageDeflate(options !== true ? options : {}, true, maxPayload);
+     perMessageDeflate.accept(offer[PerMessageDeflate.extensionName]);
+     extensions[PerMessageDeflate.extensionName] = perMessageDeflate;
+   }

--- a/packages/snyk-protect/patches/ws_20160920_0_0.patch
+++ b/packages/snyk-protect/patches/ws_20160920_0_0.patch
@@ -1,0 +1,39 @@
+// Code derived from https://github.com/websockets/ws
+// https://github.com/websockets/ws/commit/7253f06f5432c76f3e82e2c055fcea08b612d8b2
+
+// https://github.com/websockets/ws#license
+/*
+(The MIT License)
+
+Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+--- a/lib/Sender.js
++++ b/lib/Sender.js
+@@ -4,6 +4,8 @@
+  * MIT Licensed
+  */
+ 
++var crypto = require('crypto');
++
+ var events = require('events')
+   , util = require('util')
+   , EventEmitter = events.EventEmitter
+@@ -315,10 +317,5 @@
+ }
+ 
+ function getRandomMask() {
+-  return new Buffer([
+-    ~~(Math.random() * 255),
+-    ~~(Math.random() * 255),
+-    ~~(Math.random() * 255),
+-    ~~(Math.random() * 255)
+-  ]);
++  return crypto.randomBytes(4);
+ }

--- a/packages/snyk-protect/patches/yar_20140616_0_0_66b981a47655bef2fed84f90b86fc5b43edaea8e.patch
+++ b/packages/snyk-protect/patches/yar_20140616_0_0_66b981a47655bef2fed84f90b86fc5b43edaea8e.patch
@@ -1,0 +1,20 @@
+// Code derived from https://github.com/hapijs/yar
+// Reference: https://github.com/hapijs/yar/commit/66b981a47655bef2fed84f90b86fc5b43edaea8e.patch
+diff --git a/lib/index.js b/lib/index.js
+index 3d92dcd..41262aa 100755
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -178,6 +178,13 @@ exports.register = function (plugin, options, next) {
+ 
+     plugin.ext('onPreResponse', function (request, reply) {
+ 
++        if (!request.session) {
++
++            // onPreAuth was skipped because of a state error
++
++            return reply();
++        }
++
+         if (!request.session._isModified &&
+             !request.session._isLazy) {
+ 


### PR DESCRIPTION
This PR is for `@snyk/protect` package.

This change will make Snyk Protect work without calling Snyk API.
This is achieved by running (ideally) an one-off script to download all patches and metadata needed for patching. Result is a JSON file and a folder all the patches.

This affects package size, but not dramatically.
This change was made with minimal changes to the Protect package code itself, updating only the methods fetching patches to use the local JSON file and local patches.

<img width="905" alt="Screen Shot 2022-09-29 at 15 35 07" src="https://user-images.githubusercontent.com/1788727/193046101-5df49f40-55f8-4db4-beeb-96f310c1b5df.png">
