### PR TITLE
fix: remove gradle matching config error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "snyk-cpp-plugin": "2.20.1",
         "snyk-docker-plugin": "^5.6.0",
         "snyk-go-plugin": "1.19.2",
-        "snyk-gradle-plugin": "3.23.2",
+        "snyk-gradle-plugin": "3.24.1",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.31.1",
         "snyk-nodejs-lockfile-parser": "1.38.0",
@@ -14362,6 +14362,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/packageurl-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-1.0.0.tgz",
+      "integrity": "sha512-06kNFU+yB2pjDf5JyXouQeKfwSScGP8hrZK6VgB+W4SlVy4y5yB4vl+AVmh3R0GBNd+fBt0dEiSx3HKmuchuJQ=="
+    },
     "node_modules/pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
@@ -16843,9 +16848,9 @@
       }
     },
     "node_modules/snyk-gradle-plugin": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.23.2.tgz",
-      "integrity": "sha512-CbNObx/jm7u7afQbMdNBPjkrfemvfePPwLIgFtfqwPL1dYT0wGwCgGFSDz665sGzWNaeLYG2Mr7A9AEM2D1OCQ==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.24.1.tgz",
+      "integrity": "sha512-674BbnxgwoHm3n0RihCTxPK/avv5gvv+HKEK/DIdLASXIORJ3yUsfHnZRdVTpdLtDk4OeQuu6rW33cLf6PF+3Q==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",
@@ -16854,6 +16859,7 @@
         "chalk": "^3.0.0",
         "debug": "^4.1.1",
         "p-map": "^4.0.0",
+        "packageurl-js": "^1.0.0",
         "tmp": "0.2.1",
         "tslib": "^2.0.0"
       },
@@ -31310,6 +31316,11 @@
         "release-zalgo": "^1.0.0"
       }
     },
+    "packageurl-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-1.0.0.tgz",
+      "integrity": "sha512-06kNFU+yB2pjDf5JyXouQeKfwSScGP8hrZK6VgB+W4SlVy4y5yB4vl+AVmh3R0GBNd+fBt0dEiSx3HKmuchuJQ=="
+    },
     "pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
@@ -33199,9 +33210,9 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.23.2.tgz",
-      "integrity": "sha512-CbNObx/jm7u7afQbMdNBPjkrfemvfePPwLIgFtfqwPL1dYT0wGwCgGFSDz665sGzWNaeLYG2Mr7A9AEM2D1OCQ==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.24.1.tgz",
+      "integrity": "sha512-674BbnxgwoHm3n0RihCTxPK/avv5gvv+HKEK/DIdLASXIORJ3yUsfHnZRdVTpdLtDk4OeQuu6rW33cLf6PF+3Q==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",
@@ -33210,6 +33221,7 @@
         "chalk": "^3.0.0",
         "debug": "^4.1.1",
         "p-map": "^4.0.0",
+        "packageurl-js": "^1.0.0",
         "tmp": "0.2.1",
         "tslib": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "snyk-cpp-plugin": "2.20.1",
     "snyk-docker-plugin": "^5.6.0",
     "snyk-go-plugin": "1.19.2",
-    "snyk-gradle-plugin": "3.23.2",
+    "snyk-gradle-plugin": "3.24.1",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.31.1",
     "snyk-nodejs-lockfile-parser": "1.38.0",


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Bumps snyk-gradle-plugin version to 3.24.1
This version includes the following changes:
- use /rest/packages best practice Snyk REST API endpoint, add dependency on packageurl-js https://github.com/snyk/snyk-gradle-plugin/pull/232
- don't throw matching configurations error if one project in a multi-module build doesn't have requested config https://github.com/snyk/snyk-gradle-plugin/pull/235