### PR TITLE
fix: do not check stderr output in IaC smoke tests

### DIFF
--- a/test/smoke/iac/test.spec.ts
+++ b/test/smoke/iac/test.spec.ts
@@ -12,11 +12,10 @@ describe('snyk iac test', () => {
     const filePath = 'iac/depth_detection/root.tf';
 
     // Act
-    const { stderr, stdout, exitCode } = await run(`snyk iac test ${filePath}`);
+    const { stdout, exitCode } = await run(`snyk iac test ${filePath}`);
 
     // Assert
     expect(stdout).toContain('Infrastructure as Code');
-    expect(stderr).toBe('');
     expect(exitCode).toBeLessThan(2);
   });
 


### PR DESCRIPTION
Remove the check on stderr, which might not be empty because of code outside of IaC's control, like alerts.