### PR TITLE
chore: add cloud-context analytics

### DIFF
--- a/src/lib/formatters/iac-output/text/formatters.ts
+++ b/src/lib/formatters/iac-output/text/formatters.ts
@@ -9,6 +9,7 @@ import {
   IacTestData,
   Issue,
 } from './types';
+import { countSuppressedIssues } from './utils';
 
 interface FormatTestDataParams {
   oldFormattedResults: FormattedResult[];
@@ -113,12 +114,7 @@ export function formatSnykIacTestTestData(
   const suppressedResults =
     snykIacTestScanResult?.scanAnalytics?.suppressedResults;
   if (suppressedResults) {
-    contextSuppressedIssueCount = Object.values(suppressedResults).reduce(
-      function(count, resourcesForRuleId) {
-        return (count += resourcesForRuleId.length);
-      },
-      0,
-    );
+    contextSuppressedIssueCount = countSuppressedIssues(suppressedResults);
   }
 
   return {

--- a/src/lib/formatters/iac-output/text/utils.ts
+++ b/src/lib/formatters/iac-output/text/utils.ts
@@ -33,3 +33,15 @@ export const contentPadding = ' '.repeat(2);
 export const maxLineWidth = process.stdout.columns
   ? Math.min(process.stdout.columns, 80)
   : 80;
+
+export const countSuppressedIssues = (
+  suppressedIssues: Record<string, string[]>,
+): number => {
+  return Object.values(suppressedIssues).reduce(function(
+    count,
+    resourcesForRuleId,
+  ) {
+    return (count += resourcesForRuleId.length);
+  },
+  0);
+};

--- a/src/lib/iac/test/v2/analytics/iac-cloud-context.ts
+++ b/src/lib/iac/test/v2/analytics/iac-cloud-context.ts
@@ -1,0 +1,37 @@
+import { TestOutput } from '../scan/results';
+import { TestConfig } from '../types';
+import { countSuppressedIssues } from '../../../../formatters/iac-output/text/utils';
+import { IacAnalytics } from './index';
+
+type IacCloudContext = Pick<
+  IacAnalytics,
+  | 'iacCloudContext'
+  | 'iacCloudContextCloudProvider'
+  | 'iacCloudContextSuppressedIssuesCount'
+>;
+
+export function getIacCloudContext(
+  testConfig: TestConfig,
+  testOutput: TestOutput,
+): IacCloudContext {
+  let iacCloudContext;
+  if (testConfig.cloudContext) {
+    iacCloudContext = 'cloud-context';
+  } else if (testConfig.snykCloudEnvironment) {
+    iacCloudContext = 'snyk-cloud-environment';
+  }
+
+  let iacCloudContextSuppressedIssuesCount = 0;
+  const suppressedIssues = testOutput.results?.scanAnalytics?.suppressedResults;
+  if (suppressedIssues) {
+    iacCloudContextSuppressedIssuesCount = countSuppressedIssues(
+      suppressedIssues,
+    );
+  }
+
+  return {
+    iacCloudContext,
+    iacCloudContextCloudProvider: testConfig.cloudContext,
+    iacCloudContextSuppressedIssuesCount,
+  };
+}

--- a/src/lib/iac/test/v2/analytics/index.ts
+++ b/src/lib/iac/test/v2/analytics/index.ts
@@ -2,6 +2,8 @@ import { policyEngineReleaseVersion } from '../local-cache/policy-engine/constan
 import { ResourceKind, TestOutput } from '../scan/results';
 import * as analytics from '../../../../../lib/analytics';
 import { getIacType, IacType } from './iac-type';
+import { TestConfig } from '../types';
+import { getIacCloudContext } from './iac-cloud-context';
 
 export interface IacAnalytics {
   iacType: IacType;
@@ -13,10 +15,16 @@ export interface IacAnalytics {
   iacErrorCodes: number[];
   iacTestBinaryVersion: string;
   // iacRulesBundleVersion: string; // TODO: Add when we have the rules bundle version
+  iacCloudContext?: string;
+  iacCloudContextCloudProvider?: string;
+  iacCloudContextSuppressedIssuesCount: number;
 }
 
-export function addIacAnalytics(testOutput: TestOutput): void {
-  const iacAnalytics = computeIacAnalytics(testOutput);
+export function addIacAnalytics(
+  testConfig: TestConfig,
+  testOutput: TestOutput,
+): void {
+  const iacAnalytics = computeIacAnalytics(testConfig, testOutput);
 
   analytics.add('iac-type', iacAnalytics.iacType);
   analytics.add('packageManager', iacAnalytics.packageManager);
@@ -26,10 +34,27 @@ export function addIacAnalytics(testOutput: TestOutput): void {
   analytics.add('iac-resources-count', iacAnalytics.iacResourcesCount);
   analytics.add('iac-error-codes', iacAnalytics.iacErrorCodes);
   analytics.add('iac-test-binary-version', iacAnalytics.iacTestBinaryVersion);
+
+  // cloud context analytics
+  if (iacAnalytics.iacCloudContext) {
+    analytics.add('iac-cloud-context', iacAnalytics.iacCloudContext);
+    analytics.add(
+      'iac-cloud-context-cloud-provider',
+      iacAnalytics.iacCloudContextCloudProvider,
+    );
+    analytics.add(
+      'iac-cloud-context-suppressed-issues-count',
+      iacAnalytics.iacCloudContextSuppressedIssuesCount,
+    );
+  }
 }
 
-function computeIacAnalytics(testOutput: TestOutput): IacAnalytics {
+function computeIacAnalytics(
+  testConfig: TestConfig,
+  testOutput: TestOutput,
+): IacAnalytics {
   const iacType = getIacType(testOutput);
+  const iacCloudContext = getIacCloudContext(testConfig, testOutput);
 
   return {
     iacType,
@@ -45,5 +70,6 @@ function computeIacAnalytics(testOutput: TestOutput): IacAnalytics {
       [...new Set(testOutput.errors?.map((error) => error.code!))] || [],
     iacTestBinaryVersion: policyEngineReleaseVersion,
     // iacRulesBundleVersion = ''; // TODO: Add when we have the rules bundle version
+    ...iacCloudContext,
   };
 }

--- a/src/lib/iac/test/v2/index.ts
+++ b/src/lib/iac/test/v2/index.ts
@@ -13,7 +13,7 @@ export async function test(testConfig: TestConfig): Promise<TestOutput> {
 
   const testOutput = scan(testConfig, policyEnginePath, rulesBundlePath);
 
-  addIacAnalytics(testOutput);
+  addIacAnalytics(testConfig, testOutput);
 
   return testOutput;
 }

--- a/test/jest/unit/lib/iac/test/v2/analytics/fixtures/iac-analytics.json
+++ b/test/jest/unit/lib/iac/test/v2/analytics/fixtures/iac-analytics.json
@@ -1,4 +1,7 @@
 {
+    "iac-cloud-context": "cloud-context",
+    "iac-cloud-context-cloud-provider": "aws",
+    "iac-cloud-context-suppressed-issues-count": 0,
     "iac-type": {
       "terraformconfig": {
         "count": 2,
@@ -13,7 +16,7 @@
     "iac-ignored-issues-count": 3,
     "iac-files-count": 2,
     "iac-error-codes": [
-     2114
+      2114
     ],
     "iac-resources-count": 4,
     "iac-test-binary-version": "test-policy-engine-release-version"

--- a/test/jest/unit/lib/iac/test/v2/analytics/index.spec.ts
+++ b/test/jest/unit/lib/iac/test/v2/analytics/index.spec.ts
@@ -8,6 +8,7 @@ import {
   addIacAnalytics,
   IacAnalytics,
 } from '../../../../../../../../src/lib/iac/test/v2/analytics';
+import { TestConfig } from '../../../../../../../../src/lib/iac/test/v2/types';
 
 jest.mock(
   '../../../../../../../../src/lib/iac/test/v2/local-cache/policy-engine/constants',
@@ -56,11 +57,14 @@ describe('computeIacAnalytics', () => {
       addedAnalytics[key] = value;
     });
 
+    const testConfig = {
+      cloudContext: 'aws',
+    } as TestConfig;
     const testOutput = clonedeep(snykIacTestOutputFixture);
     const expectedAnalytics = clonedeep(iacAnalyticsFixture);
 
     // Act
-    addIacAnalytics(testOutput);
+    addIacAnalytics(testConfig, testOutput);
 
     // Assert
     expect(addedAnalytics).toStrictEqual(expectedAnalytics);


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR adds analytics to the `snyk iac test --cloud-context=aws` command (e.g. cloud context feature).

#### How should this be manually tested?

Run `./bin/snyk iac test --cloud-context=aws -d` with your AWS creds. For a specific use case you can try to use a terraform file with this code and enable in your AWS console the regional EBS volume encryption setting.

```hcl
resource "aws_instance" "this" {
  ami           = "ami-0c55b159cbfafe1f0"
  instance_type = "t2.micro"
}

resource "aws_ebs_volume" "this" {
  availability_zone = "us-east-2a"
  size              = 1
}
```

<img width="796" alt="image" src="https://user-images.githubusercontent.com/8110579/193858354-9ebf2b9a-d6d9-4e39-9b9e-3468ceb2b549.png">

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/CTX-32

#### Screenshots

<img width="427" alt="image" src="https://user-images.githubusercontent.com/8110579/193857929-7b8a138b-17c7-4e13-b0ae-16fb27e8d5c0.png">

```
snyk analytics {
  "args": [
    "terraform.tf",
    {
      "cloud-context": "aws",
      "debug": true,
      "iac": true
    }
  ],
  "command": "test",
  "metadata": {
    "policies": 1,
    "policyLocations": [
      "/Users/wbeuil/Snyk/snyk"
    ],
    "iac-type": {
      "terraformconfig": {
        "count": 1,
        "resource-count": 2
      }
    },
    "packageManager": [
      "terraformconfig"
    ],
    "iac-issues-count": 0,
    "iac-ignored-issues-count": 0,
    "iac-files-count": 1,
    "iac-resources-count": 2,
    "iac-error-codes": [],
    "iac-test-binary-version": "0.32.1",
    "is-iac-cloud-context": true, # HERE
    "iac-cloud-context": "aws", # HERE
    "iac-suppressed-issues-count": 1 # HERE
  },
```

