### PR TITLE
feat: disable container app scan with feature flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "snyk",
       "version": "1.0.0-monorepo",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "test:unit": "jest --runInBand --testPathPattern '/test(/jest)?/unit/'",
     "test:acceptance": "jest --runInBand --testPathPattern '/test(/jest)?/acceptance/'",
     "test:tap": "tap -Rspec --timeout=300 --node-arg=-r --node-arg=ts-node/register test/tap/*.test.* ",
-    "test:smoke": "./scripts/run-smoke-tests-locally.sh"
+    "test:smoke": "./scripts/run-smoke-tests-locally.sh",
+    "postinstall": "bash ./scripts/apply-patches.sh"
   },
   "keywords": [
     "security",

--- a/scripts/apply-patches.sh
+++ b/scripts/apply-patches.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Applying patches from vendor directory"
+
+for filename in ./vendor/*.patch; do
+    if ! git apply --reverse --check --quiet "$filename"; then
+        echo "Applying $filename"
+        git apply "$filename"
+    fi;
+done

--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -48,6 +48,7 @@ import { isMultiProjectScan } from '../../../lib/is-multi-project-scan';
 import { getEcosystem, monitorEcosystem } from '../../../lib/ecosystems';
 import { getFormattedMonitorOutput } from '../../../lib/ecosystems/monitor';
 import { processCommandArgs } from '../process-command-args';
+import { hasFeatureFlag } from '../../../lib/feature-flags';
 
 const SEPARATOR = '\n-------------------------------------------------------\n';
 const debug = Debug('snyk');
@@ -96,14 +97,31 @@ export default async function monitor(...args0: MethodArgs): Promise<any> {
   // TODO remove 'app-vulns' options and warning message once
   // https://github.com/snyk/cli/pull/3433 is merged
   if (options.docker) {
-    if (!options['app-vulns'] || options['exclude-app-vulns']) {
+    // order is important here, we want:
+    // 1) exclude-app-vulns set -> no app vulns
+    // 2) app-vulns set -> app-vulns
+    // 3) neither set -> containerAppVulnsEnabled
+    if (options['exclude-app-vulns']) {
       options['exclude-app-vulns'] = true;
-    }
+    } else if (options['app-vulns']) {
+      options['exclude-app-vulns'] = false;
+    } else {
+      options['exclude-app-vulns'] = !(await hasFeatureFlag(
+        'containerCliAppVulnsEnabled',
+        options,
+      ));
 
-    // we can't print the warning message with JSON output as that would make
-    // the JSON output invalid.
-    if (!options['app-vulns'] && !options['json']) {
-      console.log(theme.color.status.warn(appVulnsReleaseWarningMsg));
+      // we can't print the warning message with JSON output as that would make
+      // the JSON output invalid.
+      // We also only want to print the message if the user did not overwrite
+      // the default with one of the flags.
+      if (
+        options['exclude-app-vulns'] &&
+        !options['json'] &&
+        !options['sarif']
+      ) {
+        console.log(theme.color.status.warn(appVulnsReleaseWarningMsg));
+      }
     }
   }
 

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -10,6 +10,7 @@ const featureFlagDefaults = (): Map<string, boolean> => {
   return new Map([
     ['cliFailFast', false],
     ['iacIntegratedExperience', false],
+    ['containerCliAppVulnsEnabled', false],
   ]);
 };
 

--- a/test/jest/acceptance/cli-args.spec.ts
+++ b/test/jest/acceptance/cli-args.spec.ts
@@ -12,7 +12,7 @@ const isWindows =
 jest.setTimeout(1000 * 60 * 5);
 
 describe('cli args', () => {
-  let server;
+  let server: ReturnType<typeof fakeServer>;
   let env: Record<string, string>;
 
   beforeAll((done) => {
@@ -301,7 +301,7 @@ describe('cli args', () => {
   });
 
   test('iac test with flags not allowed with --sarif', async () => {
-    const { code, stdout } = await runSnykCLI(`test iac --sarif --json`, {
+    const { code, stdout } = await runSnykCLI(`iac test --sarif --json`, {
       env,
     });
     expect(stdout).toMatch(
@@ -312,10 +312,13 @@ describe('cli args', () => {
     expect(code).toEqual(2);
   });
 
-  test('iac container with flags not allowed with --sarif', async () => {
-    const { code, stdout } = await runSnykCLI(`test container --sarif --json`, {
-      env,
-    });
+  test('container test with flags not allowed with --sarif', async () => {
+    const { code, stdout } = await runSnykCLI(
+      `container test  --sarif --json`,
+      {
+        env,
+      },
+    );
     expect(stdout).toMatch(
       new UnsupportedOptionCombinationError(['test', 'sarif', 'json'])
         .userMessage,
@@ -393,9 +396,9 @@ describe('cli args', () => {
       },
     );
 
+    expect(code).toEqual(0);
     const sarifOutput = await project.readJSON(sarifPath);
     expect(sarifOutput.version).toMatch('2.1.0');
-    expect(code).toEqual(0);
   });
 
   test('container test --sarif-file-output can be used at the same time as --json', async () => {
@@ -432,7 +435,6 @@ describe('cli args', () => {
         },
       );
       const jsonOutput = JSON.parse(stdout);
-
       expect(jsonOutput.ok).toEqual(true);
       expect(code).toEqual(0);
     });

--- a/test/tap/cli-fail-on-docker.test.ts
+++ b/test/tap/cli-fail-on-docker.test.ts
@@ -81,6 +81,11 @@ test('test docker image with no fixable vulns and --fail-on=all', async (t) => {
     await cli.test('debian/sqlite3:latest', {
       failOn: 'all',
       docker: true,
+      // TODO: we should be able to remove that setting once once we remove the
+      // containerCliAppVulnsEnabled feature flag has been removed as well.
+      // Currently without setting this (or app-vulns), the code tries to reach
+      // the API to check the feature flag and throws an exception.
+      'exclude-app-vulns': true,
     });
     t.pass('should not throw exception');
   } catch (err) {
@@ -98,6 +103,11 @@ test('test docker image with fixable vulns and --fail-on=all', async (t) => {
     await cli.test('garethr/snyky:alpine', {
       failOn: 'all',
       docker: true,
+      // TODO: we should be able to remove that setting once once we remove the
+      // containerCliAppVulnsEnabled feature flag has been removed as well.
+      // Currently without setting this (or app-vulns), the code tries to reach
+      // the API to check the feature flag and throws an exception.
+      'exclude-app-vulns': true,
     });
     t.fail('expected test to throw exception');
   } catch (err) {

--- a/test/tap/cli-monitor.acceptance.test.ts
+++ b/test/tap/cli-monitor.acceptance.test.ts
@@ -1876,6 +1876,46 @@ if (!isWindows) {
     t.deepEqual(policyString, expected, 'sends correct policy');
   });
 
+  test('`monitor foo:latest --docker` with app vulns feature flag enabled', async (t) => {
+    chdirWorkspaces('npm-package-policy');
+    const spyPlugin = stubDockerPluginResponse(
+      {
+        scanResults: [
+          {
+            identity: {
+              type: 'rpm',
+            },
+            target: {
+              image: 'docker-image|foo',
+            },
+            facts: [{ type: 'depGraph', data: {} }],
+          },
+        ],
+        attributes: {},
+      },
+      t,
+    );
+
+    server.setFeatureFlag('containerCliAppVulnsEnabled', true);
+    await cli.monitor('foo:latest', {
+      docker: true,
+      org: 'explicit-org',
+    });
+    t.same(
+      spyPlugin.getCall(0).args,
+      [
+        {
+          docker: true,
+          'exclude-app-vulns': false,
+          org: 'explicit-org',
+          path: 'foo:latest',
+        },
+      ],
+      'calls docker plugin with expected arguments',
+    );
+    server.setFeatureFlag('containerCliAppVulnsEnabled', false);
+  });
+
   test('`monitor foo:latest --docker --platform=linux/arm64`', async (t) => {
     const platform = 'linux/arm64';
     const spyPlugin = stubDockerPluginResponse(

--- a/vendor/global-agent-socket-exception.patch
+++ b/vendor/global-agent-socket-exception.patch
@@ -1,0 +1,23 @@
+diff --git a/node_modules/global-agent/dist/classes/Agent.js b/node_modules/global-agent/dist/classes/Agent.js
+index ba8cc1a81..1e9bd4e8f 100644
+--- a/node_modules/global-agent/dist/classes/Agent.js
++++ b/node_modules/global-agent/dist/classes/Agent.js
+@@ -40,6 +40,18 @@ class Agent {
+       requestUrl = this.protocol + '//' + (configuration.hostname || configuration.host) + (configuration.port === 80 || configuration.port === 443 ? '' : ':' + configuration.port) + request.path;
+     }
+ 
++    // If a request should go to a local socket, proxying it through an HTTP
++    // server does not make sense as the information about the target socket
++    // will be lost and the proxy won't be able to correctly handle the request.
++    if (configuration.socketPath) {
++      log.trace({
++        destination: configuration.socketPath,
++      }, "not proxying request; destination is a socket");
++
++      this.fallbackAgent.addRequest(request, configuration);
++      return;
++    }
++
+     if (!this.isProxyConfigured()) {
+       log.trace({
+         destination: requestUrl


### PR DESCRIPTION
#### What does this PR do?

This commit adds a check for the `containerCliAppVulnsEnabled` feature flag. If neither `--exclude-app-vulns` nor `--app-vulns` are set, the feature flag will be used to determine whether app vulnerabilities will be scanned or not.

#### Any background context you want to provide?

Part of the work to enable app vulnerability scanning in containers by default. Build upon @yaronschwimmer's [change](https://github.com/snyk/cli/commit/d2aac4ba96cef4c93e75cbdf800fc2f7f3125192), but that needed some adjustments to ensure the ordering and precedence of flags.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/MYC-177
