### PR TITLE
fix: Ignored issues count displays "undefined"

### DIFF
--- a/src/lib/formatters/iac-output/text/formatters.ts
+++ b/src/lib/formatters/iac-output/text/formatters.ts
@@ -106,7 +106,7 @@ export function formatSnykIacTestTestData(
   const filesWithIssuesCount = countFilesWithIssues(snykIacTestScanResult);
   const filesWithoutIssuesCount = allFilesCount - filesWithIssuesCount;
   const ignores = snykIacTestScanResult
-    ? snykIacTestScanResult.scanAnalytics.ignoredCount
+    ? snykIacTestScanResult.metadata.ignoredCount
     : 0;
 
   let contextSuppressedIssueCount: number | undefined;

--- a/src/lib/iac/test/v2/analytics/index.ts
+++ b/src/lib/iac/test/v2/analytics/index.ts
@@ -35,7 +35,7 @@ function computeIacAnalytics(testOutput: TestOutput): IacAnalytics {
     iacType,
     packageManager: Object.keys(iacType) as ResourceKind[],
     iacIssuesCount: testOutput.results?.vulnerabilities?.length || 0,
-    iacIgnoredIssuesCount: testOutput.results?.scanAnalytics.ignoredCount || 0,
+    iacIgnoredIssuesCount: testOutput.results?.metadata.ignoredCount || 0,
     iacFilesCount: Object.values(iacType).reduce(
       (acc, packageManagerAnalytics) => acc + packageManagerAnalytics!.count,
       0,

--- a/src/lib/iac/test/v2/scan/results.ts
+++ b/src/lib/iac/test/v2/scan/results.ts
@@ -39,6 +39,7 @@ export interface Results {
 
 export interface Metadata {
   projectName: string;
+  ignoredCount: number;
 }
 
 export interface ScanAnalytics {

--- a/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results-with-suppressions.json
+++ b/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results-with-suppressions.json
@@ -147,7 +147,8 @@
       }
     ],
     "metadata": {
-      "projectName": "input-files-for-json-v2"
+      "projectName": "input-files-for-json-v2",
+      "ignoredCount": 3
     },
     "scanAnalytics": {
       "suppressedResults": {

--- a/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results.json
+++ b/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results.json
@@ -147,9 +147,7 @@
       }
     ],
     "metadata": {
-      "projectName": "input-files-for-json-v2"
-    },
-    "scanAnalytics": {
+      "projectName": "input-files-for-json-v2",
       "ignoredCount": 3
     }
   },


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

The `Ignored issues` field in the CLI output displays `undefined`, but it should display the actual number of ignored issues returned by `snyk-iac-test`.
