### PR TITLE
fix/HMMR-578_no_proxy_localhost

### DIFF
--- a/cliv2/internal/cliv2/cliv2.go
+++ b/cliv2/internal/cliv2/cliv2.go
@@ -206,6 +206,7 @@ func PrepareV1EnvironmentVariables(input []string, integrationName string, integ
 		inputAsMap[constants.SNYK_HTTPS_PROXY_ENV] = proxyAddress
 		inputAsMap[constants.SNYK_HTTP_PROXY_ENV] = proxyAddress
 		inputAsMap[constants.SNYK_CA_CERTIFICATE_LOCATION_ENV] = caCertificateLocation
+		inputAsMap[constants.SNYK_HTTP_NO_PROXY_ENV] = "localhost,127.0.0.1"
 
 		result = utils.ToSlice(inputAsMap, "=")
 	}

--- a/cliv2/internal/cliv2/cliv2_test.go
+++ b/cliv2/internal/cliv2/cliv2_test.go
@@ -26,7 +26,7 @@ func Test_PrepareV1EnvironmentVariables_Fill_and_Filter(t *testing.T) {
 		"npm_config_no_proxy=something",
 		"ALL_PROXY=something",
 	}
-	expected := []string{"something=1", "in=2", "here=3=2", "SNYK_INTEGRATION_NAME=foo", "SNYK_INTEGRATION_VERSION=bar", "HTTP_PROXY=proxy", "HTTPS_PROXY=proxy", "NODE_EXTRA_CA_CERTS=cacertlocation"}
+	expected := []string{"something=1", "in=2", "here=3=2", "SNYK_INTEGRATION_NAME=foo", "SNYK_INTEGRATION_VERSION=bar", "HTTP_PROXY=proxy", "HTTPS_PROXY=proxy", "NODE_EXTRA_CA_CERTS=cacertlocation", "NO_PROXY=localhost,127.0.0.1"}
 
 	actual, err := cliv2.PrepareV1EnvironmentVariables(input, "foo", "bar", "proxy", "cacertlocation")
 
@@ -39,7 +39,7 @@ func Test_PrepareV1EnvironmentVariables_Fill_and_Filter(t *testing.T) {
 func Test_PrepareV1EnvironmentVariables_DontOverrideExistingIntegration(t *testing.T) {
 
 	input := []string{"something=1", "in=2", "here=3", "SNYK_INTEGRATION_NAME=exists", "SNYK_INTEGRATION_VERSION=already"}
-	expected := []string{"something=1", "in=2", "here=3", "SNYK_INTEGRATION_NAME=exists", "SNYK_INTEGRATION_VERSION=already", "HTTP_PROXY=proxy", "HTTPS_PROXY=proxy", "NODE_EXTRA_CA_CERTS=cacertlocation"}
+	expected := []string{"something=1", "in=2", "here=3", "SNYK_INTEGRATION_NAME=exists", "SNYK_INTEGRATION_VERSION=already", "HTTP_PROXY=proxy", "HTTPS_PROXY=proxy", "NODE_EXTRA_CA_CERTS=cacertlocation", "NO_PROXY=localhost,127.0.0.1"}
 
 	actual, err := cliv2.PrepareV1EnvironmentVariables(input, "foo", "bar", "proxy", "cacertlocation")
 
@@ -52,7 +52,7 @@ func Test_PrepareV1EnvironmentVariables_DontOverrideExistingIntegration(t *testi
 func Test_PrepareV1EnvironmentVariables_OverrideProxyAndCerts(t *testing.T) {
 
 	input := []string{"something=1", "in=2", "here=3", "http_proxy=exists", "https_proxy=already", "NODE_EXTRA_CA_CERTS=again", "no_proxy=312123"}
-	expected := []string{"something=1", "in=2", "here=3", "SNYK_INTEGRATION_NAME=foo", "SNYK_INTEGRATION_VERSION=bar", "HTTP_PROXY=proxy", "HTTPS_PROXY=proxy", "NODE_EXTRA_CA_CERTS=cacertlocation"}
+	expected := []string{"something=1", "in=2", "here=3", "SNYK_INTEGRATION_NAME=foo", "SNYK_INTEGRATION_VERSION=bar", "HTTP_PROXY=proxy", "HTTPS_PROXY=proxy", "NODE_EXTRA_CA_CERTS=cacertlocation", "NO_PROXY=localhost,127.0.0.1"}
 
 	actual, err := cliv2.PrepareV1EnvironmentVariables(input, "foo", "bar", "proxy", "cacertlocation")
 

--- a/test/jest/acceptance/https.spec.ts
+++ b/test/jest/acceptance/https.spec.ts
@@ -4,6 +4,7 @@ import { createProjectFromWorkspace } from '../util/createProject';
 import { getFixturePath } from '../util/getFixturePath';
 import { runSnykCLI } from '../util/runSnykCLI';
 import { isCLIV2 } from '../util/isCLIV2';
+import * as os from 'os';
 
 jest.setTimeout(1000 * 30);
 
@@ -14,10 +15,11 @@ describe('https', () => {
   beforeAll(async () => {
     const port = process.env.PORT || process.env.SNYK_PORT || '12345';
     const baseApi = '/api/v1';
+    const hostname = os.hostname();
     env = {
       ...process.env,
-      SNYK_API: 'https://localhost:' + port + baseApi,
-      SNYK_HOST: 'https://localhost:' + port,
+      SNYK_API: 'https://' + hostname + ':' + port + baseApi,
+      SNYK_HOST: 'https://' + hostname + ':' + port,
       SNYK_TOKEN: '123456789',
     };
     server = fakeServer(baseApi, env.SNYK_TOKEN);


### PR DESCRIPTION
This fixes a change of behaviour when trying unavailable resources on localhost.

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Make use of the NO_PROXY settings for the internal proxy/gateway usage.

