### PR TITLE
feat: use basic auth for internal CLI proxy

### DIFF
--- a/cliv2/cmd/cliv2/main.go
+++ b/cliv2/cmd/cliv2/main.go
@@ -140,7 +140,7 @@ func MainWithErrorCode(envVariables EnvironmentVariables, args []string) int {
 	wrapperProxy.SetUpstreamProxyAuthentication(envVariables.ProxyAuthenticationMechanism)
 	http.DefaultTransport = wrapperProxy.Transport()
 
-	port, err := wrapperProxy.Start()
+	_, err = wrapperProxy.Start()
 	if err != nil {
 		fmt.Println("Failed to start the proxy")
 		fmt.Println(err)
@@ -149,7 +149,8 @@ func MainWithErrorCode(envVariables EnvironmentVariables, args []string) int {
 	}
 
 	// run the cli
-	err = cli.Execute(port, wrapperProxy.CertificateLocation, args)
+	proxyInfo := wrapperProxy.ProxyInfo()
+	err = cli.Execute(proxyInfo, wrapperProxy.CertificateLocation, args)
 	if err != nil {
 		cliAnalytics.AddError(err)
 	}

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -4,6 +4,8 @@ go 1.18
 
 require (
 	github.com/elazarl/goproxy v0.0.0-20220328115640-894aeddb713e
+	github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2
+	github.com/google/uuid v1.1.2
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd
 	github.com/spf13/viper v1.13.0

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -120,6 +120,7 @@ github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=

--- a/cliv2/internal/cliv2/cliv2_test.go
+++ b/cliv2/internal/cliv2/cliv2_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/snyk/cli/cliv2/internal/cliv2"
 	"github.com/snyk/cli/cliv2/internal/constants"
+	"github.com/snyk/cli/cliv2/internal/proxy"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -78,13 +79,20 @@ func Test_PrepareV1EnvironmentVariables_Fail_DontOverrideExisting(t *testing.T) 
 	assert.NotNil(t, warn)
 }
 
+func getProxyInfoForTest() *proxy.ProxyInfo {
+	return &proxy.ProxyInfo{
+		Port:     1000,
+		Password: "foo",
+	}
+}
+
 func Test_prepareV1Command(t *testing.T) {
 	expectedArgs := []string{"hello", "world"}
 
 	snykCmd, err := cliv2.PrepareV1Command(
 		"someExecutable",
 		expectedArgs,
-		1,
+		getProxyInfoForTest(),
 		"certLocation",
 		"name",
 		"version",
@@ -92,7 +100,7 @@ func Test_prepareV1Command(t *testing.T) {
 
 	assert.Contains(t, snykCmd.Env, "SNYK_INTEGRATION_NAME=name")
 	assert.Contains(t, snykCmd.Env, "SNYK_INTEGRATION_VERSION=version")
-	assert.Contains(t, snykCmd.Env, "HTTPS_PROXY=http://127.0.0.1:1")
+	assert.Contains(t, snykCmd.Env, "HTTPS_PROXY=http://snykcli:foo@127.0.0.1:1000")
 	assert.Contains(t, snykCmd.Env, "NODE_EXTRA_CA_CERTS=certLocation")
 	assert.Equal(t, expectedArgs, snykCmd.Args[1:])
 	assert.Nil(t, err)
@@ -110,13 +118,13 @@ func Test_executeRunV1(t *testing.T) {
 	cli, _ := cliv2.NewCLIv2(cacheDir, logger)
 
 	// run once
-	actualReturnCode := cli.DeriveExitCode(cli.Execute(1000, "", []string{"--help"}))
+	actualReturnCode := cli.DeriveExitCode(cli.Execute(getProxyInfoForTest(), "", []string{"--help"}))
 	assert.Equal(t, expectedReturnCode, actualReturnCode)
 	assert.FileExists(t, cli.GetBinaryLocation())
 	fileInfo1, _ := os.Stat(cli.GetBinaryLocation())
 
 	// run twice
-	actualReturnCode = cli.DeriveExitCode(cli.Execute(1000, "", []string{"--help"}))
+	actualReturnCode = cli.DeriveExitCode(cli.Execute(getProxyInfoForTest(), "", []string{"--help"}))
 	assert.Equal(t, expectedReturnCode, actualReturnCode)
 	assert.FileExists(t, cli.GetBinaryLocation())
 	fileInfo2, _ := os.Stat(cli.GetBinaryLocation())
@@ -137,7 +145,7 @@ func Test_executeRunV2only(t *testing.T) {
 
 	// create instance under test
 	cli, _ := cliv2.NewCLIv2(cacheDir, logger)
-	actualReturnCode := cli.DeriveExitCode(cli.Execute(1000, "", []string{"--version"}))
+	actualReturnCode := cli.DeriveExitCode(cli.Execute(getProxyInfoForTest(), "", []string{"--version"}))
 	assert.Equal(t, expectedReturnCode, actualReturnCode)
 	assert.FileExists(t, cli.GetBinaryLocation())
 
@@ -157,7 +165,7 @@ func Test_executeEnvironmentError(t *testing.T) {
 
 	// create instance under test
 	cli, _ := cliv2.NewCLIv2(cacheDir, logger)
-	actualReturnCode := cli.DeriveExitCode(cli.Execute(1000, "", []string{"--help"}))
+	actualReturnCode := cli.DeriveExitCode(cli.Execute(getProxyInfoForTest(), "", []string{"--help"}))
 	assert.Equal(t, expectedReturnCode, actualReturnCode)
 	assert.FileExists(t, cli.GetBinaryLocation())
 
@@ -172,7 +180,7 @@ func Test_executeUnknownCommand(t *testing.T) {
 
 	// create instance under test
 	cli, _ := cliv2.NewCLIv2(cacheDir, logger)
-	actualReturnCode := cli.DeriveExitCode(cli.Execute(1000, "", []string{"bogusCommand"}))
+	actualReturnCode := cli.DeriveExitCode(cli.Execute(getProxyInfoForTest(), "", []string{"bogusCommand"}))
 	assert.Equal(t, expectedReturnCode, actualReturnCode)
 
 	os.RemoveAll(cacheDir)


### PR DESCRIPTION
Adds basic authentication to the internal CLI golang proxy and then invokes TS CLI with proxy credentials.