### PR TITLE
Use basic auth for internal CLI proxy

### DIFF
--- a/cliv2/cmd/cliv2/main.go
+++ b/cliv2/cmd/cliv2/main.go
@@ -140,7 +140,7 @@ func MainWithErrorCode(envVariables EnvironmentVariables, args []string) int {
 	wrapperProxy.SetUpstreamProxyAuthentication(envVariables.ProxyAuthenticationMechanism)
 	http.DefaultTransport = wrapperProxy.Transport()
 
-	port, err := wrapperProxy.Start()
+	err = wrapperProxy.Start()
 	if err != nil {
 		fmt.Println("Failed to start the proxy")
 		fmt.Println(err)
@@ -149,7 +149,8 @@ func MainWithErrorCode(envVariables EnvironmentVariables, args []string) int {
 	}
 
 	// run the cli
-	err = cli.Execute(port, wrapperProxy.CertificateLocation, args)
+	proxyInfo := wrapperProxy.ProxyInfo()
+	err = cli.Execute(proxyInfo, wrapperProxy.CertificateLocation, args)
 	if err != nil {
 		cliAnalytics.AddError(err)
 	}

--- a/cliv2/cmd/cliv2/main.go
+++ b/cliv2/cmd/cliv2/main.go
@@ -150,7 +150,7 @@ func MainWithErrorCode(envVariables EnvironmentVariables, args []string) int {
 
 	// run the cli
 	proxyInfo := wrapperProxy.ProxyInfo()
-	err = cli.Execute(proxyInfo, wrapperProxy.CertificateLocation, args)
+	err = cli.Execute(proxyInfo, args)
 	if err != nil {
 		cliAnalytics.AddError(err)
 	}

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -13,8 +13,10 @@ require (
 require (
 	github.com/alexbrainman/sspi v0.0.0-20210105120005-909beea2cc74 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/elazarl/goproxy/ext v0.0.0-20220901064549-fbd10ff4f5a1 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/golang/mock v1.6.0 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/jcmturner/aescts/v2 v2.0.0 // indirect
 	github.com/jcmturner/dnsutils/v2 v2.0.0 // indirect

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -55,6 +55,8 @@ github.com/elazarl/goproxy v0.0.0-20220328115640-894aeddb713e h1:99KFda6F/mw8xSf
 github.com/elazarl/goproxy v0.0.0-20220328115640-894aeddb713e/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 h1:dWB6v3RcOy03t/bUadywsbyrQwCqZeNIEX6M1OtSZOM=
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
+github.com/elazarl/goproxy/ext v0.0.0-20220901064549-fbd10ff4f5a1 h1:gKaQvSexH9ByWTfiMEPYeTm9n0d9Y27l6uBC9UuJwyI=
+github.com/elazarl/goproxy/ext v0.0.0-20220901064549-fbd10ff4f5a1/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -121,6 +123,8 @@ github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=

--- a/cliv2/internal/cliv2/cliv2_test.go
+++ b/cliv2/internal/cliv2/cliv2_test.go
@@ -81,8 +81,9 @@ func Test_PrepareV1EnvironmentVariables_Fail_DontOverrideExisting(t *testing.T) 
 
 func getProxyInfoForTest() *proxy.ProxyInfo {
 	return &proxy.ProxyInfo{
-		Port:     1000,
-		Password: "foo",
+		Port:                1000,
+		Password:            "foo",
+		CertificateLocation: "certLocation",
 	}
 }
 
@@ -93,7 +94,6 @@ func Test_prepareV1Command(t *testing.T) {
 		"someExecutable",
 		expectedArgs,
 		getProxyInfoForTest(),
-		"certLocation",
 		"name",
 		"version",
 	)
@@ -118,13 +118,13 @@ func Test_executeRunV1(t *testing.T) {
 	cli, _ := cliv2.NewCLIv2(cacheDir, logger)
 
 	// run once
-	actualReturnCode := cli.DeriveExitCode(cli.Execute(getProxyInfoForTest(), "", []string{"--help"}))
+	actualReturnCode := cli.DeriveExitCode(cli.Execute(getProxyInfoForTest(), []string{"--help"}))
 	assert.Equal(t, expectedReturnCode, actualReturnCode)
 	assert.FileExists(t, cli.GetBinaryLocation())
 	fileInfo1, _ := os.Stat(cli.GetBinaryLocation())
 
 	// run twice
-	actualReturnCode = cli.DeriveExitCode(cli.Execute(getProxyInfoForTest(), "", []string{"--help"}))
+	actualReturnCode = cli.DeriveExitCode(cli.Execute(getProxyInfoForTest(), []string{"--help"}))
 	assert.Equal(t, expectedReturnCode, actualReturnCode)
 	assert.FileExists(t, cli.GetBinaryLocation())
 	fileInfo2, _ := os.Stat(cli.GetBinaryLocation())
@@ -145,7 +145,7 @@ func Test_executeRunV2only(t *testing.T) {
 
 	// create instance under test
 	cli, _ := cliv2.NewCLIv2(cacheDir, logger)
-	actualReturnCode := cli.DeriveExitCode(cli.Execute(getProxyInfoForTest(), "", []string{"--version"}))
+	actualReturnCode := cli.DeriveExitCode(cli.Execute(getProxyInfoForTest(), []string{"--version"}))
 	assert.Equal(t, expectedReturnCode, actualReturnCode)
 	assert.FileExists(t, cli.GetBinaryLocation())
 
@@ -165,7 +165,7 @@ func Test_executeEnvironmentError(t *testing.T) {
 
 	// create instance under test
 	cli, _ := cliv2.NewCLIv2(cacheDir, logger)
-	actualReturnCode := cli.DeriveExitCode(cli.Execute(getProxyInfoForTest(), "", []string{"--help"}))
+	actualReturnCode := cli.DeriveExitCode(cli.Execute(getProxyInfoForTest(), []string{"--help"}))
 	assert.Equal(t, expectedReturnCode, actualReturnCode)
 	assert.FileExists(t, cli.GetBinaryLocation())
 
@@ -180,7 +180,7 @@ func Test_executeUnknownCommand(t *testing.T) {
 
 	// create instance under test
 	cli, _ := cliv2.NewCLIv2(cacheDir, logger)
-	actualReturnCode := cli.DeriveExitCode(cli.Execute(getProxyInfoForTest(), "", []string{"bogusCommand"}))
+	actualReturnCode := cli.DeriveExitCode(cli.Execute(getProxyInfoForTest(), []string{"bogusCommand"}))
 	assert.Equal(t, expectedReturnCode, actualReturnCode)
 
 	os.RemoveAll(cacheDir)

--- a/cliv2/internal/cliv2/cliv2_test.go
+++ b/cliv2/internal/cliv2/cliv2_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/snyk/cli/cliv2/internal/cliv2"
 	"github.com/snyk/cli/cliv2/internal/constants"
+	"github.com/snyk/cli/cliv2/internal/proxy"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -78,13 +79,20 @@ func Test_PrepareV1EnvironmentVariables_Fail_DontOverrideExisting(t *testing.T) 
 	assert.NotNil(t, warn)
 }
 
+func getProxyInfoForTest() *proxy.ProxyInfo {
+	return &proxy.ProxyInfo{
+		Port:     1000,
+		Password: "foo",
+	}
+}
+
 func Test_prepareV1Command(t *testing.T) {
 	expectedArgs := []string{"hello", "world"}
 
 	snykCmd, err := cliv2.PrepareV1Command(
 		"someExecutable",
 		expectedArgs,
-		1,
+		getProxyInfoForTest(),
 		"certLocation",
 		"name",
 		"version",
@@ -92,7 +100,7 @@ func Test_prepareV1Command(t *testing.T) {
 
 	assert.Contains(t, snykCmd.Env, "SNYK_INTEGRATION_NAME=name")
 	assert.Contains(t, snykCmd.Env, "SNYK_INTEGRATION_VERSION=version")
-	assert.Contains(t, snykCmd.Env, "HTTPS_PROXY=http://127.0.0.1:1")
+	assert.Contains(t, snykCmd.Env, "HTTPS_PROXY=http://snykcli:foo@127.0.0.1:1000")
 	assert.Contains(t, snykCmd.Env, "NODE_EXTRA_CA_CERTS=certLocation")
 	assert.Equal(t, expectedArgs, snykCmd.Args[1:])
 	assert.Nil(t, err)
@@ -110,13 +118,13 @@ func Test_executeRunV1(t *testing.T) {
 	cli, _ := cliv2.NewCLIv2(cacheDir, logger)
 
 	// run once
-	actualReturnCode := cli.DeriveExitCode(cli.Execute(1000, "", []string{"--help"}))
+	actualReturnCode := cli.DeriveExitCode(cli.Execute(getProxyInfoForTest(), "", []string{"--help"}))
 	assert.Equal(t, expectedReturnCode, actualReturnCode)
 	assert.FileExists(t, cli.GetBinaryLocation())
 	fileInfo1, _ := os.Stat(cli.GetBinaryLocation())
 
 	// run twice
-	actualReturnCode = cli.DeriveExitCode(cli.Execute(1000, "", []string{"--help"}))
+	actualReturnCode = cli.DeriveExitCode(cli.Execute(getProxyInfoForTest(), "", []string{"--help"}))
 	assert.Equal(t, expectedReturnCode, actualReturnCode)
 	assert.FileExists(t, cli.GetBinaryLocation())
 	fileInfo2, _ := os.Stat(cli.GetBinaryLocation())
@@ -137,7 +145,7 @@ func Test_executeRunV2only(t *testing.T) {
 
 	// create instance under test
 	cli, _ := cliv2.NewCLIv2(cacheDir, logger)
-	actualReturnCode := cli.DeriveExitCode(cli.Execute(1000, "", []string{"--version"}))
+	actualReturnCode := cli.DeriveExitCode(cli.Execute(getProxyInfoForTest(), "", []string{"--version"}))
 	assert.Equal(t, expectedReturnCode, actualReturnCode)
 	assert.FileExists(t, cli.GetBinaryLocation())
 
@@ -157,7 +165,7 @@ func Test_executeEnvironmentError(t *testing.T) {
 
 	// create instance under test
 	cli, _ := cliv2.NewCLIv2(cacheDir, logger)
-	actualReturnCode := cli.DeriveExitCode(cli.Execute(1000, "", []string{"--help"}))
+	actualReturnCode := cli.DeriveExitCode(cli.Execute(getProxyInfoForTest(), "", []string{"--help"}))
 	assert.Equal(t, expectedReturnCode, actualReturnCode)
 	assert.FileExists(t, cli.GetBinaryLocation())
 
@@ -172,7 +180,7 @@ func Test_executeUnknownCommand(t *testing.T) {
 
 	// create instance under test
 	cli, _ := cliv2.NewCLIv2(cacheDir, logger)
-	actualReturnCode := cli.DeriveExitCode(cli.Execute(1000, "", []string{"bogusCommand"}))
+	actualReturnCode := cli.DeriveExitCode(cli.Execute(getProxyInfoForTest(), "", []string{"bogusCommand"}))
 	assert.Equal(t, expectedReturnCode, actualReturnCode)
 
 	os.RemoveAll(cacheDir)

--- a/cliv2/internal/proxy/proxy.go
+++ b/cliv2/internal/proxy/proxy.go
@@ -36,8 +36,9 @@ type WrapperProxy struct {
 }
 
 type ProxyInfo struct {
-	Port     int
-	Password string
+	Port                int
+	Password            string
+	CertificateLocation string
 }
 
 const (
@@ -100,8 +101,9 @@ func NewWrapperProxy(insecureSkipVerify bool, cacheDirectory string, cliVersion 
 
 func (p *WrapperProxy) ProxyInfo() *ProxyInfo {
 	return &ProxyInfo{
-		Port:     p.port,
-		Password: p.proxyPassword,
+		Port:                p.port,
+		Password:            p.proxyPassword,
+		CertificateLocation: p.CertificateLocation,
 	}
 }
 


### PR DESCRIPTION
Adds basic authentication to the internal CLI golang proxy and then invokes TS CLI with proxy credentials.