### PR TITLE
chore: add innerError to analytics

### DIFF
--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -276,6 +276,7 @@ export default async function test(
     error.code = errorResults[0].code;
     error.userMessage = errorResults[0].userMessage;
     error.strCode = errorResults[0].strCode;
+    error.innerError = errorResults[0].innerError;
     throw error;
   }
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -168,6 +168,7 @@ async function handleError(args, error) {
     // (see https://nodejs.org/api/errors.html#errors_error_stack)
     analytics.add('error', analyticsError.stack);
     analytics.add('error-code', error.code);
+    analytics.add('error-details', error.innerError);
     analytics.add('error-str-code', error.strCode);
     analytics.add('command', args.command);
   }

--- a/src/lib/errors/failed-to-run-test-error.ts
+++ b/src/lib/errors/failed-to-run-test-error.ts
@@ -2,11 +2,13 @@ import { CustomError } from './custom-error';
 
 export class FailedToRunTestError extends CustomError {
   private static ERROR_MESSAGE = 'Failed to run a test';
+  public innerError: any | undefined;
 
-  constructor(userMessage, errorCode?) {
+  constructor(userMessage, errorCode?, innerError?: any) {
     const code = errorCode || 500;
     super(userMessage || FailedToRunTestError.ERROR_MESSAGE);
     this.code = errorCode || code;
     this.userMessage = userMessage || FailedToRunTestError.ERROR_MESSAGE;
+    this.innerError = innerError;
   }
 }

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -320,6 +320,7 @@ export async function runTest(
         error.message ||
         `Failed to test ${projectType} project`,
       error.code,
+      error.innerError,
     );
   } finally {
     spinner.clear<void>(spinnerLbl)();

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -458,7 +458,7 @@ function handleTestHttpErrorResponse(res, body) {
     case 401:
     case 403:
       err = AuthFailedError(userMessage, statusCode);
-      err.innerError = body.stack;
+      err.innerError = body.stack || body;
       break;
     case 404:
       err = new NotFoundError(userMessage);


### PR DESCRIPTION
This PR adds innerError to CLI analytics as error-details, and uses body in 403 error innerError if body.stack is empty.
This will allow us to get more insights in analytics about 403 errors.