### PR TITLE
fix: identify gradle projects by path not name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "snyk-cpp-plugin": "2.20.1",
         "snyk-docker-plugin": "^5.6.0",
         "snyk-go-plugin": "1.19.2",
-        "snyk-gradle-plugin": "3.24.2",
+        "snyk-gradle-plugin": "3.24.4",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.31.2",
         "snyk-nodejs-lockfile-parser": "1.38.0",
@@ -16726,9 +16726,9 @@
       }
     },
     "node_modules/snyk-gradle-plugin": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.24.2.tgz",
-      "integrity": "sha512-QFZ9YBZoafF1gnthPkW7zPV4duhgjKTy85WzNsAIUQgq1IXk22lfg7xDLz9N+dSCWDo+OlHQK2xuh7RbRqCmqA==",
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.24.4.tgz",
+      "integrity": "sha512-hT5TFCKTBE+DVbNMzyXId3wXTRbJIGiX9r9Uaog1k464N1GMLr2ehT3zDTPNoZ870vW7Vb2FPU90bWqQr9xLDA==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",
@@ -32968,9 +32968,9 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.24.2.tgz",
-      "integrity": "sha512-QFZ9YBZoafF1gnthPkW7zPV4duhgjKTy85WzNsAIUQgq1IXk22lfg7xDLz9N+dSCWDo+OlHQK2xuh7RbRqCmqA==",
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.24.4.tgz",
+      "integrity": "sha512-hT5TFCKTBE+DVbNMzyXId3wXTRbJIGiX9r9Uaog1k464N1GMLr2ehT3zDTPNoZ870vW7Vb2FPU90bWqQr9xLDA==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "snyk-cpp-plugin": "2.20.1",
     "snyk-docker-plugin": "^5.6.0",
     "snyk-go-plugin": "1.19.2",
-    "snyk-gradle-plugin": "3.24.2",
+    "snyk-gradle-plugin": "3.24.4",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.31.2",
     "snyk-nodejs-lockfile-parser": "1.38.0",


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Bumps version of snyk-gradle-plugin. The latest release includes bug fixes:
- fix for duplicate names in multi-module projects - use path instead of name: https://github.com/snyk/snyk-gradle-plugin/pull/234
- modify rest package path and fix TS2304 error: https://github.com/snyk/snyk-gradle-plugin/pull/238