### PR TITLE
feat: new cloud context flag --snyk-cloud-environment

### DIFF
--- a/src/cli/commands/test/iac/local-execution/types.ts
+++ b/src/cli/commands/test/iac/local-execution/types.ts
@@ -213,6 +213,7 @@ export type IaCTestFlags = Pick<
   // Allows the caller to provide the path to a WASM bundle.
   rules?: string;
   'cloud-context'?: string;
+  'snyk-cloud-environment'?: string;
   // Tags and attributes
   'project-tags'?: string;
   'project-environment'?: string;

--- a/src/cli/commands/test/iac/v2/assert-iac-options.ts
+++ b/src/cli/commands/test/iac/v2/assert-iac-options.ts
@@ -29,6 +29,7 @@ const keys: (keyof IaCTestFlags)[] = [
   'var-file',
   'detectionDepth',
   'cloud-context',
+  'snyk-cloud-environment',
   // PolicyOptions
   'ignore-policy',
   'policy-path',

--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -53,6 +53,7 @@ async function prepareTestConfig(
   const scan = options.scan ?? 'resource-changes';
   const varFile = options['var-file'];
   const cloudContext = getFlag(options, 'cloud-context');
+  const snykCloudEnvironment = getFlag(options, 'snyk-cloud-environment');
   const insecure = options.insecure;
 
   return {
@@ -70,6 +71,7 @@ async function prepareTestConfig(
     varFile,
     depthDetection,
     cloudContext,
+    snykCloudEnvironment,
     insecure,
     org,
   };

--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -1,12 +1,12 @@
 import * as os from 'os';
 
 const policyEngineChecksums = `
-057406a372f29f765b41b32f67414224595caf5ce4aa17619ee6e12e95cd6050  snyk-iac-test_0.34.1_Windows_arm64.exe
-1a37bb164198051ede0f45e3fcfabf3de4932c2ac4ef9f271514d921b287cb96  snyk-iac-test_0.34.1_Linux_x86_64
-316c911299558c66e38c38f5205fbac10cee2cffa3f34e20bb4785950964a957  snyk-iac-test_0.34.1_Darwin_arm64
-7e8ea9c57f4a846f39ffb3843db4c2dc9f164669a3ae8084c68b425039160264  snyk-iac-test_0.34.1_Windows_x86_64.exe
-dcd933804997898aa40744d6e42a97b6990243a55f1396dcc9a6d6e1db5b534c  snyk-iac-test_0.34.1_Linux_arm64
-f15d4093f0f0d2ae573a61add594ad7481c2f57474543203d3e3e419ba04cd3b  snyk-iac-test_0.34.1_Darwin_x86_64
+2ae37310b47c48eb10c90ba18478197e1803f920ea7a21c2b924823ed9ab37ef  snyk-iac-test_0.35.0_Darwin_arm64
+6a1f9bf454780d598e7ebbba2752d94da7bea7ced4e9de644c3e0d72a0c3911e  snyk-iac-test_0.35.0_Windows_x86_64.exe
+83314c1d0a216918d8c6d4245247d10eded9e6b56e0cc2b0586445289a292772  snyk-iac-test_0.35.0_Linux_x86_64
+e2cf8da6bd1f312504510b48d0e3f1198fa5c4a754a6aadbe1d9b6010bb187d8  snyk-iac-test_0.35.0_Windows_arm64.exe
+f59caeb9320b1da49f9feb4aa5389b18e195106a04b438a0a996d1a3fc98e065  snyk-iac-test_0.35.0_Linux_arm64
+faf8eda29e5738f54bdd4d44861ec6aa5f7312a284889c39c1e59780d95e0488  snyk-iac-test_0.35.0_Darwin_x86_64
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();

--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -139,6 +139,10 @@ function processFlags(
     flags.push('-cloud-context', options.cloudContext);
   }
 
+  if (options.snykCloudEnvironment) {
+    flags.push('-snyk-cloud-environment', options.snykCloudEnvironment);
+  }
+
   if (options.insecure) {
     flags.push('-http-tls-skip-verify');
   }

--- a/src/lib/iac/test/v2/types.ts
+++ b/src/lib/iac/test/v2/types.ts
@@ -15,6 +15,7 @@ export interface TestConfig {
   varFile?: string;
   depthDetection?: number;
   cloudContext?: string;
+  snykCloudEnvironment?: string;
   insecure?: boolean;
   org?: string;
 }


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR introduces the new `--snyk-cloud-environment` flag for the cloud context feature. Instead of requesting a cloud API (e.g. AWS) to find specific resources of a given type, it will request Snyk Cloud API directly.

#### Screenshots

![image](https://user-images.githubusercontent.com/8110579/196981136-33161793-fe08-46e3-bdc7-73ebf500387c.png)
