### PR TITLE
fix: Tap Test improvements/fixes

### DIFF
--- a/test/tap/auth.test.ts
+++ b/test/tap/auth.test.ts
@@ -5,7 +5,10 @@ import * as isAuthed from '../../src/cli/commands/auth/is-authed';
 import * as errors from '../../src/lib/errors/legacy-errors';
 import { fakeServer } from '../acceptance/fake-server';
 
-const port = process.env.PORT || process.env.SNYK_PORT || '12345';
+const port =
+  process.env.PORT ||
+  process.env.SNYK_PORT ||
+  (12345 + +process.env.TAP_CHILD_ID!).toString();
 
 const apiKey = '123456789';
 const BASE_API = '/api/v1';

--- a/test/tap/auth.test.ts
+++ b/test/tap/auth.test.ts
@@ -66,7 +66,7 @@ test('auth shows an appropriate error message when a request fails with a user m
   }
 });
 
-test('teardown', (t) => {
+test('teardown', async (t) => {
   t.plan(2);
 
   delete process.env.SNYK_API;
@@ -74,7 +74,9 @@ test('teardown', (t) => {
   delete process.env.SNYK_PORT;
   t.notOk(process.env.SNYK_PORT, 'fake env values cleared');
 
-  server.close(() => {
-    t.pass('server shutdown');
+
+  await new Promise<void>((resolve) => {
+    server.close(resolve);
   });
+  t.pass('server shutdown');
 });

--- a/test/tap/cli-fail-on-docker.test.ts
+++ b/test/tap/cli-fail-on-docker.test.ts
@@ -8,7 +8,10 @@ import { getWorkspaceJSON } from '../acceptance/workspace-helper';
 const { test, only } = tap;
 (tap as any).runOnly = false; // <- for debug. set to true, and replace a test to only(..)
 
-const port = (process.env.PORT = process.env.SNYK_PORT = '12345');
+const port =
+  process.env.PORT ||
+  process.env.SNYK_PORT ||
+  (12345 + +process.env.TAP_CHILD_ID!).toString();
 const BASE_API = '/api/v1';
 process.env.SNYK_API = 'http://localhost:' + port + BASE_API;
 process.env.SNYK_HOST = 'http://localhost:' + port;

--- a/test/tap/cli-fail-on-docker.test.ts
+++ b/test/tap/cli-fail-on-docker.test.ts
@@ -4,6 +4,7 @@ import { fakeServer } from '../acceptance/fake-server';
 import * as sinon from 'sinon';
 import * as snyk from '../../src/lib';
 import { getWorkspaceJSON } from '../acceptance/workspace-helper';
+import { makeTmpDirectory } from '../utils';
 
 const { test, only } = tap;
 (tap as any).runOnly = false; // <- for debug. set to true, and replace a test to only(..)
@@ -52,6 +53,7 @@ const dockerNoFixableVulns = getWorkspaceJSON(
 );
 
 before('setup', async (t) => {
+  process.env.XDG_CONFIG_HOME = await makeTmpDirectory();
   t.plan(3);
   let key = await cli.config('get', 'api');
   oldkey = key;

--- a/test/tap/cli-fail-on-pinnable.test.ts
+++ b/test/tap/cli-fail-on-pinnable.test.ts
@@ -11,7 +11,10 @@ import {
 const { test, only } = tap;
 (tap as any).runOnly = false; // <- for debug. set to true, and replace a test to only(..)
 
-const port = (process.env.PORT = process.env.SNYK_PORT = '12345');
+const port =
+  process.env.PORT ||
+  process.env.SNYK_PORT ||
+  (12345 + +process.env.TAP_CHILD_ID!).toString();
 const BASE_API = '/api/v1';
 process.env.SNYK_API = 'http://localhost:' + port + BASE_API;
 process.env.SNYK_HOST = 'http://localhost:' + port;

--- a/test/tap/cli-fail-on-pinnable.test.ts
+++ b/test/tap/cli-fail-on-pinnable.test.ts
@@ -7,6 +7,7 @@ import {
   getWorkspaceJSON,
   chdirWorkspaces,
 } from '../acceptance/workspace-helper';
+import { makeTmpDirectory } from '../utils';
 
 const { test, only } = tap;
 (tap as any).runOnly = false; // <- for debug. set to true, and replace a test to only(..)
@@ -36,6 +37,7 @@ const pinnableVulnsResult = getWorkspaceJSON(
 const pinnableVulns = getWorkspaceJSON('fail-on', 'pinnable', 'vulns.json');
 
 before('setup', async (t) => {
+  process.env.XDG_CONFIG_HOME = await makeTmpDirectory();
   t.plan(3);
   let key = await cli.config('get', 'api');
   oldkey = key;

--- a/test/tap/cli-monitor.acceptance.test.ts
+++ b/test/tap/cli-monitor.acceptance.test.ts
@@ -21,7 +21,10 @@ import { AllProjectsTests } from './cli-monitor/cli-monitor.all-projects.spec';
 const { test, only, beforeEach } = tap;
 (tap as any).runOnly = false; // <- for debug. set to true, and replace a test to only(..)
 
-const port = (process.env.PORT = process.env.SNYK_PORT = '12345');
+const port =
+  process.env.PORT ||
+  process.env.SNYK_PORT ||
+  (12345 + +process.env.TAP_CHILD_ID!).toString();
 const BASE_API = '/api/v1';
 process.env.SNYK_API = 'http://localhost:' + port + BASE_API;
 process.env.SNYK_HOST = 'http://localhost:' + port;
@@ -1589,12 +1592,12 @@ if (!isWindows) {
     // assert results contain monitor urls
     t.match(
       results[0].manageUrl,
-      'http://localhost:12345/manage',
+      `http://localhost:${port}/manage`,
       'first monitor url is present',
     );
     t.match(
       results[1].manageUrl,
-      'http://localhost:12345/manage',
+      `http://localhost:${port}/manage`,
       'second monitor url is present',
     );
 

--- a/test/tap/cli-monitor.acceptance.test.ts
+++ b/test/tap/cli-monitor.acceptance.test.ts
@@ -10,6 +10,7 @@ import {
   chdirWorkspaces,
   getWorkspaceJSON,
 } from '../acceptance/workspace-helper';
+import { makeTmpDirectory } from '../utils';
 const isEmpty = require('lodash.isempty');
 const isObject = require('lodash.isobject');
 const get = require('lodash.get');
@@ -61,6 +62,7 @@ const isWindows =
 
 if (!isWindows) {
   before('setup', async (t) => {
+    process.env.XDG_CONFIG_HOME = await makeTmpDirectory();
     versionNumber = await getVersion();
 
     t.plan(3);

--- a/test/tap/cli-test.acceptance.test.ts
+++ b/test/tap/cli-test.acceptance.test.ts
@@ -3,6 +3,7 @@ import * as cli from '../../src/cli/commands';
 import { fakeServer } from '../acceptance/fake-server';
 import { getVersion } from '../../src/lib/version';
 import { chdirWorkspaces } from '../acceptance/workspace-helper';
+import { makeTmpDirectory } from '../utils';
 
 export interface AcceptanceTests {
   language: string;
@@ -79,6 +80,7 @@ import { snykHttpClient } from '../../src/lib/request/snyk-http-client';
 */
 
 before('setup', async (t) => {
+  process.env.XDG_CONFIG_HOME = await makeTmpDirectory();
   versionNumber = await getVersion();
 
   t.plan(3);

--- a/test/tap/cli-test.acceptance.test.ts
+++ b/test/tap/cli-test.acceptance.test.ts
@@ -49,7 +49,10 @@ const languageTests: AcceptanceTests[] = [
 const { test, only } = tap;
 (tap as any).runOnly = false; // <- for debug. set to true, and replace a test to only(..)
 
-const port = (process.env.PORT = process.env.SNYK_PORT = '12345');
+const port =
+  process.env.PORT ||
+  process.env.SNYK_PORT ||
+  (12345 + +process.env.TAP_CHILD_ID!).toString();
 const BASE_API = '/api/v1';
 process.env.SNYK_API = 'http://localhost:' + port + BASE_API;
 process.env.SNYK_HOST = 'http://localhost:' + port;

--- a/test/tap/cli.test.ts
+++ b/test/tap/cli.test.ts
@@ -52,6 +52,7 @@ const before = test;
 const after = test;
 
 before('setup', async (t) => {
+  process.env.XDG_CONFIG_HOME = await makeTmpDirectory();
   const key = await cli.config('get', 'api');
   oldKey = key; // just in case
   t.pass('existing user config captured');

--- a/test/tap/cli.test.ts
+++ b/test/tap/cli.test.ts
@@ -25,7 +25,10 @@ type Policy = {
   [id: string]: Ignore[];
 };
 
-const port = process.env.PORT || process.env.SNYK_PORT || '12345';
+const port =
+  process.env.PORT ||
+  process.env.SNYK_PORT ||
+  (12345 + +process.env.TAP_CHILD_ID!).toString();
 
 const apiKey = '123456789';
 let oldKey;
@@ -129,7 +132,7 @@ test('auth with no args', async (t) => {
     t.ok(open.calledOnce, 'called open once');
     t.match(
       open.firstCall.args[0],
-      'http://localhost:12345/login?token=',
+      `http://localhost:${port}login?token=`,
       'opens login with token param',
     );
     ciStub.restore();

--- a/test/tap/display-test-results.test.ts
+++ b/test/tap/display-test-results.test.ts
@@ -1,6 +1,7 @@
 import * as tap from 'tap';
 import * as sinon from 'sinon';
 import * as fs from 'fs';
+import stripAnsi from 'strip-ansi';
 
 import config from '../../src/lib/config';
 import * as cli from '../../src/cli/commands';
@@ -24,7 +25,7 @@ test('`test ruby-app` remediation displayed', async (t) => {
   try {
     await cli.test('ruby-app');
   } catch (error) {
-    const res = error.message;
+    const res = stripAnsi(error.message);
     t.match(
       res,
       'Upgrade rails@5.2.3 to rails@5.2.3 to fix',
@@ -61,7 +62,7 @@ test('`test ruby-app` legal instructions displayed', async (t) => {
   try {
     await cli.test('ruby-app');
   } catch (error) {
-    const res = error.message;
+    const res = stripAnsi(error.message);
     t.match(res, 'I am legal license instruction');
   }
 
@@ -83,7 +84,7 @@ test('`test pip-app-license-issue` legal instructions displayed (legacy formatte
   try {
     await cli.test('pip-app-license-issue');
   } catch (error) {
-    const res = error.message;
+    const res = stripAnsi(error.message);
     t.match(res, 'I am legal license instruction');
   }
 
@@ -106,7 +107,7 @@ test('`test npm-package-with-severity-override` show original severity upgrade',
   try {
     await cli.test('npm-package-with-severity-override');
   } catch (error) {
-    const { message } = error;
+    const message = stripAnsi(error.message);
     t.match(
       message,
       `[Low Severity (originally Medium)][${config.PUBLIC_VULN_DB_URL}/vuln/npm:node-uuid:20160328]`,
@@ -132,7 +133,7 @@ test('`test npm-package-with-severity-override` show original severity patches',
   try {
     await cli.test('npm-package-with-severity-override');
   } catch (error) {
-    const { message } = error;
+    const message = stripAnsi(error.message);
     t.match(message, 'Patch available for node-uuid@1.4.0');
     t.match(
       message,
@@ -159,7 +160,7 @@ test('`test npm-package-with-severity-override` show original severity no remedi
   try {
     await cli.test('npm-package-with-severity-override');
   } catch (error) {
-    const { message } = error;
+    const message = stripAnsi(error.message);
     t.match(
       message,
       `Low severity (originally Medium) vulnerability found in node-uuid`,
@@ -185,7 +186,7 @@ test('`test npm-package-with-severity-override` show original severity unresolve
   try {
     await cli.test('npm-package-with-severity-override');
   } catch (error) {
-    const { message } = error;
+    const message = stripAnsi(error.message);
     t.match(
       message,
       `Malicious Package [Low Severity (originally Medium)][${config.PUBLIC_VULN_DB_URL}/vuln/npm:node-uuid:20160328`,
@@ -211,7 +212,7 @@ test('`test npm-package-with-severity-override` dont show original severity if i
   try {
     await cli.test('npm-package-with-severity-override');
   } catch (error) {
-    const { message } = error;
+    const message = stripAnsi(error.message);
     t.match(
       message,
       `[Low Severity][${config.PUBLIC_VULN_DB_URL}/vuln/npm:node-uuid:20160328]`,

--- a/test/tap/docker-token.test.ts
+++ b/test/tap/docker-token.test.ts
@@ -5,7 +5,10 @@ import * as sinon from 'sinon';
 
 const { test } = tap;
 
-const port = (process.env.PORT = process.env.SNYK_PORT = '12345');
+const port =
+  process.env.PORT ||
+  process.env.SNYK_PORT ||
+  (12345 + +process.env.TAP_CHILD_ID!).toString();
 const BASE_API = '/api/v1';
 process.env.SNYK_API = 'http://localhost:' + port + BASE_API;
 process.env.SNYK_HOST = 'http://localhost:' + port;

--- a/test/tap/docker-token.test.ts
+++ b/test/tap/docker-token.test.ts
@@ -2,6 +2,7 @@ import * as tap from 'tap';
 import * as cli from '../../src/cli/commands';
 import { fakeServer } from '../acceptance/fake-server';
 import * as sinon from 'sinon';
+import { makeTmpDirectory } from '../utils';
 
 const { test } = tap;
 
@@ -24,6 +25,7 @@ import * as plugins from '../../src/lib/ecosystems/plugins';
 import { getFixturePath } from '../jest/util/getFixturePath';
 
 test('setup', async (t) => {
+  process.env.XDG_CONFIG_HOME = await makeTmpDirectory();
   t.plan(3);
 
   let key = await cli.config('get', 'api');

--- a/test/tap/monitor-target.test.ts
+++ b/test/tap/monitor-target.test.ts
@@ -8,6 +8,7 @@ import * as sinon from 'sinon';
 import * as cli from '../../src/cli/commands';
 import subProcess = require('../../src/lib/sub-process');
 import { fakeServer } from '../acceptance/fake-server';
+import { makeTmpDirectory } from '../utils';
 
 const apiKey = '123456789';
 
@@ -24,6 +25,7 @@ let oldendpoint;
 const server = fakeServer(BASE_API, apiKey);
 
 test('setup', async (t) => {
+  process.env.XDG_CONFIG_HOME = await makeTmpDirectory();
   let key = await cli.config('get', 'api');
   oldkey = key;
   t.pass('existing user config captured');

--- a/test/tap/monitor-target.test.ts
+++ b/test/tap/monitor-target.test.ts
@@ -11,7 +11,10 @@ import { fakeServer } from '../acceptance/fake-server';
 
 const apiKey = '123456789';
 
-const port = (process.env.PORT = process.env.SNYK_PORT = '12345');
+const port =
+  process.env.PORT ||
+  process.env.SNYK_PORT ||
+  (12345 + +process.env.TAP_CHILD_ID!).toString();
 const BASE_API = '/api/v1';
 process.env.SNYK_API = 'http://localhost:' + port + BASE_API;
 process.env.SNYK_HOST = 'http://localhost:' + port;

--- a/test/tap/remote-package.test.ts
+++ b/test/tap/remote-package.test.ts
@@ -3,7 +3,10 @@ import * as ciChecker from '../../src/lib/is-ci';
 import * as sinon from 'sinon';
 import { fakeServer } from '../acceptance/fake-server';
 
-const port = process.env.PORT || process.env.SNYK_PORT || '12345';
+const port =
+  process.env.PORT ||
+  process.env.SNYK_PORT ||
+  (12345 + +process.env.TAP_CHILD_ID!).toString();
 
 const apiKey = '123456789';
 let oldkey;

--- a/test/tap/remote-package.test.ts
+++ b/test/tap/remote-package.test.ts
@@ -2,6 +2,7 @@ import { test } from 'tap';
 import * as ciChecker from '../../src/lib/is-ci';
 import * as sinon from 'sinon';
 import { fakeServer } from '../acceptance/fake-server';
+import { makeTmpDirectory } from '../utils';
 
 const port =
   process.env.PORT ||
@@ -27,6 +28,7 @@ const before = test;
 const after = test;
 
 before('setup', async (t) => {
+  process.env.XDG_CONFIG_HOME = await makeTmpDirectory();
   let key = await cli.config('get', 'api');
   oldkey = key; // just in case
   t.pass('existing user config captured');

--- a/test/tap/run-test.test.ts
+++ b/test/tap/run-test.test.ts
@@ -2,6 +2,7 @@ import * as tap from 'tap';
 import { only, test } from 'tap';
 import { fakeServer } from '../acceptance/fake-server';
 import * as cli from '../../src/cli/commands';
+import { makeTmpDirectory } from '../utils';
 
 const port =
   process.env.PORT ||
@@ -26,6 +27,7 @@ import { getFixturePath } from '../jest/util/getFixturePath';
 import { getWorkspacePath } from '../jest/util/getWorkspacePath';
 
 before('setup', async (t) => {
+  process.env.XDG_CONFIG_HOME = await makeTmpDirectory();
   t.plan(3);
   let key = await cli.config('get', 'api');
   oldkey = key;

--- a/test/tap/run-test.test.ts
+++ b/test/tap/run-test.test.ts
@@ -3,7 +3,10 @@ import { only, test } from 'tap';
 import { fakeServer } from '../acceptance/fake-server';
 import * as cli from '../../src/cli/commands';
 
-const port = (process.env.PORT = process.env.SNYK_PORT = '12345');
+const port =
+  process.env.PORT ||
+  process.env.SNYK_PORT ||
+  (12345 + +process.env.TAP_CHILD_ID!).toString();
 const BASE_API = '/api/v1';
 process.env.SNYK_API = 'http://localhost:' + port + BASE_API;
 process.env.SNYK_HOST = 'http://localhost:' + port;

--- a/test/tap/severity-threshold.test.ts
+++ b/test/tap/severity-threshold.test.ts
@@ -1,5 +1,6 @@
 import { test } from 'tap';
 import cli = require('../../src/cli/commands');
+import { makeTmpDirectory } from '../utils';
 
 import { fakeServer } from '../acceptance/fake-server';
 
@@ -18,6 +19,7 @@ let oldendpoint;
 const server = fakeServer(BASE_API, apiKey);
 
 test('setup', async (t) => {
+  process.env.XDG_CONFIG_HOME = await makeTmpDirectory();
   let key = await cli.config('get', 'api');
   oldkey = key;
   t.pass('existing user config captured');

--- a/test/tap/severity-threshold.test.ts
+++ b/test/tap/severity-threshold.test.ts
@@ -5,7 +5,10 @@ import { fakeServer } from '../acceptance/fake-server';
 
 const apiKey = '123456789';
 
-const port = (process.env.PORT = process.env.SNYK_PORT = '12345');
+const port =
+  process.env.PORT ||
+  process.env.SNYK_PORT ||
+  (12345 + +process.env.TAP_CHILD_ID!).toString();
 const BASE_API = '/api/v1';
 process.env.SNYK_API = 'http://localhost:' + port + BASE_API;
 process.env.SNYK_HOST = 'http://localhost:' + port;


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Supports parallelism in the tap tests by using different XDG Configuration directories and fakeserver ports for each tap test process.
Also fixes a few minor problems in the tap tests.

#### Where should the reviewer start?
Run the tap tests.

#### How should this be manually tested?
`npm run test:tap`

#### Any background context you want to provide?
I'm splitting out some of the changes in https://github.com/snyk/cli/pull/3875 into separate PRs for easier review/merging.

#### What are the relevant tickets?
n/a

#### Screenshots
n/a

#### Additional questions
n/a