### PR TITLE
chore: upgrade node to 14; node 12 is end of life

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -909,11 +909,9 @@ workflows:
             - Build
           matrix:
             parameters:
-              node_version: ['12.22.11', '14.20.0', '16.16.0']
+              node_version: ['14.20.0', '16.16.0']
               npm_global_sudo: [true, false]
             exclude:
-              - node_version: '12.22.11'
-                npm_global_sudo: false
               - node_version: '14.20.0'
                 npm_global_sudo: false
               - node_version: '16.16.0'
@@ -997,7 +995,6 @@ workflows:
             - Prepare Release
             - Lint
             - Tap Tests
-            - Jest Tests (Node v12.22.11)
             - Jest Tests (Node v14.20.0)
             - Jest Tests (Node v16.16.0)
             - Acceptance Tests (snyk-win.exe)

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,7 +132,7 @@
         "webpack-merge": "^5.8.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@arcanis/slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "snyk": "bin/snyk"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "workspaces": [
     "packages/*"

--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -4,13 +4,10 @@
     "rootDir": ".",
     "pretty": true,
     "moduleResolution": "node",
-    // https://github.com/tsconfig/bases#node-12-tsconfigjson
-    "target": "es2019",
+    // https://github.com/tsconfig/bases#node-14-tsconfigjson
+    "target": "es2020",
     "lib": [
-      "es2019",
-      "es2020.promise",
-      "es2020.bigint",
-      "es2020.string",
+      "es2020",
       "DOM",
       "DOM.Iterable"
     ],

--- a/webpack.common.ts
+++ b/webpack.common.ts
@@ -4,7 +4,7 @@ const LicensePlugin = require('webpack-license-plugin');
 
 export default {
   entry: './src/cli/index.ts',
-  target: 'node12',
+  target: 'node14',
   output: {
     clean: true,
     path: path.resolve(__dirname, 'dist/cli/'),


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Stops testing with node 12 and drops support for it.

Node 12 went end of life on April 30, 2022.

See: https://twitter.com/nodejs/status/1524081123579596800
See: https://github.com/nodejs/Release#release-schedule

#### Where should the reviewer start?
By running the tests, building the project... there shouldn't be any differences.

#### How should this be manually tested?
Run snyk cli, use it as usual

#### Any background context you want to provide?
I'm splitting out some of the changes in https://github.com/snyk/cli/pull/3875 into separate PRs for easier review/merging.

#### What are the relevant tickets?
n/a

#### Screenshots
n/a

#### Additional questions
n/a