### PR TITLE
fix: Skip TLS verification to use the CLIv2 proxy

### DIFF
--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -53,7 +53,15 @@ async function prepareTestConfig(
   const scan = options.scan ?? 'resource-changes';
   const varFile = options['var-file'];
   const cloudContext = getFlag(options, 'cloud-context');
-  const insecure = options.insecure;
+
+  // Setting insecure to true is a temporary workaround. The CLIv2 installs an
+  // HTTP/HTTPS proxy with a self-signed CA. The CLIv2 uses the
+  // NODE_EXTRA_CA_CERTS to install the CA, but this only works for Node.js
+  // applications. snyk-iac-test will not recognize this, unless we write the
+  // code to install a CA from this environment variable. Until we do this, we
+  // skip certificate verification so every HTTP call works as expected.
+
+  const insecure = true;
 
   return {
     paths,


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This is a temporary fix to make the `snyk iac test` command work again with CLIv2 on MacOS and Windows. In these operating systems, the Snyk CLI is wrapped by the CLIv2, which installs an HTTPS proxy with a self-signed CA. Until `snyk-iac-test` is able to automatically install a new CA, this is the fastest way to restore the functionality of the command.