### PR TITLE
feat: IaC --report smoke testing

### DIFF
--- a/.github/workflows/iac-smoke-tests.yml
+++ b/.github/workflows/iac-smoke-tests.yml
@@ -30,24 +30,6 @@ jobs:
         with:
           node-version: 16.16.0
 
-      - name: Install jq on macOS
-        id: test
-        if: ${{ matrix.os == 'macos' }}
-        run: |
-          brew install jq
-
-      - name: Install jq on Windows
-        if: ${{ matrix.os == 'windows'}}
-        run: |
-          iwr -useb get.scoop.sh -outfile 'install-scoop.ps1'
-          .\install-scoop.ps1 -RunAsAdmin
-          scoop install jq
-
-      - name: Install jq on Ubuntu
-        if: ${{ matrix.os == 'ubuntu' }}
-        run: |
-          sudo apt-get install jq
-
       - name: Install dependencies
         run: |
           npm install

--- a/test/smoke/iac/README.md
+++ b/test/smoke/iac/README.md
@@ -9,31 +9,23 @@ The tests were written with Jest, and use a Snyk CLI executable either configure
 
 # Implementation details and usage
 
-These smoke tests are written with Jest, using the Snyk CLI executable identified on the runtime environment (See 'Notes on the local run' section below to read on how to override it)
+These smoke tests are written with Jest, using the Snyk CLI executable identified on the runtime environment (See 'Notes on the local run' section below to read on how to override it).
+
+The org we are using for testing is `snyk-cloud-tests` with the authentication token of the `Snyk IaC CLI smoke tests` service account which is available in [1Password](https://start.1password.com/open/i?a=PVJXHTLBRZAU5B6AZPH4R2XPKY&v=kbuze2xep3omyofrpfvvzmkwua&i=5h2xwp4d4rb4ng7arqadwxb3mu&h=team-snyk.1password.com).
 
 Spec in this folder is used as a
 
 1. **"name: Infrastructure as Code Smoke Tests" Github Action** - these run every hour and upon releases.
 2. **["Infrastructure as Code Smoke Tests (Pull Requests)"] GitHub Action** - these run for pull requests to the `master` branch which include changes to files owned by group IaC.
 
-```sh
-npm run test:smoke:iac
-```
-
 ### Notes on the local run
 
-These tests can be executed with the following npm script:
-
-```
-npm run test:smoke:iac
-```
-
-Alternatively, they can be executed directly via `jest`, by running:
+These tests can be executed directly via `jest`, by running:
 
 ```
 npx jest test/smoke/iac/
 ```
 
-You may specify any executable that will be used by the smoke tests, by configuring the `TEST_SNYK_COMMAND` environment variable. E.g. a local exuctable `TEST_SNYK_COMMAND="./snyk-macos"` or an `TEST_SNYK_COMMAND="npx snyk@1.500.0"` or `TEST_SNYK_COMMAND="node ./dist/cli"` for local execution.
+By default the jest runner uses the `bin/snyk` script in the repository which points to `dist/cli/index.js`. If you want to use a different Snyk CLI executable, you can override it by setting the `TEST_SNYK_COMMAND` environment variable.
 
-You may also configure an authentication token with the `SNYK_TOKEN` environment variable, to run the tests with any org and user needed.
+You may also configure an authentication token with the `IAC_SMOKE_TESTS_SNYK_TOKEN` environment variable, to run the tests with any org and user needed.

--- a/test/smoke/iac/test.spec.ts
+++ b/test/smoke/iac/test.spec.ts
@@ -2,6 +2,18 @@ import { run } from '../../jest/acceptance/iac/helpers';
 
 jest.setTimeout(1_000 * 120);
 
+function runWrapper(cmd: string) {
+  return run(cmd, {
+    PATH: process.env.PATH ?? '',
+  });
+}
+
+async function login() {
+  await runWrapper(`snyk auth ${process.env.IAC_SMOKE_TESTS_SNYK_TOKEN}`);
+}
+
+const SNYK_ORG = 'snyk-cloud-tests';
+
 describe('snyk iac test', () => {
   beforeAll(async () => {
     await login();
@@ -12,14 +24,32 @@ describe('snyk iac test', () => {
     const filePath = 'iac/depth_detection/root.tf';
 
     // Act
-    const { stdout, exitCode } = await run(`snyk iac test ${filePath}`);
+    const { stdout, exitCode } = await runWrapper(
+      `snyk iac test ${filePath} --org=${SNYK_ORG}`,
+    );
 
     // Assert
     expect(stdout).toContain('Infrastructure as Code');
+    expect(stdout).toContain('Test completed');
     expect(exitCode).toBeLessThan(2);
   });
 
-  async function login() {
-    await run(`snyk auth ${process.env.IAC_SMOKE_TESTS_SNYK_TOKEN}`);
-  }
+  it('Share Results successfully and resolves with a non-error exit code', async () => {
+    // Arrange
+    const filePath = 'iac/depth_detection/root.tf';
+
+    // Act
+    const { stdout, exitCode } = await runWrapper(
+      `snyk iac test ${filePath} --org=${SNYK_ORG} --report`,
+    );
+
+    // Assert
+    expect(stdout).toContain('Infrastructure as Code');
+    expect(stdout).toContain('Test completed');
+    expect(stdout).toContain('Report Complete');
+    expect(stdout).toContain(
+      `Your test results are available at: https://snyk.io/org/${SNYK_ORG}/cloud/issues?environment_name=fixtures`,
+    );
+    expect(exitCode).toBeLessThan(2);
+  });
 });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds smoke tests for the `--report` flag.

#### How should this be manually tested?
Instructions on how to run the test locally are available in the README file.

#### Any background context you want to provide?
Before merging the PR we need to update the `IAC_SMOKE_TESTS_SNYK_TOKEN` secret with the new auth token, I'll contact Hammer and ask them to update it (https://snyk.slack.com/archives/C0127HWU0E7/p1666166764583909).

#### What are the relevant tickets?
https://snyksec.atlassian.net/jira/software/c/projects/CFG/boards/301?modal=detail&selectedIssue=CFG-2164

