### PR TITLE
feat: add error code to iac json output

### DIFF
--- a/test/fixtures/iac/output-formats/test-error-json-schema.json
+++ b/test/fixtures/iac/output-formats/test-error-json-schema.json
@@ -2,9 +2,10 @@
     "type": "object",
     "properties": {
         "ok": { "type": "boolean" },
+        "code": {"type": "integer"},
         "error": { "type": "string" },
         "path": { "type": "string" }
     },
-    "required": ["ok", "error", "path"],
+    "required": ["ok", "code", "error", "path"],
     "additionalProperties": false
 }

--- a/test/jest/unit/cli/commands/test/iac/v2/index.spec.ts
+++ b/test/jest/unit/cli/commands/test/iac/v2/index.spec.ts
@@ -144,9 +144,9 @@ describe('test', () => {
         formattedUserMessage:
           "Test Failures\n\n  The Snyk CLI couldn't find any valid IaC configuration files to scan\n  Path: invalid_file.txt",
         json:
-          '[\n  {\n    "ok": false,\n    "error": "",\n    "path": "invalid_file.txt"\n  }\n]',
+          '[\n  {\n    "ok": false,\n    "code": 2114,\n    "error": "",\n    "path": "invalid_file.txt"\n  }\n]',
         jsonStringifiedResults:
-          '[\n  {\n    "ok": false,\n    "error": "",\n    "path": "invalid_file.txt"\n  }\n]',
+          '[\n  {\n    "ok": false,\n    "code": 2114,\n    "error": "",\n    "path": "invalid_file.txt"\n  }\n]',
         sarifStringifiedResults: `{\n  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",\n  "version": "2.1.0",\n  "runs": [\n    {\n      "originalUriBaseIds": {\n        "PROJECTROOT": {\n          "uri": "${
           pathToFileURL(path.join(process.cwd(), '/')).href
         }",\n          "description": {\n            "text": "The root directory for all project files."\n          }\n        }\n      },\n      "tool": {\n        "driver": {\n          "name": "Snyk IaC",\n          "fullName": "Snyk Infrastructure as Code",\n          "version": "1.0.0-monorepo",\n          "informationUri": "https://docs.snyk.io/products/snyk-infrastructure-as-code",\n          "rules": []\n        }\n      },\n      "automationDetails": {\n        "id": "snyk-iac"\n      },\n      "results": []\n    }\n  ]\n}`,
@@ -194,9 +194,9 @@ describe('test', () => {
               `"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"`,
             ),
             jsonStringifiedResults:
-              '[\n  {\n    "ok": false,\n    "error": "no loadable input: path/to/test",\n    "path": "path/to/test"\n  }\n]',
+              '[\n  {\n    "ok": false,\n    "code": 2114,\n    "error": "no loadable input: path/to/test",\n    "path": "path/to/test"\n  }\n]',
             json:
-              '[\n  {\n    "ok": false,\n    "error": "no loadable input: path/to/test",\n    "path": "path/to/test"\n  }\n]',
+              '[\n  {\n    "ok": false,\n    "code": 2114,\n    "error": "no loadable input: path/to/test",\n    "path": "path/to/test"\n  }\n]',
           }),
         );
       });
@@ -255,13 +255,13 @@ describe('test', () => {
           strCode: 'NO_FILES_TO_SCAN_ERROR',
           innerError: undefined,
           userMessage:
-            '[\n  {\n    "ok": false,\n    "error": "",\n    "path": "invalid_file.txt"\n  }\n]',
+            '[\n  {\n    "ok": false,\n    "code": 2114,\n    "error": "",\n    "path": "invalid_file.txt"\n  }\n]',
           formattedUserMessage:
-            '[\n  {\n    "ok": false,\n    "error": "",\n    "path": "invalid_file.txt"\n  }\n]',
+            '[\n  {\n    "ok": false,\n    "code": 2114,\n    "error": "",\n    "path": "invalid_file.txt"\n  }\n]',
           json:
-            '[\n  {\n    "ok": false,\n    "error": "",\n    "path": "invalid_file.txt"\n  }\n]',
+            '[\n  {\n    "ok": false,\n    "code": 2114,\n    "error": "",\n    "path": "invalid_file.txt"\n  }\n]',
           jsonStringifiedResults:
-            '[\n  {\n    "ok": false,\n    "error": "",\n    "path": "invalid_file.txt"\n  }\n]',
+            '[\n  {\n    "ok": false,\n    "code": 2114,\n    "error": "",\n    "path": "invalid_file.txt"\n  }\n]',
           sarifStringifiedResults: `{\n  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",\n  "version": "2.1.0",\n  "runs": [\n    {\n      "originalUriBaseIds": {\n        "PROJECTROOT": {\n          "uri": "${
             pathToFileURL(path.join(process.cwd(), '/')).href
           }",\n          "description": {\n            "text": "The root directory for all project files."\n          }\n        }\n      },\n      "tool": {\n        "driver": {\n          "name": "Snyk IaC",\n          "fullName": "Snyk Infrastructure as Code",\n          "version": "1.0.0-monorepo",\n          "informationUri": "https://docs.snyk.io/products/snyk-infrastructure-as-code",\n          "rules": []\n        }\n      },\n      "automationDetails": {\n        "id": "snyk-iac"\n      },\n      "results": []\n    }\n  ]\n}`,
@@ -297,7 +297,7 @@ describe('test', () => {
             expect.objectContaining({
               name: 'NoLoadableInputError',
               message:
-                '[\n  {\n    "ok": false,\n    "error": "no loadable input: path/to/test",\n    "path": "path/to/test"\n  }\n]',
+                '[\n  {\n    "ok": false,\n    "code": 2114,\n    "error": "no loadable input: path/to/test",\n    "path": "path/to/test"\n  }\n]',
               code: 1010,
               strCode: 'NO_FILES_TO_SCAN_ERROR',
               fields: {
@@ -305,16 +305,16 @@ describe('test', () => {
               },
               path: 'path/to/test',
               userMessage:
-                '[\n  {\n    "ok": false,\n    "error": "no loadable input: path/to/test",\n    "path": "path/to/test"\n  }\n]',
+                '[\n  {\n    "ok": false,\n    "code": 2114,\n    "error": "no loadable input: path/to/test",\n    "path": "path/to/test"\n  }\n]',
               formattedUserMessage:
-                '[\n  {\n    "ok": false,\n    "error": "no loadable input: path/to/test",\n    "path": "path/to/test"\n  }\n]',
+                '[\n  {\n    "ok": false,\n    "code": 2114,\n    "error": "no loadable input: path/to/test",\n    "path": "path/to/test"\n  }\n]',
               sarifStringifiedResults: expect.stringContaining(
                 `"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"`,
               ),
               jsonStringifiedResults:
-                '[\n  {\n    "ok": false,\n    "error": "no loadable input: path/to/test",\n    "path": "path/to/test"\n  }\n]',
+                '[\n  {\n    "ok": false,\n    "code": 2114,\n    "error": "no loadable input: path/to/test",\n    "path": "path/to/test"\n  }\n]',
               json:
-                '[\n  {\n    "ok": false,\n    "error": "no loadable input: path/to/test",\n    "path": "path/to/test"\n  }\n]',
+                '[\n  {\n    "ok": false,\n    "code": 2114,\n    "error": "no loadable input: path/to/test",\n    "path": "path/to/test"\n  }\n]',
             }),
           );
         });
@@ -376,7 +376,7 @@ describe('test', () => {
             pathToFileURL(path.join(process.cwd(), '/')).href
           }",\n          "description": {\n            "text": "The root directory for all project files."\n          }\n        }\n      },\n      "tool": {\n        "driver": {\n          "name": "Snyk IaC",\n          "fullName": "Snyk Infrastructure as Code",\n          "version": "1.0.0-monorepo",\n          "informationUri": "https://docs.snyk.io/products/snyk-infrastructure-as-code",\n          "rules": []\n        }\n      },\n      "automationDetails": {\n        "id": "snyk-iac"\n      },\n      "results": []\n    }\n  ]\n}`,
           jsonStringifiedResults:
-            '[\n  {\n    "ok": false,\n    "error": "",\n    "path": "invalid_file.txt"\n  }\n]',
+            '[\n  {\n    "ok": false,\n    "code": 2114,\n    "error": "",\n    "path": "invalid_file.txt"\n  }\n]',
           sarifStringifiedResults: `{\n  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",\n  "version": "2.1.0",\n  "runs": [\n    {\n      "originalUriBaseIds": {\n        "PROJECTROOT": {\n          "uri": "${
             pathToFileURL(path.join(process.cwd(), '/')).href
           }",\n          "description": {\n            "text": "The root directory for all project files."\n          }\n        }\n      },\n      "tool": {\n        "driver": {\n          "name": "Snyk IaC",\n          "fullName": "Snyk Infrastructure as Code",\n          "version": "1.0.0-monorepo",\n          "informationUri": "https://docs.snyk.io/products/snyk-infrastructure-as-code",\n          "rules": []\n        }\n      },\n      "automationDetails": {\n        "id": "snyk-iac"\n      },\n      "results": []\n    }\n  ]\n}`,
@@ -430,7 +430,7 @@ describe('test', () => {
                 `"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"`,
               ),
               jsonStringifiedResults:
-                '[\n  {\n    "ok": false,\n    "error": "no loadable input: path/to/test",\n    "path": "path/to/test"\n  }\n]',
+                '[\n  {\n    "ok": false,\n    "code": 2114,\n    "error": "no loadable input: path/to/test",\n    "path": "path/to/test"\n  }\n]',
               json: expect.stringContaining(
                 `"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"`,
               ),

--- a/test/jest/unit/iac/process-results/fixtures/integrated-json-output.json
+++ b/test/jest/unit/iac/process-results/fixtures/integrated-json-output.json
@@ -1,6 +1,7 @@
 [
   {
     "ok": false,
+    "code": 2114,
     "error": "",
     "path": "invalid_file.txt"
   },


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds to the JSON output of the IaC scan error codes when relevant.

#### How should this be manually tested?
Run `snyk iac test --json` while trying to scan an invalid file and check for an error code in the JSON output.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CFG-2193

#### Screenshots
JSON output for the new integrated IaC(top) and legacy IaC(bottom)
![image](https://user-images.githubusercontent.com/71096571/196898852-eb669a9d-1dc4-4c8a-9932-ea6f33d64a02.png)
