### PR TITLE
feat: Use separate config variables for the REST and V1 clients

### DIFF
--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -1,12 +1,12 @@
 import * as os from 'os';
 
 const policyEngineChecksums = `
-2ae37310b47c48eb10c90ba18478197e1803f920ea7a21c2b924823ed9ab37ef  snyk-iac-test_0.35.0_Darwin_arm64
-6a1f9bf454780d598e7ebbba2752d94da7bea7ced4e9de644c3e0d72a0c3911e  snyk-iac-test_0.35.0_Windows_x86_64.exe
-83314c1d0a216918d8c6d4245247d10eded9e6b56e0cc2b0586445289a292772  snyk-iac-test_0.35.0_Linux_x86_64
-e2cf8da6bd1f312504510b48d0e3f1198fa5c4a754a6aadbe1d9b6010bb187d8  snyk-iac-test_0.35.0_Windows_arm64.exe
-f59caeb9320b1da49f9feb4aa5389b18e195106a04b438a0a996d1a3fc98e065  snyk-iac-test_0.35.0_Linux_arm64
-faf8eda29e5738f54bdd4d44861ec6aa5f7312a284889c39c1e59780d95e0488  snyk-iac-test_0.35.0_Darwin_x86_64
+04fe9c50afad4ab91815281930f142d17e4047d0187564fffa81d2a04e292915  snyk-iac-test_0.35.1_Windows_x86_64.exe
+2876226d01d3b8c906bc1835d8f03ebb7b809b8a3bbce3e743d3301df86664b5  snyk-iac-test_0.35.1_Linux_x86_64
+36dbb048fc79669a7ae4924079a44248eeed83a5e785fa3877bb275d28f7be42  snyk-iac-test_0.35.1_Darwin_arm64
+4d08c4fe6027685681171903669372323f6018083bcc67ce804fd4a939ed4859  snyk-iac-test_0.35.1_Windows_arm64.exe
+4da012c52785749e24695d8b7f70782697afb06cc0125b6e3d062ba19d65b479  snyk-iac-test_0.35.1_Linux_arm64
+d6e017549e2806df32ecd61052d5f7489cca213a437af68d7e982b6200f8f81a  snyk-iac-test_0.35.1_Darwin_x86_64
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();

--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -50,8 +50,14 @@ function scanWithConfig(
 ): TestOutput {
   const env = { ...process.env };
 
-  env['SNYK_API_URL'] = getApiUrl();
-  env['SNYK_API_TOKEN'] = getApiToken();
+  env['SNYK_IAC_TEST_API_REST_URL'] =
+    process.env['SNYK_IAC_TEST_API_REST_URL'] || getApiUrl();
+  env['SNYK_IAC_TEST_API_REST_TOKEN'] =
+    process.env['SNYK_IAC_TEST_API_REST_TOKEN'] || getApiToken();
+  env['SNYK_IAC_TEST_API_V1_URL'] =
+    process.env['SNYK_IAC_TEST_API_V1_URL'] || getApiUrl();
+  env['SNYK_IAC_TEST_API_V1_TOKEN'] =
+    process.env['SNYK_IAC_TEST_API_V1_TOKEN'] || getApiToken();
 
   const args = processFlags(options, rulesBundlePath, outputPath, policyPath);
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR follows the latest calling convention established by `snyk-iac-test`.