### PR TITLE
fix: Invoke snyk-iac-test asynchronously

### DIFF
--- a/src/lib/iac/test/v2/index.ts
+++ b/src/lib/iac/test/v2/index.ts
@@ -11,7 +11,7 @@ export async function test(testConfig: TestConfig): Promise<TestOutput> {
     testConfig,
   );
 
-  const testOutput = scan(testConfig, policyEnginePath, rulesBundlePath);
+  const testOutput = await scan(testConfig, policyEnginePath, rulesBundlePath);
 
   addIacAnalytics(testOutput);
 

--- a/test/jest/unit/cli/commands/test/iac/v2/index.spec.ts
+++ b/test/jest/unit/cli/commands/test/iac/v2/index.spec.ts
@@ -113,7 +113,7 @@ describe('test', () => {
 
   describe('with no successful scans', () => {
     beforeEach(() => {
-      jest.spyOn(scanLib, 'scan').mockReturnValue(scanWithOnlyErrorsFixture);
+      jest.spyOn(scanLib, 'scan').mockResolvedValue(scanWithOnlyErrorsFixture);
     });
 
     it('throws the expected error', async () => {
@@ -155,7 +155,7 @@ describe('test', () => {
       beforeEach(() => {
         jest
           .spyOn(scanLib, 'scan')
-          .mockReturnValue(scanWithoutLoadableInputsFixture);
+          .mockResolvedValue(scanWithoutLoadableInputsFixture);
       });
 
       it('throws the expected error', async () => {
@@ -228,7 +228,9 @@ describe('test', () => {
 
     describe('with no successful scans', () => {
       beforeEach(() => {
-        jest.spyOn(scanLib, 'scan').mockReturnValue(scanWithOnlyErrorsFixture);
+        jest
+          .spyOn(scanLib, 'scan')
+          .mockResolvedValue(scanWithOnlyErrorsFixture);
       });
 
       it('throws the expected error', async () => {
@@ -270,7 +272,7 @@ describe('test', () => {
         beforeEach(() => {
           jest
             .spyOn(scanLib, 'scan')
-            .mockReturnValue(scanWithoutLoadableInputsFixture);
+            .mockResolvedValue(scanWithoutLoadableInputsFixture);
         });
 
         it('throws the expected error', async () => {
@@ -340,7 +342,9 @@ describe('test', () => {
 
     describe('with no successful scans', () => {
       beforeEach(() => {
-        jest.spyOn(scanLib, 'scan').mockReturnValue(scanWithOnlyErrorsFixture);
+        jest
+          .spyOn(scanLib, 'scan')
+          .mockResolvedValue(scanWithOnlyErrorsFixture);
       });
 
       it('throws the expected error', async () => {
@@ -385,7 +389,7 @@ describe('test', () => {
         beforeEach(() => {
           jest
             .spyOn(scanLib, 'scan')
-            .mockReturnValue(scanWithoutLoadableInputsFixture);
+            .mockResolvedValue(scanWithoutLoadableInputsFixture);
         });
 
         it('throws the expected error', async () => {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR prepares the environment for `snyk-iac-test` and runs it using only asynchronous functions. This doesn't have any difference in the functionality but, because the event loop is not blocked, the spinner we show to the user doesn't have any hiccup and runs smoothly.