### PR TITLE
feat(@snyk/fix): pipenv support for version 2022.*

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2123,9 +2123,9 @@
       "link": true
     },
     "node_modules/@snyk/fix-pipenv-pipfile": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@snyk/fix-pipenv-pipfile/-/fix-pipenv-pipfile-0.5.6.tgz",
-      "integrity": "sha512-ZqQccz0Fr94QzRO5C6azfmSyI1LiLcHqL4/LKS32anDmt5/MnhlqH8KXdq3xQO/ZFgyeEepWxXO49FPjMkP7XQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@snyk/fix-pipenv-pipfile/-/fix-pipenv-pipfile-0.6.0.tgz",
+      "integrity": "sha512-6iA0rMZcOyBUFGkhzVk7Snd3JubenGRjB8sAkips7baNTL1aVKuAsaMhldQvNj5eWUrNO8r1bB91cbISW9nHfQ==",
       "dependencies": {
         "@snyk/child-process": "^0.3.3",
         "bottleneck": "2.19.5",
@@ -19894,7 +19894,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@snyk/dep-graph": "^1.21.0",
-        "@snyk/fix-pipenv-pipfile": "0.5.6",
+        "@snyk/fix-pipenv-pipfile": "0.6.0",
         "@snyk/fix-poetry": "0.8.3",
         "chalk": "4.1.1",
         "debug": "^4.3.1",
@@ -21554,7 +21554,7 @@
       "version": "file:packages/snyk-fix",
       "requires": {
         "@snyk/dep-graph": "^1.21.0",
-        "@snyk/fix-pipenv-pipfile": "0.5.6",
+        "@snyk/fix-pipenv-pipfile": "0.6.0",
         "@snyk/fix-poetry": "0.8.3",
         "chalk": "4.1.1",
         "debug": "^4.3.1",
@@ -21606,9 +21606,9 @@
       }
     },
     "@snyk/fix-pipenv-pipfile": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@snyk/fix-pipenv-pipfile/-/fix-pipenv-pipfile-0.5.6.tgz",
-      "integrity": "sha512-ZqQccz0Fr94QzRO5C6azfmSyI1LiLcHqL4/LKS32anDmt5/MnhlqH8KXdq3xQO/ZFgyeEepWxXO49FPjMkP7XQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@snyk/fix-pipenv-pipfile/-/fix-pipenv-pipfile-0.6.0.tgz",
+      "integrity": "sha512-6iA0rMZcOyBUFGkhzVk7Snd3JubenGRjB8sAkips7baNTL1aVKuAsaMhldQvNj5eWUrNO8r1bB91cbISW9nHfQ==",
       "requires": {
         "@snyk/child-process": "^0.3.3",
         "bottleneck": "2.19.5",

--- a/packages/snyk-fix/package.json
+++ b/packages/snyk-fix/package.json
@@ -37,7 +37,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@snyk/dep-graph": "^1.21.0",
-    "@snyk/fix-pipenv-pipfile": "0.5.6",
+    "@snyk/fix-pipenv-pipfile": "0.6.0",
     "@snyk/fix-poetry": "0.8.3",
     "chalk": "4.1.1",
     "debug": "^4.3.1",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Bump version of pipenv fix package that introduces support for versions 2022.*