### PR TITLE
fix: Errors from snyk-iac-test should not be swallowed

### DIFF
--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -75,9 +75,12 @@ async function scanWithConfig(
     throw new ScanError(`spawning process: ${child.error}`);
   }
 
+  return mapSnykIacTestOutputToTestOutput(await readJson(outputPath));
+}
+
+async function readJson(path: string) {
   try {
-    const output = await readFile(outputPath);
-    return mapSnykIacTestOutputToTestOutput(JSON.parse(output));
+    return JSON.parse(await readFile(path));
   } catch (e) {
     throw new ScanError(`invalid output encoding: ${e}`);
   }


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR fixes a bug where errors returned by `snyk-iac-test` are silently swallowed instead of being thrown and displayed to the user.
