### PR TITLE
fix: relax conditions for sbt plugin inspect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "snyk-policy": "^1.25.0",
         "snyk-python-plugin": "1.24.0",
         "snyk-resolve-deps": "4.7.3",
-        "snyk-sbt-plugin": "2.15.1",
+        "snyk-sbt-plugin": "2.16.0",
         "strip-ansi": "^5.2.0",
         "tar": "^6.1.2",
         "uuid": "^8.3.2",
@@ -17239,9 +17239,9 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "node_modules/snyk-sbt-plugin": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.15.1.tgz",
-      "integrity": "sha512-B2PhcoYGnhhLTwoiwgJNj1d4POaV0N0jtDBRoJhS74dmMPs+np1LtoHHP/hdEGoUMAGqsDSzc0fbAq8LmMAxRg==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.16.0.tgz",
+      "integrity": "sha512-j+VlZ/NLsHAqMxWEGn0+pQDMKEIJZljH7hHn/fbj/XorlYBWTBSkvfEb86iIE7/hH95o2AB/gsSlX6SWH2qZRA==",
       "dependencies": {
         "debug": "^4.1.1",
         "semver": "^6.1.2",
@@ -33405,9 +33405,9 @@
       }
     },
     "snyk-sbt-plugin": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.15.1.tgz",
-      "integrity": "sha512-B2PhcoYGnhhLTwoiwgJNj1d4POaV0N0jtDBRoJhS74dmMPs+np1LtoHHP/hdEGoUMAGqsDSzc0fbAq8LmMAxRg==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.16.0.tgz",
+      "integrity": "sha512-j+VlZ/NLsHAqMxWEGn0+pQDMKEIJZljH7hHn/fbj/XorlYBWTBSkvfEb86iIE7/hH95o2AB/gsSlX6SWH2qZRA==",
       "requires": {
         "debug": "^4.1.1",
         "semver": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "snyk-policy": "^1.25.0",
     "snyk-python-plugin": "1.24.0",
     "snyk-resolve-deps": "4.7.3",
-    "snyk-sbt-plugin": "2.15.1",
+    "snyk-sbt-plugin": "2.16.0",
     "strip-ansi": "^5.2.0",
     "tar": "^6.1.2",
     "uuid": "^8.3.2",


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Bumps version of snyk-sbt-plugin to 2.16.0
Changes included:
- change conditions under which plugin inspect is used: https://github.com/snyk/snyk-sbt-plugin/pull/115
- added test for sbt v. 1.7.0: https://github.com/snyk/snyk-sbt-plugin/pull/114
- add more debug logs: https://github.com/snyk/snyk-sbt-plugin/pull/112