### PR TITLE
fix: check of incorrect environment variable

### DIFF
--- a/src/lib/iac/drift/driftctl.ts
+++ b/src/lib/iac/drift/driftctl.ts
@@ -255,7 +255,7 @@ export const runDriftCTL = async ({
   if (process.env.SNYK_SYSTEM_HTTPS_PROXY != undefined) {
     dctl_env.HTTPS_PROXY = process.env.SNYK_SYSTEM_HTTPS_PROXY;
   }
-  if (process.env.SNYK_NO_PROXY != undefined) {
+  if (process.env.SNYK_SYSTEM_NO_PROXY != undefined) {
     dctl_env.NO_PROXY = process.env.SNYK_SYSTEM_NO_PROXY;
   }
 


### PR DESCRIPTION
#### What does this PR do?
Fix a "typo" in one of the used environment variables.

