### PR TITLE
fix: undefined settings in sbt plugin inspect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "snyk-policy": "^1.25.0",
         "snyk-python-plugin": "1.24.1",
         "snyk-resolve-deps": "4.7.3",
-        "snyk-sbt-plugin": "2.16.0",
+        "snyk-sbt-plugin": "2.16.1",
         "strip-ansi": "^5.2.0",
         "tar": "^6.1.2",
         "uuid": "^8.3.2",
@@ -17280,9 +17280,9 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "node_modules/snyk-sbt-plugin": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.16.0.tgz",
-      "integrity": "sha512-j+VlZ/NLsHAqMxWEGn0+pQDMKEIJZljH7hHn/fbj/XorlYBWTBSkvfEb86iIE7/hH95o2AB/gsSlX6SWH2qZRA==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.16.1.tgz",
+      "integrity": "sha512-SUgPMLmHYa76iwM875tP/8K/10gzZfTPUEJsCkI0bA8TQPimiFDqyrB1mhNLo2NPV8YnqIHwFZgx56ibwywPKQ==",
       "dependencies": {
         "debug": "^4.1.1",
         "semver": "^6.1.2",
@@ -33483,9 +33483,9 @@
       }
     },
     "snyk-sbt-plugin": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.16.0.tgz",
-      "integrity": "sha512-j+VlZ/NLsHAqMxWEGn0+pQDMKEIJZljH7hHn/fbj/XorlYBWTBSkvfEb86iIE7/hH95o2AB/gsSlX6SWH2qZRA==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.16.1.tgz",
+      "integrity": "sha512-SUgPMLmHYa76iwM875tP/8K/10gzZfTPUEJsCkI0bA8TQPimiFDqyrB1mhNLo2NPV8YnqIHwFZgx56ibwywPKQ==",
       "requires": {
         "debug": "^4.1.1",
         "semver": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "snyk-policy": "^1.25.0",
     "snyk-python-plugin": "1.24.1",
     "snyk-resolve-deps": "4.7.3",
-    "snyk-sbt-plugin": "2.16.0",
+    "snyk-sbt-plugin": "2.16.1",
     "strip-ansi": "^5.2.0",
     "tar": "^6.1.2",
     "uuid": "^8.3.2",


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Bump the version of snyk-sbt-plugin to [2.16.1](https://github.com/snyk/snyk-sbt-plugin/releases/tag/v2.16.1)
Includes a fix for `[error] sbt.internal.util.Init$RuntimeUndefined: References to undefined settings at runtime` - filter out configs that are not public.