### PR TITLE
fix: remove allow analytics check for share results

### DIFF
--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -11,7 +11,6 @@ import * as path from 'path';
 import * as rimraf from 'rimraf';
 import config from '../../../../config';
 import { api } from '../../../../api-token';
-import { allowAnalytics } from '../../../../analytics';
 import envPaths from 'env-paths';
 
 const debug = newDebug('snyk-iac');
@@ -111,7 +110,7 @@ function processFlags(
     flags.push('-depth-detection', `${options.depthDetection}`);
   }
 
-  if (options.report && allowAnalytics()) {
+  if (options.report) {
     flags.push('-report');
   }
 


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Removes the allowed analytics condition for sharing results in the integrated test flow.

#### Background Context

- We currently only share results if the following conditions apply:
    - The `report` flag was provided.
    - Analytics are not disabled. 

    However, when analytics are enabled and the user provides the report flag, we don’t display any error indicating that the share results cannot happen, and we still display the project URL at the end of the test output, even though we did not share results.

- In the previous flow, we skipped adding Git contributors when analytics were disabled, the same happens in the integrated flow. 
- In the previous flow, we did not have the allowed analytics as a condition for sharing results. 
- In the current implementation of Share Results we use the Create Scan endpoint of the Cloud API. 
- In the current flow, we are not providing Git contributors in the request payload at the moment. 

#### Additional Information

- [Slack thread](https://snyk.slack.com/archives/C02JMMTLUF9/p1666795380651169)