### PR TITLE
[CTX-442] improve errors for cloud context

### DIFF
--- a/src/cli/commands/test/iac/scan.ts
+++ b/src/cli/commands/test/iac/scan.ts
@@ -13,7 +13,10 @@ import * as utils from '../utils';
 import { spinnerMessage } from '../../../../lib/formatters/iac-output/text';
 
 import { test as iacTest } from './local-execution';
-import { assertIaCOptionsFlags } from './local-execution/assert-iac-options-flag';
+import {
+  assertIaCOptionsFlags,
+  assertIntegratedIaCOnlyOptions,
+} from './local-execution/assert-iac-options-flag';
 import { initRules } from './local-execution/rules/rules';
 import { cleanLocalCache } from './local-execution/measurable-methods';
 import * as ora from 'ora';
@@ -79,6 +82,7 @@ export async function scan(
 
       let res: (TestResult | TestResult[]) | Error;
       try {
+        assertIntegratedIaCOnlyOptions(iacOrgSettings, process.argv);
         assertIaCOptionsFlags(process.argv);
 
         if (pathLib.relative(projectRoot, path).includes('..')) {

--- a/src/lib/iac/test/v2/errors.ts
+++ b/src/lib/iac/test/v2/errors.ts
@@ -30,15 +30,11 @@ const snykIacTestErrorsUserMessages = {
   UnableToReadPath: 'Unable to read path',
   NoLoadableInput:
     "The Snyk CLI couldn't find any valid IaC configuration files to scan",
-  FailedToMakeResourcesResolvers:
-    'An error occurred preparing the requested cloud context. Please run the command again with the `-d` flag for more information.',
-  ResourcesResolverError:
-    'An error occurred scanning cloud resources. Please run the command again with the `-d` flag for more information.',
   FailedToProcessResults:
     'An error occurred while processing results. Please run the command again with the `-d` flag for more information.',
 };
 
-export function getErrorUserMessage(code: number): string {
+export function getErrorUserMessage(code: number, error: string): string {
   if (code < 2000 || code >= 3000) {
     return 'INVALID_SNYK_IAC_TEST_ERROR';
   }
@@ -46,6 +42,14 @@ export function getErrorUserMessage(code: number): string {
   if (!errorName) {
     return 'INVALID_IAC_ERROR';
   }
+
+  if (
+    code == IaCErrorCodes.FailedToMakeResourcesResolvers ||
+    code == IaCErrorCodes.ResourcesResolverError
+  ) {
+    return `${error}. Please run the command again with the \`-d\` flag for more information.`;
+  }
+
   return snykIacTestErrorsUserMessages[errorName];
 }
 
@@ -56,7 +60,7 @@ export class SnykIacTestError extends CustomError {
     super(scanError.message);
     this.code = scanError.code;
     this.strCode = getErrorStringCode(this.code);
-    this.userMessage = getErrorUserMessage(this.code);
+    this.userMessage = getErrorUserMessage(this.code, scanError.message);
     this.fields = Object.assign(
       {
         path: '',

--- a/test/jest/unit/iac/assert-iac-options-flag.spec.ts
+++ b/test/jest/unit/iac/assert-iac-options-flag.spec.ts
@@ -1,7 +1,58 @@
 import {
   assertIaCOptionsFlags,
+  assertIntegratedIaCOnlyOptions,
   FlagValueError,
+  IntegratedFlagError,
 } from '../../../../src/cli/commands/test/iac/local-execution/assert-iac-options-flag';
+import { IacOrgSettings } from '../../../../src/cli/commands/test/iac/local-execution/types';
+
+describe('assertIntegratedIaCOnlyOptions()', () => {
+  const command = ['node', 'cli', 'iac', 'test'];
+  const files = ['input.tf'];
+  const org: IacOrgSettings = {
+    customPolicies: {},
+    meta: {
+      org: 'orgname',
+      orgPublicId: 'orgpublicid',
+    },
+  };
+
+  it('accepts all command line flags accepted by the iac command', () => {
+    const options = [
+      '--debug',
+      '--insecure',
+      '--detection-depth',
+      '--severity-threshold',
+      '--json',
+      '--sarif',
+      '--json-file-output',
+      '--sarif-file-output',
+      '-v',
+      '--version',
+      '-h',
+      '--help',
+      '-q',
+      '--quiet',
+    ];
+    expect(() =>
+      assertIntegratedIaCOnlyOptions(org, [...command, ...options, ...files]),
+    ).not.toThrow();
+  });
+
+  it('Refuses cloud-context flag', () => {
+    const options = ['--cloud-context', 'aws'];
+    expect(() =>
+      assertIntegratedIaCOnlyOptions(org, [...command, ...options, ...files]),
+    ).toThrow(new IntegratedFlagError('cloud-context', org.meta.org));
+  });
+
+  it('Refuses snyk-cloud-environment flag', () => {
+    const options = ['--snyk-cloud-environment', 'envid'];
+    expect(() =>
+      assertIntegratedIaCOnlyOptions(org, [...command, ...options, ...files]),
+    ).toThrow(new IntegratedFlagError('snyk-cloud-environment', org.meta.org));
+  });
+});
 
 describe('assertIaCOptionsFlags()', () => {
   const command = ['node', 'cli', 'iac', 'test'];

--- a/test/jest/unit/lib/iac/test/v2/errors.spec.ts
+++ b/test/jest/unit/lib/iac/test/v2/errors.spec.ts
@@ -2,12 +2,14 @@ import { getErrorUserMessage } from '../../../../../../../src/lib/iac/test/v2/er
 
 describe('getErrorUserMessage', () => {
   it('returns INVALID_SNYK_IAC_TEST_ERROR for an invalid snyk-iac-test error code', () => {
-    expect(getErrorUserMessage(0)).toEqual('INVALID_SNYK_IAC_TEST_ERROR');
-    expect(getErrorUserMessage(3000)).toEqual('INVALID_SNYK_IAC_TEST_ERROR');
+    expect(getErrorUserMessage(0, '')).toEqual('INVALID_SNYK_IAC_TEST_ERROR');
+    expect(getErrorUserMessage(3000, '')).toEqual(
+      'INVALID_SNYK_IAC_TEST_ERROR',
+    );
   });
 
   it('returns INVALID_IAC_ERROR for an invalid error code', () => {
-    expect(getErrorUserMessage(2999)).toEqual('INVALID_IAC_ERROR');
+    expect(getErrorUserMessage(2999, '')).toEqual('INVALID_IAC_ERROR');
   });
 
   it.each`
@@ -34,7 +36,7 @@ describe('getErrorUserMessage', () => {
   `(
     'returns a user message for a valid snyk-iac-test error code - $expectedErrorCode',
     ({ expectedErrorCode }) => {
-      expect(typeof getErrorUserMessage(expectedErrorCode)).toBe('string');
+      expect(typeof getErrorUserMessage(expectedErrorCode, '')).toBe('string');
     },
   );
 });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Using cloud context without integrated iac flag on your org will now display a message explaining why it doesn't work.
When an error happen with cloud context we now display the error content instead of juste asking the user to re run with -d.

#### How should this be manually tested?
Testing without the iacIntegratedExperience flag will show a new error. Testing cloud context without a proprer configutation or with a wrong snyk cloud environment id are the easiest way to test the error messages.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CTX-442

#### Screenshots
![image](https://user-images.githubusercontent.com/4931174/199700890-fc4f17c0-8ccc-42f2-b815-a83f02d56ec2.png)


#### Additional questions
