### PR TITLE
restore env proxy launching snyk-iac-test

### DIFF
--- a/src/lib/iac/drift/driftctl.ts
+++ b/src/lib/iac/drift/driftctl.ts
@@ -24,6 +24,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as crypto from 'crypto';
 import { createDirIfNotExists, isExe } from '../file-utils';
+import { restoreEnvProxy } from '../env-utils';
 
 const debug = debugLib('driftctl');
 
@@ -246,18 +247,10 @@ export const runDriftCTL = async ({
 
   debug('running driftctl %s ', args.join(' '));
 
-  const dctl_env: NodeJS.ProcessEnv = { ...process.env, DCTL_IS_SNYK: 'true' };
-
-  // WARN: We are restoring system en proxy because snyk cli override them but the proxy uses untrusted certs
-  if (process.env.SNYK_SYSTEM_HTTP_PROXY != undefined) {
-    dctl_env.HTTP_PROXY = process.env.SNYK_SYSTEM_HTTP_PROXY;
-  }
-  if (process.env.SNYK_SYSTEM_HTTPS_PROXY != undefined) {
-    dctl_env.HTTPS_PROXY = process.env.SNYK_SYSTEM_HTTPS_PROXY;
-  }
-  if (process.env.SNYK_SYSTEM_NO_PROXY != undefined) {
-    dctl_env.NO_PROXY = process.env.SNYK_SYSTEM_NO_PROXY;
-  }
+  const dctl_env: NodeJS.ProcessEnv = restoreEnvProxy({
+    ...process.env,
+    DCTL_IS_SNYK: 'true',
+  });
 
   const p = child_process.spawn(path, args, {
     stdio,

--- a/src/lib/iac/env-utils.ts
+++ b/src/lib/iac/env-utils.ts
@@ -1,0 +1,13 @@
+export function restoreEnvProxy(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  // WARN: We are restoring system en proxy because snyk cli override them but the proxy uses untrusted certs
+  if (process.env.SNYK_SYSTEM_HTTP_PROXY != undefined) {
+    env.HTTP_PROXY = process.env.SNYK_SYSTEM_HTTP_PROXY;
+  }
+  if (process.env.SNYK_SYSTEM_HTTPS_PROXY != undefined) {
+    env.HTTPS_PROXY = process.env.SNYK_SYSTEM_HTTPS_PROXY;
+  }
+  if (process.env.SNYK_SYSTEM_NO_PROXY != undefined) {
+    env.NO_PROXY = process.env.SNYK_SYSTEM_NO_PROXY;
+  }
+  return env;
+}

--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -12,6 +12,7 @@ import * as rimraf from 'rimraf';
 import config from '../../../../config';
 import { api } from '../../../../api-token';
 import envPaths from 'env-paths';
+import { restoreEnvProxy } from '../../../env-utils';
 
 const debug = newDebug('snyk-iac');
 
@@ -252,6 +253,8 @@ async function spawn(
   env: Record<string, string | undefined>,
 ) {
   return new Promise<SpawnResult>((resolve) => {
+    env = restoreEnvProxy(env);
+
     const child = childProcess.spawn(path, args, {
       stdio: 'pipe',
       env: env,


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
snyk-iac-test golang binary now also use terrafom providers in some case and thus suffer from the same issue regarding how snyk cli internal proxy has untrusted certificate. Like for describe I'm restoring the original proxy settings before running it.