### PR TITLE
feat: pass oauth token to sast, if available

### DIFF
--- a/src/lib/plugins/sast/analysis.ts
+++ b/src/lib/plugins/sast/analysis.ts
@@ -5,7 +5,7 @@ import {
 } from '@snyk/code-client';
 import { ReportingDescriptor, Result } from 'sarif';
 import { SEVERITY } from '../../snyk-test/legacy';
-import { api } from '../../api-token';
+import { getAuthHeader } from '../../api-token';
 import config from '../../config';
 import { spinner } from '../../spinner';
 import { Options } from '../../types';
@@ -76,7 +76,7 @@ async function getCodeAnalysis(
     });
   }
 
-  const sessionToken = api() || '';
+  const sessionToken = getAuthHeader();
 
   const severity = options.severityThreshold
     ? severityToAnalysisSeverity(options.severityThreshold)

--- a/test/jest/unit/lib/analytics/index.spec.ts
+++ b/test/jest/unit/lib/analytics/index.spec.ts
@@ -8,7 +8,7 @@ describe('analytics module', () => {
     jest.restoreAllMocks();
   });
 
-  it('sends anaytics with no token set', async () => {
+  it('sends analytics with no token set', async () => {
     analytics.add('k1', 'v1');
     const requestSpy = jest.spyOn(request, 'makeRequest');
     requestSpy.mockResolvedValue();


### PR DESCRIPTION
This allows SNYK_OAUTH_TOKEN support instead of just API Key.

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Passes an OAuth token into the SAST backend if specified.

#### Where should the reviewer start?

The tests: `test/jest/unit/snyk-code/snyk-code-test.spec.ts`

#### How should this be manually tested?

`SNYK_OAUTH_TOKEN=$token snyk code test`

#### Any background context you want to provide?

Previously we only passed the api key as an auth header.
This method is deprecated (no `token` scheme), and doesn't support OAuth tokens. Use existing header building to do this, so we send `bearer $jwt` if specified.

The backend has already been updated to handle this.

#### What are the relevant tickets?


#### Screenshots


#### Additional questions
