### PR TITLE
fix: improve go file path determination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.20.1",
-        "snyk-docker-plugin": "^5.6.2",
+        "snyk-docker-plugin": "^5.6.3",
         "snyk-go-plugin": "^1.19.4",
         "snyk-gradle-plugin": "3.24.4",
         "snyk-module": "3.1.0",
@@ -16457,9 +16457,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.6.2.tgz",
-      "integrity": "sha512-LRvYGzbEU+rZ1Sgi7uuh4u61ZolDiwYmK84ZqVCgeyJzEtc6nkCmwk6jqtXg2nUohyWE5SlGerl4GU9l0TX3gQ==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.6.3.tgz",
+      "integrity": "sha512-NhMB1mZN3Rr3FJso9gtC30lOUKnomJvGZxDNWVLnQ/hgT6vOArC0VcG68RYyws73JpL2w9jXEoqSheUdrPFzQQ==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.3.0",
@@ -32792,9 +32792,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.6.2.tgz",
-      "integrity": "sha512-LRvYGzbEU+rZ1Sgi7uuh4u61ZolDiwYmK84ZqVCgeyJzEtc6nkCmwk6jqtXg2nUohyWE5SlGerl4GU9l0TX3gQ==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.6.3.tgz",
+      "integrity": "sha512-NhMB1mZN3Rr3FJso9gtC30lOUKnomJvGZxDNWVLnQ/hgT6vOArC0VcG68RYyws73JpL2w9jXEoqSheUdrPFzQQ==",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.20.1",
-    "snyk-docker-plugin": "^5.6.2",
+    "snyk-docker-plugin": "^5.6.3",
     "snyk-go-plugin": "^1.19.4",
     "snyk-gradle-plugin": "3.24.4",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
Bumps the Snyk-Docker-Plugin to bring in some fixes to the Go app vulnerability scanning.

See https://github.com/snyk/snyk-docker-plugin/pull/461