### PR TITLE
fix: bump snyk-gradle-plugin to 3.24.5

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.22.1
+version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-JS-ANSIREGEX-1583908:
@@ -7,7 +7,12 @@ ignore:
         reason: Not affecting Snyk CLI. No upgrade path currently available
         expires: 2022-02-01T00:00:00.000Z
         created: 2021-11-29T17:25:19.200Z
+  'snyk:lic:npm:shescape:MPL-2.0':
+    - '*':
+        reason: --about lists all dependency licenses which is a requirement of MPL-2.0
+        expires: 2122-12-14T16:35:38.252Z
+        created: 2022-11-14T16:35:38.260Z
 patch: {}
 exclude:
   code:
-    - test/** 
+    - test/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "snyk-cpp-plugin": "2.20.1",
         "snyk-docker-plugin": "^5.6.3",
         "snyk-go-plugin": "^1.19.4",
-        "snyk-gradle-plugin": "3.24.4",
+        "snyk-gradle-plugin": "3.24.5",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.31.2",
         "snyk-nodejs-lockfile-parser": "1.44.0",
@@ -16192,6 +16192,31 @@
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
     },
+    "node_modules/shescape": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/shescape/-/shescape-1.6.1.tgz",
+      "integrity": "sha512-P9fEf91yPuOpUGfE7QdzRubWbO81/O9jR81TVDbUGKyh4ppw0ArobMzX+iBx4S1Ag8eVRli81/dq0usNMTSWow==",
+      "dependencies": {
+        "which": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12 || ^14 || ^16 || ^18"
+      }
+    },
+    "node_modules/shescape/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -16726,9 +16751,9 @@
       }
     },
     "node_modules/snyk-gradle-plugin": {
-      "version": "3.24.4",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.24.4.tgz",
-      "integrity": "sha512-hT5TFCKTBE+DVbNMzyXId3wXTRbJIGiX9r9Uaog1k464N1GMLr2ehT3zDTPNoZ870vW7Vb2FPU90bWqQr9xLDA==",
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.24.5.tgz",
+      "integrity": "sha512-Dw/wLYU7rBqlMWMoB3+lZfDEJnjeRYdfM6cQHwjZ1kdZ4904jqiXdW/o+CWyvNprknV7hJj5zf8RNNIn7geOqQ==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",
@@ -16737,6 +16762,7 @@
         "debug": "^4.1.1",
         "p-map": "^4.0.0",
         "packageurl-js": "^1.0.0",
+        "shescape": "1.6.1",
         "tmp": "0.2.1",
         "tslib": "^2.0.0"
       },
@@ -32594,6 +32620,24 @@
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
     },
+    "shescape": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/shescape/-/shescape-1.6.1.tgz",
+      "integrity": "sha512-P9fEf91yPuOpUGfE7QdzRubWbO81/O9jR81TVDbUGKyh4ppw0ArobMzX+iBx4S1Ag8eVRli81/dq0usNMTSWow==",
+      "requires": {
+        "which": "^2.0.0"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -33015,9 +33059,9 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "3.24.4",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.24.4.tgz",
-      "integrity": "sha512-hT5TFCKTBE+DVbNMzyXId3wXTRbJIGiX9r9Uaog1k464N1GMLr2ehT3zDTPNoZ870vW7Vb2FPU90bWqQr9xLDA==",
+      "version": "3.24.5",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.24.5.tgz",
+      "integrity": "sha512-Dw/wLYU7rBqlMWMoB3+lZfDEJnjeRYdfM6cQHwjZ1kdZ4904jqiXdW/o+CWyvNprknV7hJj5zf8RNNIn7geOqQ==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",
@@ -33026,6 +33070,7 @@
         "debug": "^4.1.1",
         "p-map": "^4.0.0",
         "packageurl-js": "^1.0.0",
+        "shescape": "1.6.1",
         "tmp": "0.2.1",
         "tslib": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "snyk-cpp-plugin": "2.20.1",
     "snyk-docker-plugin": "^5.6.3",
     "snyk-go-plugin": "^1.19.4",
-    "snyk-gradle-plugin": "3.24.4",
+    "snyk-gradle-plugin": "3.24.5",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.31.2",
     "snyk-nodejs-lockfile-parser": "1.44.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
- Bumps `snyk-gradle-plugin` to `3.24.5`
- https://github.com/snyk/snyk-gradle-plugin/pull/240 - escape child process arguments