### PR TITLE
fix: update snyk-docker-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.20.1",
-        "snyk-docker-plugin": "^5.6.3",
+        "snyk-docker-plugin": "^5.6.4",
         "snyk-go-plugin": "^1.19.4",
         "snyk-gradle-plugin": "3.24.4",
         "snyk-module": "3.1.0",
@@ -16457,9 +16457,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.6.3.tgz",
-      "integrity": "sha512-NhMB1mZN3Rr3FJso9gtC30lOUKnomJvGZxDNWVLnQ/hgT6vOArC0VcG68RYyws73JpL2w9jXEoqSheUdrPFzQQ==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.6.4.tgz",
+      "integrity": "sha512-cdzJT747CN66TkU+3zBlJ3V7X1X404YB3TYnJTvxg4DL/0kZ9LvVpZ2AXWlGtd/lcr91gO/O//dAsl4tJwKUFg==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.3.0",
@@ -32798,9 +32798,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.6.3.tgz",
-      "integrity": "sha512-NhMB1mZN3Rr3FJso9gtC30lOUKnomJvGZxDNWVLnQ/hgT6vOArC0VcG68RYyws73JpL2w9jXEoqSheUdrPFzQQ==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-5.6.4.tgz",
+      "integrity": "sha512-cdzJT747CN66TkU+3zBlJ3V7X1X404YB3TYnJTvxg4DL/0kZ9LvVpZ2AXWlGtd/lcr91gO/O//dAsl4tJwKUFg==",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.20.1",
-    "snyk-docker-plugin": "^5.6.3",
+    "snyk-docker-plugin": "^5.6.4",
     "snyk-go-plugin": "^1.19.4",
     "snyk-gradle-plugin": "3.24.4",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
#### What does this PR do?

fix: use full version of go modules in dep-graph

#### What are the relevant tickets?

- https://github.com/snyk/snyk-docker-plugin/pull/462
- https://github.com/snyk/snyk-docker-plugin/releases/tag/v5.6.4