### PR TITLE
feat: support severity threshold (unmanaged)

### DIFF
--- a/src/lib/ecosystems/resolve-test-facts.ts
+++ b/src/lib/ecosystems/resolve-test-facts.ts
@@ -31,6 +31,7 @@ import {
   getSelf,
 } from './unmanaged/utils';
 import { sleep } from '../common';
+import { SEVERITY } from '../snyk-test/common';
 
 export async function resolveAndTestFacts(
   ecosystem: Ecosystem,
@@ -91,6 +92,7 @@ async function fetchIssues(
   start_time,
   dep_graph_data,
   component_details,
+  target_severity: SEVERITY,
   orgId: string,
 ) {
   const response: GetIssuesResponse = await getIssues(
@@ -98,6 +100,7 @@ async function fetchIssues(
       dep_graph: dep_graph_data,
       start_time,
       component_details,
+      target_severity,
     },
     orgId,
   );
@@ -148,6 +151,7 @@ export async function resolveAndTestFactsUnmanagedDeps(
   const displayTargetFile = '';
 
   let orgId = options.org || '';
+  const target_severity: SEVERITY = options.severityThreshold || SEVERITY.LOW;
 
   if (orgId === '') {
     const self = await getSelf();
@@ -181,6 +185,7 @@ export async function resolveAndTestFactsUnmanagedDeps(
           start_time,
           dep_graph_data,
           component_details,
+          target_severity,
           orgId,
         );
 

--- a/src/lib/ecosystems/unmanaged/types.ts
+++ b/src/lib/ecosystems/unmanaged/types.ts
@@ -163,6 +163,7 @@ export interface IssuesRequestAttributes {
   start_time: number;
   dep_graph: IssuesRequestDepGraphDataOpenAPI;
   component_details: IssuesRequestComponentDetails;
+  target_severity: SEVERITY;
 }
 
 export interface Data {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Adds support to filter issues/vulnerabilities based on a severity threshold.

#### Where should the reviewer start?

#### How should this be manually tested?

1. Change directory to a folder with unmanaged deps
1. Use `snyk test --unmanaged` to verify that you have both "medium" and "high" severity-issues 
1. Test with an organization with unmanaged-deps enabled and run following command: `snyk test --unmanaged --severity-threshold=high`
1. Verify that `medium` and lower was filtered out, and that "high" and "critical" remains

#### Screenshots

<img width="236" alt="image" src="https://user-images.githubusercontent.com/833396/204282416-1b9069b9-0f20-4a45-a7e5-986fe120d67f.png">
