### PR TITLE
fix: use lenient config in gradle plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "snyk-cpp-plugin": "2.20.1",
         "snyk-docker-plugin": "^5.6.4",
         "snyk-go-plugin": "^1.19.4",
-        "snyk-gradle-plugin": "3.24.5",
+        "snyk-gradle-plugin": "3.24.6",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.31.2",
         "snyk-nodejs-lockfile-parser": "1.44.0",
@@ -16751,9 +16751,9 @@
       }
     },
     "node_modules/snyk-gradle-plugin": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.24.5.tgz",
-      "integrity": "sha512-Dw/wLYU7rBqlMWMoB3+lZfDEJnjeRYdfM6cQHwjZ1kdZ4904jqiXdW/o+CWyvNprknV7hJj5zf8RNNIn7geOqQ==",
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.24.6.tgz",
+      "integrity": "sha512-e5Sy/KbEKqDT2bKnvqs9raAdsxiyr9UNxmne9ARnJUQtD3ndNPnAURZQCdUIHBarEyBp6AIJMO/XUp42+hVWTA==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",
@@ -33059,9 +33059,9 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.24.5.tgz",
-      "integrity": "sha512-Dw/wLYU7rBqlMWMoB3+lZfDEJnjeRYdfM6cQHwjZ1kdZ4904jqiXdW/o+CWyvNprknV7hJj5zf8RNNIn7geOqQ==",
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.24.6.tgz",
+      "integrity": "sha512-e5Sy/KbEKqDT2bKnvqs9raAdsxiyr9UNxmne9ARnJUQtD3ndNPnAURZQCdUIHBarEyBp6AIJMO/XUp42+hVWTA==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "snyk-cpp-plugin": "2.20.1",
     "snyk-docker-plugin": "^5.6.4",
     "snyk-go-plugin": "^1.19.4",
-    "snyk-gradle-plugin": "3.24.5",
+    "snyk-gradle-plugin": "3.24.6",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.31.2",
     "snyk-nodejs-lockfile-parser": "1.44.0",


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Bumps the version of snyk-gradle-plugin to 3.24.6. This version introduces the use of lenient configuration to prevent the scanning of Gradle projects from failing if any one of direct dependencies in a configuration fails to resolve. See https://github.com/snyk/snyk-gradle-plugin/pull/242