### PR TITLE
feat: update unmanaged endpoints

### DIFF
--- a/src/lib/config/api-url.ts
+++ b/src/lib/config/api-url.ts
@@ -172,3 +172,11 @@ export function getRestApiUrl(
 
   return defaultRestApiUrl; // Fallback to default
 }
+
+export function getHiddenApiUrl(restUrl: string): string {
+  const parsedBaseUrl = new URL(restUrl);
+
+  parsedBaseUrl.pathname = '/hidden';
+
+  return parsedBaseUrl.toString();
+}

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -1,6 +1,11 @@
 import * as snykConfig from 'snyk-config';
 import { config as userConfig } from '../user-config';
-import { getBaseApiUrl, getRestApiUrl, getV1ApiUrl } from './api-url';
+import {
+  getBaseApiUrl,
+  getRestApiUrl,
+  getV1ApiUrl,
+  getHiddenApiUrl,
+} from './api-url';
 
 const DEFAULT_TIMEOUT = 5 * 60; // in seconds
 interface Config {
@@ -9,6 +14,7 @@ interface Config {
   API: string;
   api: string;
   API_REST_URL: string;
+  API_HIDDEN_URL: string;
   // deprecated, use API_REST_URL instead
   API_V3_URL?: string;
   disableSuggestions: string;
@@ -49,6 +55,8 @@ config.API_REST_URL = getRestApiUrl(
   process.env.API_REST_URL || config.API_REST_URL,
   process.env.API_V3_URL || config.API_V3_URL,
 );
+
+config.API_HIDDEN_URL = getHiddenApiUrl(config.API_REST_URL);
 
 const disableSuggestions = userConfig.get('disableSuggestions');
 if (disableSuggestions) {

--- a/src/lib/polling/polling-test.ts
+++ b/src/lib/polling/polling-test.ts
@@ -1,6 +1,6 @@
 import config from '../config';
 import { isCI } from '../is-ci';
-import { makeRequest } from '../request/promise';
+import { makeRequest, makeRequestRest } from '../request/promise';
 import { Options } from '../types';
 
 import { assembleQueryString } from '../snyk-test/common';
@@ -24,18 +24,11 @@ export async function getIssues(
 ): Promise<GetIssuesResponse> {
   const payload = {
     method: 'POST',
-    url: `${config.API_REST_URL}/orgs/${orgId}/unmanaged_ecosystem/issues?version=2022-06-29~experimental`,
-    json: true,
-    headers: {
-      'Content-Type': 'application/vnd.api+json',
-      'x-is-ci': isCI(),
-      authorization: getAuthHeader(),
-    },
+    url: `${config.API_HIDDEN_URL}/orgs/${orgId}/unmanaged_ecosystem/issues?version=2022-06-29~experimental`,
     body: issuesRequestAttributes,
   };
 
-  const result = await makeRequest<GetIssuesResponse>(payload);
-  return JSON.parse(result.toString());
+  return await makeRequestRest<GetIssuesResponse>(payload);
 }
 
 export async function getDepGraph(
@@ -44,17 +37,10 @@ export async function getDepGraph(
 ): Promise<GetDepGraphResponse> {
   const payload = {
     method: 'GET',
-    url: `${config.API_REST_URL}/orgs/${orgId}/unmanaged_ecosystem/depgraphs/${id}?version=2022-05-23~experimental`,
-    json: true,
-    headers: {
-      'Content-Type': 'application/vnd.api+json',
-      'x-is-ci': isCI(),
-      authorization: getAuthHeader(),
-    },
+    url: `${config.API_HIDDEN_URL}/orgs/${orgId}/unmanaged_ecosystem/depgraphs/${id}?version=2022-05-23~experimental`,
   };
 
-  const result = await makeRequest<GetDepGraphResponse>(payload);
-  return JSON.parse(result.toString());
+  return await makeRequestRest<GetDepGraphResponse>(payload);
 }
 
 export async function createDepGraph(
@@ -63,18 +49,11 @@ export async function createDepGraph(
 ): Promise<CreateDepGraphResponse> {
   const payload = {
     method: 'POST',
-    url: `${config.API_REST_URL}/orgs/${orgId}/unmanaged_ecosystem/depgraphs?version=2022-05-23~experimental`,
-    json: true,
-    headers: {
-      'Content-Type': 'application/vnd.api+json',
-      'x-is-ci': isCI(),
-      authorization: getAuthHeader(),
-    },
+    url: `${config.API_HIDDEN_URL}/orgs/${orgId}/unmanaged_ecosystem/depgraphs?version=2022-05-23~experimental`,
     body: hashes,
   };
 
-  const result = await makeRequest<CreateDepGraphResponse>(payload);
-  return JSON.parse(result.toString());
+  return await makeRequestRest<CreateDepGraphResponse>(payload);
 }
 
 export async function requestTestPollingToken(


### PR DESCRIPTION
This PR does two things:

1. Switches the unmanaged dep calls to the hidden endpoint
2. Fixes a bug when polling that was causing it to wait for 60 seconds each attempt.