### PR TITLE
chore: add proxyauth

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/elazarl/goproxy/ext v0.0.0-20220901064549-fbd10ff4f5a1
 	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
-	github.com/snyk/go-application-framework v0.0.0-20221201105605-4873440314c9
+	github.com/snyk/go-application-framework v0.0.0-20221201145925-ee0ec4cf2688
 	github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/pflag v1.0.5

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -182,8 +182,8 @@ github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYe
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/snyk/go-application-framework v0.0.0-20221201105605-4873440314c9 h1:TAIP7A1Yy9qHAW2hoztvNo2z3iodYJT87XKmH/Ty6Hc=
-github.com/snyk/go-application-framework v0.0.0-20221201105605-4873440314c9/go.mod h1:cmEA75r0NIy0dyNx5AIKLtczEg6YF0oOPXIKHWiLyWc=
+github.com/snyk/go-application-framework v0.0.0-20221201145925-ee0ec4cf2688 h1:2WOMtq2WSgP/WL9qsQJBIxctf9vuvv+xn/xl6/qgNUY=
+github.com/snyk/go-application-framework v0.0.0-20221201145925-ee0ec4cf2688/go.mod h1:cmEA75r0NIy0dyNx5AIKLtczEg6YF0oOPXIKHWiLyWc=
 github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd h1:zjDhcQ642rIVI8aIjfG5uVcw+OGotQtX2l9VHe7IqCQ=
 github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd/go.mod h1:v6t6wKizOcHXT3p4qKn6Bda7yNIjCQ54Xyl31NjgXkY=
 github.com/spf13/afero v1.9.2 h1:j49Hj62F0n+DaZ1dDCvhABaPNSGNkt32oRFxI33IEMw=

--- a/cliv2/pkg/basic_workflows/legacycli.go
+++ b/cliv2/pkg/basic_workflows/legacycli.go
@@ -3,7 +3,6 @@ package basic_workflows
 import (
 	"bufio"
 	"bytes"
-	"net/http"
 	"os"
 
 	"github.com/pkg/errors"
@@ -91,7 +90,6 @@ func legacycliWorkflow(invocation workflow.InvocationContext, input []workflow.D
 	}
 
 	wrapperProxy.SetUpstreamProxyAuthentication(proxyAuthenticationMechanism)
-	http.DefaultTransport = wrapperProxy.Transport()
 
 	err = wrapperProxy.Start()
 	if err != nil {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Update to a version of the go-application-framework that supports advanced http proxy authentication and cleanup a legacy workaround.

