### PR TITLE
chore: wrap osName() in try-catch

### DIFF
--- a/src/lib/analytics/getStandardData.ts
+++ b/src/lib/analytics/getStandardData.ts
@@ -39,8 +39,15 @@ export async function getStandardData(
   const durationMs = Date.now() - START_TIME;
   const metrics = getMetrics(durationMs);
 
+  let osNameString;
+  try {
+    osNameString = osName(os.platform(), os.release());
+  } catch (e) {
+    osNameString = 'unknown';
+  }
+
   const data = {
-    os: osName(os.platform(), os.release()),
+    os: osNameString,
     osPlatform: os.platform(),
     osRelease: os.release(),
     osArch: os.arch(),


### PR DESCRIPTION
Signed-off-by: Peter Schäfer <101886095+PeterSchafer@users.noreply.github.com>

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Add try-catch block around the usage of os-name which throws an exception on macOS Ventura.

