### PR TITLE
fix: use /rest/packages when searching by checksum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "snyk-go-plugin": "^1.19.4",
         "snyk-gradle-plugin": "3.24.6",
         "snyk-module": "3.1.0",
-        "snyk-mvn-plugin": "2.31.3",
+        "snyk-mvn-plugin": "2.32.0",
         "snyk-nodejs-lockfile-parser": "1.44.0",
         "snyk-nuget-plugin": "1.23.5",
         "snyk-php-plugin": "1.9.2",
@@ -17098,15 +17098,15 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-mvn-plugin": {
-      "version": "2.31.3",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.31.3.tgz",
-      "integrity": "sha512-VX/KnqXLRycRQDowOtGuJru4b52wCMpfNIoZDneOqJBSLlZZ0Rb/KNueUtJbT2vm6fZln5bdEXEoME3GX/6bPw==",
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.32.0.tgz",
+      "integrity": "sha512-wHoL8OUF5iEqWMI7oKUHrNWdEItuj28+j7rl9wYkhrw8fMsFQBfm2akJ2PjlFJTZ2W8IrsYPF3zMaMTIlgiG3Q==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.23.1",
         "debug": "^4.1.1",
         "glob": "^7.1.6",
-        "needle": "^2.5.0",
+        "packageurl-js": "^1.0.0",
         "shescape": "1.6.1",
         "tslib": "^2.4.0"
       }
@@ -17122,34 +17122,10 @@
         "@snyk/dep-graph": "^1"
       }
     },
-    "node_modules/snyk-mvn-plugin/node_modules/needle": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
-      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
-      "dependencies": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "needle": "bin/needle"
-      },
-      "engines": {
-        "node": ">= 4.4.x"
-      }
-    },
-    "node_modules/snyk-mvn-plugin/node_modules/needle/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
     "node_modules/snyk-mvn-plugin/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/snyk-nodejs-lockfile-parser": {
       "version": "1.44.0",
@@ -33575,15 +33551,15 @@
       }
     },
     "snyk-mvn-plugin": {
-      "version": "2.31.3",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.31.3.tgz",
-      "integrity": "sha512-VX/KnqXLRycRQDowOtGuJru4b52wCMpfNIoZDneOqJBSLlZZ0Rb/KNueUtJbT2vm6fZln5bdEXEoME3GX/6bPw==",
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.32.0.tgz",
+      "integrity": "sha512-wHoL8OUF5iEqWMI7oKUHrNWdEItuj28+j7rl9wYkhrw8fMsFQBfm2akJ2PjlFJTZ2W8IrsYPF3zMaMTIlgiG3Q==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.23.1",
         "debug": "^4.1.1",
         "glob": "^7.1.6",
-        "needle": "^2.5.0",
+        "packageurl-js": "^1.0.0",
         "shescape": "1.6.1",
         "tslib": "^2.4.0"
       },
@@ -33596,30 +33572,10 @@
             "@types/graphlib": "^2"
           }
         },
-        "needle": {
-          "version": "2.9.1",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
-          "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
-          "requires": {
-            "debug": "^3.2.6",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.2.7",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-              "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            }
-          }
-        },
         "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "snyk-go-plugin": "^1.19.4",
     "snyk-gradle-plugin": "3.24.6",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "2.31.3",
+    "snyk-mvn-plugin": "2.32.0",
     "snyk-nodejs-lockfile-parser": "1.44.0",
     "snyk-nuget-plugin": "1.23.5",
     "snyk-php-plugin": "1.9.2",


### PR DESCRIPTION

#### What does this PR do?

Includes the latest release of snyk-mvn-plugin v.2.32.0 which uses the `/rest/packages` endpoint to 
search for maven coordinated for unmanaged files. 