### PR TITLE
fix: improve the time interval for retries during test of unmanaged

### DIFF
--- a/src/lib/ecosystems/resolve-test-facts.ts
+++ b/src/lib/ecosystems/resolve-test-facts.ts
@@ -65,8 +65,8 @@ async function pollDepGraphAttributes(
   id: string,
   orgId: string,
 ): Promise<Attributes> {
-  const minIntervalMs = 5000;
-  const maxIntervalMs = 30000;
+  const minIntervalMs = 2000;
+  const maxIntervalMs = 20000;
 
   let totalElaspedTime = 0;
   let attempts = 1;


### PR DESCRIPTION
By lowering the minIntervalMs and maxIntervalMs to 2000ms and 20000ms we will decrease the risk for cancellation, and improve the performance.

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Lowers number of seconds between retries for tests of unmanaged ecosystems.

#### How should this be manually tested?

Run tests on following [repo](https://github.com/snyk-fixtures/cpp-goof) and make sure it behaves the same as before the diff.

#### Any background context you want to provide?

Old implementation used a max value of 30seconds.
30 seconds or more might trigger a cancellation within our system, and that's the intended design.
Therefor we should lower number of seconds for maxIntervalMs.

We did also decrease number of seconds for the minimum number of seconds between retries, which
means that retries will happen more often and it could improve the performance in some situations.
