### PR TITLE
fix: handle self being undefined

### DIFF
--- a/src/lib/ecosystems/resolve-test-facts.ts
+++ b/src/lib/ecosystems/resolve-test-facts.ts
@@ -52,6 +52,10 @@ export async function resolveAndTestFacts(
     : resolveAndTestFactsRegistry(ecosystem, scans, options);
 }
 
+async function getOrgDefaultContext(): Promise<string> {
+  return (await getSelf())?.data.attributes.default_org_context;
+}
+
 async function submitHashes(
   hashes: FileHashes,
   orgId: string,
@@ -154,12 +158,12 @@ export async function resolveAndTestFactsUnmanagedDeps(
   const packageManager = 'Unmanaged (C/C++)';
   const displayTargetFile = '';
 
-  let orgId = options.org || '';
+  const orgId = options.org || (await getOrgDefaultContext()) || '';
   const target_severity: SEVERITY = options.severityThreshold || SEVERITY.LOW;
 
   if (orgId === '') {
-    const self = await getSelf();
-    orgId = self.data.attributes.default_org_context;
+    errors.push('organisation-id missing');
+    return [results, errors];
   }
 
   for (const [path, scanResults] of Object.entries(scans)) {


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
`getSelf()` can return undefined so that case must be handled,  otherwise the following error will occur:
```
TypeError: Cannot read properties of undefined (reading 'default_org_context')
```

Note: Original PR is located [here](https://github.com/snyk/cli/pull/4201), due to permission issues we have moved it to this one.

#### Where should the reviewer start?
Take a look at the defintion of the `getSelf()`: https://github.com/snyk/cli/blob/e4d0eaf1bbdcec185890894350d67a446452f164/src/lib/ecosystems/unmanaged/utils.ts#L50

#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions