### PR TITLE
fix: iac usage tracking missing custom org

### DIFF
--- a/src/cli/commands/test/iac/local-execution/index.ts
+++ b/src/cli/commands/test/iac/local-execution/index.ts
@@ -118,7 +118,7 @@ export async function test(
   );
 
   try {
-    await trackUsage(filteredIssues);
+    await trackUsage(filteredIssues, iacOrgSettings.meta.org);
   } catch (e) {
     if (e instanceof TestLimitReachedError) {
       throw e;

--- a/src/cli/commands/test/iac/local-execution/usage-tracking.ts
+++ b/src/cli/commands/test/iac/local-execution/usage-tracking.ts
@@ -5,6 +5,7 @@ import { CustomError } from '../../../../../lib/errors';
 
 export async function trackUsage(
   formattedResults: TrackableResult[],
+  org: string, // e.g. "my.org"
 ): Promise<void> {
   const trackingData = formattedResults.map((res) => {
     return {
@@ -19,6 +20,7 @@ export async function trackUsage(
     },
     url: `${config.API}/track-iac-usage/cli`,
     body: { results: trackingData },
+    qs: { org },
     gzip: true,
     json: true,
   });

--- a/test/jest/unit/iac/usage-tracking.spec.ts
+++ b/test/jest/unit/iac/usage-tracking.spec.ts
@@ -29,6 +29,8 @@ const results = [
   },
 ];
 
+const org = 'test-org';
+
 describe('tracking IaC test usage', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -44,9 +46,10 @@ describe('tracking IaC test usage', () => {
       });
     });
 
-    await trackUsage(results);
+    await trackUsage(results, org);
 
     expect(mockedMakeRequest.mock.calls.length).toEqual(1);
+    expect(mockedMakeRequest.mock.calls[0][0].qs).toEqual({ org });
     expect(mockedMakeRequest.mock.calls[0][0].body).toEqual({
       results: [
         {
@@ -71,7 +74,7 @@ describe('tracking IaC test usage', () => {
       });
     });
 
-    await expect(trackUsage(results)).rejects.toThrow(
+    await expect(trackUsage(results, org)).rejects.toThrow(
       new TestLimitReachedError(),
     );
   });
@@ -86,7 +89,7 @@ describe('tracking IaC test usage', () => {
       });
     });
 
-    await expect(trackUsage(results)).rejects.toThrow(
+    await expect(trackUsage(results, org)).rejects.toThrow(
       new CustomError(
         'An error occurred while attempting to track test usage: {"foo":"bar"}',
       ),


### PR DESCRIPTION
#### What does this PR do?

Fixes an issue in IaC usage tracking where it was not passing the org data to Registry, causing it to count for the default org instead of the custom set org. 

#### How should this be manually tested?
- Run registry locally.
- Create another org in the Admin UI.
- Set the CLI to point to the local registry API.
- Set the CLI to the custom org you created, either via the env `SNYK_CFG_ORG` variable or the `--org` flag.  
- Make a CLI scan to an IaC file.
- See in the UI that the test-count was increased to the default org instead of the custom one.

With this branch, the correct test-count for the custom org will be increased.

#### Any background context you want to provide?

1. This came up in a [Customer Support Ticket](https://snyk.zendesk.com/agent/tickets/38402), when a customer was using the VS-Code plugin with a custom org to scan IaC files, they mentioned that scan counts are increased for wrong organization. I was able to replicate this quickly and worked on a solution.

2. I've also validated this solution with VSCode and made sure it resolved the original issue.
To try the solution in VsCode, generate a custom `snyk-macos` binary from the CLI using the Make file and point the plugin in VSCode to it via the advanced settings. 

3. This did not happen when fetching org-settings as the correct query-string data was passed:
![image](https://user-images.githubusercontent.com/43777855/209804684-0e3ad914-ceac-4dbb-b3e7-533f66f4f434.png)

#### What are the relevant tickets?

Support Ticket:
https://snyk.zendesk.com/agent/tickets/38402

#### Screenshots

### CLI output shows a Custom Org is used as expected (`test-org` and not `ron.tal`) ✅ 
![image](https://user-images.githubusercontent.com/43777855/209800920-8aed6c8e-001c-4468-b724-c236e0cc500a.png)

## Before Fix 👎 

### IaC Usage tracking endpoint in Registry detects the wrong org (default org): `73234f0b-a44f-4838-8562-3e0160070570` ❌ 
![image](https://user-images.githubusercontent.com/43777855/209802289-9cbdd170-2249-4714-bbf6-a1af6e69d667.png)

## After Fix 👍 

### Registry Usage tracking endpoint detects the right org (custom one): `7160edb4-5c66-4fd1-bc84-c1350b240cc1` ✅  
![image](https://user-images.githubusercontent.com/43777855/209801835-3f3ba842-0b6e-4240-95cb-2fb00086fb60.png)

