### PR TITLE
chore: add runbook to iac smoke tests alert

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@
 packages/snyk-fix/ @snyk/tech-services
 packages/snyk-protect/ @snyk/hammer
 packages/cli-alert/ @snyk/hammer
+packages/iac-cli-alert/ @snyk/group-infrastructure-as-code
 
 README.md  @snyk/hammer
 CONTRIBUTING.md @snyk/hammer

--- a/packages/iac-cli-alert/src/index.ts
+++ b/packages/iac-cli-alert/src/index.ts
@@ -44,7 +44,7 @@ async function sendSlackAlert() {
   console.log('IaC smoke tests failed. Sending Slack alert...');
   const args: IncomingWebhookDefaultArguments = {
     text:
-      'Infrastructure as Code Smoke Tests jobs failed. \n<https://github.com/snyk/cli/actions/workflows/iac-smoke-tests.yml?query=workflow%3A|Infrastructure as Code Smoke Tests Results>',
+      'Infrastructure as Code Smoke Tests jobs failed. \n Core functionality in the Integrated IaC CLI flows may not be working as expected. \n <https://github.com/snyk/cli/actions/workflows/iac-smoke-tests.yml?query=workflow%3A|Infrastructure as Code Smoke Tests Results> \n <https://www.notion.so/snyk/Alert-Infrastructure-as-Code-Smoke-Tests-jobs-failed-ad6a89ea7fb74cc4aab4763c5ac59cbc|View the runbook for this alert>',
   };
   await slackWebhook.send(args);
   console.log('Slack alert sent.');


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Expands the alert message for the IaC smoke tests alert to make it clearer.
- Adds the alert's runbook to its message.
- Assigns IaC as the owner for the `iac-cli-alert` package.

#### Additional Information

- [Slack thread](https://snyk.slack.com/archives/C026G6ESL3Y/p1672759266716499)