### PR TITLE
feat: support org slugname lookup

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/snyk/cli-extension-sbom v0.0.0-20221212093410-6b474ed1a42a
-	github.com/snyk/go-application-framework v0.0.0-20221229122623-b3cc236e9f58
+	github.com/snyk/go-application-framework v0.0.0-20230108154252-b4819d803624
 	github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/pflag v1.0.5

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -184,8 +184,8 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/snyk/cli-extension-sbom v0.0.0-20221212093410-6b474ed1a42a h1:kImXWA4kbwaREeC+kaJ8H0aOukWzpK8K/UzAsExj6MU=
 github.com/snyk/cli-extension-sbom v0.0.0-20221212093410-6b474ed1a42a/go.mod h1:ohrrgC94Gx82/cgSiac02JQrsMjFtggvhAvXGuGjDGU=
-github.com/snyk/go-application-framework v0.0.0-20221229122623-b3cc236e9f58 h1:lRYloO4hulZTT3391WYezDJgpXj7uUb0vndFHqJCB68=
-github.com/snyk/go-application-framework v0.0.0-20221229122623-b3cc236e9f58/go.mod h1:5hLGqObbxLWnZkhn3Xc5PblESjQOfjN509ucQ4dtqz8=
+github.com/snyk/go-application-framework v0.0.0-20230108154252-b4819d803624 h1:hSkeC6T7h5ppnRCMy236LGi1atqmhBJkLWSI7vsYOTk=
+github.com/snyk/go-application-framework v0.0.0-20230108154252-b4819d803624/go.mod h1:HtfqpR9P9WmTym2HruG7w/be5w+/HBfl5Y82CXSZ7tU=
 github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd h1:zjDhcQ642rIVI8aIjfG5uVcw+OGotQtX2l9VHe7IqCQ=
 github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd/go.mod h1:v6t6wKizOcHXT3p4qKn6Bda7yNIjCQ54Xyl31NjgXkY=
 github.com/spf13/afero v1.9.2 h1:j49Hj62F0n+DaZ1dDCvhABaPNSGNkt32oRFxI33IEMw=

--- a/test/jest/acceptance/analytics.spec.ts
+++ b/test/jest/acceptance/analytics.spec.ts
@@ -273,10 +273,13 @@ describe('analytics module', () => {
       'npm/with-vulnerable-lodash-dep',
     );
 
-    const { code } = await runSnykCLI('test --org=1234', {
-      cwd: project.path(),
-      env,
-    });
+    const { code } = await runSnykCLI(
+      'test --org=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      {
+        cwd: project.path(),
+        env,
+      },
+    );
 
     expect(code).toBe(2);
 

--- a/test/jest/acceptance/extra-certs.spec.ts
+++ b/test/jest/acceptance/extra-certs.spec.ts
@@ -83,23 +83,29 @@ describe('Extra CA certificates specified with `NODE_EXTRA_CA_CERTS`', () => {
     let res4 = { code: 0 };
     if (isCLIV2()) {
       // invoke WITHOUT additional certificate set => succeeds
-      res3 = await runSnykCLI(`sbom --experimental --debug --org 1234`, {
-        env: {
-          ...process.env,
-          SNYK_API: SNYK_API,
-          SNYK_TOKEN: token,
+      res3 = await runSnykCLI(
+        `sbom --experimental --debug --org aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`,
+        {
+          env: {
+            ...process.env,
+            SNYK_API: SNYK_API,
+            SNYK_TOKEN: token,
+          },
         },
-      });
+      );
 
       // invoke WITH additional certificate set => succeeds
-      res4 = await runSnykCLI(`sbom --experimental --debug --org 1234`, {
-        env: {
-          ...process.env,
-          NODE_EXTRA_CA_CERTS: 'cliv2/mytestcert.crt',
-          SNYK_API: SNYK_API,
-          SNYK_TOKEN: token,
+      res4 = await runSnykCLI(
+        `sbom --experimental --debug --org aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`,
+        {
+          env: {
+            ...process.env,
+            NODE_EXTRA_CA_CERTS: 'cliv2/mytestcert.crt',
+            SNYK_API: SNYK_API,
+            SNYK_TOKEN: token,
+          },
         },
-      });
+      );
     }
 
     await server.closePromise();

--- a/test/jest/acceptance/iac/cli-share-results.spec.ts
+++ b/test/jest/acceptance/iac/cli-share-results.spec.ts
@@ -174,7 +174,7 @@ describe('CLI Share Results', () => {
       server.setNextStatusCode(429);
 
       const { stdout, exitCode } = await run(
-        'snyk iac test ./iac/arm/rule_test.json --report --project-business-criticality=high --org=1234',
+        'snyk iac test ./iac/arm/rule_test.json --report --project-business-criticality=high --org=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
       );
 
       expect(stdout).toMatch(/test limit reached/i);

--- a/test/jest/acceptance/snyk-fix/fix.spec.ts
+++ b/test/jest/acceptance/snyk-fix/fix.spec.ts
@@ -91,10 +91,13 @@ describe('snyk fix', () => {
   it('fails when api requests fail', async () => {
     const project = await createProjectFromWorkspace('no-vulns');
     server.setNextStatusCode(500);
-    const { code, stdout, stderr } = await runSnykCLI('fix --org=1234', {
-      cwd: project.path(),
-      env,
-    });
+    const { code, stdout, stderr } = await runSnykCLI(
+      'fix --org=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      {
+        cwd: project.path(),
+        env,
+      },
+    );
     expect(code).toBe(2);
     expect(stdout).toMatch('No successful fixes');
     expect(stderr).toBe('');

--- a/test/jest/acceptance/snyk-test/fail-on.spec.ts
+++ b/test/jest/acceptance/snyk-test/fail-on.spec.ts
@@ -43,10 +43,17 @@ describe('snyk test --fail-on', () => {
       server.setNextResponse(await project.read('vulns-result.json'));
 
       // setting the "org" is a workaround to fix this test, the limitation of a single next response is actually the root cause because it requires the first request to be the test request.
-      const { code } = await runSnykCLI(`test --fail-on=${failOn} --org=1234`, {
-        cwd: project.path(),
-        env,
-      });
+      const { code, stdout } = await runSnykCLI(
+        `test --fail-on=${failOn} --org=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`,
+        {
+          cwd: project.path(),
+          env,
+        },
+      );
+
+      if (code != expectedCode) {
+        console.debug(stdout);
+      }
 
       expect(code).toEqual(expectedCode);
     },

--- a/test/jest/acceptance/snyk-test/missing-node-modules.spec.ts
+++ b/test/jest/acceptance/snyk-test/missing-node-modules.spec.ts
@@ -53,10 +53,13 @@ describe('snyk test with missing node_modules', () => {
   test('does not throw when missing node_modules & package.json has no dependencies', async () => {
     server.setNextResponse(noVulnsResult);
     const project = await createProject('npm/no-dependencies');
-    const { code, stdout } = await runSnykCLI('test --org=1234', {
-      cwd: project.path(),
-      env,
-    });
+    const { code, stdout } = await runSnykCLI(
+      'test --org=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      {
+        cwd: project.path(),
+        env,
+      },
+    );
     expect(stdout).toMatch('for known issues, no vulnerable paths found.');
     expect(code).toEqual(0);
   });
@@ -64,10 +67,13 @@ describe('snyk test with missing node_modules', () => {
   test('does not throw when missing node_modules & package.json has no dependencies (with --dev)', async () => {
     server.setNextResponse(noVulnsResult);
     const project = await createProject('npm/no-dependencies');
-    const { code, stdout } = await runSnykCLI('test --dev --org=1234', {
-      cwd: project.path(),
-      env,
-    });
+    const { code, stdout } = await runSnykCLI(
+      'test --dev --org=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      {
+        cwd: project.path(),
+        env,
+      },
+    );
     expect(stdout).toMatch('for known issues, no vulnerable paths found.');
     expect(code).toEqual(0);
   });


### PR DESCRIPTION
… through an update of the application framework.

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Adds support for specifying an Organization (org) as ID or Slugname. 

#### Where should the reviewer start?
The actual logic is part of the application framework udpate.

#### How should this be manually tested?
> snyk sbom --experimental -d

Should show the preferred Organization in the debug output.

> snyk sbom --experimental -d --org=id
> snyk sbom --experimental -d --org=slugname

Should show the Organization ID of the specified org in the debug output.

