### PR TITLE
feat: disable gradle config caching by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "snyk-cpp-plugin": "2.20.1",
         "snyk-docker-plugin": "5.7.2",
         "snyk-go-plugin": "^1.19.4",
-        "snyk-gradle-plugin": "3.24.6",
+        "snyk-gradle-plugin": "3.25.1",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.32.0",
         "snyk-nodejs-lockfile-parser": "1.45.1",
@@ -16859,9 +16859,9 @@
       }
     },
     "node_modules/snyk-gradle-plugin": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.24.6.tgz",
-      "integrity": "sha512-e5Sy/KbEKqDT2bKnvqs9raAdsxiyr9UNxmne9ARnJUQtD3ndNPnAURZQCdUIHBarEyBp6AIJMO/XUp42+hVWTA==",
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.25.1.tgz",
+      "integrity": "sha512-qBFehAQ0/t84Vk8sTn5WHO1jrym9UrlRbHjqP62810ptWA23iT9neXo12Y8A0XQR/tr5gA2ayDu4XP/emcqLcQ==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",
@@ -33402,9 +33402,9 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.24.6.tgz",
-      "integrity": "sha512-e5Sy/KbEKqDT2bKnvqs9raAdsxiyr9UNxmne9ARnJUQtD3ndNPnAURZQCdUIHBarEyBp6AIJMO/XUp42+hVWTA==",
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.25.1.tgz",
+      "integrity": "sha512-qBFehAQ0/t84Vk8sTn5WHO1jrym9UrlRbHjqP62810ptWA23iT9neXo12Y8A0XQR/tr5gA2ayDu4XP/emcqLcQ==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "snyk-cpp-plugin": "2.20.1",
     "snyk-docker-plugin": "5.7.2",
     "snyk-go-plugin": "^1.19.4",
-    "snyk-gradle-plugin": "3.24.6",
+    "snyk-gradle-plugin": "3.25.1",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.32.0",
     "snyk-nodejs-lockfile-parser": "1.45.1",


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Bump the version of snyk-gradle-plugin. The latest release includes the following changes:
- we don't support Gradle's configuration caching (introduced in Gradle 7) so we disable config caching by default, even if it's requested by the user: https://github.com/snyk/snyk-gradle-plugin/pull/249
- remove bulky dependencies from test fixtures https://github.com/snyk/snyk-gradle-plugin/pull/250