### PR TITLE
chore: explicitly set —timestamp for codesign

### DIFF
--- a/cliv2/scripts/sign_darwin.sh
+++ b/cliv2/scripts/sign_darwin.sh
@@ -48,7 +48,7 @@ rm $APPLE_SIGNING_SECRETS
 security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
 
 echo "$LOG_PREFIX Signing binary $APP_PATH"
-codesign -s "$APPLE_SIGNING_IDENTITY" -v "$APP_PATH" --options runtime
+codesign -s "$APPLE_SIGNING_IDENTITY" -v "$APP_PATH" --timestamp --options runtime 
 
 #
 # notarization


### PR DESCRIPTION
just to ensure that timestamping is being used.

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
sets `--timestamp` when running `codesign` for macOS signing, so ensure that timestamping is definitely used.

from the codesign man page
>  --timestamp [=URL]
             During signing, requests that a timestamp authority server be contacted to authenticate the time of signing. The server contacted is given by the URL value.  If this option is given without a value,
             a default server provided by Apple is used.  Note that this server may not support signatures made with identities not furnished by Apple.  If the timestamp authority service cannot be contacted over
             the Internet, or it malfunctions or refuses service, the signing operation will fail.
             If this option is not given at all, a system-specific default behavior is invoked.  This may result in some but not all code signatures being timestamped.
             The special value none explicitly disables the use of timestamp services.

