### PR TITLE
fix: additional parameter for swiftpm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
         "snyk-python-plugin": "1.24.2",
         "snyk-resolve-deps": "4.7.3",
         "snyk-sbt-plugin": "2.17.0",
-        "snyk-swiftpm-plugin": "1.2.1",
+        "snyk-swiftpm-plugin": "1.2.3",
         "strip-ansi": "^5.2.0",
         "tar": "^6.1.2",
         "uuid": "^8.3.2",
@@ -17440,13 +17440,16 @@
       }
     },
     "node_modules/snyk-swiftpm-plugin": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/snyk-swiftpm-plugin/-/snyk-swiftpm-plugin-1.2.1.tgz",
-      "integrity": "sha512-Im4I6mDMwzP3UpPx94QBNQQPDLsRB4k1n4g/uhSZfnu6uqrX8Ex51eyDoEfW4xl1wSqrBIMItdCeJ1ylcAg8oA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/snyk-swiftpm-plugin/-/snyk-swiftpm-plugin-1.2.3.tgz",
+      "integrity": "sha512-k07WZIfOwiLXePESuaxfqTFsoXPNuyvDHDZlQj8vVjm0jY4zJ/r6iyTje5VrpmNAL9Ti9QbmLN33G2u/SJyOWQ==",
       "dependencies": {
         "@snyk/dep-graph": "^2.3.0",
         "lookpath": "^1.2.2",
         "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/snyk-swiftpm-plugin/node_modules/@snyk/dep-graph": {
@@ -33902,9 +33905,9 @@
       }
     },
     "snyk-swiftpm-plugin": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/snyk-swiftpm-plugin/-/snyk-swiftpm-plugin-1.2.1.tgz",
-      "integrity": "sha512-Im4I6mDMwzP3UpPx94QBNQQPDLsRB4k1n4g/uhSZfnu6uqrX8Ex51eyDoEfW4xl1wSqrBIMItdCeJ1ylcAg8oA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/snyk-swiftpm-plugin/-/snyk-swiftpm-plugin-1.2.3.tgz",
+      "integrity": "sha512-k07WZIfOwiLXePESuaxfqTFsoXPNuyvDHDZlQj8vVjm0jY4zJ/r6iyTje5VrpmNAL9Ti9QbmLN33G2u/SJyOWQ==",
       "requires": {
         "@snyk/dep-graph": "^2.3.0",
         "lookpath": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "snyk-python-plugin": "1.24.2",
     "snyk-resolve-deps": "4.7.3",
     "snyk-sbt-plugin": "2.17.0",
-    "snyk-swiftpm-plugin": "1.2.1",
+    "snyk-swiftpm-plugin": "1.2.2",
     "strip-ansi": "^5.2.0",
     "tar": "^6.1.2",
     "uuid": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "snyk-python-plugin": "1.24.2",
     "snyk-resolve-deps": "4.7.3",
     "snyk-sbt-plugin": "2.17.0",
-    "snyk-swiftpm-plugin": "1.2.2",
+    "snyk-swiftpm-plugin": "1.2.3",
     "strip-ansi": "^5.2.0",
     "tar": "^6.1.2",
     "uuid": "^8.3.2",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Fix for two problems with swiftpm

- fix additional params - set them after the `package` sub command of the `swift` cli (for the full list see `swift package --help`
- delete redundant `.build` folder and `Package.resolved` if created by the snyk cli

