### PR TITLE
fix: Correctly parse the remote URLs set by actions/checkokut

### DIFF
--- a/src/cli/commands/test/iac/meta.ts
+++ b/src/cli/commands/test/iac/meta.ts
@@ -78,6 +78,7 @@ export function getProjectNameFromGitUrl(url: string) {
     /^ssh:\/\/([^@]+@)?[^:/]+(:[^/]+)?\/(?<name>.*).git\/?$/,
     /^(git|https?|ftp):\/\/[^:/]+(:[^/]+)?\/(?<name>.*).git\/?$/,
     /^[^@]+@[^:]+:(?<name>.*).git$/,
+    /^(https?):\/\/github.com\/(?<name>.*)$/,
   ];
 
   const trimmed = url.trim();

--- a/test/jest/unit/cli/commands/test/iac/meta.spec.ts
+++ b/test/jest/unit/cli/commands/test/iac/meta.spec.ts
@@ -230,6 +230,11 @@ describe('getProjectNameFromGitUrl', () => {
 
     'git@github.com:user/repo.git',
 
+    // Remote URLs set up by 'actions/checkout' in GitHub workflows.
+
+    'https://github.com/user/repo',
+    'http://github.com/user/repo',
+
     // If everything else fails, the URL should be returned as-is, but trimmed.
 
     'user/repo',


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

The `snyk iac test` command doesn't properly parse the Git remote URLs set by `actions/checkout` in GitHub workflows. These URLs are like `https://github.com/user/repo`, which is not a format that the command currently understand. The consequence of this bug is that using `--report` in GitHub actions generates malformed project names as shown below:

![image](https://user-images.githubusercontent.com/404227/212014974-ae9c41fa-2827-41e2-987b-527ad21ec80d.png)
