### PR TITLE
chore: enable Extensible CLI changes in release notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ $(BINARY_OUTPUT_FOLDER)/release.json: $(BINARY_OUTPUT_FOLDER)/version $(wildcard
 #   :(exclude) syntax: https://git-scm.com/docs/gitglossary.html#Documentation/gitglossary.txt-exclude
 # Release notes uses version from package.json so we need to prepack beforehand.
 $(BINARY_OUTPUT_FOLDER)/RELEASE_NOTES.md: prepack | $(BINARY_RELEASES_FOLDER_TS_CLI)
-	npx conventional-changelog-cli -p angular -l -r 1 --commit-path ':(exclude)cliv2' > $(BINARY_OUTPUT_FOLDER)/RELEASE_NOTES.md
+	npx conventional-changelog-cli -p angular -l -r 1 > $(BINARY_OUTPUT_FOLDER)/RELEASE_NOTES.md
 
 # Generates a shasum of a target with the same name.
 # See "Automatic Variables" in GNU Make docs (linked at the top)


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Remove the explicit exclude of changes in the cliv2 directory from the Changelog.
