### PR TITLE
chore: improve cache directory

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/snyk/cli-extension-sbom v0.0.0-20221212093410-6b474ed1a42a
-	github.com/snyk/go-application-framework v0.0.0-20230108154252-b4819d803624
+	github.com/snyk/go-application-framework v0.0.0-20230125123834-dfb806074f4a
 	github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/pflag v1.0.5

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -188,6 +188,8 @@ github.com/snyk/cli-extension-sbom v0.0.0-20221212093410-6b474ed1a42a h1:kImXWA4
 github.com/snyk/cli-extension-sbom v0.0.0-20221212093410-6b474ed1a42a/go.mod h1:ohrrgC94Gx82/cgSiac02JQrsMjFtggvhAvXGuGjDGU=
 github.com/snyk/go-application-framework v0.0.0-20230108154252-b4819d803624 h1:hSkeC6T7h5ppnRCMy236LGi1atqmhBJkLWSI7vsYOTk=
 github.com/snyk/go-application-framework v0.0.0-20230108154252-b4819d803624/go.mod h1:HtfqpR9P9WmTym2HruG7w/be5w+/HBfl5Y82CXSZ7tU=
+github.com/snyk/go-application-framework v0.0.0-20230125123834-dfb806074f4a h1:PAW3dFhSDGXefDi6I4sK4/6G23czznRQOaZoBSe0Q3M=
+github.com/snyk/go-application-framework v0.0.0-20230125123834-dfb806074f4a/go.mod h1:HtfqpR9P9WmTym2HruG7w/be5w+/HBfl5Y82CXSZ7tU=
 github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd h1:zjDhcQ642rIVI8aIjfG5uVcw+OGotQtX2l9VHe7IqCQ=
 github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd/go.mod h1:v6t6wKizOcHXT3p4qKn6Bda7yNIjCQ54Xyl31NjgXkY=
 github.com/spf13/afero v1.9.2 h1:j49Hj62F0n+DaZ1dDCvhABaPNSGNkt32oRFxI33IEMw=

--- a/cliv2/internal/cliv2/cliv2.go
+++ b/cliv2/internal/cliv2/cliv2.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/gofrs/flock"
-	"github.com/pkg/errors"
 	"github.com/snyk/cli/cliv2/internal/constants"
 	"github.com/snyk/cli/cliv2/internal/embedded"
 	"github.com/snyk/cli/cliv2/internal/embedded/cliv1"
@@ -76,11 +75,7 @@ func (c *CLI) Init() (err error) {
 		if _, err = os.Stat(c.CacheDirectory); os.IsNotExist(err) {
 			err = os.Mkdir(c.CacheDirectory, local_utils.CACHEDIR_PERMISSION)
 			if err != nil {
-				// If the path given contains sub directories, ask user to create them (as using MkdirAll will result in concurrency issues)
-				if strings.Contains(c.CacheDirectory, "/") {
-					errors.Wrap("Cache directory path contains sub-directories. Please create all sub-directories in the path")
-				}
-				return err
+				return fmt.Errorf("Cache directory path is invalid: %w", err)
 			}
 		}
 	}

--- a/cliv2/internal/cliv2/cliv2.go
+++ b/cliv2/internal/cliv2/cliv2.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/gofrs/flock"
+	"github.com/pkg/errors"
 	"github.com/snyk/cli/cliv2/internal/constants"
 	"github.com/snyk/cli/cliv2/internal/embedded"
 	"github.com/snyk/cli/cliv2/internal/embedded/cliv1"
@@ -75,6 +76,10 @@ func (c *CLI) Init() (err error) {
 		if _, err = os.Stat(c.CacheDirectory); os.IsNotExist(err) {
 			err = os.Mkdir(c.CacheDirectory, local_utils.CACHEDIR_PERMISSION)
 			if err != nil {
+				// If the path given contains sub directories, ask user to create them (as using MkdirAll will result in concurrency issues)
+				if strings.Contains(c.CacheDirectory, "/") {
+					errors.Wrap("Cache directory path contains sub-directories. Please create all sub-directories in the path")
+				}
 				return err
 			}
 		}


### PR DESCRIPTION
We can’t use MkdirAll since it’ll result in concurrency issues. Log information if user is trying to use a cache directory path with sub-directories. Also update go-application-framework to use version that returns “snyk” instead of an empty string in case of an error creating a cache directory

[JIRA ticket](https://snyksec.atlassian.net/browse/HEAD-84)