### PR TITLE
Fix: support configured endpoint in Extensible CLI

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/snyk/cli-extension-sbom v0.0.0-20221212093410-6b474ed1a42a
-	github.com/snyk/go-application-framework v0.0.0-20230125123834-dfb806074f4a
+	github.com/snyk/go-application-framework v0.0.0-20230127154548-a9c237373827
 	github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/pflag v1.0.5

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -186,10 +186,8 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/snyk/cli-extension-sbom v0.0.0-20221212093410-6b474ed1a42a h1:kImXWA4kbwaREeC+kaJ8H0aOukWzpK8K/UzAsExj6MU=
 github.com/snyk/cli-extension-sbom v0.0.0-20221212093410-6b474ed1a42a/go.mod h1:ohrrgC94Gx82/cgSiac02JQrsMjFtggvhAvXGuGjDGU=
-github.com/snyk/go-application-framework v0.0.0-20230108154252-b4819d803624 h1:hSkeC6T7h5ppnRCMy236LGi1atqmhBJkLWSI7vsYOTk=
-github.com/snyk/go-application-framework v0.0.0-20230108154252-b4819d803624/go.mod h1:HtfqpR9P9WmTym2HruG7w/be5w+/HBfl5Y82CXSZ7tU=
-github.com/snyk/go-application-framework v0.0.0-20230125123834-dfb806074f4a h1:PAW3dFhSDGXefDi6I4sK4/6G23czznRQOaZoBSe0Q3M=
-github.com/snyk/go-application-framework v0.0.0-20230125123834-dfb806074f4a/go.mod h1:HtfqpR9P9WmTym2HruG7w/be5w+/HBfl5Y82CXSZ7tU=
+github.com/snyk/go-application-framework v0.0.0-20230127154548-a9c237373827 h1:cUpEEJ7g404dDABJbQU5auuqSFqTBx9+6g45TCcFOTQ=
+github.com/snyk/go-application-framework v0.0.0-20230127154548-a9c237373827/go.mod h1:HtfqpR9P9WmTym2HruG7w/be5w+/HBfl5Y82CXSZ7tU=
 github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd h1:zjDhcQ642rIVI8aIjfG5uVcw+OGotQtX2l9VHe7IqCQ=
 github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd/go.mod h1:v6t6wKizOcHXT3p4qKn6Bda7yNIjCQ54Xyl31NjgXkY=
 github.com/spf13/afero v1.9.2 h1:j49Hj62F0n+DaZ1dDCvhABaPNSGNkt32oRFxI33IEMw=

--- a/test/jest/acceptance/snyk-config/snyk-config.spec.ts
+++ b/test/jest/acceptance/snyk-config/snyk-config.spec.ts
@@ -1,4 +1,7 @@
 import { runSnykCLI } from '../../util/runSnykCLI';
+import { FakeServer, fakeServer } from '../../../acceptance/fake-server';
+import { createProjectFromWorkspace } from '../../util/createProject';
+import { isCLIV2 } from '../../util/isCLIV2';
 
 jest.setTimeout(1000 * 60);
 
@@ -13,4 +16,88 @@ test('returns value in one line', async () => {
   });
   expect(code).toEqual(0);
   expect(stdout).toEqual(expectedToken + '\n');
+});
+
+describe('snyk config set endpoint', () => {
+  let server: FakeServer;
+  const port = process.env.PORT || process.env.SNYK_PORT || '12345';
+  const baseApi = '/api';
+  const token = '123456789';
+
+  beforeAll((done) => {
+    server = fakeServer(baseApi + '/v1', token);
+    server.listen(port, () => {
+      done();
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    server.restore();
+  });
+
+  afterAll((done) => {
+    server.close(() => {
+      done();
+    });
+  });
+
+  it('set and use endpoint', async () => {
+    const env = {
+      ...process.env,
+      SNYK_TOKEN: token,
+      SNYK_HTTP_PROTOCOL_UPGRADE: '0',
+    };
+
+    delete env['SNYK_API'];
+
+    // ensure that we start from scratch
+    const requestCount0 = server.getRequests().length;
+    expect(requestCount0).toEqual(0);
+
+    // set endpoint
+    const endpoint = 'http://127.0.0.1:' + server.getPort() + baseApi;
+    const resultconfigSet = await runSnykCLI(
+      'config set endpoint=' + endpoint + ' -d',
+      {
+        env: env,
+      },
+    );
+    expect(resultconfigSet.code).toEqual(0);
+
+    // run a tests against the endpoint
+    const project = await createProjectFromWorkspace('npm-package');
+
+    const resultTest = await runSnykCLI(
+      'test --debug --org=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      {
+        cwd: project.path(),
+        env: env,
+      },
+    );
+    expect(resultTest.code).toEqual(0);
+    expect(resultTest.stderr).toContain(endpoint);
+    expect(resultTest.stderr).not.toContain('snyk.io');
+
+    const requestCount1 = server.getRequests().length;
+    expect(requestCount1).toBeGreaterThan(requestCount0);
+
+    if (isCLIV2()) {
+      // generate an sbom against the endpoint
+      const resultSBOM = await runSnykCLI(
+        `sbom --experimental --debug --org aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`,
+        {
+          env: env,
+        },
+      );
+      expect(resultSBOM.code).toEqual(0);
+      expect(resultSBOM.stderr).toContain(endpoint);
+      expect(resultSBOM.stderr).not.toContain('snyk.io');
+
+      const requestCount2 = server.getRequests().length;
+      expect(requestCount2).toBeGreaterThan(requestCount1);
+    }
+
+    await runSnykCLI('config unset endpoint');
+  });
 });


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
In addition to SNYK_API the Extensible CLI now supports the endpoint being configured via `snyk config endpoint=<value>`. Therefore the go-application-framework was updated.

#### Where should the reviewer start?
* The actual logic is in the go-application-framework
* The newly added test

#### How should this be manually tested?
`snyk config endpoint=https://app.eu.snyk.io/api`
`snyk auth`

--> should lead to authenticate against https://app.eu.snyk.io

