### PR TITLE
fix: maven aggregate project test scope

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "snyk-go-plugin": "^1.19.4",
         "snyk-gradle-plugin": "3.25.2",
         "snyk-module": "3.1.0",
-        "snyk-mvn-plugin": "2.32.0",
+        "snyk-mvn-plugin": "2.32.2",
         "snyk-nodejs-lockfile-parser": "1.45.1",
         "snyk-nuget-plugin": "1.23.5",
         "snyk-php-plugin": "1.9.2",
@@ -17104,9 +17104,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-mvn-plugin": {
-      "version": "2.32.0",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.32.0.tgz",
-      "integrity": "sha512-wHoL8OUF5iEqWMI7oKUHrNWdEItuj28+j7rl9wYkhrw8fMsFQBfm2akJ2PjlFJTZ2W8IrsYPF3zMaMTIlgiG3Q==",
+      "version": "2.32.2",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.32.2.tgz",
+      "integrity": "sha512-BBD8UarOZHPxKCZMg/zHXb37BVuh6XcHy4gyKSkqP4KFDs+tHP7b7BYaoL/1cTLamRIz9nO/BUR09k9aLm73Dw==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.23.1",
@@ -33679,9 +33679,9 @@
       }
     },
     "snyk-mvn-plugin": {
-      "version": "2.32.0",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.32.0.tgz",
-      "integrity": "sha512-wHoL8OUF5iEqWMI7oKUHrNWdEItuj28+j7rl9wYkhrw8fMsFQBfm2akJ2PjlFJTZ2W8IrsYPF3zMaMTIlgiG3Q==",
+      "version": "2.32.2",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.32.2.tgz",
+      "integrity": "sha512-BBD8UarOZHPxKCZMg/zHXb37BVuh6XcHy4gyKSkqP4KFDs+tHP7b7BYaoL/1cTLamRIz9nO/BUR09k9aLm73Dw==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.23.1",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "snyk-go-plugin": "^1.19.4",
     "snyk-gradle-plugin": "3.25.2",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "2.32.0",
+    "snyk-mvn-plugin": "2.32.2",
     "snyk-nodejs-lockfile-parser": "1.45.1",
     "snyk-nuget-plugin": "1.23.5",
     "snyk-php-plugin": "1.9.2",


### PR DESCRIPTION


- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Support --dev flag and --maven-aggregate-project. The --maven-aggregate-project flag now defaults to non test scope dependencies. Only when using --dev will Snyk include test scope dependencies.

This is more inline with the way other Snyk plugins work, defaulting to production dependencies only.

See https://github.com/snyk/snyk-mvn-plugin/pull/144
