### PR TITLE
fix: Update unsupported-entitlement-error.ts

### DIFF
--- a/src/lib/errors/unsupported-entitlement-error.ts
+++ b/src/lib/errors/unsupported-entitlement-error.ts
@@ -9,7 +9,7 @@ export class UnsupportedEntitlementError extends CustomError {
     entitlement: string,
     userMessage = `This feature is currently not enabled for your org. To enable it, please contact snyk support.`,
   ) {
-    super('Unsupported feature - Missing the ${entitlementName} entitlement');
+    super(`Unsupported feature - Missing the ${entitlementName} entitlement`);
     this.entitlement = entitlement;
     this.code = UnsupportedEntitlementError.ERROR_CODE;
     this.userMessage = userMessage;


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Changes incorrect quote marks ('') used in entitlement error message to backticks (``) to allow for variable substitution ```${entitlementName}``` to work as intended.

#### Where should the reviewer start?
/src/lib/errors/unsupported-entitlement-error.ts#L12

#### How should this be manually tested?
Run CLI test where user/org is not entitled to feature. E.g: test IaC template without IaC entitlement.

#### Any background context you want to provide?
Raised in Github Issue #4268

#### What are the relevant tickets?
Zendesk: #42663
GH Issues: #4268

#### Screenshots
N/A

#### Additional questions
N/A