### PR TITLE
feat: npm lock v2 and v3 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "snyk-gradle-plugin": "3.26.0",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.32.2",
-        "snyk-nodejs-lockfile-parser": "1.47.5",
+        "snyk-nodejs-lockfile-parser": "1.48.0",
         "snyk-nuget-plugin": "1.23.5",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.25.0",
@@ -14656,9 +14656,9 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -17014,9 +17014,9 @@
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/snyk-nodejs-lockfile-parser": {
-      "version": "1.47.5",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.47.5.tgz",
-      "integrity": "sha512-BtcUzhKrOW9mpow0TLEgr6h2mbsuKZdJDNuOCpixRiLIMm8ciSG54dFT1vZysqBCCyZhFf90DMD2XsRthvVeSg==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.48.0.tgz",
+      "integrity": "sha512-kq4gVwL5V0SUatDxyyzbptKkaX4Ew9N3ZDNR5r7sqBRparY+U+xGuYBhTaJdweBUD+jkvs7rKO1JV1h0Z8c2ew==",
       "dependencies": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -17028,6 +17028,7 @@
         "lodash.flatmap": "^4.5.0",
         "lodash.isempty": "^4.4.0",
         "lodash.topairs": "^4.3.0",
+        "micromatch": "^4.0.5",
         "semver": "^7.3.5",
         "snyk-config": "^5.0.0",
         "tslib": "^1.9.3",
@@ -17098,6 +17099,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/snyk-nodejs-lockfile-parser/node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/snyk-nodejs-lockfile-parser/node_modules/object-hash": {
@@ -31736,9 +31749,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pidtree": {
       "version": "0.3.1",
@@ -33526,9 +33539,9 @@
       }
     },
     "snyk-nodejs-lockfile-parser": {
-      "version": "1.47.5",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.47.5.tgz",
-      "integrity": "sha512-BtcUzhKrOW9mpow0TLEgr6h2mbsuKZdJDNuOCpixRiLIMm8ciSG54dFT1vZysqBCCyZhFf90DMD2XsRthvVeSg==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.48.0.tgz",
+      "integrity": "sha512-kq4gVwL5V0SUatDxyyzbptKkaX4Ew9N3ZDNR5r7sqBRparY+U+xGuYBhTaJdweBUD+jkvs7rKO1JV1h0Z8c2ew==",
       "requires": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -33540,6 +33553,7 @@
         "lodash.flatmap": "^4.5.0",
         "lodash.isempty": "^4.4.0",
         "lodash.topairs": "^4.3.0",
+        "micromatch": "^4.0.5",
         "semver": "^7.3.5",
         "snyk-config": "^5.0.0",
         "tslib": "^1.9.3",
@@ -33597,6 +33611,15 @@
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "requires": {
             "yallist": "^4.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+          "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+          "requires": {
+            "braces": "^3.0.2",
+            "picomatch": "^2.3.1"
           }
         },
         "object-hash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "snyk-gradle-plugin": "3.26.0",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.32.2",
-        "snyk-nodejs-lockfile-parser": "1.45.1",
+        "snyk-nodejs-lockfile-parser": "1.47.5",
         "snyk-nuget-plugin": "1.23.5",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.25.0",
@@ -17014,9 +17014,9 @@
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/snyk-nodejs-lockfile-parser": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.45.1.tgz",
-      "integrity": "sha512-uj3dGoruveEZ1l/i5Qv4RS+dTBgAfmXXvTEmvH14fNuTEzDzb/PFe6+H1VPExrihwjrjHci1WIUhm9lQpYZZCQ==",
+      "version": "1.47.5",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.47.5.tgz",
+      "integrity": "sha512-BtcUzhKrOW9mpow0TLEgr6h2mbsuKZdJDNuOCpixRiLIMm8ciSG54dFT1vZysqBCCyZhFf90DMD2XsRthvVeSg==",
       "dependencies": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -17029,7 +17029,7 @@
         "lodash.isempty": "^4.4.0",
         "lodash.topairs": "^4.3.0",
         "semver": "^7.3.5",
-        "snyk-config": "^4.0.0-rc.2",
+        "snyk-config": "^5.0.0",
         "tslib": "^1.9.3",
         "uuid": "^8.3.0"
       },
@@ -17120,6 +17120,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/snyk-nodejs-lockfile-parser/node_modules/snyk-config": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/snyk-config/-/snyk-config-5.1.0.tgz",
+      "integrity": "sha512-wqVMxUGqjjHX+MJrz0WHa/pJTDWU17aRv6cnI/6i7cq93J3TkkJZ8sjgvwCgP8cWX5wTHIlRuMV+IAd59K4X/g==",
+      "dependencies": {
+        "async": "^3.2.0",
+        "debug": "^4.1.1",
+        "lodash.merge": "^4.6.2",
+        "minimist": "^1.2.5"
       }
     },
     "node_modules/snyk-nodejs-lockfile-parser/node_modules/yallist": {
@@ -33515,9 +33526,9 @@
       }
     },
     "snyk-nodejs-lockfile-parser": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.45.1.tgz",
-      "integrity": "sha512-uj3dGoruveEZ1l/i5Qv4RS+dTBgAfmXXvTEmvH14fNuTEzDzb/PFe6+H1VPExrihwjrjHci1WIUhm9lQpYZZCQ==",
+      "version": "1.47.5",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.47.5.tgz",
+      "integrity": "sha512-BtcUzhKrOW9mpow0TLEgr6h2mbsuKZdJDNuOCpixRiLIMm8ciSG54dFT1vZysqBCCyZhFf90DMD2XsRthvVeSg==",
       "requires": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -33530,7 +33541,7 @@
         "lodash.isempty": "^4.4.0",
         "lodash.topairs": "^4.3.0",
         "semver": "^7.3.5",
-        "snyk-config": "^4.0.0-rc.2",
+        "snyk-config": "^5.0.0",
         "tslib": "^1.9.3",
         "uuid": "^8.3.0"
       },
@@ -33599,6 +33610,17 @@
           "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "requires": {
             "lru-cache": "^6.0.0"
+          }
+        },
+        "snyk-config": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/snyk-config/-/snyk-config-5.1.0.tgz",
+          "integrity": "sha512-wqVMxUGqjjHX+MJrz0WHa/pJTDWU17aRv6cnI/6i7cq93J3TkkJZ8sjgvwCgP8cWX5wTHIlRuMV+IAd59K4X/g==",
+          "requires": {
+            "async": "^3.2.0",
+            "debug": "^4.1.1",
+            "lodash.merge": "^4.6.2",
+            "minimist": "^1.2.5"
           }
         },
         "yallist": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "snyk-gradle-plugin": "3.26.0",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.32.2",
-    "snyk-nodejs-lockfile-parser": "1.45.1",
+    "snyk-nodejs-lockfile-parser": "1.47.5",
     "snyk-nuget-plugin": "1.23.5",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.25.0",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "snyk-gradle-plugin": "3.26.0",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.32.2",
-    "snyk-nodejs-lockfile-parser": "1.47.5",
+    "snyk-nodejs-lockfile-parser": "1.48.0",
     "snyk-nuget-plugin": "1.23.5",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.25.0",

--- a/src/lib/plugins/nodejs-plugin/npm-lock-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/npm-lock-parser.ts
@@ -60,7 +60,9 @@ export async function parse(
   );
   if (
     lockfileVersion === NodeLockfileVersion.YarnLockV1 ||
-    lockfileVersion === NodeLockfileVersion.YarnLockV2
+    lockfileVersion === NodeLockfileVersion.YarnLockV2 ||
+    lockfileVersion === NodeLockfileVersion.NpmLockV2 ||
+    lockfileVersion === NodeLockfileVersion.NpmLockV3
   ) {
     return await buildDepGraph(
       root,
@@ -124,6 +126,13 @@ async function buildDepGraph(
       );
     case NodeLockfileVersion.YarnLockV2:
       return lockFileParser.parseYarnLockV2Project(
+        manifestFileContents,
+        lockFileContents,
+        options,
+      );
+    case NodeLockfileVersion.NpmLockV2:
+    case NodeLockfileVersion.NpmLockV3:
+      return lockFileParser.parseNpmLockV2Project(
         manifestFileContents,
         lockFileContents,
         options,

--- a/src/lib/plugins/nodejs-plugin/npm-workspaces-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/npm-workspaces-parser.ts
@@ -1,0 +1,180 @@
+import * as baseDebug from 'debug';
+import * as pathUtil from 'path';
+const sortBy = require('lodash.sortby');
+const groupBy = require('lodash.groupby');
+import * as micromatch from 'micromatch';
+
+const debug = baseDebug('snyk-npm-workspaces');
+import * as lockFileParser from 'snyk-nodejs-lockfile-parser';
+import {
+  MultiProjectResultCustom,
+  ScannedProjectCustom,
+} from '../get-multi-plugin-result';
+import { getFileContents } from '../../get-file-contents';
+import { NoSupportedManifestsFoundError } from '../../errors';
+
+export async function processNpmWorkspaces(
+  root: string,
+  settings: {
+    strictOutOfSync?: boolean;
+    dev?: boolean;
+    yarnWorkspaces?: boolean;
+  },
+  targetFiles: string[],
+): Promise<MultiProjectResultCustom> {
+  // the order of npmTargetFiles folders is important
+  // must have the root level most folders at the top
+  const mappedAndFiltered = targetFiles
+    .map((p) => ({ path: p, ...pathUtil.parse(p) }))
+    .filter((res) => ['package.json', 'package-lock.json'].includes(res.base));
+  const sorted = sortBy(mappedAndFiltered, 'dir');
+  const grouped = groupBy(sorted, 'dir');
+
+  const npmTargetFiles: {
+    [dir: string]: Array<{
+      path: string;
+      base: string;
+      dir: string;
+    }>;
+  } = grouped;
+
+  debug(`Processing potential Npm workspaces (${targetFiles.length})`);
+  if (settings.yarnWorkspaces && Object.keys(npmTargetFiles).length === 0) {
+    throw NoSupportedManifestsFoundError([root]);
+  }
+  let npmWorkspacesMap = {};
+  const workspacesFilesMap = {};
+  const result: MultiProjectResultCustom = {
+    plugin: {
+      name: 'snyk-nodejs-npm-workspaces',
+      runtime: process.version,
+    },
+    scannedProjects: [],
+  };
+  // the folders must be ordered highest first
+  for (const directory of Object.keys(npmTargetFiles)) {
+    debug(`Processing ${directory} as a potential npm workspace`);
+    let isWorkspacePackage = false;
+    let isRootPackageJson = false;
+    const packageJsonFileName = pathUtil.join(directory, 'package.json');
+    const packageJson = getFileContents(root, packageJsonFileName);
+    npmWorkspacesMap = {
+      ...npmWorkspacesMap,
+      ...getWorkspacesMap(packageJson),
+    };
+    for (const workspaceRoot of Object.keys(npmWorkspacesMap)) {
+      const match = packageJsonBelongsToWorkspace(
+        packageJsonFileName,
+        npmWorkspacesMap,
+        workspaceRoot,
+      );
+      if (match) {
+        debug(`${packageJsonFileName} matches an existing workspace pattern`);
+        workspacesFilesMap[packageJsonFileName] = {
+          root: workspaceRoot,
+        };
+        isWorkspacePackage = true;
+      }
+      if (packageJsonFileName === workspaceRoot) {
+        isRootPackageJson = true;
+      }
+    }
+
+    if (!(isWorkspacePackage || isRootPackageJson)) {
+      debug(
+        `${packageJsonFileName} is not part of any detected workspace, skipping`,
+      );
+      continue;
+    }
+    try {
+      const rootDir = isWorkspacePackage
+        ? pathUtil.dirname(workspacesFilesMap[packageJsonFileName].root)
+        : pathUtil.dirname(packageJsonFileName);
+      const rootLockfileName = pathUtil.join(rootDir, 'package-lock.json');
+      const lockContent = getFileContents(root, rootLockfileName);
+
+      const res = lockFileParser.parseNpmLockV2Project(
+        packageJson.content,
+        lockContent.content,
+        {
+          includeDevDeps: settings.dev || false,
+          strictOutOfSync: settings.strictOutOfSync || false,
+          includeOptionalDeps: false,
+          pruneCycles: true,
+        },
+      );
+
+      const project: ScannedProjectCustom = {
+        packageManager: 'npm',
+        targetFile: pathUtil.relative(root, packageJson.fileName),
+        depGraph: res as any,
+        plugin: {
+          name: 'snyk-nodejs-lockfile-parser',
+          runtime: process.version,
+        },
+      };
+      result.scannedProjects.push(project);
+    } catch (e) {
+      if (settings.yarnWorkspaces) {
+        throw e;
+      }
+      debug(`Error process workspace: ${packageJsonFileName}. ERROR: ${e}`);
+    }
+  }
+  if (!result.scannedProjects.length) {
+    debug(
+      `No npm workspaces detected in any of the ${targetFiles.length} target files.`,
+    );
+  }
+  return result;
+}
+
+interface NpmWorkspacesMap {
+  [packageJsonName: string]: {
+    workspaces: string[];
+  };
+}
+
+export function getWorkspacesMap(file: {
+  content: string;
+  fileName: string;
+}): NpmWorkspacesMap {
+  const workspacesMap = {};
+  if (!file) {
+    return workspacesMap;
+  }
+
+  try {
+    const rootFileWorkspacesDefinitions =
+      JSON.parse(file.content).workspaces || false;
+    if (rootFileWorkspacesDefinitions && rootFileWorkspacesDefinitions.length) {
+      workspacesMap[file.fileName] = {
+        workspaces: rootFileWorkspacesDefinitions,
+      };
+    }
+  } catch (e) {
+    debug('Failed to process a workspace', e.message);
+  }
+  return workspacesMap;
+}
+
+export function packageJsonBelongsToWorkspace(
+  packageJsonFileName: string,
+  workspacesMap: NpmWorkspacesMap,
+  workspaceRoot: string,
+): boolean {
+  const workspaceRootFolder = pathUtil.dirname(
+    workspaceRoot.replace(/\\/g, '/'),
+  );
+  const workspacesGlobs = (
+    workspacesMap[workspaceRoot].workspaces || []
+  ).map((workspace) => pathUtil.join(workspaceRootFolder, workspace));
+
+  const match = micromatch.isMatch(
+    packageJsonFileName.replace(/\\/g, '/'),
+    workspacesGlobs.map((p) =>
+      pathUtil.normalize(pathUtil.join(p, 'package.json')).replace(/\\/g, '/'),
+    ),
+  );
+  return match;
+}

--- a/test/acceptance/workspaces/npm-package-lockfile-v2/package-lock.json
+++ b/test/acceptance/workspaces/npm-package-lockfile-v2/package-lock.json
@@ -1,0 +1,62 @@
+{
+  "name": "npm-package-lockfile-v2",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "npm-package-lockfile-v2",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "debug": "2.2.0"
+      },
+      "devDependencies": {
+        "object-assign": "4.1.1"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
+      "dependencies": {
+        "ms": "0.7.1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg=="
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "dependencies": {
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
+      "requires": {
+        "ms": "0.7.1"
+      }
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true
+    }
+  }
+}

--- a/test/acceptance/workspaces/npm-package-lockfile-v2/package.json
+++ b/test/acceptance/workspaces/npm-package-lockfile-v2/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "npm-package-lockfile-v2",
+  "version": "1.0.0",
+  "description": "Simple NPM package",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "snyk",
+  "license": "ISC",
+  "dependencies": {
+    "debug": "2.2.0"
+  },
+  "devDependencies": {
+    "object-assign": "4.1.1"
+  }
+}

--- a/test/acceptance/workspaces/npm-package-lockfile-v3/package-lock.json
+++ b/test/acceptance/workspaces/npm-package-lockfile-v3/package-lock.json
@@ -1,0 +1,41 @@
+{
+  "name": "npm-package-lockfile-v3",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "npm-package-lockfile-v3",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "debug": "2.2.0"
+      },
+      "devDependencies": {
+        "object-assign": "4.1.1"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
+      "dependencies": {
+        "ms": "0.7.1"
+      }
+    },
+    "node_modules/ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg=="
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  }
+}

--- a/test/acceptance/workspaces/npm-package-lockfile-v3/package.json
+++ b/test/acceptance/workspaces/npm-package-lockfile-v3/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "npm-package-lockfile-v3",
+  "version": "1.0.0",
+  "description": "Simple NPM package",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "snyk",
+  "license": "ISC",
+  "dependencies": {
+    "debug": "2.2.0"
+  },
+  "devDependencies": {
+    "object-assign": "4.1.1"
+  }
+}

--- a/test/jest/unit/lib/plugins/get-multiplugin-result.spec.ts
+++ b/test/jest/unit/lib/plugins/get-multiplugin-result.spec.ts
@@ -1,16 +1,16 @@
 import * as pathLib from 'path';
 import { SupportedPackageManagers } from '../../../../../src/lib/package-managers';
-import { filterOutProcessedWorkspaces } from '../../../../../src/lib/plugins/get-multi-plugin-result';
+import { filterOutProcessedYarnWorkspaces } from '../../../../../src/lib/plugins/get-multi-plugin-result';
 
 const root = '../../../../acceptance/workspaces/yarn-workspaces';
-describe('filterOutProcessedWorkspaces', () => {
+describe('filterOutProcessedYarnWorkspaces', () => {
   test('all package.json belong to the same workspace', () => {
     const allTargetFiles = [
       'yarn.lock',
       'packages/tomatoes/yarn.lock',
       'packages/apples/package.json',
     ];
-    const unprocessedFiles = filterOutProcessedWorkspaces(
+    const unprocessedFiles = filterOutProcessedYarnWorkspaces(
       root,
       scannedProjects as any,
       allTargetFiles,
@@ -23,7 +23,7 @@ describe('filterOutProcessedWorkspaces', () => {
       'packages/tomatoes/yarn.lock',
       'packages/apples/package.json',
     ].map((p) => pathLib.resolve(root, p));
-    const unprocessedFiles = filterOutProcessedWorkspaces(
+    const unprocessedFiles = filterOutProcessedYarnWorkspaces(
       root,
       scannedProjects as any,
       allTargetFiles,
@@ -37,7 +37,7 @@ describe('filterOutProcessedWorkspaces', () => {
       'not-part-of-workspace-yarn/yarn.lock',
       'packages/apples/package.json',
     ].map((p) => pathLib.resolve(root, p));
-    const unprocessedFiles = filterOutProcessedWorkspaces(
+    const unprocessedFiles = filterOutProcessedYarnWorkspaces(
       root,
       scannedProjects as any,
       allTargetFiles,
@@ -55,7 +55,7 @@ describe('filterOutProcessedWorkspaces', () => {
       'not-part-of-workspace-yarn/yarn.lock',
       'packages/apples/package.json',
     ].map((p) => pathLib.resolve(root, p));
-    const unprocessedFiles = filterOutProcessedWorkspaces(
+    const unprocessedFiles = filterOutProcessedYarnWorkspaces(
       root,
       scannedProjects as any,
       allTargetFiles,
@@ -76,7 +76,7 @@ describe('filterOutProcessedWorkspaces', () => {
       'packages/apples/package.json',
       'packages/apples/Pipfile',
     ].map((p) => pathLib.resolve(root, p));
-    const unprocessedFiles = filterOutProcessedWorkspaces(
+    const unprocessedFiles = filterOutProcessedYarnWorkspaces(
       root,
       scannedProjects as any,
       allTargetFiles,

--- a/test/tap/cli-test/cli-test.npm.spec.ts
+++ b/test/tap/cli-test/cli-test.npm.spec.ts
@@ -21,6 +21,30 @@ export const NpmTests: AcceptanceTests = {
       t.match(req.body.targetFile, undefined, 'target is undefined');
     },
 
+    '`test npm-package with lockfile v2`': (params, utils) => async (t) => {
+      utils.chdirWorkspaces();
+      await params.cli.test('npm-package-lockfile-v2');
+      const req = params.server.popRequest();
+      const depGraph = req.body.depGraph;
+      t.same(
+        depGraph.pkgs.map((p) => p.id).sort(),
+        ['npm-package-lockfile-v2@1.0.0', 'ms@0.7.1', 'debug@2.2.0'].sort(),
+        'depGraph looks fine',
+      );
+    },
+
+    '`test npm-package with lockfile v3`': (params, utils) => async (t) => {
+      utils.chdirWorkspaces();
+      await params.cli.test('npm-package-lockfile-v3');
+      const req = params.server.popRequest();
+      const depGraph = req.body.depGraph;
+      t.same(
+        depGraph.pkgs.map((p) => p.id).sort(),
+        ['npm-package-lockfile-v3@1.0.0', 'ms@0.7.1', 'debug@2.2.0'].sort(),
+        'depGraph looks fine',
+      );
+    },
+
     'test npm-package remoteUrl': (params, utils) => async (t) => {
       utils.chdirWorkspaces();
       process.env.GIT_DIR = 'npm-package/gitdir';


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This adds cli support for `package-lock` versions 2 and 3. These versions have been in use since npm7.

Previous support for npm-lock-v2 exists but was using older `dep-tree` logic. This PR also upgrades this to use dep-graph solely.
