### PR TITLE
feat: allow gradle daemon usage on unix based systems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "snyk-cpp-plugin": "2.20.1",
         "snyk-docker-plugin": "^5.7.4",
         "snyk-go-plugin": "^1.19.4",
-        "snyk-gradle-plugin": "3.25.2",
+        "snyk-gradle-plugin": "^3.26.0",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.32.2",
         "snyk-nodejs-lockfile-parser": "1.45.1",
@@ -16946,9 +16946,9 @@
       }
     },
     "node_modules/snyk-gradle-plugin": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.25.2.tgz",
-      "integrity": "sha512-oSvUKSSWqsRMG0BYBqDfMn4B5R+v+HCdetWgHyR+Q552vo9GVtRF7XmRNZ+6Feu13/DzphASkyaebkFF1AxvRQ==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.26.0.tgz",
+      "integrity": "sha512-w82yXN7oBa2cuSsXnSIUzad4FtRKVI9YZqoOs7H9WkvuRYZ55S7kLPhSGlDWwwvV9VVETkHpj+lwDx83IuitSg==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",
@@ -33556,9 +33556,9 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.25.2.tgz",
-      "integrity": "sha512-oSvUKSSWqsRMG0BYBqDfMn4B5R+v+HCdetWgHyR+Q552vo9GVtRF7XmRNZ+6Feu13/DzphASkyaebkFF1AxvRQ==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-3.26.0.tgz",
+      "integrity": "sha512-w82yXN7oBa2cuSsXnSIUzad4FtRKVI9YZqoOs7H9WkvuRYZ55S7kLPhSGlDWwwvV9VVETkHpj+lwDx83IuitSg==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "snyk-cpp-plugin": "2.20.1",
     "snyk-docker-plugin": "^5.7.4",
     "snyk-go-plugin": "^1.19.4",
-    "snyk-gradle-plugin": "3.25.2",
+    "snyk-gradle-plugin": "3.26.0",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.32.2",
     "snyk-nodejs-lockfile-parser": "1.45.1",


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This bumps the version of snyk-gradle-plugin. Changes included:
- allow using Gradle daemon to improve performance: https://github.com/snyk/snyk-gradle-plugin/pull/253
- https://github.com/snyk/snyk-gradle-plugin/pull/251