### PR TITLE
fix: add check if the s3 bucket contains the version already

### DIFF
--- a/release-scripts/validate-repository.sh
+++ b/release-scripts/validate-repository.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+VERSION_TAG="v$(cat binary-releases/version)"
+
 if git describe --contains --tags; then
     echo "This commit has already been released."
+    exit 1
+fi
+
+aws s3 ls s3://"${PUBLIC_S3_BUCKET}"/cli/"${VERSION_TAG}"/
+if [ "${?}" -eq "0" ]; then
+    echo "Version ${VERSION_TAG} has already been released."
     exit 1
 fi


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
As a test before pre-releasing to the S3 bucket, ensure that the version is not already there.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
