### PR TITLE
fix: missing sdkman java version

### DIFF
--- a/.circleci/install-sdks-unix.sh
+++ b/.circleci/install-sdks-unix.sh
@@ -2,7 +2,7 @@
 # Can't set -u as sdkman has unbound variables.
 set -eo pipefail
 
-sdk install java   11.0.11.hs-adpt
+sdk install java   11.0.17-tem
 sdk install maven  3.8.2
 sdk install gradle 6.8.3
 sdk install sbt    1.5.5


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
The AdoptOpenJDK distribution of the Java JDK has been renamed, and this is blocking the release pipeline. This PR updates the test setup to install version `11.0.17-tel` of the JDK rather than `11.0.11.hs-adpt`, as its nearest replacement.
