### PR TITLE
fix: usage of git tag instead of describe

### DIFF
--- a/release-scripts/validate-repository.sh
+++ b/release-scripts/validate-repository.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 VERSION_TAG="v$(cat binary-releases/version)"
 
-if git describe --contains --tags; then
+if git -P tag --list --contains; then
     echo "This commit has already been released."
     exit 1
 fi


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
due to a fatal exception in git

