### PR TITLE
fix: ./iac-data/ location

### DIFF
--- a/src/cli/commands/test/iac/local-execution/file-utils.ts
+++ b/src/cli/commands/test/iac/local-execution/file-utils.ts
@@ -23,7 +23,7 @@ export function createIacDir(): void {
   const iacPath: fs.PathLike = path.join(LOCAL_POLICY_ENGINE_DIR);
   try {
     if (!fs.existsSync(iacPath)) {
-      fs.mkdirSync(iacPath, '700');
+      fs.mkdirSync(iacPath, { recursive: true, mode: 0o700 });
     }
     fs.accessSync(iacPath, fs.constants.W_OK);
   } catch {

--- a/src/cli/commands/test/iac/local-execution/local-cache.ts
+++ b/src/cli/commands/test/iac/local-execution/local-cache.ts
@@ -9,10 +9,15 @@ import * as analytics from '../../../../../lib/analytics';
 import { getErrorStringCode } from './error-utils';
 import config from '../../../../../lib/config';
 import { streamRequest } from '../../../../../lib/request/request';
+import envPaths from 'env-paths';
 
 const debug = Debug('iac-local-cache');
 
-export const LOCAL_POLICY_ENGINE_DIR = '.iac-data';
+const cachePath = config.CACHE_PATH ?? envPaths('snyk').cache;
+const uuid = Math.random()
+  .toString(36)
+  .substring(2);
+export const LOCAL_POLICY_ENGINE_DIR = cachePath + '/iac-data/' + uuid;
 
 const KUBERNETES_POLICY_ENGINE_WASM_PATH = path.join(
   LOCAL_POLICY_ENGINE_DIR,
@@ -68,28 +73,28 @@ export function getLocalCachePath(engineType: EngineType): string[] {
   switch (engineType) {
     case EngineType.Kubernetes:
       return [
-        `${process.cwd()}/${KUBERNETES_POLICY_ENGINE_WASM_PATH}`,
-        `${process.cwd()}/${KUBERNETES_POLICY_ENGINE_DATA_PATH}`,
+        `${KUBERNETES_POLICY_ENGINE_WASM_PATH}`,
+        `${KUBERNETES_POLICY_ENGINE_DATA_PATH}`,
       ];
     case EngineType.Terraform:
       return [
-        `${process.cwd()}/${TERRAFORM_POLICY_ENGINE_WASM_PATH}`,
-        `${process.cwd()}/${TERRAFORM_POLICY_ENGINE_DATA_PATH}`,
+        `${TERRAFORM_POLICY_ENGINE_WASM_PATH}`,
+        `${TERRAFORM_POLICY_ENGINE_DATA_PATH}`,
       ];
     case EngineType.CloudFormation:
       return [
-        `${process.cwd()}/${CLOUDFORMATION_POLICY_ENGINE_WASM_PATH}`,
-        `${process.cwd()}/${CLOUDFORMATION_POLICY_ENGINE_DATA_PATH}`,
+        `${CLOUDFORMATION_POLICY_ENGINE_WASM_PATH}`,
+        `${CLOUDFORMATION_POLICY_ENGINE_DATA_PATH}`,
       ];
     case EngineType.ARM:
       return [
-        `${process.cwd()}/${ARM_POLICY_ENGINE_WASM_PATH}`,
-        `${process.cwd()}/${ARM_POLICY_ENGINE_DATA_PATH}`,
+        `${ARM_POLICY_ENGINE_WASM_PATH}`,
+        `${ARM_POLICY_ENGINE_DATA_PATH}`,
       ];
     case EngineType.Custom:
       return [
-        `${process.cwd()}/${CUSTOM_POLICY_ENGINE_WASM_PATH}`,
-        `${process.cwd()}/${CUSTOM_POLICY_ENGINE_DATA_PATH}`,
+        `${CUSTOM_POLICY_ENGINE_WASM_PATH}`,
+        `${CUSTOM_POLICY_ENGINE_DATA_PATH}`,
       ];
     default:
       assertNever(engineType);
@@ -154,10 +159,7 @@ export async function initLocalCache({
 
 export function cleanLocalCache() {
   // path to delete is hardcoded for now
-  const iacPath: fs.PathLike = path.join(
-    `${process.cwd()}`,
-    LOCAL_POLICY_ENGINE_DIR,
-  );
+  const iacPath: fs.PathLike = path.normalize(LOCAL_POLICY_ENGINE_DIR);
   try {
     // when we support Node version >= 12.10.0 , we can replace rimraf
     // with the native fs.rmdirSync(path, {recursive: true})

--- a/test/jest/unit/iac/file-scanner.spec.ts
+++ b/test/jest/unit/iac/file-scanner.spec.ts
@@ -5,7 +5,6 @@ import {
   validateResultFromCustomRules,
 } from '../../../../src/cli/commands/test/iac/local-execution/file-scanner';
 import * as localCacheModule from '../../../../src/cli/commands/test/iac/local-execution/local-cache';
-import { LOCAL_POLICY_ENGINE_DIR } from '../../../../src/cli/commands/test/iac/local-execution/local-cache';
 import {
   EngineType,
   IacFileParsed,
@@ -38,11 +37,11 @@ describe('scanFiles', () => {
     it('returns the expected violated policies', async () => {
       const policyEngineCoreDataPath = path.resolve(
         __dirname,
-        path.join('../../../smoke', LOCAL_POLICY_ENGINE_DIR),
+        path.normalize('../../../smoke/.iac-data'),
       );
       const policyEngineMetaDataPath = path.resolve(
         __dirname,
-        path.join('../../../smoke', LOCAL_POLICY_ENGINE_DIR),
+        path.normalize('../../../smoke/.iac-data'),
       );
 
       const spy = jest

--- a/test/jest/unit/iac/local-cache.spec.ts
+++ b/test/jest/unit/iac/local-cache.spec.ts
@@ -83,10 +83,7 @@ describe('initLocalCache - downloads bundle successfully', () => {
   });
 
   it('cleans up the custom folder after finishes', () => {
-    const iacPath: fs.PathLike = path.join(
-      `${process.cwd()}`,
-      LOCAL_POLICY_ENGINE_DIR,
-    );
+    const iacPath: fs.PathLike = path.normalize(LOCAL_POLICY_ENGINE_DIR);
     const spy = jest.spyOn(rimraf, 'sync');
 
     localCacheModule.cleanLocalCache();


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Following a [feedback](https://snyk.slack.com/archives/CEPPB1XNE/p1675794455260329) from @lirantal, we've decided to move the location of the `iac-data` folder from the cwd to the Snyk CLI cache directory.

In addition to that, this PR creates a sub-dir in `iac-data` with a random name to allow the IDE to run several scans concurrently without any problem. 

#### How should this be manually tested?
run IaC commands and check that they are still running and working as expected.
