### PR TITLE
chore: upgrade SBOM CLI Extension

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gofrs/flock v0.8.1
 	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
-	github.com/snyk/cli-extension-sbom v0.0.0-20230213075649-2cb2b355a7ab
+	github.com/snyk/cli-extension-sbom v0.0.0-20230215160928-37f78b6a60ff
 	github.com/snyk/go-application-framework v0.0.0-20230210131245-b0117ae1bcff
 	github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd
 	github.com/spf13/cobra v1.6.0

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -184,8 +184,8 @@ github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYe
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/snyk/cli-extension-sbom v0.0.0-20230213075649-2cb2b355a7ab h1:opLV5s9iLBRL3F7AAW0ef9UtUGs/EcyuDubAjrplcqY=
-github.com/snyk/cli-extension-sbom v0.0.0-20230213075649-2cb2b355a7ab/go.mod h1:ohrrgC94Gx82/cgSiac02JQrsMjFtggvhAvXGuGjDGU=
+github.com/snyk/cli-extension-sbom v0.0.0-20230215160928-37f78b6a60ff h1:NchU7E14sffqTXhxu7OOdlbWJQPsfA7qVU2VEZzr8z0=
+github.com/snyk/cli-extension-sbom v0.0.0-20230215160928-37f78b6a60ff/go.mod h1:ohrrgC94Gx82/cgSiac02JQrsMjFtggvhAvXGuGjDGU=
 github.com/snyk/go-application-framework v0.0.0-20230210131245-b0117ae1bcff h1:bb85jUKTq3UjeO7cKiTlFtUenyHFu2wJ/AZ8df7rieQ=
 github.com/snyk/go-application-framework v0.0.0-20230210131245-b0117ae1bcff/go.mod h1:HtfqpR9P9WmTym2HruG7w/be5w+/HBfl5Y82CXSZ7tU=
 github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd h1:zjDhcQ642rIVI8aIjfG5uVcw+OGotQtX2l9VHe7IqCQ=


### PR DESCRIPTION
#### What does this PR do?

We recently extended the SBOM Export API with additional output formats, which enables users to specify a format when running the SBOM command, e.g.

```bash
$ snyk sbom --experimental --format=spdx2.3+json
```

This upgrade the CLI Extension to the latest version which documents the new SBOM formats.