### PR TITLE
test: fix broken smoke tests

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -179,7 +179,7 @@ jobs:
         run: |
           which snyk
           snyk version
-          shellspec -f d --skip-message quiet
+          shellspec -f d --skip-message quiet --no-warning-as-failure
 
       - name: Run shellspec tests - Windows
         if: ${{ matrix.os == 'windows' }}


### PR DESCRIPTION
Fix broken smoke tests resulting from the addition of `HOMEBREW_NO_AUTO_UPDATE=1` to the macos testing