### PR TITLE
fix: entitlement error should explain which entitlement

### DIFF
--- a/src/lib/errors/unsupported-entitlement-error.ts
+++ b/src/lib/errors/unsupported-entitlement-error.ts
@@ -9,7 +9,11 @@ export class UnsupportedEntitlementError extends CustomError {
     entitlement: string,
     userMessage = `This feature is currently not enabled for your org. To enable it, please contact snyk support.`,
   ) {
-    super('Unsupported feature - Missing the ${entitlementName} entitlement');
+    super(
+      `Unsupported feature - Missing the ${
+        entitlement ? entitlement : 'required'
+      } entitlement`,
+    );
     this.entitlement = entitlement;
     this.code = UnsupportedEntitlementError.ERROR_CODE;
     this.userMessage = userMessage;


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Fix to display the entitlement variable when Entitlement error is thrown, with a fall back;
#### Any background context you want to provide?


#### What are the relevant tickets?
https://github.com/snyk/cli/issues/4268 
