### PR TITLE
fix: pass org to code-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@sentry/node": "^7.34.0",
         "@snyk/cli-interface": "2.11.0",
         "@snyk/cloud-config-parser": "^1.14.5",
-        "@snyk/code-client": "^4.16.1",
+        "@snyk/code-client": "^4.16.2",
         "@snyk/dep-graph": "^1.27.1",
         "@snyk/docker-registry-v2-client": "^2.7.3",
         "@snyk/fix": "file:packages/snyk-fix",
@@ -2061,9 +2061,9 @@
       }
     },
     "node_modules/@snyk/code-client": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.16.1.tgz",
-      "integrity": "sha512-EPD1i1I+ZcW9qzKLAbT5WOUb4gjQlhzeIaHsTOkSkLY84Zj88BsJjzZaHKT4GWhDv69GVEv2Sx9DtfRgNAaEKQ==",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.16.2.tgz",
+      "integrity": "sha512-aWdJz2PrQ8uhcsUmLc3znVPHCimF2f9B2FN1cqh68UkP7NxdeNXLFC8IDS1YpCu+OLrmM0YMqFY7n8sLByo8jQ==",
       "dependencies": {
         "@deepcode/dcignore": "^1.0.4",
         "@types/flat-cache": "^2.0.0",
@@ -21913,9 +21913,9 @@
       }
     },
     "@snyk/code-client": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.16.1.tgz",
-      "integrity": "sha512-EPD1i1I+ZcW9qzKLAbT5WOUb4gjQlhzeIaHsTOkSkLY84Zj88BsJjzZaHKT4GWhDv69GVEv2Sx9DtfRgNAaEKQ==",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.16.2.tgz",
+      "integrity": "sha512-aWdJz2PrQ8uhcsUmLc3znVPHCimF2f9B2FN1cqh68UkP7NxdeNXLFC8IDS1YpCu+OLrmM0YMqFY7n8sLByo8jQ==",
       "requires": {
         "@deepcode/dcignore": "^1.0.4",
         "@types/flat-cache": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@sentry/node": "^7.34.0",
     "@snyk/cli-interface": "2.11.0",
     "@snyk/cloud-config-parser": "^1.14.5",
-    "@snyk/code-client": "^4.16.1",
+    "@snyk/code-client": "^4.16.2",
     "@snyk/dep-graph": "^1.27.1",
     "@snyk/docker-registry-v2-client": "^2.7.3",
     "@snyk/fix": "file:packages/snyk-fix",

--- a/src/lib/plugins/sast/analysis.ts
+++ b/src/lib/plugins/sast/analysis.ts
@@ -70,6 +70,8 @@ async function getCodeAnalysis(
     ? sastSettings.localCodeEngine.url
     : getCodeClientProxyUrl();
 
+  const org = sastSettings.org;
+
   // TODO(james) This mirrors the implementation in request.ts and we need to use this for deeproxy calls
   // This ensures we support lowercase http(s)_proxy values as well
   // The weird IF around it ensures we don't create an envvar with
@@ -94,12 +96,14 @@ async function getCodeAnalysis(
   const severity = options.severityThreshold
     ? severityToAnalysisSeverity(options.severityThreshold)
     : AnalysisSeverity.info;
+
   const result = await analyzeFolders({
     connection: {
       baseURL,
       sessionToken,
       source,
       requestId,
+      org,
     },
     analysisOptions: { severity },
     fileOptions: { paths: [root] },


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Continuation for [code-client#169](https://github.com/snyk/code-client/pull/169):

> fix: fixed http library to properly set API header with organization name
>
>Currently, we don't set a header with organization name for getAnalysis call.
>These changes are all internal and don't affect public API