### PR TITLE
feat: add cloud custom rules to iac behind feature flag

### DIFF
--- a/src/cli/commands/test/iac/local-execution/types.ts
+++ b/src/cli/commands/test/iac/local-execution/types.ts
@@ -212,6 +212,8 @@ export type IaCTestFlags = Pick<
   path?: string;
   // Allows the caller to provide the path to a WASM bundle.
   rules?: string;
+  // Enables Snyk Cloud custom rules
+  'custom-rules'?: boolean;
   'cloud-context'?: string;
   'snyk-cloud-environment'?: string;
   // Tags and attributes
@@ -400,6 +402,7 @@ export enum IaCErrorCodes {
   FailedToProcessResults = 2200,
   EntitlementNotEnabled = 2201,
   ReadSettings = 2202,
+  FeatureFlagNotEnabled = 2203,
 }
 
 export interface TestReturnValue {

--- a/src/cli/commands/test/iac/v2/assert-iac-options.ts
+++ b/src/cli/commands/test/iac/v2/assert-iac-options.ts
@@ -30,6 +30,8 @@ const keys: (keyof IaCTestFlags)[] = [
   'detectionDepth',
   'cloud-context',
   'snyk-cloud-environment',
+  'custom-rules',
+  'experimental',
   // PolicyOptions
   'ignore-policy',
   'policy-path',

--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -55,6 +55,8 @@ async function prepareTestConfig(
   const cloudContext = getFlag(options, 'cloud-context');
   const snykCloudEnvironment = getFlag(options, 'snyk-cloud-environment');
   const insecure = options.insecure;
+  const customRules = options['custom-rules'];
+  const experimental = options.experimental;
 
   return {
     paths,
@@ -74,5 +76,7 @@ async function prepareTestConfig(
     snykCloudEnvironment,
     insecure,
     org,
+    customRules,
+    experimental,
   };
 }

--- a/src/lib/formatters/iac-output/text/formatters.ts
+++ b/src/lib/formatters/iac-output/text/formatters.ts
@@ -200,6 +200,7 @@ function formatSnykIacTestScanVulnerability(
     impact: vulnerability.rule.description,
     resolve,
     documentation: vulnerability.rule.documentation,
+    isGeneratedByCustomRule: vulnerability.rule.isGeneratedByCustomRule,
     remediation: {
       [iacRemediationTypes[vulnerability.resource.kind]]: resolve,
     },

--- a/src/lib/iac/test/v2/errors.ts
+++ b/src/lib/iac/test/v2/errors.ts
@@ -50,6 +50,10 @@ export function getErrorUserMessage(code: number, error: string): string {
     return `${error}. Please run the command again with the \`-d\` flag for more information.`;
   }
 
+  if (code == IaCErrorCodes.FeatureFlagNotEnabled) {
+    return error;
+  }
+
   return snykIacTestErrorsUserMessages[errorName];
 }
 

--- a/src/lib/iac/test/v2/json.ts
+++ b/src/lib/iac/test/v2/json.ts
@@ -67,7 +67,7 @@ export interface IacIssue {
   isIgnored: boolean;
   iacDescription: IacDescription;
   lineNumber: number;
-  documentation: string;
+  documentation?: string;
   isGeneratedByCustomRule: boolean;
   path: string[];
   policyEngineType?: string;
@@ -263,7 +263,7 @@ function vulnerabilitiesToIacIssues(
       },
       lineNumber: v.resource.line || -1,
       documentation: v.rule.documentation, // only works for rules available on snyk.io
-      isGeneratedByCustomRule: false,
+      isGeneratedByCustomRule: !!v.rule.isGeneratedByCustomRule,
       path: v.resource.path || [], // needs to be fixed, currently doesn't show the full path
       compliance: [],
       description: v.rule.description,

--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -1,12 +1,12 @@
 import * as os from 'os';
 
 const policyEngineChecksums = `
-0e505b9284ff31465a50656006a9fbbca943988e3dc1a2860ee0ab3e6b2573bc  snyk-iac-test_0.39.0_Windows_arm64.exe
-566d8587057312ecbe8298ad0acf712904689e332652c43c6bd0a499d677a44c  snyk-iac-test_0.39.0_Darwin_arm64
-7258a935fc08634a47f0c111400664cb9ff176f1cda67131891421f78bce115c  snyk-iac-test_0.39.0_Linux_arm64
-b172acbb0a84f40a9917f196e1f7b4d1aa21feddc1b2f1670ed6ef9dc71fb2e4  snyk-iac-test_0.39.0_Linux_x86_64
-c3f38885ba20087ecf20587dd83ebc4f9df27438cd9d9281700cd670877f3144  snyk-iac-test_0.39.0_Windows_x86_64.exe
-e1286f48b4bd297c05a52d256ddc4487d7c10a0e48298a177c43f3825ef83944  snyk-iac-test_0.39.0_Darwin_x86_64
+2cc88f4f928d47ec914d6ab40c773ce3efef18a879db1c702df0500e250666fa  snyk-iac-test_0.40.3_Darwin_arm64
+987a9bb850739c727dff6f47f0daa673489ca2bf0ae87ca253c7a4c66ce81285  snyk-iac-test_0.40.3_Darwin_x86_64
+ff9e2dfaca90f0efe270cffc843a25252dec266d8ba3307babf70af4d28509e6  snyk-iac-test_0.40.3_Linux_arm64
+0b516c5a25aa23950646b314d182236106ea984322837aa17e928dd9f24a0103  snyk-iac-test_0.40.3_Linux_x86_64
+505f9371d0a5cc874ae979127b8d5690bd4ddc6c38046dcb43d091ce67c4978e  snyk-iac-test_0.40.3_Windows_arm64.exe
+62dbb08941b6d520ba68a1ab1aa804b1797133dc4f91560a4762e9510d14292b  snyk-iac-test_0.40.3_Windows_x86_64.exe
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();

--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -155,6 +155,16 @@ function processFlags(
     flags.push('-org', options.org);
   }
 
+  if (options.customRules) {
+    if (options.experimental) {
+      flags.push('-custom-rules');
+    } else {
+      debug(
+        '--custom-rules specified without --experimental. ignoring --custom-rules.',
+      );
+    }
+  }
+
   return flags;
 }
 

--- a/src/lib/iac/test/v2/scan/results.ts
+++ b/src/lib/iac/test/v2/scan/results.ts
@@ -99,7 +99,8 @@ export interface Rule {
   references?: string;
   labels?: string[];
   category?: string;
-  documentation: string; // TODO: revisit this field when adding support for custom rules
+  documentation?: string;
+  isGeneratedByCustomRule?: boolean;
 }
 
 export interface Resource {

--- a/src/lib/iac/test/v2/types.ts
+++ b/src/lib/iac/test/v2/types.ts
@@ -18,4 +18,6 @@ export interface TestConfig {
   snykCloudEnvironment?: string;
   insecure?: boolean;
   org?: string;
+  customRules?: boolean;
+  experimental?: boolean;
 }

--- a/test/fixtures/iac/depth_detection/one/one.tf
+++ b/test/fixtures/iac/depth_detection/one/one.tf
@@ -1,3 +1,7 @@
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+
 resource "aws_subnet" "private2" {
   vpc_id = aws_vpc.main.id
   cidr_block = "10.0.4.0/24"


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR adds initial support for Snyk Cloud custom rules to `snyk iac test` behind a feature flag. I also needed to fix a bug that caused non-fatal parse errors to be treated as fatal, because the most recent policy-engine emits those non-fatal errors in more situations than it used to. After this PR, we'll just debug log those errors until we can design a better way to communicate them.

#### How should this be manually tested?

Please reach out to me and I can help you get setup to test.

#### What are the relevant tickets?

`CLOUD-1176`

#### Screenshots

A custom rule in the results:
![Screenshot 2023-02-22 at 8 31 16 AM](https://user-images.githubusercontent.com/99991410/220634507-c45864f7-dd6d-46f8-ab4b-5f8ba0dcbb50.png)
