### PR TITLE
fix: add project details to analysisContext

### DIFF
--- a/src/lib/plugins/sast/analysis.ts
+++ b/src/lib/plugins/sast/analysis.ts
@@ -119,9 +119,9 @@ async function getCodeAnalysis(
       flow: source,
       projectName: config.PROJECT_NAME,
       org: {
-        name: sastSettings.org || 'unknown',
+        name: sastSettings.org || options['org'] || 'unknown',
         displayName: 'unknown',
-        publicId: 'unknown',
+        publicId: options['org'] || 'unknown',
         flags: {},
       },
     },


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
adds project details to `analysisContext` for better observability in the cli upload and ignores flow

#### Where should the reviewer start?


#### How should this be manually tested?
run the cli report flow locally 

#### Any background context you want to provide?


#### What are the relevant tickets?
[ZEN-511](https://snyksec.atlassian.net/browse/ZEN-511)

#### Screenshots


#### Additional questions


[ZEN-511]: https://snyksec.atlassian.net/browse/ZEN-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ