### PR TITLE
fix: use apt-get instead of sdkman

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ commands:
             - sdkman-archive-cache-v3-{{ arch }}-{{ checksum ".circleci/install-sdks-unix.sh" }}
       - run:
           name: Installing SDKs
-          command: ./.circleci/install-sdks-unix.sh
+          command: sudo ./.circleci/install-sdks-unix.sh
       - save_cache:
           name: Saving SDKMAN archive cache
           key: sdkman-archive-cache-v3-{{ arch }}-{{ checksum ".circleci/install-sdks-unix.sh" }}
@@ -181,8 +181,9 @@ commands:
       - run:
           name: Installing golang
           command: |
-            brew install go gradle python elixir composer
-      - install_sdks_unix
+            brew install go gradle python elixir composer gradle@6 maven sbt
+      - aws-cli/install:
+          version: << pipeline.parameters.aws_version >>
   install_shellspec_dependencies:
     steps:
       - run:

--- a/.circleci/install-sdks-unix.sh
+++ b/.circleci/install-sdks-unix.sh
@@ -2,7 +2,15 @@
 # Can't set -u as sdkman has unbound variables.
 set -eo pipefail
 
-sdk install java   11.0.17-tem
-sdk install maven  3.8.2
-sdk install gradle 6.8.3
-sdk install sbt    1.5.5
+apt-get install -y \
+    maven \
+    gradle \
+    openjdk-11-jdk-headless \
+    openjdk-11-jre-headless \
+
+echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list
+echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee /etc/apt/sources.list.d/sbt_old.list
+curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/scalasbt-release.gpg --import
+chmod 644 /etc/apt/trusted.gpg.d/scalasbt-release.gpg
+apt-get update
+apt-get install sbt

--- a/cliv2/scripts/sign_windows.sh
+++ b/cliv2/scripts/sign_windows.sh
@@ -26,7 +26,7 @@ osslsigncode sign -h sha512 \
   -pass "$SIGNING_SECRETS_PASSWORD" \
   -n "Snyk CLI" \
   -i "https://snyk.io" \
-  -t "http://timestamp.comodoca.com/authenticode" \
+  -t "http://timestamp.sectigo.com" \
   -in "$APP_PATH_UNSIGNED" \
   -out "$APP_PATH"
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
* Replace the usage of `sdkman` by `apt-get` on linux and `brew` on macos
* Also update timestamp url for windows signing, since the old one started failing.