### PR TITLE
fix: custom rules remediation output

### DIFF
--- a/src/lib/formatters/iac-output/text/issues-list/issue.ts
+++ b/src/lib/formatters/iac-output/text/issues-list/issue.ts
@@ -52,8 +52,6 @@ function formatProperties(
   result: FormattedOutputResult,
   options?: Options,
 ): string[] {
-  const remediationKey = iacRemediationTypes?.[result.projectType];
-
   const properties = [
     ['Info', formatInfo(result.issue)],
     [
@@ -72,15 +70,10 @@ function formatProperties(
           : ''
       }`,
     ],
-    [
-      'Resolve',
-      remediationKey && result.issue.remediation?.[remediationKey]
-        ? result.issue.remediation[remediationKey]
-        : result.issue.resolve,
-    ],
+    ['Resolve', getRemediationText(result)],
   ];
 
-  const propKeyColWidth = Math.max(...properties.map(([key]) => key.length));
+  const propKeyColWidth = Math.max(...properties.map(([key]) => key!.length));
   const propValColWidth =
     maxLineWidth - contentPadding.length - propKeyColWidth - 2;
   const indentLength = propKeyColWidth + 2;
@@ -103,4 +96,14 @@ function isValidLineNumber(lineNumber: number | undefined): boolean {
   return (
     typeof lineNumber === 'number' && lineNumber! > 0 && lineNumber! % 1 === 0
   );
+}
+
+function getRemediationText(result: FormattedOutputResult): string | undefined {
+  const remediationKey = iacRemediationTypes?.[result.projectType];
+
+  if (result.issue.remediation) {
+    return result.issue.remediation[remediationKey] ?? result.issue.remediation;
+  }
+
+  return result.issue.resolve;
 }


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
[A user reported a bug](https://snyk.slack.com/archives/C034QFM0DH8/p1677532733366459) where we don't output the remediation advice for custom rules in our CLI.
The cause of the issue was the fact that in our custom rules SDK we named the remediation advice field `remediation` and not `resolve`.
This PR fixes this issue by adding the relevant logic to consider this case.

#### How should this be manually tested?
Using a custom rule, run `snyk iac test` and check for remediation advice in output.


#### What are the relevant tickets?
https://snyk.zendesk.com/agent/tickets/42713

#### Screenshots
<img width="457" alt="image" src="https://user-images.githubusercontent.com/71096571/222197176-d3f7761d-9545-4db9-ac6c-975b44a47c14.png">


