### PR TITLE
chore: adds debug param acceptance test

### DIFF
--- a/src/cli/commands/woof/getWoof.ts
+++ b/src/cli/commands/woof/getWoof.ts
@@ -8,6 +8,7 @@ const woofs = {
   cs: ' Haf!',
   uk: ' Гав!',
   de: 'Wuff!',
+  cat: 'Meow?',
 };
 
 export default function getWoof(args: MethodArgs): string {
@@ -19,6 +20,12 @@ export default function getWoof(args: MethodArgs): string {
     Object.keys(woofs).includes(options.language)
   ) {
     lang = options.language;
+  }
+
+  if (lang === 'cat') {
+    for (const option in options) {
+      console.debug(`${option}:::`, options[option], `:::${option}`);
+    }
   }
 
   return woofs[lang];

--- a/test/jest/acceptance/cli-args.spec.ts
+++ b/test/jest/acceptance/cli-args.spec.ts
@@ -39,6 +39,21 @@ describe('cli args', () => {
     });
   });
 
+  test('delimiting args should pass expected args to the command as expected', async () => {
+    const { stdout } = await runSnykCLI(
+      `-d woof --language=cat -- --hello --world`,
+      {
+        env,
+      },
+    );
+    const doubleDashArgsStart = stdout.indexOf('_doubleDashArgs:::');
+    const doubleDashArgsEnd = stdout.indexOf(':::_doubleDashArgs');
+    const doubleDashArgs = stdout.slice(doubleDashArgsStart, doubleDashArgsEnd);
+    expect(doubleDashArgs).toStrictEqual(
+      "_doubleDashArgs::: [ '--hello', '--world' ] ",
+    );
+  });
+
   test('snyk test command should fail when --file is not specified correctly', async () => {
     const { code, stdout } = await runSnykCLI(`test --file package-lock.json`, {
       env,


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This PR should add an acceptance test to check that no additional parameters are passed when a delimeter (--) is used