### PR TITLE
fix: move message from stdout to stderr

### DIFF
--- a/ts-binary-wrapper/src/common.ts
+++ b/ts-binary-wrapper/src/common.ts
@@ -259,7 +259,7 @@ export function downloadExecutable(
       resolve(error);
     };
 
-    console.debug(
+    console.error(
       "Downloading from '" + downloadUrl + "' to '" + filename + "'",
     );
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Move "Download" message to stderr to not interfer with other output