### PR TITLE
fix: bump snyk-iac-test to v0.40.4

### DIFF
--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -1,12 +1,12 @@
 import * as os from 'os';
 
 const policyEngineChecksums = `
-2cc88f4f928d47ec914d6ab40c773ce3efef18a879db1c702df0500e250666fa  snyk-iac-test_0.40.3_Darwin_arm64
-987a9bb850739c727dff6f47f0daa673489ca2bf0ae87ca253c7a4c66ce81285  snyk-iac-test_0.40.3_Darwin_x86_64
-ff9e2dfaca90f0efe270cffc843a25252dec266d8ba3307babf70af4d28509e6  snyk-iac-test_0.40.3_Linux_arm64
-0b516c5a25aa23950646b314d182236106ea984322837aa17e928dd9f24a0103  snyk-iac-test_0.40.3_Linux_x86_64
-505f9371d0a5cc874ae979127b8d5690bd4ddc6c38046dcb43d091ce67c4978e  snyk-iac-test_0.40.3_Windows_arm64.exe
-62dbb08941b6d520ba68a1ab1aa804b1797133dc4f91560a4762e9510d14292b  snyk-iac-test_0.40.3_Windows_x86_64.exe
+a09ab6b2a225ab52a4d5e03ca7c572f54765ef9832146fa02b262d98829ad733  snyk-iac-test_0.40.4_Darwin_arm64
+ceb038fbf466cba9f35c0fd78d32c21826202330c8878ea7c401e4fa700c296c  snyk-iac-test_0.40.4_Darwin_x86_64
+a408ec25b6d9fd245f037d7bc2b2b6c706652d4d917ca01812732804f03575e0  snyk-iac-test_0.40.4_Linux_arm64
+df77d6ce46f242402dbc72dc7115dcca70729bbb48729bd0dab7fec7369bfedd  snyk-iac-test_0.40.4_Linux_x86_64
+434784b5c9d8442a9341b57a16c94a5aef55bca5a4d89c2972e80c07b13a6e2a  snyk-iac-test_0.40.4_Windows_arm64.exe
+0cf599d63335c99b5979e03fee93d55dc6236a194439146360107856aa2b3f36  snyk-iac-test_0.40.4_Windows_x86_64.exe
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR updates `snyk-iac-test` to v0.40.4. This version fixes a bug in the custom rules feature flag check.

#### How should this be manually tested?

Please reach out to me for help with manual testing.
