### PR TITLE
fix: upgrade docker plugin to resolve OCI errors and go 1.20 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.20.1",
-        "snyk-docker-plugin": "^6.0.0",
+        "snyk-docker-plugin": "6.2.0",
         "snyk-go-plugin": "^1.19.4",
         "snyk-gradle-plugin": "3.26.0",
         "snyk-module": "3.1.0",
@@ -16634,9 +16634,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.0.0.tgz",
-      "integrity": "sha512-StsA8eivHswxylDSni1RS5Ag/rdeRTYVhTN4l0ZasU0hQ8D66iAP0uiqz7/nQtkjaTCs4AGr7oDt9X6VfXx4Rw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.2.0.tgz",
+      "integrity": "sha512-M+M78vQkyk1is1R1dU9O4nTLIDTZ6eCq3jcnnnLfwtkegqddydQttXptsAzhAWdWLZzIiofo+9asQmj1clCV5g==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.5.0",
@@ -33210,9 +33210,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.0.0.tgz",
-      "integrity": "sha512-StsA8eivHswxylDSni1RS5Ag/rdeRTYVhTN4l0ZasU0hQ8D66iAP0uiqz7/nQtkjaTCs4AGr7oDt9X6VfXx4Rw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.2.0.tgz",
+      "integrity": "sha512-M+M78vQkyk1is1R1dU9O4nTLIDTZ6eCq3jcnnnLfwtkegqddydQttXptsAzhAWdWLZzIiofo+9asQmj1clCV5g==",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.20.1",
-    "snyk-docker-plugin": "^6.0.0",
+    "snyk-docker-plugin": "6.2.0",
     "snyk-go-plugin": "^1.19.4",
     "snyk-gradle-plugin": "3.26.0",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Upgrade docker plugin to resolve OCI errors and go 1.20 support

