### PR TITLE
fix: support new setuptools version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "snyk-nuget-plugin": "1.23.5",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.25.0",
-        "snyk-python-plugin": "1.24.2",
+        "snyk-python-plugin": "1.24.4",
         "snyk-resolve-deps": "4.7.3",
         "snyk-sbt-plugin": "2.17.0",
         "snyk-swiftpm-plugin": "1.2.1",
@@ -17216,9 +17216,9 @@
       "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
     },
     "node_modules/snyk-poetry-lockfile-parser": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/snyk-poetry-lockfile-parser/-/snyk-poetry-lockfile-parser-1.1.7.tgz",
-      "integrity": "sha512-5waaslW7odDlox3WQMouSh/BjBrKq2rolMox3Ij/Vaju8r/3eWvs7anikzJUzNKwNcLm8AR5u4ftG/hxqDJJgA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/snyk-poetry-lockfile-parser/-/snyk-poetry-lockfile-parser-1.2.0.tgz",
+      "integrity": "sha512-U41LqVX0C2iQrAOPQtQ7RjrpYtp+WNK7nRoV4bBesoomlrYAix2aTqEZckjaIqanAF184WeS08n4/SJMv4hEAw==",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
         "@snyk/cli-interface": "^2.9.2",
@@ -17282,14 +17282,14 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-python-plugin": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.24.2.tgz",
-      "integrity": "sha512-jzCBREfDGYLizRse8dFdZwx09tCh4p2z5HdA2zwdHj9Rl+LOKQUMrvr1elZGSt244WYqR3rdsObztrh3mDPWVQ==",
+      "version": "1.24.4",
+      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.24.4.tgz",
+      "integrity": "sha512-KmeXHZCN5jp2iBhFj965YnRUSuU6rwDugI28EHpHhTjoGBpbMZXgKm91gtWOgOKjZT8rD/tu7aQtDB0ank0Dsw==",
       "dependencies": {
         "@snyk/cli-interface": "^2.11.2",
         "@snyk/dep-graph": "^1.28.1",
         "shescape": "1.6.1",
-        "snyk-poetry-lockfile-parser": "^1.1.7",
+        "snyk-poetry-lockfile-parser": "^1.2.0",
         "tmp": "0.2.1"
       }
     },
@@ -33692,9 +33692,9 @@
       }
     },
     "snyk-poetry-lockfile-parser": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/snyk-poetry-lockfile-parser/-/snyk-poetry-lockfile-parser-1.1.7.tgz",
-      "integrity": "sha512-5waaslW7odDlox3WQMouSh/BjBrKq2rolMox3Ij/Vaju8r/3eWvs7anikzJUzNKwNcLm8AR5u4ftG/hxqDJJgA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/snyk-poetry-lockfile-parser/-/snyk-poetry-lockfile-parser-1.2.0.tgz",
+      "integrity": "sha512-U41LqVX0C2iQrAOPQtQ7RjrpYtp+WNK7nRoV4bBesoomlrYAix2aTqEZckjaIqanAF184WeS08n4/SJMv4hEAw==",
       "requires": {
         "@iarna/toml": "^2.2.5",
         "@snyk/cli-interface": "^2.9.2",
@@ -33750,14 +33750,14 @@
       }
     },
     "snyk-python-plugin": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.24.2.tgz",
-      "integrity": "sha512-jzCBREfDGYLizRse8dFdZwx09tCh4p2z5HdA2zwdHj9Rl+LOKQUMrvr1elZGSt244WYqR3rdsObztrh3mDPWVQ==",
+      "version": "1.24.4",
+      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.24.4.tgz",
+      "integrity": "sha512-KmeXHZCN5jp2iBhFj965YnRUSuU6rwDugI28EHpHhTjoGBpbMZXgKm91gtWOgOKjZT8rD/tu7aQtDB0ank0Dsw==",
       "requires": {
         "@snyk/cli-interface": "^2.11.2",
         "@snyk/dep-graph": "^1.28.1",
         "shescape": "1.6.1",
-        "snyk-poetry-lockfile-parser": "^1.1.7",
+        "snyk-poetry-lockfile-parser": "^1.2.0",
         "tmp": "0.2.1"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "snyk-nuget-plugin": "1.23.5",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.25.0",
-    "snyk-python-plugin": "1.24.2",
+    "snyk-python-plugin": "1.24.4",
     "snyk-resolve-deps": "4.7.3",
     "snyk-sbt-plugin": "2.17.0",
     "snyk-swiftpm-plugin": "1.2.1",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
since setuptools version 67.1.0 our cli is failing when any dependency/transitive has an unsupported version (i.e. ">dev")
this change includes the changes in the snyk-python-plugin to fix this. link: https://github.com/snyk/snyk-python-plugin/pull/203
