### PR TITLE
chore: test that binary wrapper does not output to stdout [HEAD-202]

### DIFF
--- a/ts-binary-wrapper/test/acceptance/basic.spec.ts
+++ b/ts-binary-wrapper/test/acceptance/basic.spec.ts
@@ -104,7 +104,7 @@ describe('Basic acceptance test', () => {
     expect(resultIndex.status).toEqual(0);
     // The binary wrapper should not output anything to stdout
     // Assert the only stdout is from the CLI --version flag
-    expect(resultIndex.stdout.toString().trim()).toEqual(cliVersionForTesting);
+    expect(resultIndex.stdout.toString().split(' ')[0].trim()).toEqual(cliVersionForTesting);
 
     fs.unlinkSync(executable);
   });

--- a/ts-binary-wrapper/test/acceptance/basic.spec.ts
+++ b/ts-binary-wrapper/test/acceptance/basic.spec.ts
@@ -100,7 +100,6 @@ describe('Basic acceptance test', () => {
       console.debug(resultIndex.stderr.toString());
     }
 
-    
     expect(fs.existsSync(executable)).toBeTruthy();
     expect(resultIndex.status).toEqual(0);
     // The binary wrapper should not output anything to stdout

--- a/ts-binary-wrapper/test/acceptance/basic.spec.ts
+++ b/ts-binary-wrapper/test/acceptance/basic.spec.ts
@@ -104,7 +104,12 @@ describe('Basic acceptance test', () => {
     expect(resultIndex.status).toEqual(0);
     // The binary wrapper should not output anything to stdout
     // Assert the only stdout is from the CLI --version flag
-    expect(resultIndex.stdout.toString().split(' ')[0].trim()).toEqual(cliVersionForTesting);
+    expect(
+      resultIndex.stdout
+        .toString()
+        .split(' ')[0]
+        .trim(),
+    ).toEqual(cliVersionForTesting);
 
     fs.unlinkSync(executable);
   });

--- a/ts-binary-wrapper/test/acceptance/basic.spec.ts
+++ b/ts-binary-wrapper/test/acceptance/basic.spec.ts
@@ -42,8 +42,16 @@ describe('Basic acceptance test', () => {
       'node ' + bootstrapScript + ' exec',
       { shell: true },
     );
-    console.debug(resultBootstrap.stdout.toString());
-    console.error(resultBootstrap.stderr.toString());
+
+    if (resultBootstrap.status != 0) {
+      console.debug(resultBootstrap.stdout.toString());
+      console.error(resultBootstrap.stderr.toString());
+    }
+
+    // The binary wrapper should not output anything to stdout
+    // as it will conflict with stdout from the CLI leading to incidents
+    expect(resultBootstrap.stdout.toString()).toEqual('');
+
     expect(resultBootstrap.status).toEqual(0);
     expect(fs.existsSync(executable)).toBeTruthy();
 
@@ -92,11 +100,12 @@ describe('Basic acceptance test', () => {
       console.debug(resultIndex.stderr.toString());
     }
 
+    
     expect(fs.existsSync(executable)).toBeTruthy();
     expect(resultIndex.status).toEqual(0);
-    expect(
-      resultIndex.stdout.toString().includes(cliVersionForTesting),
-    ).toBeTruthy();
+    // The binary wrapper should not output anything to stdout
+    // Assert the only stdout is from the CLI --version flag
+    expect(resultIndex.stdout.toString().trim()).toEqual(cliVersionForTesting);
 
     fs.unlinkSync(executable);
   });
@@ -197,8 +206,11 @@ describe('Basic acceptance test', () => {
       'node ' + bootstrapScript + ' exec',
       { shell: true, env: { ...process.env } },
     );
-    console.debug(resultBootstrap.stdout.toString());
-    console.error(resultBootstrap.stderr.toString());
+
+    if (resultBootstrap.status != 0) {
+      console.debug(resultBootstrap.stdout.toString());
+      console.error(resultBootstrap.stderr.toString());
+    }
 
     const expectedErrorMessage = 'ECONNREFUSED';
     const expectedError = resultBootstrap.stderr


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This PR should test that the binary wrapper does not output to stdout. If it does, it could lead to issues when products use the cli output