### PR TITLE
fix: send additional report options to analyzeFolders [ZEN-556]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@sentry/node": "^7.34.0",
         "@snyk/cli-interface": "2.11.0",
         "@snyk/cloud-config-parser": "^1.14.5",
-        "@snyk/code-client": "^4.16.2",
+        "@snyk/code-client": "^4.18.1",
         "@snyk/dep-graph": "^1.27.1",
         "@snyk/docker-registry-v2-client": "^2.7.3",
         "@snyk/fix": "file:packages/snyk-fix",
@@ -2060,9 +2060,9 @@
       }
     },
     "node_modules/@snyk/code-client": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.16.2.tgz",
-      "integrity": "sha512-aWdJz2PrQ8uhcsUmLc3znVPHCimF2f9B2FN1cqh68UkP7NxdeNXLFC8IDS1YpCu+OLrmM0YMqFY7n8sLByo8jQ==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.18.1.tgz",
+      "integrity": "sha512-3O3HrqtL5coaDoiMH/OfUn8IFCm3FfDRLoh0Hr20Bp208OGFeptSKd4w13Lx6hPcGew1MAgNYrPhyYAUdlKC5w==",
       "dependencies": {
         "@deepcode/dcignore": "^1.0.4",
         "@types/flat-cache": "^2.0.0",
@@ -21840,9 +21840,9 @@
       }
     },
     "@snyk/code-client": {
-      "version": "4.16.2",
-      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.16.2.tgz",
-      "integrity": "sha512-aWdJz2PrQ8uhcsUmLc3znVPHCimF2f9B2FN1cqh68UkP7NxdeNXLFC8IDS1YpCu+OLrmM0YMqFY7n8sLByo8jQ==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.18.1.tgz",
+      "integrity": "sha512-3O3HrqtL5coaDoiMH/OfUn8IFCm3FfDRLoh0Hr20Bp208OGFeptSKd4w13Lx6hPcGew1MAgNYrPhyYAUdlKC5w==",
       "requires": {
         "@deepcode/dcignore": "^1.0.4",
         "@types/flat-cache": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@sentry/node": "^7.34.0",
     "@snyk/cli-interface": "2.11.0",
     "@snyk/cloud-config-parser": "^1.14.5",
-    "@snyk/code-client": "^4.16.2",
+    "@snyk/code-client": "^4.18.1",
     "@snyk/dep-graph": "^1.27.1",
     "@snyk/docker-registry-v2-client": "^2.7.3",
     "@snyk/fix": "file:packages/snyk-fix",

--- a/src/lib/plugins/sast/analysis.ts
+++ b/src/lib/plugins/sast/analysis.ts
@@ -111,7 +111,9 @@ async function getCodeAnalysis(
       reportOptions: {
         enabled: options.report ?? false,
         projectName: options['project-name'],
+        targetName: options['target-name'],
         targetRef: options['target-reference'],
+        remoteRepoUrl: options['remote-repo-url'],
       },
     }),
     analysisContext: {

--- a/test/jest/unit/snyk-code/snyk-code-test.spec.ts
+++ b/test/jest/unit/snyk-code/snyk-code-test.spec.ts
@@ -829,6 +829,13 @@ describe('Test snyk code', () => {
       localCodeEngine: { url: '', allowCloudUpload: true, enabled: false },
     };
 
+    const reportOptions = {
+      projectName: 'test-project-name',
+      targetName: 'test-target-name',
+      targetRef: 'test-target-ref',
+      remoteRepoUrl: 'https://github.com/owner/repo',
+    };
+
     analyzeFoldersMock.mockResolvedValue(
       sampleAnalyzeFoldersWithReportAndIgnoresResponse,
     );
@@ -837,9 +844,23 @@ describe('Test snyk code', () => {
       {
         path: '',
         code: true,
+        report: true,
+        'project-name': reportOptions.projectName,
+        'target-name': reportOptions.targetName,
+        'target-reference': reportOptions.targetRef,
+        'remote-repo-url': reportOptions.remoteRepoUrl,
       },
       sastSettings,
       'test-id',
+    );
+
+    expect(analyzeFoldersMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reportOptions: {
+          enabled: true,
+          ...reportOptions,
+        },
+      }),
     );
 
     const expectedReportResults = {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Pass additional parameters related to Code CLI uploads/reporting to `analyzeFolders`.

TODO:
- [x] Merge `code-client` companion PR: https://github.com/snyk/code-client/pull/177
- [x] Bump `code-client` version

#### Where should the reviewer start?


#### How should this be manually tested?

```
snyk code test --report --org=test-org --project-name=test-project --target-name=test-target --target-reference=test-ref --remote-repo-url=https://test.com
```

#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
