### PR TITLE
feat: add debug info for failed send test payload request

### DIFF
--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -486,6 +486,9 @@ function sendTestPayload(
       }
       if (res.statusCode !== 200) {
         const err = handleTestHttpErrorResponse(res, body);
+        debug('sendTestPayload request URL:', payload.url);
+        debug('sendTestPayload response status code:', res.statusCode);
+        debug('sendTestPayload response body:', body);
         return reject(err);
       }
 


### PR DESCRIPTION
This PR adds some debug info to the failed `sendTestPayload` request. This will help debugging upstream issues.