### PR TITLE
feat: add user-agent header to HTTP requests

### DIFF
--- a/cliv2/cmd/cliv2/main.go
+++ b/cliv2/cmd/cliv2/main.go
@@ -342,7 +342,7 @@ func MainWithErrorCode() int {
 	// init NetworkAccess
 	networkAccess := engine.GetNetworkAccess()
 	networkAccess.AddHeaderField("x-snyk-cli-version", cliv2.GetFullVersion())
-	//networkAccess.AddHeaderField("User-agent", "snyk-cli/"+cliv2.GetFullVersion())
+	networkAccess.AddHeaderField("User-Agent", "snyk-cli/"+cliv2.GetFullVersion())
 
 	if debugEnabled {
 		writeLogHeader(config, networkAccess)


### PR DESCRIPTION
Add `User-Agent` HTTP header to requests to identify Snyk CLI versions out there from the backend.