### PR TITLE
fix: bump nodejs parser to 1.48.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "snyk-gradle-plugin": "3.26.1",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.32.2",
-        "snyk-nodejs-lockfile-parser": "1.48.0",
+        "snyk-nodejs-lockfile-parser": "1.48.1",
         "snyk-nuget-plugin": "1.23.5",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.25.0",
@@ -17014,9 +17014,9 @@
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/snyk-nodejs-lockfile-parser": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.48.0.tgz",
-      "integrity": "sha512-kq4gVwL5V0SUatDxyyzbptKkaX4Ew9N3ZDNR5r7sqBRparY+U+xGuYBhTaJdweBUD+jkvs7rKO1JV1h0Z8c2ew==",
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.48.1.tgz",
+      "integrity": "sha512-1I3bOGiC9+RfgxIpufFayekiL4tul+wljPYM3ayFjhhYJVxvbS55VSheWUTMayq6PKN2fUZ71yI7tcTVGTkypA==",
       "dependencies": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -33539,9 +33539,9 @@
       }
     },
     "snyk-nodejs-lockfile-parser": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.48.0.tgz",
-      "integrity": "sha512-kq4gVwL5V0SUatDxyyzbptKkaX4Ew9N3ZDNR5r7sqBRparY+U+xGuYBhTaJdweBUD+jkvs7rKO1JV1h0Z8c2ew==",
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.48.1.tgz",
+      "integrity": "sha512-1I3bOGiC9+RfgxIpufFayekiL4tul+wljPYM3ayFjhhYJVxvbS55VSheWUTMayq6PKN2fUZ71yI7tcTVGTkypA==",
       "requires": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/graphlib": "2.1.9-patch.3",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "snyk-gradle-plugin": "3.26.1",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.32.2",
-    "snyk-nodejs-lockfile-parser": "1.48.0",
+    "snyk-nodejs-lockfile-parser": "1.48.1",
     "snyk-nuget-plugin": "1.23.5",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.25.0",


### PR DESCRIPTION
This bumps the nodejs parser version. For details please see https://github.com/snyk/nodejs-lockfile-parser/releases/tag/v1.48.1