### PR TITLE
chore: pass logger into updated gaf

### DIFF
--- a/cliv2/cmd/cliv2/main.go
+++ b/cliv2/cmd/cliv2/main.go
@@ -260,7 +260,7 @@ func logHeaderAuthorizationInfo(config configuration.Configuration, networkAcces
 		tokenDetails = fmt.Sprintf(" (type=%s)", tokenType)
 	}
 
-	if config.GetBool(configuration.OAUTH_AUTH_ENABLED) {
+	if config.GetBool(configuration.FF_OAUTH_AUTH_FLOW_ENABLED) {
 		oauthEnabled = "Enabled"
 		token, err := auth.GetOAuthToken(config)
 		if token != nil && err == nil {
@@ -305,7 +305,7 @@ func MainWithErrorCode() int {
 	_ = rootCommand.ParseFlags(os.Args)
 
 	// create engine
-	engine = app.CreateAppEngine()
+	engine = app.CreateAppEngineWithLogger(debugLogger)
 	config = engine.GetConfiguration()
 	err = config.AddFlagSet(rootCommand.LocalFlags())
 	if err != nil {

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/snyk/cli-extension-sbom v0.0.0-20230227081105-8d914d783ad3
-	github.com/snyk/go-application-framework v0.0.0-20230324100548-fde8434379eb
+	github.com/snyk/go-application-framework v0.0.0-20230327163414-e727d9c05801
 	github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd
 	github.com/snyk/snyk-iac-capture v0.6.0
 	github.com/spf13/cobra v1.6.0

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -198,6 +198,8 @@ github.com/snyk/cli-extension-sbom v0.0.0-20230227081105-8d914d783ad3 h1:Qq1yHiZ
 github.com/snyk/cli-extension-sbom v0.0.0-20230227081105-8d914d783ad3/go.mod h1:ohrrgC94Gx82/cgSiac02JQrsMjFtggvhAvXGuGjDGU=
 github.com/snyk/go-application-framework v0.0.0-20230324100548-fde8434379eb h1:4Q8wcTOa2nRNMK/SRHi9/PrVk9384Ik+J1H1ifI/7+8=
 github.com/snyk/go-application-framework v0.0.0-20230324100548-fde8434379eb/go.mod h1:xfjfnqXFxI0soW+f3wvk7x+khrR46I69W9ssLVH4284=
+github.com/snyk/go-application-framework v0.0.0-20230327163414-e727d9c05801 h1:ZbWsr+o+3Kezy6MInuHPeh/BWcIU9j3q8w0G2vrpUy0=
+github.com/snyk/go-application-framework v0.0.0-20230327163414-e727d9c05801/go.mod h1:xfjfnqXFxI0soW+f3wvk7x+khrR46I69W9ssLVH4284=
 github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd h1:zjDhcQ642rIVI8aIjfG5uVcw+OGotQtX2l9VHe7IqCQ=
 github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd/go.mod h1:v6t6wKizOcHXT3p4qKn6Bda7yNIjCQ54Xyl31NjgXkY=
 github.com/snyk/snyk-iac-capture v0.6.0 h1:P9GWIyvl+F23XZOCuJvzGV6tME/vxbKpZM7/9dw48as=

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -196,8 +196,6 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/snyk/cli-extension-sbom v0.0.0-20230227081105-8d914d783ad3 h1:Qq1yHiZiZtjNv2bM1l1T7GTa8Jl/8f9+B50Z1ZgAJyQ=
 github.com/snyk/cli-extension-sbom v0.0.0-20230227081105-8d914d783ad3/go.mod h1:ohrrgC94Gx82/cgSiac02JQrsMjFtggvhAvXGuGjDGU=
-github.com/snyk/go-application-framework v0.0.0-20230324100548-fde8434379eb h1:4Q8wcTOa2nRNMK/SRHi9/PrVk9384Ik+J1H1ifI/7+8=
-github.com/snyk/go-application-framework v0.0.0-20230324100548-fde8434379eb/go.mod h1:xfjfnqXFxI0soW+f3wvk7x+khrR46I69W9ssLVH4284=
 github.com/snyk/go-application-framework v0.0.0-20230327163414-e727d9c05801 h1:ZbWsr+o+3Kezy6MInuHPeh/BWcIU9j3q8w0G2vrpUy0=
 github.com/snyk/go-application-framework v0.0.0-20230327163414-e727d9c05801/go.mod h1:xfjfnqXFxI0soW+f3wvk7x+khrR46I69W9ssLVH4284=
 github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd h1:zjDhcQ642rIVI8aIjfG5uVcw+OGotQtX2l9VHe7IqCQ=

--- a/cliv2/pkg/basic_workflows/legacycli.go
+++ b/cliv2/pkg/basic_workflows/legacycli.go
@@ -58,7 +58,7 @@ func legacycliWorkflow(
 	debugLogger := invocation.GetLogger()
 	networkAccess := invocation.GetNetworkAccess()
 
-	oauthIsAvailable := config.GetBool(configuration.OAUTH_AUTH_ENABLED)
+	oauthIsAvailable := config.GetBool(configuration.FF_OAUTH_AUTH_FLOW_ENABLED)
 	args := config.GetStringSlice(configuration.RAW_CMD_ARGS)
 	useStdIo := config.GetBool(configuration.WORKFLOW_USE_STDIO)
 	cacheDirectory := config.GetString(configuration.CACHE_PATH)


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This PR should update the go-application-framework dependency and allow the CLI to pass a logger when creating the app engine
