### PR TITLE
feat: support oauth for deeproxy

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/snyk/cli-extension-sbom v0.0.0-20230227081105-8d914d783ad3
-	github.com/snyk/go-application-framework v0.0.0-20230327163414-e727d9c05801
+	github.com/snyk/go-application-framework v0.0.0-20230328170739-33c1de01f488
 	github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd
 	github.com/snyk/snyk-iac-capture v0.6.0
 	github.com/spf13/cobra v1.6.0

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -196,8 +196,8 @@ github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZV
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/snyk/cli-extension-sbom v0.0.0-20230227081105-8d914d783ad3 h1:Qq1yHiZiZtjNv2bM1l1T7GTa8Jl/8f9+B50Z1ZgAJyQ=
 github.com/snyk/cli-extension-sbom v0.0.0-20230227081105-8d914d783ad3/go.mod h1:ohrrgC94Gx82/cgSiac02JQrsMjFtggvhAvXGuGjDGU=
-github.com/snyk/go-application-framework v0.0.0-20230327163414-e727d9c05801 h1:ZbWsr+o+3Kezy6MInuHPeh/BWcIU9j3q8w0G2vrpUy0=
-github.com/snyk/go-application-framework v0.0.0-20230327163414-e727d9c05801/go.mod h1:xfjfnqXFxI0soW+f3wvk7x+khrR46I69W9ssLVH4284=
+github.com/snyk/go-application-framework v0.0.0-20230328170739-33c1de01f488 h1:ePcxsmU+nFpgw+EIaO1rmDnig7JaBSknteolLJL+LE4=
+github.com/snyk/go-application-framework v0.0.0-20230328170739-33c1de01f488/go.mod h1:xfjfnqXFxI0soW+f3wvk7x+khrR46I69W9ssLVH4284=
 github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd h1:zjDhcQ642rIVI8aIjfG5uVcw+OGotQtX2l9VHe7IqCQ=
 github.com/snyk/go-httpauth v0.0.0-20220915135832-0edf62cf8cdd/go.mod h1:v6t6wKizOcHXT3p4qKn6Bda7yNIjCQ54Xyl31NjgXkY=
 github.com/snyk/snyk-iac-capture v0.6.0 h1:P9GWIyvl+F23XZOCuJvzGV6tME/vxbKpZM7/9dw48as=


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Through the update of the application framework the oauth authentication will also be added for requests to deeproxy.