### PR TITLE
fix: Help behaviour for Extensions

### DIFF
--- a/cliv2/cmd/cliv2/main_test.go
+++ b/cliv2/cmd/cliv2/main_test.go
@@ -56,14 +56,16 @@ func Test_CreateCommandsForWorkflowWithSubcommands(t *testing.T) {
 	subcmd3, _, _ := rootCommand.Find([]string{"cmd", "subcmd1", "subcmd3"})
 	cmd2, _, _ := rootCommand.Find([]string{"cmd2"})
 	something, _, _ := rootCommand.Find([]string{"cmd2", "something"})
+	parseError := cmd.ParseFlags([]string{"cmd", "--unknown"})
 
-	// test which command triggers a doFallback() and which not
-	assert.False(t, doFallback(cmd.RunE(cmd, []string{})))
-	assert.False(t, doFallback(subcmd2.RunE(subcmd2, []string{})))
-	assert.False(t, doFallback(subcmd3.RunE(subcmd3, []string{})))
-	assert.False(t, doFallback(something.RunE(something, []string{})))
-	assert.True(t, doFallback(subcmd1.RunE(subcmd1, []string{})))
-	assert.True(t, doFallback(cmd2.RunE(cmd2, []string{})))
+	// test which command triggers a handleError() and which not
+	assert.Equal(t, handleErrorUnhandled, handleError(cmd.RunE(cmd, []string{})))
+	assert.Equal(t, handleErrorUnhandled, handleError(subcmd2.RunE(subcmd2, []string{})))
+	assert.Equal(t, handleErrorUnhandled, handleError(subcmd3.RunE(subcmd3, []string{})))
+	assert.Equal(t, handleErrorUnhandled, handleError(something.RunE(something, []string{})))
+	assert.Equal(t, handleErrorFallbackToLegacyCLI, handleError(subcmd1.RunE(subcmd1, []string{})))
+	assert.Equal(t, handleErrorFallbackToLegacyCLI, handleError(cmd2.RunE(cmd2, []string{})))
+	assert.Equal(t, handleErrorShowHelp, handleError(parseError))
 
 	assert.True(t, subcmd1.DisableFlagParsing)
 	assert.False(t, subcmd2.DisableFlagParsing)


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Fix logic to ensure that in case of usage errors for commands that are implemented as Extension, the help is properly shown.

![image](https://user-images.githubusercontent.com/101886095/228880033-f3964bd9-b0d8-4691-ae61-83fa7ec51b23.png)

