### PR TITLE
feat: add `IAC_RULES_CLIENT_URL` to override the URL of the rules client [CCSC-1536]

### DIFF
--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -63,6 +63,7 @@ async function prepareTestConfig(
     iacCachePath,
     userRulesBundlePath: config.IAC_BUNDLE_PATH,
     userPolicyEnginePath: config.IAC_POLICY_ENGINE_PATH,
+    userRulesClientURL: config.IAC_RULES_CLIENT_URL,
     severityThreshold: options.severityThreshold,
     report: !!options.report,
     targetReference: options['target-reference'],

--- a/src/lib/config/index.ts
+++ b/src/lib/config/index.ts
@@ -31,6 +31,7 @@ interface Config {
   DRIFTCTL_URL?: string;
   IAC_BUNDLE_PATH?: string;
   IAC_POLICY_ENGINE_PATH?: string;
+  IAC_RULES_CLIENT_URL?: string;
   PUBLIC_VULN_DB_URL: string;
 }
 

--- a/src/lib/iac/test/v2/index.ts
+++ b/src/lib/iac/test/v2/index.ts
@@ -7,11 +7,18 @@ import { addIacAnalytics } from './analytics';
 export { TestConfig } from './types';
 
 export async function test(testConfig: TestConfig): Promise<TestOutput> {
-  const { policyEnginePath, rulesBundlePath } = await initLocalCache(
-    testConfig,
-  );
+  const {
+    policyEnginePath,
+    rulesBundlePath,
+    rulesClientURL,
+  } = await initLocalCache(testConfig);
 
-  const testOutput = await scan(testConfig, policyEnginePath, rulesBundlePath);
+  const testOutput = await scan(
+    testConfig,
+    policyEnginePath,
+    rulesBundlePath,
+    rulesClientURL,
+  );
 
   addIacAnalytics(testConfig, testOutput);
 

--- a/src/lib/iac/test/v2/local-cache/index.ts
+++ b/src/lib/iac/test/v2/local-cache/index.ts
@@ -1,5 +1,5 @@
 import { TestConfig } from '../types';
-import { getLocalRulesBundle } from './rules-bundle';
+import { overrideDevelopmentPaths } from './rules-bundle';
 import { initPolicyEngine } from './policy-engine';
 import { createDirIfNotExists } from '../../../file-utils';
 import { CustomError } from '../../../../errors';
@@ -8,6 +8,7 @@ import { FailedToInitLocalCacheError } from '../../../../../cli/commands/test/ia
 interface LocalCache {
   policyEnginePath: string;
   rulesBundlePath: string;
+  rulesClientURL: string;
 }
 
 export async function initLocalCache(
@@ -17,9 +18,9 @@ export async function initLocalCache(
     await createDirIfNotExists(testConfig.iacCachePath);
 
     const policyEnginePath = await initPolicyEngine(testConfig);
-    const rulesBundlePath = getLocalRulesBundle();
+    const { rulesBundlePath, rulesClientURL } = overrideDevelopmentPaths();
 
-    return { policyEnginePath, rulesBundlePath };
+    return { policyEnginePath, rulesBundlePath, rulesClientURL };
   } catch (err) {
     throw err instanceof CustomError ? err : new FailedToInitLocalCacheError();
   }

--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -1,12 +1,12 @@
 import * as os from 'os';
 
 const policyEngineChecksums = `
-50a0af84203660f5a023c949921596e22b92987a0b35d4d07e06bcaf48f2d0d0  snyk-iac-test_0.41.0_Darwin_arm64
-01ca4b4b5cc0dd8d0e1c91ae649191aa9111a239dbd6ebf854cf9a80ed26a05c  snyk-iac-test_0.41.0_Darwin_x86_64
-1c52a7e8b9f85a49f0da7fcf8a0ef67e547c003eeb183df22006b93adf97305c  snyk-iac-test_0.41.0_Linux_arm64
-0de09e1e9fed752cacc59ef5ac01a9291cc4e035186cac7242190e389df91675  snyk-iac-test_0.41.0_Linux_x86_64
-87eb40a77f2553a1190b2ae303cb184f62ed5bd611f18a53d2e0a841fef8a99c  snyk-iac-test_0.41.0_Windows_arm64.exe
-98437131a4de041bd2ec3a851606f5ecae375d34b5e2fc749dc5391ec254919a  snyk-iac-test_0.41.0_Windows_x86_64.exe
+076e9c9be17bd0bac244af679c864620558ab1bda6d13562be5271c1a1a3d03a  snyk-iac-test_0.42.0_Linux_arm64
+17b29c5c39caa962cded8a30647f55f1a63bf77d820c8bb034a8964ea0655355  snyk-iac-test_0.42.0_Darwin_arm64
+1d12f5d02e7e8bac6dd2965a308804d699520aff6624af6b6019557eedea3c82  snyk-iac-test_0.42.0_Darwin_x86_64
+27f68ef2eae39a2a06f45af3a4a67ff7fcc433cb8de96bf9ca788d90c49e397e  snyk-iac-test_0.42.0_Windows_arm64.exe
+720a9ce6c08a93c875e031cf5ca96085a70d83e49aeb939823e7e62c0d01a75d  snyk-iac-test_0.42.0_Linux_x86_64
+a6f386cae16d046273028dbb3e377f292371c2a52ab9678f8efbae9210c183d6  snyk-iac-test_0.42.0_Windows_x86_64.exe
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();

--- a/src/lib/iac/test/v2/local-cache/rules-bundle/index.ts
+++ b/src/lib/iac/test/v2/local-cache/rules-bundle/index.ts
@@ -3,12 +3,26 @@ import * as createDebugLogger from 'debug';
 
 const debugLog = createDebugLogger('snyk-iac');
 
-export function getLocalRulesBundle(): string {
-  // IAC_BUNDLE_PATH is a developer setting that is not useful to most users. It
-  // is not a replacement for custom rules.
-  if (!config.IAC_BUNDLE_PATH) {
-    return '';
+export function overrideDevelopmentPaths(): {
+  rulesBundlePath: string;
+  rulesClientURL: string;
+} {
+  // IAC_BUNDLE_PATH and IAC_RULES_CLIENT_URL are developer settings that are not useful to most users.
+  // They are not a replacement for custom rules.
+  let rulesBundlePath = '',
+    rulesClientURL = '';
+  if (config.IAC_BUNDLE_PATH) {
+    debugLog(`Located a local rules bundle at ${config.IAC_BUNDLE_PATH}`);
+    rulesBundlePath = config.IAC_BUNDLE_PATH;
   }
-  debugLog(`Located a local rules bundle at ${config.IAC_BUNDLE_PATH}`);
-  return config.IAC_BUNDLE_PATH;
+  if (config.IAC_RULES_CLIENT_URL) {
+    debugLog(
+      `rulesClientURL is now overridden with ${config.IAC_RULES_CLIENT_URL}`,
+    );
+    rulesClientURL = config.IAC_RULES_CLIENT_URL;
+  }
+  return {
+    rulesBundlePath,
+    rulesClientURL,
+  };
 }

--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -22,6 +22,7 @@ export async function scan(
   options: TestConfig,
   policyEnginePath: string,
   rulesBundlePath: string,
+  rulesClientURL: string,
 ): Promise<TestOutput> {
   const {
     tempOutput: outputPath,
@@ -33,8 +34,9 @@ export async function scan(
       options,
       policyEnginePath,
       rulesBundlePath,
-      outputPath,
+      rulesClientURL,
       tempPolicyPath,
+      outputPath,
     );
   } finally {
     await deleteTemporaryFiles(tempDirPath);
@@ -45,8 +47,9 @@ async function scanWithConfig(
   options: TestConfig,
   policyEnginePath: string,
   rulesBundlePath: string,
-  outputPath: string,
+  rulesClientURL: string,
   policyPath: string,
+  outputPath: string,
 ): Promise<TestOutput> {
   const env = { ...process.env };
 
@@ -63,7 +66,13 @@ async function scanWithConfig(
   env['SNYK_IAC_TEST_API_V1_OAUTH_TOKEN'] =
     process.env['SNYK_IAC_TEST_API_V1_OAUTH_TOKEN'] || getOAuthToken();
 
-  const args = processFlags(options, rulesBundlePath, outputPath, policyPath);
+  const args = processFlags(
+    options,
+    rulesBundlePath,
+    rulesClientURL,
+    outputPath,
+    policyPath,
+  );
 
   args.push(...options.paths);
 
@@ -93,6 +102,7 @@ async function readJson(path: string) {
 function processFlags(
   options: TestConfig,
   rulesBundlePath: string,
+  rulesClientURL: string,
   outputPath: string,
   policyPath: string,
 ) {
@@ -163,6 +173,10 @@ function processFlags(
         '--custom-rules specified without --experimental. ignoring --custom-rules.',
       );
     }
+  }
+
+  if (options.userRulesClientURL) {
+    flags.push('-rulesClientURL', rulesClientURL);
   }
 
   return flags;

--- a/src/lib/iac/test/v2/types.ts
+++ b/src/lib/iac/test/v2/types.ts
@@ -5,6 +5,7 @@ export interface TestConfig {
   iacCachePath: string;
   userRulesBundlePath?: string;
   userPolicyEnginePath?: string;
+  userRulesClientURL?: string;
   report: boolean;
   severityThreshold?: SEVERITY;
   targetReference?: string;

--- a/test/jest/unit/lib/iac/test/v2/setup/local-cache/index.spec.ts
+++ b/test/jest/unit/lib/iac/test/v2/setup/local-cache/index.spec.ts
@@ -64,6 +64,7 @@ describe('initLocalCache', () => {
     const expected = {
       policyEnginePath: testPolicyEnginePath,
       rulesBundlePath: '',
+      rulesClientURL: '',
     };
     const res = await initLocalCache(testTestConfig);
 


### PR DESCRIPTION
This is a "hidden" (aka for development) env var to override the url of the rulesClient that is being used later in snyk-iac-test, to create a client for opa-rules-distribution. With this flag, we will be able to test bundles in development, while going through the opa-rules-distribution automatic download process.

To use locally:
``` 
SNYK_IAC_RULES_CLIENT_URL=https://something.com snyk-dev iac test test/fixtures/iac/terraform/sg_open_ssh.tf
```

To use with this branch: https://github.com/snyk/snyk-iac-test/pull/187: build the executable and run:

```
 SNYK_IAC_RULES_CLIENT_URL=https://something.com SNYK_IAC_POLICY_ENGINE_PATH=~/snyk-repos/snyk-iac-test/snyk-iac-test  snyk-dev iac test test/fixtures/iac/terraform/sg_open_ssh.tf

```

### Screenshots
Override with the bucket we already have:
![image](https://user-images.githubusercontent.com/6989529/228566920-24695e54-2e5f-48e4-bab5-ed3e53cf0401.png)

Override with a non existing URL:
<img width="1681" alt="image" src="https://user-images.githubusercontent.com/6989529/228567073-06345643-e427-401c-86ef-0966fabc9fcf.png">

No flag:
<img width="1676" alt="image" src="https://user-images.githubusercontent.com/6989529/228578982-b5727604-75b1-4401-8e60-8a88affb9d51.png">

