### PR TITLE
fix: custom rules json output missing `resolve` field

### DIFF
--- a/src/cli/commands/test/iac/local-execution/file-scanner.ts
+++ b/src/cli/commands/test/iac/local-execution/file-scanner.ts
@@ -30,6 +30,12 @@ export async function scanFiles(
       const { validatedResult, invalidIssues } = validateResultFromCustomRules(
         result,
       );
+      validatedResult.violatedPolicies.forEach((policy) => {
+        // custom rules will have a remediation field that is a string, so we need to map it to the resolve field.
+        if (typeof policy.remediation === 'string') {
+          policy.resolve = policy.remediation;
+        }
+      });
       scannedFiles.push(validatedResult);
       failedScans = [...failedScans, ...invalidIssues];
     } else {

--- a/src/cli/commands/test/iac/local-execution/types.ts
+++ b/src/cli/commands/test/iac/local-execution/types.ts
@@ -169,6 +169,7 @@ export interface PolicyMetadata {
   resolve: string;
   references: string[];
   // Included only in new policies
+  // Only custom rules will have a string remediation field
   remediation?: Partial<
     Record<'terraform' | 'cloudformation' | 'arm' | 'kubernetes', string>
   >;


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Users and other Snyk tools(`snyk-to-html` for example) expect to have a `resolve` field with remediation advice for each IaC issue.

Currently, IaC issues that got generated by using custom rules will not have this field, this PR fix this issue.

#### Any background context you want to provide?
https://snyk.slack.com/archives/C034QFM0DH8/p1680119186872949

#### Screenshots
Before
<img width="453" alt="image" src="https://user-images.githubusercontent.com/71096571/229348777-c41befb9-34d4-4e6f-9012-16f6a8d52aa7.png">

After
<img width="451" alt="image" src="https://user-images.githubusercontent.com/71096571/229348791-534bbea1-6e38-45f9-a4c3-1c213fbfb935.png">


