### PR TITLE
fix: upgrade nuget plugin - enable large dotnet core projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.32.2",
         "snyk-nodejs-lockfile-parser": "1.48.3",
-        "snyk-nuget-plugin": "1.23.5",
+        "snyk-nuget-plugin": "1.24.1",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.25.0",
         "snyk-python-plugin": "1.24.4",
@@ -17152,9 +17152,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-nuget-plugin": {
-      "version": "1.23.5",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.23.5.tgz",
-      "integrity": "sha512-PUcCo2fiGQmyprRj5+W22c9UINtQLiofhCjDSARTX186G28/xS4y8eiER5vq6JQ6NXQogTj2MF/QsnQ41R8FzA==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.24.1.tgz",
+      "integrity": "sha512-P9+UguaABwAauxbv2pijnhSALFlg21gDFwcacqRKyKaJoLZEk11YqqzuGkjQLXkBaimo1R/gTaV/MMZQ26muaQ==",
       "dependencies": {
         "debug": "^4.1.1",
         "dotnet-deps-parser": "5.1.0",
@@ -33654,9 +33654,9 @@
       }
     },
     "snyk-nuget-plugin": {
-      "version": "1.23.5",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.23.5.tgz",
-      "integrity": "sha512-PUcCo2fiGQmyprRj5+W22c9UINtQLiofhCjDSARTX186G28/xS4y8eiER5vq6JQ6NXQogTj2MF/QsnQ41R8FzA==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.24.1.tgz",
+      "integrity": "sha512-P9+UguaABwAauxbv2pijnhSALFlg21gDFwcacqRKyKaJoLZEk11YqqzuGkjQLXkBaimo1R/gTaV/MMZQ26muaQ==",
       "requires": {
         "debug": "^4.1.1",
         "dotnet-deps-parser": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.32.2",
     "snyk-nodejs-lockfile-parser": "1.48.3",
-    "snyk-nuget-plugin": "1.23.5",
+    "snyk-nuget-plugin": "1.24.1",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.25.0",
     "snyk-python-plugin": "1.24.4",


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This PR upgrade `snyk-nuget-plugin` dependency to `1.24.1` in order to fix a bug where large dotnet project files would fail to test.

Further information is in https://github.com/snyk/snyk-nuget-plugin/pull/131
