### PR TITLE
feat: add license type and legal instructions

### DIFF
--- a/packages/snyk-fix/src/types.ts
+++ b/packages/snyk-fix/src/types.ts
@@ -76,7 +76,14 @@ export interface IssuesData {
     id: string;
     severity: SEVERITY;
     title: string;
+    type?: string | undefined;
+    legalInstructionsArray?: LegalInstruction[];
   };
+}
+
+export interface LegalInstruction {
+  licenseName: string;
+  legalContent: string;
 }
 
 /* Remediation Data

--- a/src/lib/ecosystems/types.ts
+++ b/src/lib/ecosystems/types.ts
@@ -85,7 +85,14 @@ export interface IssuesData {
     id: string;
     severity: SEVERITY;
     title: string;
+    type?: string | undefined;
+    legalInstructionsArray?: LegalInstruction[];
   };
+}
+
+export interface LegalInstruction {
+  licenseName: string;
+  legalContent: string;
 }
 
 export interface DepsFilePaths {

--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -85,6 +85,8 @@ export interface IssueData {
   packageManager?: SupportedProjectTypes;
   from?: string[];
   name?: string;
+  type?: string | undefined;
+  legalInstructionsArray?: LegalInstruction[];
 }
 
 export interface IssueDataUnmanaged extends IssueData {


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

In order to show c/cpp licenses legal instructions the LegalInstruction interface has to be in the IssuesData interface that snyk-cpp-plugin looks at. Also the type as license is needed for snyk-cpp-plugin to separate between vulnerabilities and licenses in a simple way.

#### Any background context you want to provide?

This is part of improving c/cpp licenses detection in Open Beta.

#### Screenshots

<img width="577" alt="Screenshot 2023-04-13 at 13 48 38" src="https://user-images.githubusercontent.com/78362317/232230487-e0740bc8-4992-411a-b32b-9e284f21bc08.png">


