### PR TITLE
feat: bump nodejs parser version 1.49.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "snyk-gradle-plugin": "3.26.3",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.32.3",
-        "snyk-nodejs-lockfile-parser": "1.48.3",
+        "snyk-nodejs-lockfile-parser": "1.49.0",
         "snyk-nuget-plugin": "1.24.1",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.25.0",
@@ -17026,9 +17026,9 @@
       "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/snyk-nodejs-lockfile-parser": {
-      "version": "1.48.3",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.48.3.tgz",
-      "integrity": "sha512-+hPMt3w95r7C6NNXJQALJuSKzRY0Z8S5Dad5Dm0R7Qvm7mg1Tcd9yFXtWGTUP82VPIXcuxbw1YDqZ9DnnuyNPw==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.49.0.tgz",
+      "integrity": "sha512-73iqwHB8YSWex/PTx+TRUwtNPyKn5wP4n/kxEPbX9EfN3uSIcw6mSKiLm8gSKl5gtf8hcP0R0f1tBFjjdzQvRQ==",
       "dependencies": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -17041,6 +17041,7 @@
         "lodash.isempty": "^4.4.0",
         "lodash.topairs": "^4.3.0",
         "micromatch": "^4.0.5",
+        "p-map": "^4.0.0",
         "semver": "^7.3.5",
         "snyk-config": "^5.0.0",
         "tslib": "^1.9.3",
@@ -33560,9 +33561,9 @@
       }
     },
     "snyk-nodejs-lockfile-parser": {
-      "version": "1.48.3",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.48.3.tgz",
-      "integrity": "sha512-+hPMt3w95r7C6NNXJQALJuSKzRY0Z8S5Dad5Dm0R7Qvm7mg1Tcd9yFXtWGTUP82VPIXcuxbw1YDqZ9DnnuyNPw==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.49.0.tgz",
+      "integrity": "sha512-73iqwHB8YSWex/PTx+TRUwtNPyKn5wP4n/kxEPbX9EfN3uSIcw6mSKiLm8gSKl5gtf8hcP0R0f1tBFjjdzQvRQ==",
       "requires": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -33575,6 +33576,7 @@
         "lodash.isempty": "^4.4.0",
         "lodash.topairs": "^4.3.0",
         "micromatch": "^4.0.5",
+        "p-map": "^4.0.0",
         "semver": "^7.3.5",
         "snyk-config": "^5.0.0",
         "tslib": "^1.9.3",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "snyk-gradle-plugin": "3.26.3",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.32.3",
-    "snyk-nodejs-lockfile-parser": "1.48.3",
+    "snyk-nodejs-lockfile-parser": "1.49.0",
     "snyk-nuget-plugin": "1.24.1",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.25.0",

--- a/src/lib/plugins/nodejs-plugin/npm-lock-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/npm-lock-parser.ts
@@ -125,14 +125,14 @@ async function buildDepGraph(
         options,
       );
     case NodeLockfileVersion.YarnLockV2:
-      return lockFileParser.parseYarnLockV2Project(
+      return await lockFileParser.parseYarnLockV2Project(
         manifestFileContents,
         lockFileContents,
         options,
       );
     case NodeLockfileVersion.NpmLockV2:
     case NodeLockfileVersion.NpmLockV3:
-      return lockFileParser.parseNpmLockV2Project(
+      return await lockFileParser.parseNpmLockV2Project(
         manifestFileContents,
         lockFileContents,
         options,

--- a/src/lib/plugins/nodejs-plugin/npm-workspaces-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/npm-workspaces-parser.ts
@@ -93,7 +93,7 @@ export async function processNpmWorkspaces(
       const rootLockfileName = pathUtil.join(rootDir, 'package-lock.json');
       const lockContent = getFileContents(root, rootLockfileName);
 
-      const res = lockFileParser.parseNpmLockV2Project(
+      const res = await lockFileParser.parseNpmLockV2Project(
         packageJson.content,
         lockContent.content,
         {


### PR DESCRIPTION
#### What does this PR do?
This bumps the version of `snyk-nodejs-lockfile-parser` please see here for details: https://github.com/snyk/nodejs-lockfile-parser/releases/tag/v1.49.0
