### PR TITLE
fix: use printf rather than echo for escaping in cliv2 Makefile

### DIFF
--- a/cliv2/Makefile
+++ b/cliv2/Makefile
@@ -101,7 +101,7 @@ $(CACHE_DIR)/version.mk: $(CACHE_DIR)
 ifeq ($(CLI_V1_VERSION_TAG), $(_EMPTY))
 	$(eval CLI_V1_VERSION_TAG := $(shell curl --fail --progress-bar -L https://static.snyk.io/cli/latest/version))
 endif
-	@echo "CLI_V1_VERSION_TAG=$(CLI_V1_VERSION_TAG)\nCLI_V2_VERSION_TAG=$(CLI_V2_VERSION_TAG)" > $(CACHE_DIR)/version.mk
+	@printf "CLI_V1_VERSION_TAG=$(CLI_V1_VERSION_TAG)\nCLI_V2_VERSION_TAG=$(CLI_V2_VERSION_TAG)" > $(CACHE_DIR)/version.mk
 	@echo "$(LOG_PREFIX) Using cliv1 version ( $(CLI_V1_VERSION_TAG) )"
 	@echo "$(LOG_PREFIX) Building cliv2 version ( $(CLI_V2_VERSION_TAG) )"
 
@@ -112,7 +112,7 @@ $(CACHE_DIR):
 	@mkdir $@
 
 $(CACHE_DIR)/variables.mk: $(CACHE_DIR)
-	@echo "GOOS=$(GOOS)\nGOARCH=$(GOARCH)\n" > $(CACHE_DIR)/variables.mk
+	@printf "GOOS=$(GOOS)\nGOARCH=$(GOARCH)\n" > $(CACHE_DIR)/variables.mk
 
 $(V1_DIRECTORY)/$(V1_EMBEDDED_FILE_OUTPUT):
 	@echo "$(LOG_PREFIX) Generating ( $(V1_DIRECTORY)/$(V1_EMBEDDED_FILE_OUTPUT) )"


### PR DESCRIPTION
#### What does this PR do?

`cliv2/Makefile` is using `echo` in a way that relies on MacOS/zsh specifics, where `echo` will interpret escape sequences by default.  This not the case everywhere. Using `echo -e` works on some platforms (zsh and bash) but it's not part of POSIX, so using `printf` is the most idiomatic way to do it.

#### Where should the reviewer start?

N/A

#### How should this be manually tested?

1. Run `bash`
2. Run `echo "foo\nbar"` -- escaping is not interpreted
3. Run `printf "foo\nbar"`  -- outputs foo and bar with a newline between them

#### Any background context you want to provide?

Without this, we write badly formatted files to `_cache/variables.mk` and `_cache/version.mk`, e.g.:

```
$ cat _cache/variables.mk
GOOS=linux\nGOARCH=amd64\n
```

This causes a bizarre interpretation of `$GOOS` leading to bizarre files like:

```
Generating ( /home/jasper/Snyk/cli/cliv2/internal/embedded/cliv1/embedded_linux\nGOARCH=amd64\n_amd64.go )
```

#### What are the relevant tickets?

N/A

#### Screenshots

N/A

#### Additional questions

N/A