### PR TITLE
chore: add custom code-client errors [ZEN-541]

### DIFF
--- a/src/lib/plugins/sast/errors/code-client-error.ts
+++ b/src/lib/plugins/sast/errors/code-client-error.ts
@@ -1,0 +1,15 @@
+import { CustomError } from '../../../errors/custom-error';
+
+export class CodeClientError extends CustomError {
+  constructor(
+    statusCode: number,
+    statusText: string,
+    feature: string,
+    additionalUserHelp = '',
+  ) {
+    super(statusText);
+    this.code = statusCode;
+
+    this.userMessage = `There was a problem running ${feature}. ${additionalUserHelp}\nPlease retry and contact support if the problem persists.`;
+  }
+}

--- a/src/lib/plugins/sast/errors/index.ts
+++ b/src/lib/plugins/sast/errors/index.ts
@@ -1,2 +1,3 @@
 export { MissingConfigurationError } from './missing-configuration-error';
 export { FeatureNotSupportedBySnykCodeError } from './unsupported-feature-snyk-code-error';
+export { CodeClientError } from './code-client-error';


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Improves error handling and client side error messages for the code report flow.

Related PR: [code-client#178](https://github.com/snyk/code-client/pull/178)

TODO:
 - [ ] update code-client version when the PR gets merged
 - [ ] add error messages for the cases where some services are not available
 - [ ] ensure backwards-compatibility
 - [ ] add tests (?)

#### How should this be manually tested?
Run `snyk code test --report --project-name=x` with the relevant errors to test the different messages.

#### What are the relevant tickets?
[ZEN-541](https://snyksec.atlassian.net/browse/ZEN-541)

#### Screenshots

Newly introduced errors: 

 - SARIF too large
<img width="693" alt="Pasted Graphic" src="https://user-images.githubusercontent.com/97087926/233382600-7ae06105-ba86-41d7-9274-dec8cffbea81.png">

 - Project name with invalid symbols
<img width="661" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/97087926/233382627-c2a443f6-7e91-4695-94c4-2f5ada5f2640.png">

<img width="697" alt="Pasted Graphic 2" src="https://user-images.githubusercontent.com/97087926/233382643-7e8be910-fd97-4459-8eb3-4c2f45894c7a.png">

 - Project name too large
<img width="1183" alt="Pasted Graphic 3" src="https://user-images.githubusercontent.com/97087926/233382659-fb3e7dad-4d82-46c3-b78e-288c9178e4f5.png">

 - FF is off
<img width="745" alt="Pasted Graphic 4" src="https://user-images.githubusercontent.com/97087926/233382681-4978de14-3708-4d72-959e-6daf3e74622c.png">


[ZEN-541]: https://snyksec.atlassian.net/browse/ZEN-541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ