### PR TITLE
fix: bump snyk-docker-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.22.0",
-        "snyk-docker-plugin": "^6.3.0",
+        "snyk-docker-plugin": "^6.3.1",
         "snyk-go-plugin": "^1.19.5",
         "snyk-gradle-plugin": "3.26.3",
         "snyk-module": "3.1.0",
@@ -16645,9 +16645,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.3.0.tgz",
-      "integrity": "sha512-M4pe49/L8WGyPW0vBllveDbtq8i7smAIcr3Oo/wMUIzqcZjSF/7Oluxi9eUEtZ8SSF73QojnNzlDZSJIglpx2w==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.3.1.tgz",
+      "integrity": "sha512-Ml8AAfl/tJB5h+SGotyK+AHhZ5j8EzrDRmYPx3sjXxwDJjgZBNSOPF4HeRbFyWyn+HDGuvof+r2ofgyP0RfPKA==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.5.0",
@@ -33255,9 +33255,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.3.0.tgz",
-      "integrity": "sha512-M4pe49/L8WGyPW0vBllveDbtq8i7smAIcr3Oo/wMUIzqcZjSF/7Oluxi9eUEtZ8SSF73QojnNzlDZSJIglpx2w==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.3.1.tgz",
+      "integrity": "sha512-Ml8AAfl/tJB5h+SGotyK+AHhZ5j8EzrDRmYPx3sjXxwDJjgZBNSOPF4HeRbFyWyn+HDGuvof+r2ofgyP0RfPKA==",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.22.0",
-    "snyk-docker-plugin": "^6.3.0",
+    "snyk-docker-plugin": "^6.3.1",
     "snyk-go-plugin": "^1.19.5",
     "snyk-gradle-plugin": "3.26.3",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
The new version contains a fix for Go binary scanning on Windows.

See https://github.com/snyk/snyk-docker-plugin/pull/485.

