### PR TITLE
fix: gradle acceptance test [HEAD-283]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ executors:
     resource_class: arm.large
   linux:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2204:2023.02.1
     working_directory: /mnt/ramdisk/snyk
     resource_class: large
   macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ executors:
     resource_class: large
   arm64:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2204:2023.02.1
     working_directory: /mnt/ramdisk/snyk
     resource_class: arm.large
   linux:

--- a/test/jest/acceptance/snyk-test/basic-test-all-languages.spec.ts
+++ b/test/jest/acceptance/snyk-test/basic-test-all-languages.spec.ts
@@ -89,8 +89,7 @@ describe('`snyk test` of basic projects for each language/ecosystem', () => {
     expect(code).toEqual(0);
   });
 
-  // temporarily skipping test to unblock pipeline
-  test.skip('run `snyk test` on a gradle project', async () => {
+  test('run `snyk test` on a gradle project', async () => {
     const project = await createProjectFromWorkspace('gradle-app');
 
     const { code } = await runSnykCLI('test -d', {


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
- Fixes Gradle acceptance test by pinning Ubuntu image used in the pipeline to the one with JDK 11.
The problem stem from the current version [updated lately](https://discuss.circleci.com/t/ubuntu-linux-vm-machine-images-2022-april-q2-update/43749) by CircleCI.

- Pins image version for Linux executor as well.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
