### PR TITLE
chore: moved logic from application framework to CLI

### DIFF
--- a/cliv2/cmd/cliv2/main.go
+++ b/cliv2/cmd/cliv2/main.go
@@ -82,6 +82,7 @@ func main() {
 	os.Exit(errorCode)
 }
 
+// Initialize the given configuration with CLI specific aspects
 func initApplicationConfiguration(config configuration.Configuration) {
 	config.AddAlternativeKeys(configuration.AUTHENTICATION_TOKEN, []string{"snyk_token", "snyk_cfg_api", "api"})
 	config.AddAlternativeKeys(configuration.AUTHENTICATION_BEARER_TOKEN, []string{"snyk_oauth_token", "snyk_docker_token"})
@@ -89,7 +90,7 @@ func initApplicationConfiguration(config configuration.Configuration) {
 	config.AddAlternativeKeys(configuration.ADD_TRUSTED_CA_FILE, []string{"NODE_EXTRA_CA_CERTS"})
 
 	config.AddDefaultValue(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, func(existingValue any) any {
-		// if the CONFIG_KEY_OAUTH_TOKEN is specified as env var, we don#t apply any additional logic
+		// if the CONFIG_KEY_OAUTH_TOKEN is specified as env var, we don't apply any additional logic
 		_, ok := os.LookupEnv(auth.CONFIG_KEY_OAUTH_TOKEN)
 		if !ok {
 			alternativeBearerKeys := config.GetAlternativeKeys(configuration.AUTHENTICATION_BEARER_TOKEN)

--- a/cliv2/cmd/cliv2/main.go
+++ b/cliv2/cmd/cliv2/main.go
@@ -89,18 +89,19 @@ func initApplicationConfiguration(config configuration.Configuration) {
 	config.AddAlternativeKeys(configuration.ADD_TRUSTED_CA_FILE, []string{"NODE_EXTRA_CA_CERTS"})
 
 	config.AddDefaultValue(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, func(existingValue any) any {
-		alternativeBearerKeys := config.GetAlternativeKeys(configuration.AUTHENTICATION_BEARER_TOKEN)
-		alternativeAuthKeys := config.GetAlternativeKeys(configuration.AUTHENTICATION_TOKEN)
-		alternativeKeys := append(alternativeBearerKeys, alternativeAuthKeys...)
-
-		for _, key := range alternativeKeys {
-			hasPrefix := strings.HasPrefix(key, "snyk_")
-			if hasPrefix {
-				formattedKey := strings.ToUpper(key)
-				_, ok := os.LookupEnv(formattedKey)
-				if ok {
-					debugLogger.Printf("Found environment variable %s, disabling OAuth flow", formattedKey)
-					return false
+		// if the CONFIG_KEY_OAUTH_TOKEN is specified as env var, we don#t apply any additional logic
+		_, ok := os.LookupEnv(auth.CONFIG_KEY_OAUTH_TOKEN)
+		if !ok {
+			alternativeBearerKeys := config.GetAlternativeKeys(configuration.AUTHENTICATION_BEARER_TOKEN)
+			for _, key := range alternativeBearerKeys {
+				hasPrefix := strings.HasPrefix(key, "snyk_")
+				if hasPrefix {
+					formattedKey := strings.ToUpper(key)
+					_, ok := os.LookupEnv(formattedKey)
+					if ok {
+						debugLogger.Printf("Found environment variable %s, disabling OAuth flow", formattedKey)
+						return false
+					}
 				}
 			}
 		}

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.1
 	github.com/snyk/cli-extension-sbom v0.0.0-20230331093938-3d6a5dfdae22
-	github.com/snyk/go-application-framework v0.0.0-20230503080200-ff9b694e294a
+	github.com/snyk/go-application-framework v0.0.0-20230504094423-9452a0ac9448
 	github.com/snyk/go-httpauth v0.0.0-20230328170530-1af63c87b650
 	github.com/snyk/snyk-iac-capture v0.6.0
 	github.com/spf13/cobra v1.7.0

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -205,8 +205,8 @@ github.com/rs/zerolog v1.29.1/go.mod h1:Le6ESbR7hc+DP6Lt1THiV8CQSdkkNrd3R0XbEgp3
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/snyk/cli-extension-sbom v0.0.0-20230331093938-3d6a5dfdae22 h1:ucnmZwoo1gGU+YjmbYZAix5HKIZ1FYBNDau5RPwCSS8=
 github.com/snyk/cli-extension-sbom v0.0.0-20230331093938-3d6a5dfdae22/go.mod h1:83CWQ4Oy3mL8cVkj/etP+bh7I8I1xb+n2bpsE6URuPs=
-github.com/snyk/go-application-framework v0.0.0-20230503080200-ff9b694e294a h1:87j43GIH2Xtbsl0pmijmc+OqRu3gBg9yr7cD5wcnqC8=
-github.com/snyk/go-application-framework v0.0.0-20230503080200-ff9b694e294a/go.mod h1:QMdFROeuG06UULLD2hzN/P9RlKE6Ma6eskMwAqVOMkM=
+github.com/snyk/go-application-framework v0.0.0-20230504094423-9452a0ac9448 h1:jZhlN2gNmhOjNQdE0SwHnNaNZki1557ZT/azuMnS664=
+github.com/snyk/go-application-framework v0.0.0-20230504094423-9452a0ac9448/go.mod h1:QMdFROeuG06UULLD2hzN/P9RlKE6Ma6eskMwAqVOMkM=
 github.com/snyk/go-httpauth v0.0.0-20230328170530-1af63c87b650 h1:CsLoEIHxq4i3d9di8RoN3J3D1/oK20oroEZUGShor0o=
 github.com/snyk/go-httpauth v0.0.0-20230328170530-1af63c87b650/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/snyk-iac-capture v0.6.0 h1:P9GWIyvl+F23XZOCuJvzGV6tME/vxbKpZM7/9dw48as=

--- a/test/jest/acceptance/cli-token-precedence.spec.ts
+++ b/test/jest/acceptance/cli-token-precedence.spec.ts
@@ -169,12 +169,13 @@ describe('cli token precedence', () => {
           it('SNYK_OAUTH_TOKEN should NOT override other env var', async () => {
             env = {
               ...env,
-              INTERNAL_OAUTH_TOKEN_STORAGE: snykOAuthConfig.snykConfig.internal_oauth_token_storage,
+              INTERNAL_OAUTH_TOKEN_STORAGE:
+                snykOAuthConfig.snykConfig.internal_oauth_token_storage,
               SNYK_OAUTH_TOKEN: 'snkyOAuthToken',
             };
-  
+
             await runSnykCLI(`-d`, { env });
-  
+
             const authHeader = server.popRequest().headers?.authorization;
             expect(authHeader).toEqual(`Bearer ${auth.expectedToken}`);
           });

--- a/test/jest/acceptance/cli-token-precedence.spec.ts
+++ b/test/jest/acceptance/cli-token-precedence.spec.ts
@@ -65,7 +65,7 @@ describe('cli token precedence', () => {
     name: string;
     expectedAuthType: string;
     expectedToken: string;
-    snykConfig?: Record<string, string>;
+    snykConfig: Record<string, string>;
   };
 
   const snykAPIConfig: AuthConfig = {
@@ -138,31 +138,48 @@ describe('cli token precedence', () => {
         });
       });
 
-      describe('when token env vars are set', () => {
-        it('SNYK_TOKEN should override config', async () => {
-          env = {
-            ...env,
-            SNYK_TOKEN: 'snykToken',
-          };
+      if (snykOAuthConfig.name != auth.name) {
+        describe('when token env vars are set', () => {
+          it('SNYK_TOKEN should override config', async () => {
+            env = {
+              ...env,
+              SNYK_TOKEN: 'snykToken',
+            };
 
-          await runSnykCLI(`-d`, { env });
+            await runSnykCLI(`-d`, { env });
 
-          const authHeader = server.popRequest().headers?.authorization;
-          expect(authHeader).toEqual(`token ${env.SNYK_TOKEN}`);
+            const authHeader = server.popRequest().headers?.authorization;
+            expect(authHeader).toEqual(`token ${env.SNYK_TOKEN}`);
+          });
+
+          it('SNYK_CFG_API should override config', async () => {
+            env = {
+              ...env,
+              SNYK_CFG_API: 'snykCfgApiToken',
+            };
+
+            await runSnykCLI(`-d`, { env });
+
+            const authHeader = server.popRequest().headers?.authorization;
+            expect(authHeader).toEqual(`token ${env.SNYK_CFG_API}`);
+          });
         });
-
-        it('SNYK_CFG_API should override config', async () => {
-          env = {
-            ...env,
-            SNYK_CFG_API: 'snykCfgApiToken',
-          };
-
-          await runSnykCLI(`-d`, { env });
-
-          const authHeader = server.popRequest().headers?.authorization;
-          expect(authHeader).toEqual(`token ${env.SNYK_CFG_API}`);
+      } else {
+        describe('when INTERNAL_OAUTH_TOKEN_STORAGE env var is set', () => {
+          it('SNYK_OAUTH_TOKEN should NOT override other env var', async () => {
+            env = {
+              ...env,
+              INTERNAL_OAUTH_TOKEN_STORAGE: snykOAuthConfig.snykConfig.internal_oauth_token_storage,
+              SNYK_OAUTH_TOKEN: 'snkyOAuthToken',
+            };
+  
+            await runSnykCLI(`-d`, { env });
+  
+            const authHeader = server.popRequest().headers?.authorization;
+            expect(authHeader).toEqual(`Bearer ${auth.expectedToken}`);
+          });
         });
-      });
+      }
     });
   });
 });

--- a/test/jest/acceptance/cli-token-precedence.spec.ts
+++ b/test/jest/acceptance/cli-token-precedence.spec.ts
@@ -164,7 +164,7 @@ describe('cli token precedence', () => {
             expect(authHeader).toEqual(`token ${env.SNYK_CFG_API}`);
           });
         });
-      } else {
+      } else if (isCLIV2()) {
         describe('when INTERNAL_OAUTH_TOKEN_STORAGE env var is set', () => {
           it('SNYK_OAUTH_TOKEN should NOT override other env var', async () => {
             env = {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
* Some of the configuration initialization logic previously done in the application framework is more specific to the CLI, so we moved it out of the framework to the CLI code.
* Also the logic about token precedence required a small change for oauth authentication.

#### Where should the reviewer start?
cmd/cliv2/main.go
