### PR TITLE
fix: support new setuptools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "snyk-nuget-plugin": "1.24.1",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.25.0",
-        "snyk-python-plugin": "1.24.4",
+        "snyk-python-plugin": "1.25.0",
         "snyk-resolve-deps": "4.7.3",
         "snyk-sbt-plugin": "2.17.0",
         "snyk-swiftpm-plugin": "1.2.1",
@@ -17319,9 +17319,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-python-plugin": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.24.4.tgz",
-      "integrity": "sha512-KmeXHZCN5jp2iBhFj965YnRUSuU6rwDugI28EHpHhTjoGBpbMZXgKm91gtWOgOKjZT8rD/tu7aQtDB0ank0Dsw==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.25.0.tgz",
+      "integrity": "sha512-sBHQ86L3xIp0Iu3Iio5ANVxLVOKey1ggNVUu+WFXKM8vuvBS9j2wKrmzge5jQMd9mPCefVsCkY7ch1RYxN30Ig==",
       "dependencies": {
         "@snyk/cli-interface": "^2.11.2",
         "@snyk/dep-graph": "^1.28.1",
@@ -33818,9 +33818,9 @@
       }
     },
     "snyk-python-plugin": {
-      "version": "1.24.4",
-      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.24.4.tgz",
-      "integrity": "sha512-KmeXHZCN5jp2iBhFj965YnRUSuU6rwDugI28EHpHhTjoGBpbMZXgKm91gtWOgOKjZT8rD/tu7aQtDB0ank0Dsw==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.25.0.tgz",
+      "integrity": "sha512-sBHQ86L3xIp0Iu3Iio5ANVxLVOKey1ggNVUu+WFXKM8vuvBS9j2wKrmzge5jQMd9mPCefVsCkY7ch1RYxN30Ig==",
       "requires": {
         "@snyk/cli-interface": "^2.11.2",
         "@snyk/dep-graph": "^1.28.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "snyk-nuget-plugin": "1.24.1",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.25.0",
-        "snyk-python-plugin": "1.25.0",
+        "snyk-python-plugin": "^1.25.1",
         "snyk-resolve-deps": "4.7.3",
         "snyk-sbt-plugin": "2.17.0",
         "snyk-swiftpm-plugin": "1.2.1",
@@ -17319,9 +17319,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-python-plugin": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.25.0.tgz",
-      "integrity": "sha512-sBHQ86L3xIp0Iu3Iio5ANVxLVOKey1ggNVUu+WFXKM8vuvBS9j2wKrmzge5jQMd9mPCefVsCkY7ch1RYxN30Ig==",
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.25.1.tgz",
+      "integrity": "sha512-TPTppH8Plhh5PUepwXKAlZ4vmB1cdq+HgIOzosU5VxStkz9jOtxz0k74b7dO2GlantQMwDrL0++0AuSARraHcA==",
       "dependencies": {
         "@snyk/cli-interface": "^2.11.2",
         "@snyk/dep-graph": "^1.28.1",
@@ -33818,9 +33818,9 @@
       }
     },
     "snyk-python-plugin": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.25.0.tgz",
-      "integrity": "sha512-sBHQ86L3xIp0Iu3Iio5ANVxLVOKey1ggNVUu+WFXKM8vuvBS9j2wKrmzge5jQMd9mPCefVsCkY7ch1RYxN30Ig==",
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.25.1.tgz",
+      "integrity": "sha512-TPTppH8Plhh5PUepwXKAlZ4vmB1cdq+HgIOzosU5VxStkz9jOtxz0k74b7dO2GlantQMwDrL0++0AuSARraHcA==",
       "requires": {
         "@snyk/cli-interface": "^2.11.2",
         "@snyk/dep-graph": "^1.28.1",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "snyk-nuget-plugin": "1.24.1",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.25.0",
-    "snyk-python-plugin": "1.25.0",
+    "snyk-python-plugin": "^1.25.1",
     "snyk-resolve-deps": "4.7.3",
     "snyk-sbt-plugin": "2.17.0",
     "snyk-swiftpm-plugin": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "snyk-nuget-plugin": "1.24.1",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.25.0",
-    "snyk-python-plugin": "1.24.4",
+    "snyk-python-plugin": "1.25.0",
     "snyk-resolve-deps": "4.7.3",
     "snyk-sbt-plugin": "2.17.0",
     "snyk-swiftpm-plugin": "1.2.1",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
upgrades a version of the snyk-python-plugin to support newer versions of setuptools (>=67.0.0)
