### PR TITLE
feat: bump go plugin v1.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.22.1",
         "snyk-docker-plugin": "6.3.4",
-        "snyk-go-plugin": "^1.19.5",
+        "snyk-go-plugin": "1.21.0",
         "snyk-gradle-plugin": "3.26.4",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.32.3",
@@ -16799,9 +16799,9 @@
       }
     },
     "node_modules/snyk-go-plugin": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.19.5.tgz",
-      "integrity": "sha512-Ajki/2BKdTQBCY5TArWvNtaEU+088NSGj2ZIPDr+CHyrTB91wrCB3KvC6KHlwPwqTrvF1b01BrDAWPmBtQZtfQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.21.0.tgz",
+      "integrity": "sha512-kQD7xFeqfMv3TLM/vszjSqeglrJ7Jpi9NHER5CTc76jF5IwXgWSjN+2ZQuT5Bnfn0xr+OpsFVhvSg6KfMKyAxA==",
       "dependencies": {
         "@snyk/dep-graph": "^1.23.1",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -33377,9 +33377,9 @@
       }
     },
     "snyk-go-plugin": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.19.5.tgz",
-      "integrity": "sha512-Ajki/2BKdTQBCY5TArWvNtaEU+088NSGj2ZIPDr+CHyrTB91wrCB3KvC6KHlwPwqTrvF1b01BrDAWPmBtQZtfQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.21.0.tgz",
+      "integrity": "sha512-kQD7xFeqfMv3TLM/vszjSqeglrJ7Jpi9NHER5CTc76jF5IwXgWSjN+2ZQuT5Bnfn0xr+OpsFVhvSg6KfMKyAxA==",
       "requires": {
         "@snyk/dep-graph": "^1.23.1",
         "@snyk/graphlib": "2.1.9-patch.3",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.22.1",
     "snyk-docker-plugin": "6.3.4",
-    "snyk-go-plugin": "^1.19.5",
+    "snyk-go-plugin": "1.21.0",
     "snyk-gradle-plugin": "3.26.4",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.32.3",


### PR DESCRIPTION
This bumps the version of `snyk-go-plugin` to v1.21.0 for additional details see https://github.com/snyk/snyk-go-plugin/pull/111