### PR TITLE
fix: respect exit codes for unmanaged

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "rimraf": "^2.6.3",
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.22.1",
+        "snyk-cpp-plugin": "2.22.2",
         "snyk-docker-plugin": "6.3.4",
         "snyk-go-plugin": "1.21.0",
         "snyk-gradle-plugin": "3.26.4",
@@ -16528,9 +16528,9 @@
       }
     },
     "node_modules/snyk-cpp-plugin": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.22.1.tgz",
-      "integrity": "sha512-A8EwF6e+Hu/NYtdKa2ddi6BOS4Kge/K0nsb6uMxn5LF7CjQv4p9OY4aAJ3DK9ePL9ac7EBLrRZCMR2nfmzhZ9Q==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.22.2.tgz",
+      "integrity": "sha512-+HvaTJZTGAWoNEL3ESoAAlpIK6EorOiiDNqBYUHQqROuH5gcNM07xdU9Va9+q4r/7T3jLs7U3aEpVnb2M5xNPA==",
       "dependencies": {
         "@snyk/dep-graph": "^1.19.3",
         "@types/minimatch": "^3.0.5",
@@ -33166,9 +33166,9 @@
       }
     },
     "snyk-cpp-plugin": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.22.1.tgz",
-      "integrity": "sha512-A8EwF6e+Hu/NYtdKa2ddi6BOS4Kge/K0nsb6uMxn5LF7CjQv4p9OY4aAJ3DK9ePL9ac7EBLrRZCMR2nfmzhZ9Q==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.22.2.tgz",
+      "integrity": "sha512-+HvaTJZTGAWoNEL3ESoAAlpIK6EorOiiDNqBYUHQqROuH5gcNM07xdU9Va9+q4r/7T3jLs7U3aEpVnb2M5xNPA==",
       "requires": {
         "@snyk/dep-graph": "^1.19.3",
         "@types/minimatch": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "rimraf": "^2.6.3",
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
-    "snyk-cpp-plugin": "2.22.1",
+    "snyk-cpp-plugin": "2.22.2",
     "snyk-docker-plugin": "6.3.4",
     "snyk-go-plugin": "1.21.0",
     "snyk-gradle-plugin": "3.26.4",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Makes sure that the CLI exits with error codes provided by the snyk-cpp-plugin.

#### How should this be manually tested?

Run `snyk test --unmanaged` with:

- an empty project (dir)
- an unmanaged project

Sanity-check the behaviour for Snyk's goof-project, so that existing logic for managed ecosystems is not broken.

Make sure the exit values follow the values specified in

`snyk test --help`