### PR TITLE
chore: disable standalone iac for fedramp

### DIFF
--- a/src/lib/feature-flags/index.ts
+++ b/src/lib/feature-flags/index.ts
@@ -28,6 +28,13 @@ export async function hasFeatureFlag(
   featureFlag: string,
   options: Options,
 ): Promise<boolean | undefined> {
+  if (
+    featureFlag === 'iacIntegratedExperience' &&
+    config.API.includes('snykgov')
+  ) {
+    return true;
+  }
+
   const { code, error, ok } = await isFeatureFlagSupportedForOrg(
     featureFlag,
     options.org,

--- a/test/jest/unit/lib/feature-flags/feature-flags.spec.ts
+++ b/test/jest/unit/lib/feature-flags/feature-flags.spec.ts
@@ -1,7 +1,14 @@
+import config from '../../../../../src/lib/config';
 import { hasFeatureFlag } from '../../../../../src/lib/feature-flags';
 import * as request from '../../../../../src/lib/request';
 
 describe('hasFeatureFlag fn', () => {
+  const configApiDefault = config.API;
+
+  afterAll(() => {
+    config.API = configApiDefault;
+  });
+
   it.each`
     hasFlag  | expected
     ${true}  | ${true}
@@ -33,5 +40,13 @@ describe('hasFeatureFlag fn', () => {
     await expect(
       hasFeatureFlag('test-ff', { path: 'test-path' }),
     ).rejects.toThrowError('Forbidden');
+  });
+
+  it('should return iacIntegratedExperience feature flag being true for FedRAMP', async () => {
+    config.API = 'https://app.snykgov.io/api/v1';
+    const result = await hasFeatureFlag('iacIntegratedExperience', {
+      path: 'test-path',
+    });
+    expect(result).toEqual(true);
   });
 });


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Enforces the usage of integrated IaC (disables standalone IaC) for FedRAMP.

#### Where should the reviewer start?
-

#### How should this be manually tested?
1. Set the endpoint like: `snyk-dev config set endpoint=http://api.snykgov.io/v1`
2. `snyk-dev iac test (-- report)` and see integrated IaC is used

#### Any background context you want to provide?
In the future we will transition all our customers to the integrated IaC and decommission the standalone one. 
So no real disablement here, just enforcing the new flow on which we focus to make compliant.

#### What are the relevant tickets?
[CFG-2291](https://snyksec.atlassian.net/browse/CFG-2291)

#### Screenshots
-

#### Additional questions
-

[CFG-2291]: https://snyksec.atlassian.net/browse/CFG-2291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ