### PR TITLE
feat: bump go plugin to v1.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.22.2",
         "snyk-docker-plugin": "6.3.4",
-        "snyk-go-plugin": "1.21.0",
+        "snyk-go-plugin": "1.23.0",
         "snyk-gradle-plugin": "3.26.4",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.32.3",
@@ -2267,6 +2267,22 @@
       "engines": {
         "node": ">= 4.2.4"
       }
+    },
+    "node_modules/@snyk/go-semver": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@snyk/go-semver/-/go-semver-1.2.1.tgz",
+      "integrity": "sha512-Opm+xS4IbpqdeVpEEL0dStMDJaa1yeTFvHzaH2fDdbPl2/TD+O746uwMs+6KfGwehzd522aD0ICNq2t85lZkjQ==",
+      "dependencies": {
+        "tslib": "^2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@snyk/go-semver/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/@snyk/graphlib": {
       "version": "2.1.9-patch.3",
@@ -16787,29 +16803,107 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-go-parser": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/snyk-go-parser/-/snyk-go-parser-1.4.1.tgz",
-      "integrity": "sha512-StU3uHB85VMEkcgXta63M0Fgd+9cs5sMCjQXTBoYTdE4dxarPn7U67yCuwkRRdZdny1ZXtzfY8LKns9i0+dy9w==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/snyk-go-parser/-/snyk-go-parser-1.13.0.tgz",
+      "integrity": "sha512-uYFXsibIlscJF6qUdNhs5bFNTJnCokrQb5Rrh8fREpVYazjNxC1V3aon+dBT6qGJ+iq7/8ArEGj+AFKbdZJS/A==",
       "dependencies": {
-        "toml": "^3.0.0",
-        "tslib": "^1.10.0"
+        "@iarna/toml": "^2.2.5",
+        "@snyk/dep-graph": "^2.6.1",
+        "@snyk/go-semver": "1.2.1",
+        "event-loop-spinner": "^2.1.0",
+        "tslib": "^2.5.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=12"
       }
     },
+    "node_modules/snyk-go-parser/node_modules/@snyk/dep-graph": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-2.6.1.tgz",
+      "integrity": "sha512-8N+wgLCUDGbyjDpHSpPICM+elcJ06WKFRl/1nVe6OE9dFBpjC64wtFohQgQDlazPxQC2eOLqImR8QlwNQ6hoDQ==",
+      "dependencies": {
+        "event-loop-spinner": "^2.1.0",
+        "lodash.clone": "^4.5.0",
+        "lodash.constant": "^3.0.0",
+        "lodash.filter": "^4.6.0",
+        "lodash.foreach": "^4.5.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.map": "^4.6.0",
+        "lodash.reduce": "^4.6.0",
+        "lodash.size": "^4.2.0",
+        "lodash.transform": "^4.6.0",
+        "lodash.union": "^4.6.0",
+        "lodash.values": "^4.3.0",
+        "object-hash": "^3.0.0",
+        "packageurl-js": "^1.0.0",
+        "semver": "^7.0.0",
+        "tslib": "^2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/snyk-go-parser/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/snyk-go-parser/node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/snyk-go-parser/node_modules/semver": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/snyk-go-parser/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/snyk-go-parser/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "node_modules/snyk-go-plugin": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.21.0.tgz",
-      "integrity": "sha512-kQD7xFeqfMv3TLM/vszjSqeglrJ7Jpi9NHER5CTc76jF5IwXgWSjN+2ZQuT5Bnfn0xr+OpsFVhvSg6KfMKyAxA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.23.0.tgz",
+      "integrity": "sha512-77By6kjzIx42CYEwVMnMCoNqvv9uvUEN9ZQZE0vO8lpiwAnEZt0VAaWNiC+DElFvapDtiifUFEApYRFfoeUIJQ==",
       "dependencies": {
         "@snyk/dep-graph": "^1.23.1",
         "@snyk/graphlib": "2.1.9-patch.3",
         "debug": "^4.1.1",
         "lookpath": "^1.2.2",
-        "snyk-go-parser": "1.4.1",
+        "snyk-go-parser": "1.13.0",
         "tmp": "0.2.1",
         "tslib": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/snyk-go-plugin/node_modules/rimraf": {
@@ -22089,6 +22183,21 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@snyk/gemfile/-/gemfile-1.2.0.tgz",
       "integrity": "sha512-nI7ELxukf7pT4/VraL4iabtNNMz8mUo7EXlqCFld8O5z6mIMLX9llps24iPpaIZOwArkY3FWA+4t+ixyvtTSIA=="
+    },
+    "@snyk/go-semver": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@snyk/go-semver/-/go-semver-1.2.1.tgz",
+      "integrity": "sha512-Opm+xS4IbpqdeVpEEL0dStMDJaa1yeTFvHzaH2fDdbPl2/TD+O746uwMs+6KfGwehzd522aD0ICNq2t85lZkjQ==",
+      "requires": {
+        "tslib": "^2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        }
+      }
     },
     "@snyk/graphlib": {
       "version": "2.1.9-patch.3",
@@ -33368,24 +33477,86 @@
       }
     },
     "snyk-go-parser": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/snyk-go-parser/-/snyk-go-parser-1.4.1.tgz",
-      "integrity": "sha512-StU3uHB85VMEkcgXta63M0Fgd+9cs5sMCjQXTBoYTdE4dxarPn7U67yCuwkRRdZdny1ZXtzfY8LKns9i0+dy9w==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/snyk-go-parser/-/snyk-go-parser-1.13.0.tgz",
+      "integrity": "sha512-uYFXsibIlscJF6qUdNhs5bFNTJnCokrQb5Rrh8fREpVYazjNxC1V3aon+dBT6qGJ+iq7/8ArEGj+AFKbdZJS/A==",
       "requires": {
-        "toml": "^3.0.0",
-        "tslib": "^1.10.0"
+        "@iarna/toml": "^2.2.5",
+        "@snyk/dep-graph": "^2.6.1",
+        "@snyk/go-semver": "1.2.1",
+        "event-loop-spinner": "^2.1.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@snyk/dep-graph": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-2.6.1.tgz",
+          "integrity": "sha512-8N+wgLCUDGbyjDpHSpPICM+elcJ06WKFRl/1nVe6OE9dFBpjC64wtFohQgQDlazPxQC2eOLqImR8QlwNQ6hoDQ==",
+          "requires": {
+            "event-loop-spinner": "^2.1.0",
+            "lodash.clone": "^4.5.0",
+            "lodash.constant": "^3.0.0",
+            "lodash.filter": "^4.6.0",
+            "lodash.foreach": "^4.5.0",
+            "lodash.isempty": "^4.4.0",
+            "lodash.isequal": "^4.5.0",
+            "lodash.isfunction": "^3.0.9",
+            "lodash.isundefined": "^3.0.1",
+            "lodash.map": "^4.6.0",
+            "lodash.reduce": "^4.6.0",
+            "lodash.size": "^4.2.0",
+            "lodash.transform": "^4.6.0",
+            "lodash.union": "^4.6.0",
+            "lodash.values": "^4.3.0",
+            "object-hash": "^3.0.0",
+            "packageurl-js": "^1.0.0",
+            "semver": "^7.0.0",
+            "tslib": "^2"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "object-hash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+          "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
+        },
+        "semver": {
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+          "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
       }
     },
     "snyk-go-plugin": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.21.0.tgz",
-      "integrity": "sha512-kQD7xFeqfMv3TLM/vszjSqeglrJ7Jpi9NHER5CTc76jF5IwXgWSjN+2ZQuT5Bnfn0xr+OpsFVhvSg6KfMKyAxA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.23.0.tgz",
+      "integrity": "sha512-77By6kjzIx42CYEwVMnMCoNqvv9uvUEN9ZQZE0vO8lpiwAnEZt0VAaWNiC+DElFvapDtiifUFEApYRFfoeUIJQ==",
       "requires": {
         "@snyk/dep-graph": "^1.23.1",
         "@snyk/graphlib": "2.1.9-patch.3",
         "debug": "^4.1.1",
         "lookpath": "^1.2.2",
-        "snyk-go-parser": "1.4.1",
+        "snyk-go-parser": "1.13.0",
         "tmp": "0.2.1",
         "tslib": "^1.10.0"
       },

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.22.2",
     "snyk-docker-plugin": "6.3.4",
-    "snyk-go-plugin": "1.21.0",
+    "snyk-go-plugin": "1.23.0",
     "snyk-gradle-plugin": "3.26.4",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.32.3",


### PR DESCRIPTION
This bumps the snyk-go-plugin version to 1.23.0 - for more info see here https://github.com/snyk/snyk-go-plugin/releases