### PR TITLE
fix: [SUP-1093] Replaced manual `pMap` with actual `pMap`

### DIFF
--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -9,6 +9,7 @@ import { parsePackageString as moduleToObject } from 'snyk-module';
 import * as depGraphLib from '@snyk/dep-graph';
 import * as theme from '../../lib/theme';
 import { jsonStringifyLargeObject } from '../../lib/json';
+import * as pMap from 'p-map';
 
 import {
   AffectedPackages,
@@ -22,20 +23,21 @@ import {
 } from './legacy';
 import {
   AuthFailedError,
+  BadGatewayError,
   DockerImageNotFoundError,
+  errorMessageWithRetry,
   FailedToGetVulnerabilitiesError,
   FailedToGetVulnsFromUnavailableResource,
   FailedToRunTestError,
   InternalServerError,
   NoSupportedManifestsFoundError,
   NotFoundError,
-  errorMessageWithRetry,
-  BadGatewayError,
   ServiceUnavailableError,
 } from '../errors';
 import * as snyk from '../';
 import { isCI } from '../is-ci';
 import * as common from './common';
+import { RETRY_ATTEMPTS, RETRY_DELAY } from './common';
 import config from '../config';
 import * as analytics from '../analytics';
 import { maybePrintDepGraph, maybePrintDepTree } from '../print-deps';
@@ -58,9 +60,9 @@ import { extractPackageManager } from '../plugins/extract-package-manager';
 import { getExtraProjectCount } from '../plugins/get-extra-project-count';
 import { findAndLoadPolicy } from '../policy';
 import {
+  DepTreeFromResolveDeps,
   Payload,
   PayloadBody,
-  DepTreeFromResolveDeps,
   TestDependenciesRequest,
 } from './types';
 import { getAuthHeader } from '../api-token';
@@ -71,7 +73,6 @@ import { makeRequest } from '../request';
 import { spinner } from '../spinner';
 import { hasUnknownVersions } from '../dep-graph';
 import { sleep } from '../common';
-import { RETRY_ATTEMPTS, RETRY_DELAY } from './common';
 
 const debug = debugModule('snyk:run-test');
 
@@ -237,61 +238,43 @@ async function sendAndParseResults(
     originalPayload: Payload;
     response: any;
   };
-  const requests: (() => Promise<TestResponse>)[] = [];
-  for (const originalPayload of payloads) {
-    const request = async (): Promise<TestResponse> => {
-      let step = 0;
-      let error;
 
-      while (step < RETRY_ATTEMPTS) {
-        debug(`sendTestPayload retry step ${step} out of ${RETRY_ATTEMPTS}`);
-        try {
-          /** sendTestPayload() deletes the request.body from the payload once completed. */
-          const payload = Object.assign({}, originalPayload);
-          const response = await sendTestPayload(payload);
+  const sendRequest = async (
+    originalPayload: Payload,
+  ): Promise<TestResponse> => {
+    let step = 0;
+    let error;
 
-          return { payload, originalPayload, response };
-        } catch (err) {
-          error = err;
-          step++;
+    while (step < RETRY_ATTEMPTS) {
+      debug(`sendTestPayload retry step ${step} out of ${RETRY_ATTEMPTS}`);
+      try {
+        /** sendTestPayload() deletes the request.body from the payload once completed. */
+        const payload = Object.assign({}, originalPayload);
+        const response = await sendTestPayload(payload);
 
-          if (
-            err instanceof InternalServerError ||
-            err instanceof BadGatewayError ||
-            err instanceof ServiceUnavailableError
-          ) {
-            await sleep(RETRY_DELAY);
-          } else {
-            break;
-          }
+        return { payload, originalPayload, response };
+      } catch (err) {
+        error = err;
+        step++;
+
+        if (
+          err instanceof InternalServerError ||
+          err instanceof BadGatewayError ||
+          err instanceof ServiceUnavailableError
+        ) {
+          await sleep(RETRY_DELAY);
+        } else {
+          break;
         }
       }
-
-      throw error;
-    };
-
-    requests.push(request);
-  }
-
-  // Start block adapted from https://gist.github.com/jcouyang/632709f30e12a7879a73e9e132c0d56b?permalink_comment_id=3591045#gistcomment-3591045
-  let index = 0;
-  const responses: TestResponse[] = [];
-
-  const execRequest = async () => {
-    while (index < requests.length) {
-      // index is shared across "threads", so capture the current value for this
-      // iteration on this "thread" and increment it for the rest of the world.
-      const curIndex = index++;
-      responses[curIndex] = await requests[curIndex]();
     }
+
+    throw error;
   };
 
-  const threads: Promise<void>[] = [];
-  for (let thread = 0; thread < MAX_CONCURRENCY; thread++) {
-    threads.push(execRequest());
-  }
-  await Promise.all(threads);
-  // End block adapted from https://gist.github.com/jcouyang/632709f30e12a7879a73e9e132c0d56b?permalink_comment_id=3591045#gistcomment-3591045
+  const responses = await pMap(payloads, sendRequest, {
+    concurrency: MAX_CONCURRENCY,
+  });
 
   for (const { payload, originalPayload, response } of responses) {
     const {


### PR DESCRIPTION
#### What does this PR do?

A while back we introduced some pseudo-parallelization (to the extend Node allows) of promises when sending requests to our backend. The solution sped up things a bit, but the Promise-chunk would wait until the slowest promise had finished before starting a new batch.

`pMap` accounts for this problem.

The original author of the PR had addressed why they were not using `pMap`, namely to avoid extra dependencies to the project and things were breaking when they tried using it.

Since it is already a dependency in this project and used multiple places, and this seems to work now, this should speed up things a bit.

This change comes on the back of a customer support ticket, where scanning a large project takes over an hour. 

The bottleneck as far as I have been able to identify reveals itself around the requests to vulndb. 