### PR TITLE
chore: bump GAF version to include OAuth

### DIFF
--- a/cliv2/cmd/cliv2/main.go
+++ b/cliv2/cmd/cliv2/main.go
@@ -89,25 +89,23 @@ func initApplicationConfiguration(config configuration.Configuration) {
 	config.AddAlternativeKeys(configuration.API_URL, []string{"endpoint"})
 	config.AddAlternativeKeys(configuration.ADD_TRUSTED_CA_FILE, []string{"NODE_EXTRA_CA_CERTS"})
 
-	config.AddDefaultValue(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, func(existingValue any) any {
-		// if the CONFIG_KEY_OAUTH_TOKEN is specified as env var, we don't apply any additional logic
-		_, ok := os.LookupEnv(auth.CONFIG_KEY_OAUTH_TOKEN)
-		if !ok {
-			alternativeBearerKeys := config.GetAlternativeKeys(configuration.AUTHENTICATION_BEARER_TOKEN)
-			for _, key := range alternativeBearerKeys {
-				hasPrefix := strings.HasPrefix(key, "snyk_")
-				if hasPrefix {
-					formattedKey := strings.ToUpper(key)
-					_, ok := os.LookupEnv(formattedKey)
-					if ok {
-						debugLogger.Printf("Found environment variable %s, disabling OAuth flow", formattedKey)
-						return false
-					}
+	// if the CONFIG_KEY_OAUTH_TOKEN is specified as env var, we don't apply any additional logic
+	_, ok := os.LookupEnv(auth.CONFIG_KEY_OAUTH_TOKEN)
+	if !ok {
+		alternativeBearerKeys := config.GetAlternativeKeys(configuration.AUTHENTICATION_BEARER_TOKEN)
+		for _, key := range alternativeBearerKeys {
+			hasPrefix := strings.HasPrefix(key, "snyk_")
+			if hasPrefix {
+				formattedKey := strings.ToUpper(key)
+				_, ok := os.LookupEnv(formattedKey)
+				if ok {
+					debugLogger.Printf("Found environment variable %s, disabling OAuth flow", formattedKey)
+					config.Set(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, false)
+					break
 				}
 			}
 		}
-		return existingValue
-	})
+	}
 }
 
 func getFullCommandString(cmd *cobra.Command) string {

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.1
 	github.com/snyk/cli-extension-sbom v0.0.0-20230331093938-3d6a5dfdae22
-	github.com/snyk/go-application-framework v0.0.0-20230504094423-9452a0ac9448
-	github.com/snyk/go-httpauth v0.0.0-20230328170530-1af63c87b650
+	github.com/snyk/go-application-framework v0.0.0-20230519090414-ce080e28fec1
+	github.com/snyk/go-httpauth v0.0.0-20230512081507-800aedece3cb
 	github.com/snyk/snyk-iac-capture v0.6.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -205,10 +205,10 @@ github.com/rs/zerolog v1.29.1/go.mod h1:Le6ESbR7hc+DP6Lt1THiV8CQSdkkNrd3R0XbEgp3
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/snyk/cli-extension-sbom v0.0.0-20230331093938-3d6a5dfdae22 h1:ucnmZwoo1gGU+YjmbYZAix5HKIZ1FYBNDau5RPwCSS8=
 github.com/snyk/cli-extension-sbom v0.0.0-20230331093938-3d6a5dfdae22/go.mod h1:83CWQ4Oy3mL8cVkj/etP+bh7I8I1xb+n2bpsE6URuPs=
-github.com/snyk/go-application-framework v0.0.0-20230504094423-9452a0ac9448 h1:jZhlN2gNmhOjNQdE0SwHnNaNZki1557ZT/azuMnS664=
-github.com/snyk/go-application-framework v0.0.0-20230504094423-9452a0ac9448/go.mod h1:QMdFROeuG06UULLD2hzN/P9RlKE6Ma6eskMwAqVOMkM=
-github.com/snyk/go-httpauth v0.0.0-20230328170530-1af63c87b650 h1:CsLoEIHxq4i3d9di8RoN3J3D1/oK20oroEZUGShor0o=
-github.com/snyk/go-httpauth v0.0.0-20230328170530-1af63c87b650/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
+github.com/snyk/go-application-framework v0.0.0-20230519090414-ce080e28fec1 h1:pwHKIc2+NMoseY3hH5gr7okrc39DdYA6xTFsGKik0mg=
+github.com/snyk/go-application-framework v0.0.0-20230519090414-ce080e28fec1/go.mod h1:Aun65T/AmzxjZe9jZZBqia6RHwoS7oq8QB2UfQIcPjU=
+github.com/snyk/go-httpauth v0.0.0-20230512081507-800aedece3cb h1:UwbUBfe1u5MYLhtCNOsFEM98tfEUWqgmaXam/UxU88Q=
+github.com/snyk/go-httpauth v0.0.0-20230512081507-800aedece3cb/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/snyk-iac-capture v0.6.0 h1:P9GWIyvl+F23XZOCuJvzGV6tME/vxbKpZM7/9dw48as=
 github.com/snyk/snyk-iac-capture v0.6.0/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
 github.com/spf13/afero v1.9.3 h1:41FoI0fD7OR7mGcKE/aOiLkGreyf8ifIOQmJANWogMk=


### PR DESCRIPTION
Bumping GAF version.
Also, when determining oauth token precedence, replace the existing default value function for `FF_OAUTH_AUTH_FLOW_ENABLED`, by explicitly setting it to false if necessary.  This enables deriving the oauth feature flag from the endpoint.