### PR TITLE
fix: respect different ways to disable analytics

### DIFF
--- a/cliv2/cmd/cliv2/main_test.go
+++ b/cliv2/cmd/cliv2/main_test.go
@@ -27,6 +27,63 @@ func Test_MainWithErrorCode(t *testing.T) {
 	assert.Equal(t, 0, err)
 }
 
+func Test_initApplicationConfiguration_DisablesAnalytics(t *testing.T) {
+	t.Run("via SNYK_DISABLE_ANALYTICS (true)", func(t *testing.T) {
+		c := configuration.NewInMemory()
+		assert.False(t, c.GetBool(configuration.ANALYTICS_DISABLED))
+
+		c.Set("SNYK_DISABLE_ANALYTICS", "true")
+		initApplicationConfiguration(c)
+
+		assert.True(t, c.GetBool(configuration.ANALYTICS_DISABLED))
+	})
+	t.Run("via SNYK_DISABLE_ANALYTICS (1)", func(t *testing.T) {
+		c := configuration.NewInMemory()
+		assert.False(t, c.GetBool(configuration.ANALYTICS_DISABLED))
+
+		c.Set("SNYK_DISABLE_ANALYTICS", "1")
+		initApplicationConfiguration(c)
+
+		assert.True(t, c.GetBool(configuration.ANALYTICS_DISABLED))
+	})
+	t.Run("via SNYK_CFG_DISABLE_ANALYTICS (true)", func(t *testing.T) {
+		c := configuration.NewInMemory()
+		assert.False(t, c.GetBool(configuration.ANALYTICS_DISABLED))
+
+		c.Set("SNYK_CFG_DISABLE_ANALYTICS", "true")
+		initApplicationConfiguration(c)
+
+		assert.True(t, c.GetBool(configuration.ANALYTICS_DISABLED))
+	})
+	t.Run("via SNYK_CFG_DISABLE_ANALYTICS (1)", func(t *testing.T) {
+		c := configuration.NewInMemory()
+		assert.False(t, c.GetBool(configuration.ANALYTICS_DISABLED))
+
+		c.Set("SNYK_CFG_DISABLE_ANALYTICS", "1")
+		initApplicationConfiguration(c)
+
+		assert.True(t, c.GetBool(configuration.ANALYTICS_DISABLED))
+	})
+	t.Run("via DISABLE-ANALYTICS (true)", func(t *testing.T) {
+		c := configuration.NewInMemory()
+		assert.False(t, c.GetBool(configuration.ANALYTICS_DISABLED))
+
+		c.Set("disable-analytics", "true")
+		initApplicationConfiguration(c)
+
+		assert.True(t, c.GetBool(configuration.ANALYTICS_DISABLED))
+	})
+	t.Run("via DISABLE-ANALYTICS (1)", func(t *testing.T) {
+		c := configuration.NewInMemory()
+		assert.False(t, c.GetBool(configuration.ANALYTICS_DISABLED))
+
+		c.Set("disable-analytics", "1")
+		initApplicationConfiguration(c)
+
+		assert.True(t, c.GetBool(configuration.ANALYTICS_DISABLED))
+	})
+}
+
 func Test_CreateCommandsForWorkflowWithSubcommands(t *testing.T) {
 	defer cleanup()
 
@@ -49,7 +106,7 @@ func Test_CreateCommandsForWorkflowWithSubcommands(t *testing.T) {
 		}
 	}
 
-	engine.Init()
+	_ = engine.Init()
 	rootCommand := prepareRootCommand()
 
 	// invoke method under test

--- a/test/jest/acceptance/analytics.spec.ts
+++ b/test/jest/acceptance/analytics.spec.ts
@@ -29,8 +29,17 @@ describe('analytics module', () => {
     });
   });
 
+  beforeEach(() => {
+    runSnykCLI(`config unset disable-analytics`);
+    runSnykCLI(`config unset SNYK_DISABLE_ANALYTICS`);
+    runSnykCLI(`config unset SNYK_CFG_DISABLE_ANALYTICS`);
+  });
+
   afterEach(() => {
     server.restore();
+    runSnykCLI(`config unset disable-analytics`);
+    runSnykCLI(`config unset SNYK_DISABLE_ANALYTICS`);
+    runSnykCLI(`config unset SNYK_CFG_DISABLE_ANALYTICS`);
   });
 
   afterAll((done) => {
@@ -90,17 +99,17 @@ describe('analytics module', () => {
           integrationVersion: '1.2.3',
           // prettier-ignore
           metrics: {
-            'network_time': {
-              type: 'timer',
-              values: expect.any(Array),
-              total: expect.any(Number),
-            },
-            'cpu_time': {
-              type: 'synthetic',
-              values: [expect.any(Number)],
-              total: expect.any(Number),
-            },
-          },
+                        'network_time': {
+                            type: 'timer',
+                            values: expect.any(Array),
+                            total: expect.any(Number),
+                        },
+                        'cpu_time': {
+                            type: 'synthetic',
+                            values: [expect.any(Number)],
+                            total: expect.any(Number),
+                        },
+                    },
           nodeVersion: expect.any(String),
           os: expect.any(String),
           standalone: expect.any(Boolean),
@@ -176,17 +185,17 @@ describe('analytics module', () => {
           integrationVersion: '1.2.3',
           // prettier-ignore
           metrics: {
-            'network_time': {
-              type: 'timer',
-              values: expect.any(Array),
-              total: expect.any(Number),
-            },
-            'cpu_time': {
-              type: 'synthetic',
-              values: [expect.any(Number)],
-              total: expect.any(Number),
-            },
-          },
+                        'network_time': {
+                            type: 'timer',
+                            values: expect.any(Array),
+                            total: expect.any(Number),
+                        },
+                        'cpu_time': {
+                            type: 'synthetic',
+                            values: [expect.any(Number)],
+                            total: expect.any(Number),
+                        },
+                    },
           nodeVersion: expect.any(String),
           os: expect.any(String),
           standalone: expect.any(Boolean),
@@ -245,17 +254,17 @@ describe('analytics module', () => {
           integrationVersion: '1.2.3',
           // prettier-ignore
           metrics: {
-            'network_time': {
-              type: 'timer',
-              values: expect.any(Array),
-              total: expect.any(Number),
-            },
-            'cpu_time': {
-              type: 'synthetic',
-              values: [expect.any(Number)],
-              total: expect.any(Number),
-            },
-          },
+                        'network_time': {
+                            type: 'timer',
+                            values: expect.any(Array),
+                            total: expect.any(Number),
+                        },
+                        'cpu_time': {
+                            type: 'synthetic',
+                            values: [expect.any(Number)],
+                            total: expect.any(Number),
+                        },
+                    },
           nodeVersion: expect.any(String),
           os: expect.any(String),
           standalone: expect.any(Boolean),
@@ -325,17 +334,17 @@ describe('analytics module', () => {
           integrationVersion: '1.2.3',
           // prettier-ignore
           metrics: {
-            'network_time': {
-              type: 'timer',
-              values: expect.any(Array),
-              total: expect.any(Number),
-            },
-            'cpu_time': {
-              type: 'synthetic',
-              values: [expect.any(Number)],
-              total: expect.any(Number),
-            },
-          },
+                        'network_time': {
+                            type: 'timer',
+                            values: expect.any(Array),
+                            total: expect.any(Number),
+                        },
+                        'cpu_time': {
+                            type: 'synthetic',
+                            values: [expect.any(Number)],
+                            total: expect.any(Number),
+                        },
+                    },
           nodeVersion: expect.any(String),
           os: expect.any(String),
           standalone: expect.any(Boolean),
@@ -386,17 +395,17 @@ describe('analytics module', () => {
           integrationVersion: '1.2.3',
           // prettier-ignore
           metrics: {
-            'network_time': {
-              type: 'timer',
-              values: expect.any(Array),
-              total: expect.any(Number),
-            },
-            'cpu_time': {
-              type: 'synthetic',
-              values: [expect.any(Number)],
-              total: expect.any(Number),
-            },
-          },
+                        'network_time': {
+                            type: 'timer',
+                            values: expect.any(Array),
+                            total: expect.any(Number),
+                        },
+                        'cpu_time': {
+                            type: 'synthetic',
+                            values: [expect.any(Number)],
+                            total: expect.any(Number),
+                        },
+                    },
           nodeVersion: expect.any(String),
           os: expect.any(String),
           standalone: expect.any(Boolean),
@@ -466,13 +475,51 @@ describe('analytics module', () => {
     });
   });
 
-  it("won't send analytics if disable analytics is set", async () => {
+  it("won't send analytics if disable analytics is set via SNYK_DISABLE_ANALYTICS", async () => {
     const { code } = await runSnykCLI(`version`, {
       env: {
         ...env,
         SNYK_DISABLE_ANALYTICS: '1',
       },
     });
+    expect(code).toBe(0);
+
+    const requests = server.getRequests().filter((value) => {
+      return value.url == '/api/v1/analytics/cli';
+    });
+
+    const lastRequest = requests.pop();
+    expect(lastRequest).toBeUndefined();
+  });
+  it("won't send analytics if disable analytics is set via SNYK_CFG_DISABLE_ANALYTICS", async () => {
+    const { code } = await runSnykCLI(`version`, {
+      env: {
+        ...env,
+        SNYK_CFG_DISABLE_ANALYTICS: '1',
+      },
+    });
+    expect(code).toBe(0);
+
+    const requests = server.getRequests().filter((value) => {
+      return value.url == '/api/v1/analytics/cli';
+    });
+
+    const lastRequest = requests.pop();
+    expect(lastRequest).toBeUndefined();
+  });
+  it("won't send analytics if disable analytics is set via config and disable-analytics", async () => {
+    const envWithDisabledAnalytics = {
+      ...env,
+      SNYK_DISABLE_ANALYTICS: '1',
+    };
+
+    // set config
+    await runSnykCLI(`config set disable-analytics=1`, {
+      env: envWithDisabledAnalytics,
+    });
+
+    const { code } = await runSnykCLI(`version`);
+
     expect(code).toBe(0);
 
     const requests = server.getRequests().filter((value) => {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds alternative config parameter names, to support previously communicated ways to disable analytics (e.g. https://docs.snyk.io/snyk-cli/configure-the-snyk-cli/configure-snyk-cli-to-connect-to-snyk-api, https://snyk.io/policies/tracking-and-analytics/)

This is achieved by registering aliases for the `ANALYTICS_DISABLED` configuration key.

```
config.AddAlternativeKeys(configuration.ANALYTICS_DISABLED, []string{"snyk_analytics_disabled", "disable-analytics", "disable_analytics", "snyk_cfg_disable_analytics"})
```

#### Where should the reviewer start?
https://github.com/snyk/cli/blob/277a1e0a1432201ffeed9b3a3eb64e8e791e75c3/cliv2/cmd/cliv2/main.go#L91

#### How should this be manually tested?
use `snyk config set disable-analytics=1` and start snyk with -d. It should NOT output any text in the end regarding sending analytics.

#### Any background context you want to provide?
https://snyksec.atlassian.net/browse/HEAD-325

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/HEAD-325

#### Screenshots


#### Additional questions
