### PR TITLE
feat: [SUP-1093] improve cli yarn performance for yarn workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "snyk-gradle-plugin": "3.26.4",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.32.3",
-        "snyk-nodejs-lockfile-parser": "1.49.0",
+        "snyk-nodejs-lockfile-parser": "1.51.0",
         "snyk-nuget-plugin": "1.24.1",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.25.0",
@@ -17567,9 +17567,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-nodejs-lockfile-parser": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.49.0.tgz",
-      "integrity": "sha512-73iqwHB8YSWex/PTx+TRUwtNPyKn5wP4n/kxEPbX9EfN3uSIcw6mSKiLm8gSKl5gtf8hcP0R0f1tBFjjdzQvRQ==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.51.0.tgz",
+      "integrity": "sha512-uepLn2WELhgAVoYZ7QOt3nFwBVZvJAUfdDyebhb2Wqn5ftTthELzUp5/kCqxOXWoXBSg2KQIjI42U7SRq8gxLg==",
       "dependencies": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -34680,9 +34680,9 @@
       }
     },
     "snyk-nodejs-lockfile-parser": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.49.0.tgz",
-      "integrity": "sha512-73iqwHB8YSWex/PTx+TRUwtNPyKn5wP4n/kxEPbX9EfN3uSIcw6mSKiLm8gSKl5gtf8hcP0R0f1tBFjjdzQvRQ==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.51.0.tgz",
+      "integrity": "sha512-uepLn2WELhgAVoYZ7QOt3nFwBVZvJAUfdDyebhb2Wqn5ftTthELzUp5/kCqxOXWoXBSg2KQIjI42U7SRq8gxLg==",
       "requires": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/graphlib": "2.1.9-patch.3",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "snyk-gradle-plugin": "3.26.4",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.32.3",
-    "snyk-nodejs-lockfile-parser": "1.49.0",
+    "snyk-nodejs-lockfile-parser": "1.51.0",
     "snyk-nuget-plugin": "1.24.1",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.25.0",

--- a/src/lib/plugins/nodejs-plugin/npm-lock-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/npm-lock-parser.ts
@@ -122,13 +122,24 @@ async function buildDepGraph(
       return await lockFileParser.parseYarnLockV1Project(
         manifestFileContents,
         lockFileContents,
-        options,
+        {
+          includeDevDeps: options.includeDevDeps,
+          includeOptionalDeps: options.includeOptionalDeps,
+          includePeerDeps: options.includePeerDeps || false,
+          pruneLevel: 'withinTopLevelDeps',
+          strictOutOfSync: options.strictOutOfSync,
+        },
       );
     case NodeLockfileVersion.YarnLockV2:
       return await lockFileParser.parseYarnLockV2Project(
         manifestFileContents,
         lockFileContents,
-        options,
+        {
+          includeDevDeps: options.includeDevDeps,
+          includeOptionalDeps: options.includeOptionalDeps,
+          pruneWithinTopLevelDeps: true,
+          strictOutOfSync: options.strictOutOfSync,
+        },
       );
     case NodeLockfileVersion.NpmLockV2:
     case NodeLockfileVersion.NpmLockV3:

--- a/test/tap/cli-test/cli-test.yarn-workspaces.spec.ts
+++ b/test/tap/cli-test/cli-test.yarn-workspaces.spec.ts
@@ -22,7 +22,7 @@ export const YarnWorkspacesTests: AcceptanceTests = {
         t.equal(
           e.message,
           '\nTesting yarn-workspace-out-of-sync...\n\n' +
-            'Dependency snyk was not found in yarn.lock.' +
+            'Dependency snyk@1.320.0 was not found in yarn.lock.' +
             ' Your package.json and yarn.lock are probably out of sync.' +
             ' Please run "yarn install" and try again.',
           'Contains enough info about err',


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

We have recently introduced a fix in our yarn parsing logic of Node package files that now creates a depGraph directly, instead of the legacy depTree logic, which required doing a lot of conversions back and forward.

Now we're introducing the use of this parser in the CLI for generating yarn-workspace results, which increases the performance of scanning yarn workspaces tremendously.

## Comparison

Scanning a yarn workspace with 72 projects in it using `snyk test --yarn-workspaces --detection-depth=3`

Previous: 32 minutes
This fix: 43 seconds

An increase of 45x.