### PR TITLE
chore: remove integrated IaC FF check in FedRAMP env [CFG-2413]

### DIFF
--- a/src/lib/feature-flags/index.ts
+++ b/src/lib/feature-flags/index.ts
@@ -28,13 +28,6 @@ export async function hasFeatureFlag(
   featureFlag: string,
   options: Options,
 ): Promise<boolean | undefined> {
-  if (
-    featureFlag === 'iacIntegratedExperience' &&
-    config.API.includes('snykgov')
-  ) {
-    return true;
-  }
-
   const { code, error, ok } = await isFeatureFlagSupportedForOrg(
     featureFlag,
     options.org,

--- a/test/jest/unit/lib/feature-flags/feature-flags.spec.ts
+++ b/test/jest/unit/lib/feature-flags/feature-flags.spec.ts
@@ -1,14 +1,7 @@
-import config from '../../../../../src/lib/config';
 import { hasFeatureFlag } from '../../../../../src/lib/feature-flags';
 import * as request from '../../../../../src/lib/request';
 
 describe('hasFeatureFlag fn', () => {
-  const configApiDefault = config.API;
-
-  afterAll(() => {
-    config.API = configApiDefault;
-  });
-
   it.each`
     hasFlag  | expected
     ${true}  | ${true}
@@ -40,13 +33,5 @@ describe('hasFeatureFlag fn', () => {
     await expect(
       hasFeatureFlag('test-ff', { path: 'test-path' }),
     ).rejects.toThrowError('Forbidden');
-  });
-
-  it('should return iacIntegratedExperience feature flag being true for FedRAMP', async () => {
-    config.API = 'https://app.snykgov.io/api/v1';
-    const result = await hasFeatureFlag('iacIntegratedExperience', {
-      path: 'test-path',
-    });
-    expect(result).toEqual(true);
   });
 });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules
#### What does this PR do?
Following the merge of [this PR](https://github.com/snyk/registry/pull/31790), the check we are currently doing in the CLI to enforce the Integrated IaC experience in the FedRAMP environment is not needed anymore.

#### Any background context you want to provide?
This PR basically deletes all the logic/test that was added in [this PR](https://github.com/snyk/cli/pull/4597).

#### What are the relevant tickets?
https://snyksec.atlassian.net/jira/software/c/projects/CFG/boards/301?modal=detail&selectedIssue=CFG-2413
