### PR TITLE
chore: upgrade cli-extension-iac-rules to latest from main

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.1
-	github.com/snyk/cli-extension-iac-rules v0.0.0-20230523125328-59db55ecc135
+	github.com/snyk/cli-extension-iac-rules v0.0.0-20230525100639-98d6755d43d7
 	github.com/snyk/cli-extension-sbom v0.0.0-20230526074203-8198a7341fbc
 	github.com/snyk/go-application-framework v0.0.0-20230526065140-1fabe799e3f9
 	github.com/snyk/go-httpauth v0.0.0-20230512081507-800aedece3cb

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -574,14 +574,10 @@ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/sahilm/fuzzy v0.1.0/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
-github.com/snyk/cli-extension-iac-rules v0.0.0-20230523125328-59db55ecc135 h1:b0QaMf9Wq6Tlpv2Rpbc9115S7sLraaNWv74O/IKZFYY=
-github.com/snyk/cli-extension-iac-rules v0.0.0-20230523125328-59db55ecc135/go.mod h1:5/IYYTgf32pST7St4GhS3KNz32WE17Ys+Hdb5Pqxex0=
-github.com/snyk/cli-extension-sbom v0.0.0-20230526064837-a45a2564bc54 h1:bUlOtaYRWyiaUoV1QC8cW7z932GJlD+rK88JGx6yyNA=
-github.com/snyk/cli-extension-sbom v0.0.0-20230526064837-a45a2564bc54/go.mod h1:iq3uCtvc71ay9Y1tHuKwQ9feUwAi/6CjKfSFKxFaLeQ=
+github.com/snyk/cli-extension-iac-rules v0.0.0-20230525100639-98d6755d43d7 h1:+TDTl/jnYO/yNUxWBG5S7VZdzZlbau32ekOvIaqxTX0=
+github.com/snyk/cli-extension-iac-rules v0.0.0-20230525100639-98d6755d43d7/go.mod h1:5/IYYTgf32pST7St4GhS3KNz32WE17Ys+Hdb5Pqxex0=
 github.com/snyk/cli-extension-sbom v0.0.0-20230526074203-8198a7341fbc h1:hJzxC5ievJ+lwudvkDwzvifRUtLtima7vTXs8ePDrJE=
 github.com/snyk/cli-extension-sbom v0.0.0-20230526074203-8198a7341fbc/go.mod h1:m0SL0IQ33c9uC5TI+Xo6bx0Dj8L1GgHxCaO/ZyGwhhw=
-github.com/snyk/go-application-framework v0.0.0-20230525093644-7c923f48a33d h1:TUgvGsj1C7yRAkzlnITX6DqA5l/xDvTdRbdLlw81QAI=
-github.com/snyk/go-application-framework v0.0.0-20230525093644-7c923f48a33d/go.mod h1:Aun65T/AmzxjZe9jZZBqia6RHwoS7oq8QB2UfQIcPjU=
 github.com/snyk/go-application-framework v0.0.0-20230526065140-1fabe799e3f9 h1:FS0NA9lcbrW4Oha217+DppFXlECeWcHa8RBIKIK3+Qs=
 github.com/snyk/go-application-framework v0.0.0-20230526065140-1fabe799e3f9/go.mod h1:Aun65T/AmzxjZe9jZZBqia6RHwoS7oq8QB2UfQIcPjU=
 github.com/snyk/go-httpauth v0.0.0-20230512081507-800aedece3cb h1:UwbUBfe1u5MYLhtCNOsFEM98tfEUWqgmaXam/UxU88Q=


### PR DESCRIPTION
#### What does this PR do?

Updates the iac-rules CLI extension with a few minor adjustments, [diff here](https://github.com/snyk/cli-extension-iac-rules/compare/59db55ecc135a40aecebc456f82d28c2190fc524...98d6755d43d74818e05245f36956ad4f23d2d4fa).