### PR TITLE
fix: pass resolution to yarn workspaces parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "snyk-gradle-plugin": "3.26.4",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.32.3",
-        "snyk-nodejs-lockfile-parser": "1.51.0",
+        "snyk-nodejs-lockfile-parser": "1.51.1",
         "snyk-nuget-plugin": "1.24.1",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.25.0",
@@ -17567,9 +17567,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-nodejs-lockfile-parser": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.51.0.tgz",
-      "integrity": "sha512-uepLn2WELhgAVoYZ7QOt3nFwBVZvJAUfdDyebhb2Wqn5ftTthELzUp5/kCqxOXWoXBSg2KQIjI42U7SRq8gxLg==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.51.1.tgz",
+      "integrity": "sha512-NVD93nZwuLg/uhgHpMLk0e28r1Xz2wTsY00zK9L7dPMGF1BKbh05O5WXGagCb7yL5zFcb/xNyIkYyGoaTxWtmQ==",
       "dependencies": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -34683,9 +34683,9 @@
       }
     },
     "snyk-nodejs-lockfile-parser": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.51.0.tgz",
-      "integrity": "sha512-uepLn2WELhgAVoYZ7QOt3nFwBVZvJAUfdDyebhb2Wqn5ftTthELzUp5/kCqxOXWoXBSg2KQIjI42U7SRq8gxLg==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.51.1.tgz",
+      "integrity": "sha512-NVD93nZwuLg/uhgHpMLk0e28r1Xz2wTsY00zK9L7dPMGF1BKbh05O5WXGagCb7yL5zFcb/xNyIkYyGoaTxWtmQ==",
       "requires": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/graphlib": "2.1.9-patch.3",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "snyk-gradle-plugin": "3.26.4",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.32.3",
-    "snyk-nodejs-lockfile-parser": "1.51.0",
+    "snyk-nodejs-lockfile-parser": "1.51.1",
     "snyk-nuget-plugin": "1.24.1",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.25.0",

--- a/src/lib/plugins/nodejs-plugin/yarn-workspaces-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/yarn-workspaces-parser.ts
@@ -52,6 +52,8 @@ export async function processYarnWorkspaces(
     },
     scannedProjects: [],
   };
+
+  let rootWorkspaceManifestContent = {};
   // the folders must be ordered highest first
   for (const directory of Object.keys(yarnTargetFiles)) {
     debug(`Processing ${directory} as a potential Yarn workspace`);
@@ -79,6 +81,7 @@ export async function processYarnWorkspaces(
       }
       if (packageJsonFileName === workspaceRoot) {
         isRootPackageJson = true;
+        rootWorkspaceManifestContent = JSON.parse(packageJson.content);
       }
     }
 
@@ -129,6 +132,12 @@ export async function processYarnWorkspaces(
                 settings.strictOutOfSync === undefined
                   ? true
                   : settings.strictOutOfSync,
+            },
+            {
+              isWorkspacePkg: true,
+              isRoot: isRootPackageJson,
+              rootResolutions:
+                rootWorkspaceManifestContent?.['resolutions'] || {},
             },
           );
           break;


### PR DESCRIPTION
This change simply passes workspace information to the yarn parser when we are parsing yarn 2+ workspaces projects