### PR TITLE
chore: replace deprecated macos CCI runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ executors:
     macos:
       # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
       xcode: '13.3.0'
-    resource_class: medium
+    resource_class: macos.x86.medium.gen2
 
 commands:
   install_sdks_windows:


### PR DESCRIPTION
[Jira ticket](https://snyksec.atlassian.net/browse/HEAD-267)
Replace deprecated macos Cirecle CI runner with the new runner. This will make testing and signing our macos binaries a lot faster.