### PR TITLE
fix: use prettier version from package for user docs formatting

### DIFF
--- a/.github/workflows/sync-cli-help-to-user-docs.yml
+++ b/.github/workflows/sync-cli-help-to-user-docs.yml
@@ -25,7 +25,8 @@ jobs:
           if [[ $(git -C ./cli status --porcelain) ]]; then
             echo "Documentation changes detected"
             cd ./cli
-            npx prettier --write ./help/cli-commands
+            npm clean-install
+            npx prettier --write ./help/cli-commands/*.md
             git --no-pager diff --name-only
             git add .
             git commit -m "docs: synchronizing help from snyk/user-docs"


### PR DESCRIPTION
use prettier version from package for user docs formatting because the GH sync docs action ends up using the latest prettier version, not the one pinned in `package.json`, which ends up not formatting changes that then our CircleCI linting finds.