### PR TITLE
feat: bump SwiftPM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "snyk-python-plugin": "^1.25.2",
         "snyk-resolve-deps": "4.7.3",
         "snyk-sbt-plugin": "2.17.0",
-        "snyk-swiftpm-plugin": "1.2.1",
+        "snyk-swiftpm-plugin": "1.4.0",
         "strip-ansi": "^5.2.0",
         "tar": "^6.1.2",
         "uuid": "^8.3.2",
@@ -18072,13 +18072,16 @@
       }
     },
     "node_modules/snyk-swiftpm-plugin": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/snyk-swiftpm-plugin/-/snyk-swiftpm-plugin-1.2.1.tgz",
-      "integrity": "sha512-Im4I6mDMwzP3UpPx94QBNQQPDLsRB4k1n4g/uhSZfnu6uqrX8Ex51eyDoEfW4xl1wSqrBIMItdCeJ1ylcAg8oA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/snyk-swiftpm-plugin/-/snyk-swiftpm-plugin-1.4.0.tgz",
+      "integrity": "sha512-TeJR/wD9v6ApVV1DgDmk0FgYTXIpgNP9ilGg9NAUIdTibeH+nq/gJfwJ/WTcK3ljPG6sQcCry4iZgJ8h/mLSRw==",
       "dependencies": {
         "@snyk/dep-graph": "^2.3.0",
         "lookpath": "^1.2.2",
         "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/snyk-swiftpm-plugin/node_modules/tslib": {
@@ -35116,9 +35119,9 @@
       }
     },
     "snyk-swiftpm-plugin": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/snyk-swiftpm-plugin/-/snyk-swiftpm-plugin-1.2.1.tgz",
-      "integrity": "sha512-Im4I6mDMwzP3UpPx94QBNQQPDLsRB4k1n4g/uhSZfnu6uqrX8Ex51eyDoEfW4xl1wSqrBIMItdCeJ1ylcAg8oA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/snyk-swiftpm-plugin/-/snyk-swiftpm-plugin-1.4.0.tgz",
+      "integrity": "sha512-TeJR/wD9v6ApVV1DgDmk0FgYTXIpgNP9ilGg9NAUIdTibeH+nq/gJfwJ/WTcK3ljPG6sQcCry4iZgJ8h/mLSRw==",
       "requires": {
         "@snyk/dep-graph": "^2.3.0",
         "lookpath": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "snyk-python-plugin": "^1.25.2",
     "snyk-resolve-deps": "4.7.3",
     "snyk-sbt-plugin": "2.17.0",
-    "snyk-swiftpm-plugin": "1.2.1",
+    "snyk-swiftpm-plugin": "1.4.0",
     "strip-ansi": "^5.2.0",
     "tar": "^6.1.2",
     "uuid": "^8.3.2",


### PR DESCRIPTION
The previous version of SwiftPM had some broken logic that would cause dependency graph generation to error out in some cases.

This is now [fixed](https://github.com/snyk/snyk-swiftpm-plugin/pull/28).