### PR TITLE
fix: block unsupported pm

### DIFF
--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -176,8 +176,10 @@ export default async function monitor(...args0: MethodArgs): Promise<any> {
         label: string;
         name: string;
       }> = [{ label: 'Swift PM', name: 'swift' }];
-      const unsupportedPackageManager = unsupportedPackageManagers.find(
-        (pm) => pm.name === packageManager,
+      const unsupportedPackageManager = unsupportedPackageManagers.find((pm) =>
+        packageManager
+          ? pm.name === packageManager
+          : pm.name === detect.detectPackageManager(path, options),
       );
       if (unsupportedPackageManager) {
         return `${unsupportedPackageManager.label} projects do not currently support "snyk monitor"`;


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Currently the blocking logic for unsupported package managers is bypassed when `monitor` is run with `--all-projects`. This PR rectifies that issue

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
