### PR TITLE
feat: Enable header modification for all legacy CLI requests

### DIFF
--- a/cliv2/pkg/basic_workflows/legacycli.go
+++ b/cliv2/pkg/basic_workflows/legacycli.go
@@ -116,13 +116,11 @@ func legacycliWorkflow(
 
 	wrapperProxy.SetUpstreamProxyAuthentication(proxyAuthenticationMechanism)
 
-	if oauthIsAvailable {
-		proxyHeaderFunc := func(req *http.Request) error {
-			err := networkAccess.AddHeaders(req)
-			return err
-		}
-		wrapperProxy.SetHeaderFunction(proxyHeaderFunc)
+	proxyHeaderFunc := func(req *http.Request) error {
+		err := networkAccess.AddHeaders(req)
+		return err
 	}
+	wrapperProxy.SetHeaderFunction(proxyHeaderFunc)
 
 	err = wrapperProxy.Start()
 	if err != nil {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Always modify HTTP headers from the legacy CLI to make them consistent with headers from the Extensible CLI.