### PR TITLE
chore: bump nodejs parser 1.52.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "snyk-gradle-plugin": "3.26.4",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.33.0",
-        "snyk-nodejs-lockfile-parser": "1.51.1",
+        "snyk-nodejs-lockfile-parser": "1.52.1",
         "snyk-nuget-plugin": "1.24.1",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.25.0",
@@ -17580,9 +17580,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-nodejs-lockfile-parser": {
-      "version": "1.51.1",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.51.1.tgz",
-      "integrity": "sha512-NVD93nZwuLg/uhgHpMLk0e28r1Xz2wTsY00zK9L7dPMGF1BKbh05O5WXGagCb7yL5zFcb/xNyIkYyGoaTxWtmQ==",
+      "version": "1.52.1",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.52.1.tgz",
+      "integrity": "sha512-5sheRswIk9Ode6gMISLK65XBstJ+M0siGLIZeHHZgTAII/avOTk0fHLkhXsKb8+goeg5JPT+b4tYgQVlqHreTA==",
       "dependencies": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -34671,9 +34671,9 @@
       }
     },
     "snyk-nodejs-lockfile-parser": {
-      "version": "1.51.1",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.51.1.tgz",
-      "integrity": "sha512-NVD93nZwuLg/uhgHpMLk0e28r1Xz2wTsY00zK9L7dPMGF1BKbh05O5WXGagCb7yL5zFcb/xNyIkYyGoaTxWtmQ==",
+      "version": "1.52.1",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.52.1.tgz",
+      "integrity": "sha512-5sheRswIk9Ode6gMISLK65XBstJ+M0siGLIZeHHZgTAII/avOTk0fHLkhXsKb8+goeg5JPT+b4tYgQVlqHreTA==",
       "requires": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/graphlib": "2.1.9-patch.3",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "snyk-gradle-plugin": "3.26.4",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.33.0",
-    "snyk-nodejs-lockfile-parser": "1.51.1",
+    "snyk-nodejs-lockfile-parser": "1.52.1",
     "snyk-nuget-plugin": "1.24.1",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.25.0",

--- a/test/acceptance/workspaces/npm-package-lockfile-v3-bundled-deps/package-lock.json
+++ b/test/acceptance/workspaces/npm-package-lockfile-v3-bundled-deps/package-lock.json
@@ -1,0 +1,6726 @@
+{
+  "name": "bundled-deps",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bundled-deps",
+      "dependencies": {
+        "@snyk/sweater-comb": "^1.24.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
+      "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb": {
+      "version": "1.24.7",
+      "resolved": "https://registry.npmjs.org/@snyk/sweater-comb/-/sweater-comb-1.24.7.tgz",
+      "integrity": "sha512-ZK6TCNtEdvTqZrUpcb0M4/V4zWCfRTCfSpH2CPIHLac+JMJdfu2CVeTU5OvV8Hh+UA0dv8aX7dkSkkP6h18b9Q==",
+      "bundleDependencies": [
+        "@useoptic/json-pointer-helpers",
+        "@useoptic/openapi-cli",
+        "@useoptic/openapi-io",
+        "@useoptic/optic-ci",
+        "@useoptic/openapi-utilities",
+        "@useoptic/rulesets-base"
+      ],
+      "dependencies": {
+        "@babel/runtime": "^7.19.0",
+        "@useoptic/json-pointer-helpers": "0.35.8",
+        "@useoptic/openapi-cli": "0.35.8",
+        "@useoptic/openapi-io": "0.35.8",
+        "@useoptic/openapi-utilities": "0.35.8",
+        "@useoptic/optic-ci": "0.35.8",
+        "@useoptic/rulesets-base": "0.36.5",
+        "chai": "^4.3.4",
+        "chalk": "^4.0.0",
+        "change-case": "^4.1.2",
+        "commander": "9.4.1",
+        "find-parent-dir": "^0.3.1",
+        "fs-extra": "^10.0.0",
+        "lodash.isequal": "^4.5.0",
+        "nice-try": "^3.0.0",
+        "parse-url": "8.1.0",
+        "yaml": "^2.2.2",
+        "yargs": "~17.6.0"
+      },
+      "bin": {
+        "sweater-comb": "build/index.js"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.0.9",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@asyncapi/specs": {
+      "version": "3.2.1",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@graphql-tools/merge": {
+      "version": "8.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/utils": "8.9.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@graphql-tools/schema": {
+      "version": "8.5.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-tools/merge": "8.3.1",
+        "@graphql-tools/utils": "8.9.0",
+        "tslib": "^2.4.0",
+        "value-or-promise": "1.0.11"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@graphql-tools/utils": {
+      "version": "8.9.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@httptoolkit/httpolyglot": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "dependencies": {
+        "@types/node": "^16.7.10"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@httptoolkit/httpolyglot/node_modules/@types/node": {
+      "version": "16.18.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@httptoolkit/subscriptions-transport-ws": {
+      "version": "0.11.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "backo2": "^1.0.2",
+        "eventemitter3": "^3.1.0",
+        "iterall": "^1.2.1",
+        "symbol-observable": "^1.0.4",
+        "ws": "^8.8.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.7.2 || ^16.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@httptoolkit/subscriptions-transport-ws/node_modules/eventemitter3": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@httptoolkit/websocket-stream": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/ws": "*",
+        "duplexify": "^3.5.1",
+        "inherits": "^2.0.1",
+        "isomorphic-ws": "^4.0.1",
+        "readable-stream": "^2.3.3",
+        "safe-buffer": "^5.1.2",
+        "ws": "*",
+        "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@httptoolkit/websocket-stream/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@httptoolkit/websocket-stream/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@httptoolkit/websocket-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@httptoolkit/websocket-stream/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@jsep-plugin/regex": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@jsep-plugin/ternary": {
+      "version": "1.1.3",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/auth-token": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/core": {
+      "version": "4.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^3.0.0",
+        "@octokit/graphql": "^5.0.0",
+        "@octokit/request": "^6.0.0",
+        "@octokit/request-error": "^3.0.0",
+        "@octokit/types": "^8.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/endpoint": {
+      "version": "7.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^8.0.0",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/graphql": {
+      "version": "5.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^6.0.0",
+        "@octokit/types": "^8.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/openapi-types": {
+      "version": "14.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/plugin-request-log": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/plugin-request-log/node_modules/@octokit/auth-token": {
+      "version": "2.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/plugin-request-log/node_modules/@octokit/core": {
+      "version": "3.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.3",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/plugin-request-log/node_modules/@octokit/endpoint": {
+      "version": "6.0.12",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/plugin-request-log/node_modules/@octokit/graphql": {
+      "version": "4.8.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/plugin-request-log/node_modules/@octokit/openapi-types": {
+      "version": "12.11.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/plugin-request-log/node_modules/@octokit/request": {
+      "version": "5.6.3",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/plugin-request-log/node_modules/@octokit/request-error": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/plugin-request-log/node_modules/@octokit/types": {
+      "version": "6.41.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@octokit/openapi-types": "^12.11.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/plugin-request-log/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/request": {
+      "version": "6.2.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^7.0.0",
+        "@octokit/request-error": "^3.0.0",
+        "@octokit/types": "^8.0.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/request-error": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^8.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/request/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/rest": {
+      "version": "18.12.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^3.5.1",
+        "@octokit/plugin-paginate-rest": "^2.16.8",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/rest/node_modules/@octokit/auth-token": {
+      "version": "2.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/rest/node_modules/@octokit/core": {
+      "version": "3.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.3",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/rest/node_modules/@octokit/endpoint": {
+      "version": "6.0.12",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/rest/node_modules/@octokit/graphql": {
+      "version": "4.8.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/rest/node_modules/@octokit/openapi-types": {
+      "version": "12.11.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/rest/node_modules/@octokit/plugin-paginate-rest": {
+      "version": "2.21.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^6.40.0"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=2"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/rest/node_modules/@octokit/plugin-request-log": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/rest/node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.16.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^6.39.0",
+        "deprecation": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/rest/node_modules/@octokit/request": {
+      "version": "5.6.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/rest/node_modules/@octokit/request-error": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/rest/node_modules/@octokit/types": {
+      "version": "6.41.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^12.11.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/rest/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@octokit/types": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^14.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@pnpm/network.ca-file": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "4.2.10"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@pnpm/npm-conf": {
+      "version": "1.0.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/network.ca-file": "^1.0.1",
+        "config-chain": "^1.1.11"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@segment/loosely-validate-event": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "dependencies": {
+        "component-type": "^1.2.1",
+        "join-component": "^1.1.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@sentry/core": {
+      "version": "7.17.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.17.4",
+        "@sentry/utils": "7.17.4",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@sentry/core/node_modules/tslib": {
+      "version": "1.14.1",
+      "inBundle": true,
+      "license": "0BSD"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@sentry/node": {
+      "version": "7.17.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.17.4",
+        "@sentry/types": "7.17.4",
+        "@sentry/utils": "7.17.4",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@sentry/node/node_modules/tslib": {
+      "version": "1.14.1",
+      "inBundle": true,
+      "license": "0BSD"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@sentry/types": {
+      "version": "7.17.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@sentry/utils": {
+      "version": "7.17.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.17.4",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@sentry/utils/node_modules/tslib": {
+      "version": "1.14.1",
+      "inBundle": true,
+      "license": "0BSD"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@sindresorhus/is": {
+      "version": "5.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/better-ajv-errors": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonpointer": "^5.0.0",
+        "leven": "^3.1.0"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      },
+      "peerDependencies": {
+        "ajv": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/json": {
+      "version": "3.20.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stoplight/ordered-object-literal": "^1.0.3",
+        "@stoplight/path": "^1.3.2",
+        "@stoplight/types": "^13.6.0",
+        "jsonc-parser": "~2.2.1",
+        "lodash": "^4.17.21",
+        "safe-stable-stringify": "^1.1"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/json-ref-readers": {
+      "version": "1.2.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-fetch": "^2.6.0",
+        "tslib": "^1.14.1"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/json-ref-readers/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/json-ref-readers/node_modules/tslib": {
+      "version": "1.14.1",
+      "inBundle": true,
+      "license": "0BSD"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/json-ref-resolver": {
+      "version": "3.1.4",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stoplight/json": "^3.17.0",
+        "@stoplight/path": "^1.3.2",
+        "@stoplight/types": "^12.3.0 || ^13.0.0",
+        "@types/urijs": "^1.19.19",
+        "dependency-graph": "~0.11.0",
+        "fast-memoize": "^2.5.2",
+        "immer": "^9.0.6",
+        "lodash": "^4.17.21",
+        "tslib": "^2.3.1",
+        "urijs": "^1.19.11"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/json/node_modules/safe-stable-stringify": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/ordered-object-literal": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/path": {
+      "version": "1.3.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/spectral-core": {
+      "version": "1.15.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stoplight/better-ajv-errors": "1.0.3",
+        "@stoplight/json": "~3.20.1",
+        "@stoplight/path": "1.3.2",
+        "@stoplight/spectral-parsers": "^1.0.0",
+        "@stoplight/spectral-ref-resolver": "^1.0.0",
+        "@stoplight/spectral-runtime": "^1.0.0",
+        "@stoplight/types": "~13.6.0",
+        "@types/es-aggregate-error": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "ajv": "^8.6.0",
+        "ajv-errors": "~3.0.0",
+        "ajv-formats": "~2.1.0",
+        "es-aggregate-error": "^1.0.7",
+        "jsonpath-plus": "7.1.0",
+        "lodash": "~4.17.21",
+        "lodash.topath": "^4.5.2",
+        "minimatch": "3.1.2",
+        "nimma": "0.2.2",
+        "pony-cause": "^1.0.0",
+        "simple-eval": "1.0.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/spectral-core/node_modules/@stoplight/types": {
+      "version": "13.6.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.4",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/spectral-formats": {
+      "version": "1.4.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stoplight/json": "^3.17.0",
+        "@stoplight/spectral-core": "^1.8.0",
+        "@types/json-schema": "^7.0.7",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/spectral-functions": {
+      "version": "1.7.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stoplight/better-ajv-errors": "1.0.3",
+        "@stoplight/json": "^3.17.1",
+        "@stoplight/spectral-core": "^1.7.0",
+        "@stoplight/spectral-formats": "^1.0.0",
+        "@stoplight/spectral-runtime": "^1.1.0",
+        "ajv": "^8.6.3",
+        "ajv-draft-04": "~1.0.0",
+        "ajv-errors": "~3.0.0",
+        "ajv-formats": "~2.1.0",
+        "lodash": "~4.17.21",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/spectral-parsers": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stoplight/json": "~3.20.1",
+        "@stoplight/types": "^13.6.0",
+        "@stoplight/yaml": "~4.2.3",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/spectral-ref-resolver": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stoplight/json-ref-readers": "1.2.2",
+        "@stoplight/json-ref-resolver": "~3.1.4",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "dependency-graph": "0.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/spectral-rulesets": {
+      "version": "1.14.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@asyncapi/specs": "^3.2.0",
+        "@stoplight/better-ajv-errors": "1.0.3",
+        "@stoplight/json": "^3.17.0",
+        "@stoplight/spectral-core": "^1.8.1",
+        "@stoplight/spectral-formats": "^1.4.0",
+        "@stoplight/spectral-functions": "^1.5.1",
+        "@stoplight/spectral-runtime": "^1.1.1",
+        "@stoplight/types": "^13.6.0",
+        "@types/json-schema": "^7.0.7",
+        "ajv": "^8.8.2",
+        "ajv-formats": "~2.1.0",
+        "json-schema-traverse": "^1.0.0",
+        "lodash": "~4.17.21",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/spectral-runtime": {
+      "version": "1.1.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stoplight/json": "^3.17.0",
+        "@stoplight/path": "^1.3.2",
+        "@stoplight/types": "^12.3.0",
+        "abort-controller": "^3.0.0",
+        "lodash": "^4.17.21",
+        "node-fetch": "^2.6.7",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/spectral-runtime/node_modules/@stoplight/types": {
+      "version": "12.5.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.4",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/spectral-runtime/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/types": {
+      "version": "13.8.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.4",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/yaml": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stoplight/ordered-object-literal": "^1.0.1",
+        "@stoplight/types": "^13.0.0",
+        "@stoplight/yaml-ast-parser": "0.0.48",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@stoplight/yaml-ast-parser": {
+      "version": "0.0.48",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@szmarczak/http-timer": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@types/cors": {
+      "version": "2.8.12",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@types/es-aggregate-error": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@types/http-cache-semantics": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@types/json-schema": {
+      "version": "7.0.11",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@types/node": {
+      "version": "18.11.9",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@types/node-forge": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@types/urijs": {
+      "version": "1.19.19",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@types/ws": {
+      "version": "8.5.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/json-pointer-helpers": {
+      "version": "0.35.8",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonpointer": "^5.0.1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/openapi-cli": {
+      "version": "0.35.8",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@httptoolkit/httpolyglot": "^2.0.1",
+        "@jsdevtools/ono": "^7.1.3",
+        "@sentry/node": "^7.10.0",
+        "@types/node-forge": "^1.0.4",
+        "@useoptic/json-pointer-helpers": "0.35.8",
+        "@useoptic/openapi-io": "0.35.8",
+        "@useoptic/openapi-utilities": "0.35.8",
+        "ajv-formats": "~2.1.0",
+        "analytics-node": "^6.2.0",
+        "async-exit-hook": "^2.0.1",
+        "axax": "^0.2.2",
+        "chalk": "^5.0.1",
+        "commander": "^9.4.1",
+        "conf": "^10.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "har-schema": "^2.0.0",
+        "is-url": "^1.2.4",
+        "json-schema-traverse": "^1.0.0",
+        "log": "^6.3.1",
+        "log-node": "^8.0.3",
+        "mockttp": "^3.3.1",
+        "node-abort-controller": "^3.0.1",
+        "node-forge": "^1.2.1",
+        "node-machine-id": "^1.1.12",
+        "ora": "^6.1.2",
+        "portfinder": "^1.0.28",
+        "semver": "^7.3.7",
+        "slice-ansi": "^4.0.0",
+        "stream-chain": "^2.2.5",
+        "stream-json": "^1.7.4",
+        "strip-ansi": "^6.0.1",
+        "ts-invariant": "^0.9.4",
+        "ts-results": "^3.3.0",
+        "update-notifier": "^6.0.2",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "bin": {
+        "oas": "build/index.js"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/openapi-cli/node_modules/chalk": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/openapi-io": {
+      "version": "0.35.8",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.9",
+        "@jsdevtools/ono": "^7.1.3",
+        "@useoptic/json-pointer-helpers": "0.35.8",
+        "@useoptic/openapi-utilities": "0.35.8",
+        "ajv": "^8.6.0",
+        "ajv-errors": "~3.0.0",
+        "ajv-formats": "~2.1.0",
+        "bottleneck": "^2.19.5",
+        "chalk": "^4.1.2",
+        "copyfiles": "^2.4.1",
+        "crypto-js": "^4.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-json-patch": "^3.1.1",
+        "fs-extra": "^10.1.0",
+        "is-url": "^1.2.4",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify": "^1.0.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.sortby": "^4.7.0",
+        "node-fetch": "^2.6.7",
+        "openapi-types": "^12.0.2",
+        "semver": "^7.3.7",
+        "ts-invariant": "^0.9.3",
+        "upath": "^2.0.1",
+        "yaml-ast-parser": "^0.0.43"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/openapi-io/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/openapi-utilities": {
+      "version": "0.35.8",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/rest": "^18.12.0",
+        "@sentry/node": "^7.10.0",
+        "@useoptic/json-pointer-helpers": "0.35.8",
+        "ajv": "^8.6.0",
+        "ajv-errors": "~3.0.0",
+        "ajv-formats": "~2.1.0",
+        "analytics-node": "^6.2.0",
+        "chalk": "^4.1.2",
+        "fast-deep-equal": "^3.1.3",
+        "is-url": "^1.2.4",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify": "^1.0.1",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isequal": "^4.5.0",
+        "lodash.omit": "^4.5.0",
+        "lodash.sortby": "^4.7.0",
+        "openapi-types": "^12.0.2",
+        "ts-invariant": "^0.9.3",
+        "yaml-ast-parser": "^0.0.43"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/optic-ci": {
+      "version": "0.35.8",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.6",
+        "@octokit/rest": "^18.12.0",
+        "@sentry/node": "^7.10.0",
+        "@stoplight/spectral-core": "^1.8.1",
+        "@useoptic/openapi-io": "0.35.8",
+        "@useoptic/openapi-utilities": "0.35.8",
+        "@useoptic/rulesets-base": "0.35.8",
+        "ajv": "^8.6.0",
+        "bottleneck": "^2.19.5",
+        "chalk": "^4.1.2",
+        "commander": "^9.4.1",
+        "is-url": "^1.2.4",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify": "^1.0.1",
+        "loglevel": "^1.8.0",
+        "node-fetch": "^2.6.7",
+        "open": "^8.4.0",
+        "picomatch": "^2.3.1",
+        "url-join": "^4.0.1",
+        "uuid": "^9.0.0"
+      },
+      "bin": {
+        "optic-ci": "build/index.js"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/optic-ci/node_modules/@babel/runtime": {
+      "version": "7.20.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/optic-ci/node_modules/@useoptic/rulesets-base": {
+      "version": "0.35.8",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stoplight/spectral-core": "^1.8.1",
+        "@stoplight/spectral-rulesets": "^1.14.1",
+        "@useoptic/json-pointer-helpers": "0.35.8",
+        "@useoptic/openapi-utilities": "0.35.8",
+        "lodash.pick": "^4.4.0",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "rulesets-base": "build/index.js"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/optic-ci/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/optic-ci/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/optic-ci/node_modules/uuid": {
+      "version": "9.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/rulesets-base": {
+      "version": "0.36.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stoplight/spectral-core": "^1.8.1",
+        "@stoplight/spectral-rulesets": "^1.14.1",
+        "@useoptic/json-pointer-helpers": "0.36.5",
+        "@useoptic/openapi-utilities": "0.36.5",
+        "lodash.pick": "^4.4.0",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "rulesets-base": "build/index.js"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/rulesets-base/node_modules/@octokit/openapi-types": {
+      "version": "16.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/rulesets-base/node_modules/@octokit/plugin-paginate-rest": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^9.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=4"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/rulesets-base/node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "7.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^9.0.0",
+        "deprecation": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/rulesets-base/node_modules/@octokit/rest": {
+      "version": "19.0.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^4.1.0",
+        "@octokit/plugin-paginate-rest": "^6.0.0",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/rulesets-base/node_modules/@octokit/types": {
+      "version": "9.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^16.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/rulesets-base/node_modules/@useoptic/json-pointer-helpers": {
+      "version": "0.36.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonpointer": "^5.0.1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/rulesets-base/node_modules/@useoptic/openapi-utilities": {
+      "version": "0.36.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/rest": "^19.0.0",
+        "@sentry/node": "^7.10.0",
+        "@useoptic/json-pointer-helpers": "0.36.5",
+        "ajv": "^8.6.0",
+        "ajv-errors": "~3.0.0",
+        "ajv-formats": "~2.1.0",
+        "analytics-node": "^6.2.0",
+        "chalk": "^4.1.2",
+        "fast-deep-equal": "^3.1.3",
+        "is-url": "^1.2.4",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify": "^1.0.1",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isequal": "^4.5.0",
+        "lodash.omit": "^4.5.0",
+        "lodash.sortby": "^4.7.0",
+        "openapi-types": "^12.0.2",
+        "ts-invariant": "^0.9.3",
+        "yaml-ast-parser": "^0.0.43"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/@useoptic/rulesets-base/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/abort-controller": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/accepts": {
+      "version": "1.3.8",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/acorn": {
+      "version": "8.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/agent-base": {
+      "version": "6.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ajv": {
+      "version": "8.11.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.0.1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/analytics-node": {
+      "version": "6.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@segment/loosely-validate-event": "^2.0.0",
+        "axios": "^0.27.2",
+        "axios-retry": "3.2.0",
+        "lodash.isstring": "^4.0.1",
+        "md5": "^2.2.1",
+        "ms": "^2.0.0",
+        "remove-trailing-slash": "^0.1.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ansi-align": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ansi-styles/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/argparse": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/array-flatten": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ast-types": {
+      "version": "0.13.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/astring": {
+      "version": "1.8.3",
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/async": {
+      "version": "2.6.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/async-exit-hook": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/asynckit": {
+      "version": "0.4.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/atomically": {
+      "version": "1.7.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/axax": {
+      "version": "0.2.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/axios": {
+      "version": "0.27.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/axios-retry": {
+      "version": "3.2.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-retry-allowed": "^1.1.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/backo2": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/base64-arraybuffer": {
+      "version": "0.1.5",
+      "inBundle": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/base64-js": {
+      "version": "1.5.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/bl": {
+      "version": "5.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/bl/node_modules/buffer": {
+      "version": "6.0.3",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/body-parser": {
+      "version": "1.20.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.11.0",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/body-parser/node_modules/bytes": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/bottleneck": {
+      "version": "2.19.5",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/boxen": {
+      "version": "7.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^7.0.0",
+        "chalk": "^5.0.1",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^5.1.2",
+        "type-fest": "^2.13.0",
+        "widest-line": "^4.0.1",
+        "wrap-ansi": "^8.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/boxen/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/boxen/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/boxen/node_modules/camelcase": {
+      "version": "7.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/boxen/node_modules/chalk": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/boxen/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/boxen/node_modules/string-width": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/boxen/node_modules/strip-ansi": {
+      "version": "7.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/boxen/node_modules/type-fest": {
+      "version": "2.19.0",
+      "inBundle": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "8.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/brotli-wasm": {
+      "version": "1.3.1",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/cacheable-lookup": {
+      "version": "6.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/cacheable-request": {
+      "version": "10.2.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "^4.0.1",
+        "get-stream": "^6.0.1",
+        "http-cache-semantics": "^4.1.0",
+        "keyv": "^4.5.0",
+        "mimic-response": "^4.0.0",
+        "normalize-url": "^7.2.0",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/cacheable-request/node_modules/mimic-response": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/call-bind": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/chalk": {
+      "version": "4.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/charenc": {
+      "version": "0.0.2",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ci-info": {
+      "version": "3.5.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/cli-color": {
+      "version": "2.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.61",
+        "es6-iterator": "^2.0.3",
+        "memoizee": "^0.4.15",
+        "timers-ext": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/cli-spinners": {
+      "version": "2.7.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/cli-sprintf-format": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "cli-color": "^2.0.1",
+        "es5-ext": "^0.10.53",
+        "sprintf-kit": "^2.0.1",
+        "supports-color": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/cli-sprintf-format/node_modules/supports-color": {
+      "version": "6.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/clone": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/combined-stream": {
+      "version": "1.0.8",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/commander": {
+      "version": "9.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/common-tags": {
+      "version": "1.8.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/component-type": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/concat-map": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/conf": {
+      "version": "10.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.6.3",
+        "ajv-formats": "^2.1.1",
+        "atomically": "^1.7.0",
+        "debounce-fn": "^4.0.0",
+        "dot-prop": "^6.0.1",
+        "env-paths": "^2.2.1",
+        "json-schema-typed": "^7.0.3",
+        "onetime": "^5.1.2",
+        "pkg-up": "^3.1.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/config-chain": {
+      "version": "1.1.13",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/configstore": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dot-prop": "^6.0.1",
+        "graceful-fs": "^4.2.6",
+        "unique-string": "^3.0.0",
+        "write-file-atomic": "^3.0.3",
+        "xdg-basedir": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/yeoman/configstore?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/connect": {
+      "version": "3.7.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.2",
+        "parseurl": "~1.3.3",
+        "utils-merge": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/connect/node_modules/debug": {
+      "version": "2.6.9",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/connect/node_modules/ms": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/content-type": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/cookie": {
+      "version": "0.4.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/copyfiles": {
+      "version": "2.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^1.0.4",
+        "noms": "0.0.0",
+        "through2": "^2.0.1",
+        "untildify": "^4.0.0",
+        "yargs": "^16.1.0"
+      },
+      "bin": {
+        "copyfiles": "copyfiles",
+        "copyup": "copyfiles"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/copyfiles/node_modules/cliui": {
+      "version": "7.0.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/copyfiles/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/copyfiles/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/copyfiles/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/copyfiles/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/copyfiles/node_modules/through2": {
+      "version": "2.0.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/copyfiles/node_modules/yargs": {
+      "version": "16.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/core-util-is": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/cors": {
+      "version": "2.8.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/cors-gate": {
+      "version": "1.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "2.6.7"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/crypt": {
+      "version": "0.0.2",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/crypto-js": {
+      "version": "4.1.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/crypto-random-string": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "inBundle": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/d": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/d/node_modules/type": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/data-uri-to-buffer": {
+      "version": "4.0.0",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/debounce-fn": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/debounce-fn/node_modules/mimic-fn": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/debug": {
+      "version": "4.3.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/decompress-response": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/deep-extend": {
+      "version": "0.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/deep-is": {
+      "version": "0.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/defaults": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/define-properties": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/degenerator": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.2",
+        "escodegen": "^1.8.1",
+        "esprima": "^4.0.0",
+        "vm2": "^3.9.8"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/depd": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/dependency-graph": {
+      "version": "0.11.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/deprecation": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/destroy": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/destroyable-server": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/dot-prop": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/duplexify": {
+      "version": "3.7.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/duplexify/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/duplexify/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/duplexify/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/duration": {
+      "version": "0.2.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.46"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ee-first": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/env-paths": {
+      "version": "2.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/es-abstract": {
+      "version": "1.20.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
+        "get-intrinsic": "^1.1.3",
+        "get-symbol-description": "^1.0.0",
+        "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.7",
+        "is-negative-zero": "^2.0.2",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.2",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "safe-regex-test": "^1.0.0",
+        "string.prototype.trimend": "^1.0.5",
+        "string.prototype.trimstart": "^1.0.5",
+        "unbox-primitive": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/es-aggregate-error": {
+      "version": "1.0.9",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "function-bind": "^1.1.1",
+        "functions-have-names": "^1.2.3",
+        "get-intrinsic": "^1.1.3",
+        "globalthis": "^1.0.3",
+        "has-property-descriptors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/es5-ext": {
+      "version": "0.10.62",
+      "hasInstallScript": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/es6-symbol": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/es6-weak-map": {
+      "version": "2.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/escalade": {
+      "version": "3.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/escape-goat": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/escape-html": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/escodegen": {
+      "version": "1.14.3",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/escodegen/node_modules/estraverse": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/escodegen/node_modules/levn": {
+      "version": "0.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/escodegen/node_modules/optionator": {
+      "version": "0.8.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/esprima": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/esutils": {
+      "version": "2.0.3",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/etag": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/event-emitter": {
+      "version": "0.3.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/express": {
+      "version": "4.18.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.1",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.5.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.2.0",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.11.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/express-graphql": {
+      "version": "0.11.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.7",
+        "content-type": "^1.0.4",
+        "http-errors": "1.8.0",
+        "raw-body": "^2.4.1"
+      },
+      "engines": {
+        "node": ">= 10.x"
+      },
+      "peerDependencies": {
+        "graphql": "^14.7.0 || ^15.3.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/express-graphql/node_modules/depd": {
+      "version": "1.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/express-graphql/node_modules/http-errors": {
+      "version": "1.8.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/express-graphql/node_modules/statuses": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/express-graphql/node_modules/toidentifier": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/express/node_modules/content-disposition": {
+      "version": "0.5.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/express/node_modules/cookie": {
+      "version": "0.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/express/node_modules/finalhandler": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/express/node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ext": {
+      "version": "1.7.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "type": "^2.7.2"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/fast-json-patch": {
+      "version": "3.1.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/fast-memoize": {
+      "version": "2.5.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "extraneous": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/file-uri-to-path": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/finalhandler": {
+      "version": "1.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/finalhandler/node_modules/on-finished": {
+      "version": "2.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/finalhandler/node_modules/statuses": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/form-data": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/form-data-encoder": {
+      "version": "2.1.3",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.17"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/forwarded": {
+      "version": "0.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/fresh": {
+      "version": "0.5.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ftp": {
+      "version": "0.3.10",
+      "inBundle": true,
+      "dependencies": {
+        "readable-stream": "1.1.x",
+        "xregexp": "2.0.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ftp/node_modules/isarray": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ftp/node_modules/readable-stream": {
+      "version": "1.1.14",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/function-bind": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/function.prototype.name": {
+      "version": "1.1.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/get-intrinsic": {
+      "version": "1.1.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/get-stream": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/get-symbol-description": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/get-uri": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "data-uri-to-buffer": "3",
+        "debug": "4",
+        "file-uri-to-path": "2",
+        "fs-extra": "^8.1.0",
+        "ftp": "^0.3.10"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/get-uri/node_modules/data-uri-to-buffer": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/get-uri/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/get-uri/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/get-uri/node_modules/universalify": {
+      "version": "0.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/glob": {
+      "version": "7.2.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/globalthis": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/got": {
+      "version": "12.5.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^5.2.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^10.2.1",
+        "decompress-response": "^6.0.0",
+        "form-data-encoder": "^2.1.2",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/got/node_modules/cacheable-lookup": {
+      "version": "7.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/got/node_modules/http2-wrapper": {
+      "version": "2.1.11",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/graphql": {
+      "version": "15.8.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/graphql-subscriptions": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "iterall": "^1.3.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.10.5 || ^0.11.3 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/graphql-tag": {
+      "version": "2.12.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/har-schema": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/has": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/has-bigints": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/has-flag": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/has-property-descriptors": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/has-symbols": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/has-tostringtag": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/has-yarn": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/http-cache-semantics": {
+      "version": "4.1.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/http-encoding": {
+      "version": "1.5.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "brotli-wasm": "^1.1.0",
+        "pify": "^5.0.0",
+        "zstd-codec": "^0.1.4"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/http-encoding/node_modules/pify": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/http-errors": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/http2-wrapper": {
+      "version": "2.0.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ieee754": {
+      "version": "1.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/immer": {
+      "version": "9.0.16",
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/import-lazy": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/inflight": {
+      "version": "1.0.6",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/inherits": {
+      "version": "2.0.4",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ini": {
+      "version": "1.3.8",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/internal-slot": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ip": {
+      "version": "1.1.8",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-bigint": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-boolean-object": {
+      "version": "1.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-buffer": {
+      "version": "1.1.6",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-callable": {
+      "version": "1.2.7",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-ci": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^3.2.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-date-object": {
+      "version": "1.0.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-docker": {
+      "version": "2.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-installed-globally": {
+      "version": "0.4.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-dirs": "^3.0.0",
+        "is-path-inside": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-installed-globally/node_modules/global-dirs": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-installed-globally/node_modules/ini": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-interactive": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-negative-zero": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-npm": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-number-object": {
+      "version": "1.0.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-obj": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-regex": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-retry-allowed": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-shared-array-buffer": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-string": {
+      "version": "1.0.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-symbol": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-url": {
+      "version": "1.2.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-weakref": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/is-yarn-global": {
+      "version": "0.4.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/isarray": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/iterall": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/join-component": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/jsep": {
+      "version": "1.3.7",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/json-buffer": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/json-schema-typed": {
+      "version": "7.0.3",
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/json-stable-stringify": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonify": "~0.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/jsonc-parser": {
+      "version": "2.2.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/jsonify": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/jsonpath-plus": {
+      "version": "7.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/jsonpointer": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/keyv": {
+      "version": "4.5.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/latest-version": {
+      "version": "7.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-json": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/leven": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/lodash": {
+      "version": "4.17.21",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/lodash.omit": {
+      "version": "4.5.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/lodash.pick": {
+      "version": "4.4.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/lodash.topath": {
+      "version": "4.5.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/log": {
+      "version": "6.3.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "duration": "^0.2.2",
+        "es5-ext": "^0.10.53",
+        "event-emitter": "^0.3.5",
+        "sprintf-kit": "^2.0.1",
+        "type": "^2.5.0",
+        "uni-global": "^1.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/log-node": {
+      "version": "8.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "cli-color": "^2.0.1",
+        "cli-sprintf-format": "^1.1.1",
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.53",
+        "sprintf-kit": "^2.0.1",
+        "supports-color": "^8.1.1",
+        "type": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "peerDependencies": {
+        "log": "^6.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/log-node/node_modules/has-flag": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/log-node/node_modules/supports-color": {
+      "version": "8.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/log-symbols": {
+      "version": "5.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.0.0",
+        "is-unicode-supported": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/log-symbols/node_modules/chalk": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/loglevel": {
+      "version": "1.8.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/lowercase-keys": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/lru_map": {
+      "version": "0.3.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/lru-queue": {
+      "version": "0.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "es5-ext": "~0.10.2"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/md5": {
+      "version": "2.3.0",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/media-typer": {
+      "version": "0.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/memoizee": {
+      "version": "0.4.15",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.53",
+        "es6-weak-map": "^2.0.3",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.2.2",
+        "lru-queue": "^0.1.0",
+        "next-tick": "^1.1.0",
+        "timers-ext": "^0.1.7"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/memoizee/node_modules/is-promise": {
+      "version": "2.2.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/methods": {
+      "version": "1.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/mime-db": {
+      "version": "1.52.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/minimatch": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/minimist": {
+      "version": "1.2.7",
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/mockttp": {
+      "version": "3.5.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@graphql-tools/schema": "^8.5.0",
+        "@graphql-tools/utils": "^8.8.0",
+        "@httptoolkit/httpolyglot": "^2.1.0",
+        "@httptoolkit/subscriptions-transport-ws": "^0.11.2",
+        "@httptoolkit/websocket-stream": "^6.0.1",
+        "@types/cors": "^2.8.6",
+        "@types/node": "*",
+        "base64-arraybuffer": "^0.1.5",
+        "body-parser": "^1.15.2",
+        "cacheable-lookup": "^6.0.0",
+        "common-tags": "^1.8.0",
+        "connect": "^3.7.0",
+        "cors": "^2.8.4",
+        "cors-gate": "^1.1.3",
+        "cross-fetch": "^3.1.5",
+        "destroyable-server": "^1.0.0",
+        "express": "^4.14.0",
+        "express-graphql": "^0.11.0",
+        "graphql": "^14.0.2 || ^15.5",
+        "graphql-subscriptions": "^1.1.0",
+        "graphql-tag": "^2.12.6",
+        "http-encoding": "^1.5.1",
+        "http2-wrapper": "2.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "isomorphic-ws": "^4.0.1",
+        "lodash": "^4.16.4",
+        "lru-cache": "^7.14.0",
+        "native-duplexpair": "^1.0.0",
+        "node-forge": "^1.2.1",
+        "pac-proxy-agent": "^5.0.0",
+        "parse-multipart-data": "^1.4.0",
+        "performance-now": "^2.1.0",
+        "portfinder": "1.0.28",
+        "read-tls-client-hello": "^1.0.0",
+        "socks-proxy-agent": "^7.0.0",
+        "typed-error": "^3.0.2",
+        "uuid": "^8.3.2",
+        "ws": "^8.8.0"
+      },
+      "bin": {
+        "mockttp": "dist/admin/admin-bin.js"
+      },
+      "engines": {
+        "node": ">=14.14.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/mockttp/node_modules/@graphql-tools/utils": {
+      "version": "8.13.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/mockttp/node_modules/debug": {
+      "version": "3.2.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/mockttp/node_modules/lru-cache": {
+      "version": "7.14.1",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/mockttp/node_modules/portfinder": {
+      "version": "1.0.28",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.5"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ms": {
+      "version": "2.1.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/native-duplexpair": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/negotiator": {
+      "version": "0.6.3",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/netmask": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/next-tick": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/nimma": {
+      "version": "0.2.2",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsep-plugin/regex": "^1.0.1",
+        "@jsep-plugin/ternary": "^1.0.2",
+        "astring": "^1.8.1",
+        "jsep": "^1.2.0"
+      },
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      },
+      "optionalDependencies": {
+        "jsonpath-plus": "^6.0.1",
+        "lodash.topath": "^4.5.2"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/nimma/node_modules/jsonpath-plus": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/node-abort-controller": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/node-domexception": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/node-fetch": {
+      "version": "3.2.10",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/node-forge": {
+      "version": "1.3.1",
+      "inBundle": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/node-machine-id": {
+      "version": "1.1.12",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/noms": {
+      "version": "0.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/noms/node_modules/isarray": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/noms/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/normalize-url": {
+      "version": "7.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/object-assign": {
+      "version": "4.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/object-inspect": {
+      "version": "1.12.2",
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/object-keys": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/object.assign": {
+      "version": "4.1.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/on-finished": {
+      "version": "2.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/once": {
+      "version": "1.4.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/onetime": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/open": {
+      "version": "8.4.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/openapi-types": {
+      "version": "12.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ora": {
+      "version": "6.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^5.0.0",
+        "chalk": "^5.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-spinners": "^2.6.1",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^1.1.0",
+        "log-symbols": "^5.1.0",
+        "strip-ansi": "^7.0.1",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ora/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ora/node_modules/chalk": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ora/node_modules/strip-ansi": {
+      "version": "7.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/p-cancelable": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/p-try": {
+      "version": "2.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/pac-proxy-agent": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4",
+        "get-uri": "3",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "5",
+        "pac-resolver": "^5.0.0",
+        "raw-body": "^2.2.0",
+        "socks-proxy-agent": "5"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/pac-proxy-agent/node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/pac-proxy-agent/node_modules/socks-proxy-agent": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "4",
+        "socks": "^2.3.3"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/pac-resolver": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^3.0.2",
+        "ip": "^1.1.5",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/package-json": {
+      "version": "8.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "got": "^12.1.0",
+        "registry-auth-token": "^5.0.1",
+        "registry-url": "^6.0.0",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/parse-multipart-data": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/parseurl": {
+      "version": "1.3.3",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/performance-now": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/picomatch": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/pkg-up": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/pkg-up/node_modules/find-up": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/pkg-up/node_modules/locate-path": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/pkg-up/node_modules/p-limit": {
+      "version": "2.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/pkg-up/node_modules/p-locate": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/pkg-up/node_modules/path-exists": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/pony-cause": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "0BSD",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/portfinder": {
+      "version": "1.0.32",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^2.6.4",
+        "debug": "^3.2.7",
+        "mkdirp": "^0.5.6"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/portfinder/node_modules/debug": {
+      "version": "3.2.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "inBundle": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/proto-list": {
+      "version": "1.2.4",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/punycode": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/pupa": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-goat": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/qs": {
+      "version": "6.11.0",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/quick-lru": {
+      "version": "5.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/range-parser": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/raw-body": {
+      "version": "2.5.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/raw-body/node_modules/bytes": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/rc": {
+      "version": "1.2.8",
+      "inBundle": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/read-tls-client-hello": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/readable-stream/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/regexp.prototype.flags": {
+      "version": "1.4.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/registry-auth-token": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/npm-conf": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/registry-url": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "1.2.8"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/remove-trailing-slash": {
+      "version": "0.1.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/require-directory": {
+      "version": "2.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/responselike": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/safe-regex-test": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/semver": {
+      "version": "7.3.8",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/semver-diff": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/send": {
+      "version": "0.18.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/send/node_modules/mime": {
+      "version": "1.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/serve-static": {
+      "version": "1.15.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.18.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/side-channel": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/simple-eval": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsep": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/socks": {
+      "version": "2.7.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/socks-proxy-agent": {
+      "version": "7.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/socks/node_modules/ip": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/source-map": {
+      "version": "0.6.1",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/sprintf-kit": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.53"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/statuses": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/stream-chain": {
+      "version": "2.2.5",
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/stream-json": {
+      "version": "1.7.4",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-chain": "^2.2.5"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/stream-shift": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/string.prototype.trimend": {
+      "version": "1.0.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/string.prototype.trimstart": {
+      "version": "1.0.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/supports-color": {
+      "version": "7.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/supports-color/node_modules/has-flag": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/symbol-observable": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/timers-ext": {
+      "version": "0.1.7",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "~0.10.46",
+        "next-tick": "1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/toidentifier": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/tr46": {
+      "version": "0.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ts-invariant": {
+      "version": "0.9.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ts-results": {
+      "version": "3.3.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/tslib": {
+      "version": "2.4.1",
+      "inBundle": true,
+      "license": "0BSD"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/type": {
+      "version": "2.7.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/type-check": {
+      "version": "0.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/type-is": {
+      "version": "1.6.18",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/typed-error": {
+      "version": "3.2.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/typedarray-to-buffer": {
+      "version": "3.1.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/unbox-primitive": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/uni-global": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "type": "^2.5.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/unique-string": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/universal-user-agent": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/universalify": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/unpipe": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/untildify": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/upath": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/update-notifier": {
+      "version": "6.0.2",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boxen": "^7.0.0",
+        "chalk": "^5.0.1",
+        "configstore": "^6.0.0",
+        "has-yarn": "^3.0.0",
+        "import-lazy": "^4.0.0",
+        "is-ci": "^3.0.1",
+        "is-installed-globally": "^0.4.0",
+        "is-npm": "^6.0.0",
+        "is-yarn-global": "^0.4.0",
+        "latest-version": "^7.0.0",
+        "pupa": "^3.1.0",
+        "semver": "^7.3.7",
+        "semver-diff": "^4.0.0",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/yeoman/update-notifier?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/update-notifier/node_modules/chalk": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/uri-js": {
+      "version": "4.4.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/urijs": {
+      "version": "1.19.11",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/url-join": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/utility-types": {
+      "version": "3.10.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/utils-merge": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/uuid": {
+      "version": "8.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/value-or-promise": {
+      "version": "1.0.11",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/vary": {
+      "version": "1.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/vm2": {
+      "version": "3.9.18",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.7.0",
+        "acorn-walk": "^8.2.0"
+      },
+      "bin": {
+        "vm2": "bin/vm2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/wcwidth": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "extraneous": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/widest-line": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/widest-line/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/widest-line/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/widest-line/node_modules/string-width": {
+      "version": "5.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/widest-line/node_modules/strip-ansi": {
+      "version": "7.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/word-wrap": {
+      "version": "1.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/wrappy": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/write-file-atomic": {
+      "version": "3.0.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/ws": {
+      "version": "8.11.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/xdg-basedir": {
+      "version": "5.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/xregexp": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/xtend": {
+      "version": "4.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/y18n": {
+      "version": "5.0.8",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/yallist": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@snyk/sweater-comb/node_modules/zstd-codec": {
+      "version": "0.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/capital-case": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+      "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^4.1.2",
+        "get-func-name": "^2.0.0",
+        "loupe": "^2.3.1",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/change-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "capital-case": "^1.0.4",
+        "constant-case": "^3.0.4",
+        "dot-case": "^3.0.4",
+        "header-case": "^2.0.4",
+        "no-case": "^3.0.4",
+        "param-case": "^3.0.4",
+        "pascal-case": "^3.1.2",
+        "path-case": "^3.0.4",
+        "sentence-case": "^3.0.4",
+        "snake-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/constant-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case": "^2.0.2"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/find-parent-dir": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.1.tgz",
+      "integrity": "sha512-o4UcykWV/XN9wm+jMEtWLPlV8RXCZnMhQI6F6OdHeSez7iiJWePw8ijOlskJZMsaQoGR/b7dH6lO02HhaTN7+A=="
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/header-case": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+      "dependencies": {
+        "capital-case": "^1.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "dependencies": {
+        "get-func-name": "^2.0.0"
+      }
+    },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/nice-try": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-3.0.1.tgz",
+      "integrity": "sha512-Fge6ClHO5v/z/tN31B2wlCPfRm289/ag1O2oi+EWNdAhxOZqGW1fWsisROvUuXaE7UEAYdd+upiAMvz57bK2MQ=="
+    },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/parse-path": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.0.0.tgz",
+      "integrity": "sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==",
+      "dependencies": {
+        "protocols": "^2.0.0"
+      }
+    },
+    "node_modules/parse-url": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-8.1.0.tgz",
+      "integrity": "sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==",
+      "dependencies": {
+        "parse-path": "^7.0.0"
+      }
+    },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/path-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/protocols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
+      "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q=="
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sentence-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3",
+        "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/snake-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/upper-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/upper-case-first": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/test/acceptance/workspaces/npm-package-lockfile-v3-bundled-deps/package.json
+++ b/test/acceptance/workspaces/npm-package-lockfile-v3-bundled-deps/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "bundled-deps",
+  "dependencies": {
+    "@snyk/sweater-comb": "^1.24.0"
+  }
+}

--- a/test/tap/cli-test/cli-test.npm.spec.ts
+++ b/test/tap/cli-test/cli-test.npm.spec.ts
@@ -45,6 +45,19 @@ export const NpmTests: AcceptanceTests = {
       );
     },
 
+    '`test npm-package with lockfile v3 bundled deps`': (
+      params,
+      utils,
+    ) => async (t) => {
+      utils.chdirWorkspaces();
+      const res = await params.cli.test('npm-package-lockfile-v3-bundled-deps');
+      t.match(
+        res,
+        /Tested 570 dependencies for known vulnerabilities/,
+        'should succeed scanning npm lock v3 with bundled deps',
+      );
+    },
+
     'test npm-package remoteUrl': (params, utils) => async (t) => {
       utils.chdirWorkspaces();
       process.env.GIT_DIR = 'npm-package/gitdir';


### PR DESCRIPTION
This bumps nodejs parser 1.52.1

The changes in this lib update allow more accurate dependency resolution of transitive dependencies in npm lockfile v2 and v3 projects that use bundled dependencies. 

There is an [existing acceptance test](https://github.com/snyk/cli/blob/master/test/tap/cli-test/cli-test.npm.spec.ts#L36-L46) that should cover any breaking behavior and we have added a new one that takes a test fixture from the library to add another layer of testing on this specific feature.