### PR TITLE
fix: updates snyk-policy to lastest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "snyk-nodejs-lockfile-parser": "1.52.1",
         "snyk-nuget-plugin": "1.24.1",
         "snyk-php-plugin": "1.9.2",
-        "snyk-policy": "^1.25.0",
+        "snyk-policy": "^2.0.8",
         "snyk-python-plugin": "^1.25.3",
         "snyk-resolve-deps": "4.7.3",
         "snyk-sbt-plugin": "2.17.1",
@@ -17917,15 +17917,14 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-policy": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-1.25.0.tgz",
-      "integrity": "sha512-naAoqjlspwioBDlrSk5/pPGlSX2dMG42XDhoUdU/41NPS57jsifpENgiT83HEJDbTRGHOPTmQ1B4lvRupb70hQ==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-2.0.8.tgz",
+      "integrity": "sha512-kTLtcPpJVvczreZfTqZdTPpqb19GAIWUd5pY8Y2NDrdHMXuUJY5QKFzMuT/UppJ79sxM0Ozra3M7CLH9WeJViQ==",
       "dependencies": {
         "debug": "^4.1.1",
         "email-validator": "^2.0.4",
         "js-yaml": "^3.13.1",
         "lodash.clonedeep": "^4.5.0",
-        "promise-fs": "^2.1.1",
         "semver": "^7.3.4",
         "snyk-module": "^3.0.0",
         "snyk-resolve": "^1.1.0",
@@ -35023,15 +35022,14 @@
       }
     },
     "snyk-policy": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-1.25.0.tgz",
-      "integrity": "sha512-naAoqjlspwioBDlrSk5/pPGlSX2dMG42XDhoUdU/41NPS57jsifpENgiT83HEJDbTRGHOPTmQ1B4lvRupb70hQ==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-2.0.8.tgz",
+      "integrity": "sha512-kTLtcPpJVvczreZfTqZdTPpqb19GAIWUd5pY8Y2NDrdHMXuUJY5QKFzMuT/UppJ79sxM0Ozra3M7CLH9WeJViQ==",
       "requires": {
         "debug": "^4.1.1",
         "email-validator": "^2.0.4",
         "js-yaml": "^3.13.1",
         "lodash.clonedeep": "^4.5.0",
-        "promise-fs": "^2.1.1",
         "semver": "^7.3.4",
         "snyk-module": "^3.0.0",
         "snyk-resolve": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "snyk-nodejs-lockfile-parser": "1.52.1",
     "snyk-nuget-plugin": "1.24.1",
     "snyk-php-plugin": "1.9.2",
-    "snyk-policy": "^1.25.0",
+    "snyk-policy": "^2.0.8",
     "snyk-python-plugin": "^1.25.3",
     "snyk-resolve-deps": "4.7.3",
     "snyk-sbt-plugin": "2.17.1",

--- a/test/acceptance/workspaces/npm-package-policy/.snyk
+++ b/test/acceptance/workspaces/npm-package-policy/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.25.0
+version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   'npm:marked:20170907':

--- a/test/acceptance/workspaces/npm-package-policy/custom-location/.snyk
+++ b/test/acceptance/workspaces/npm-package-policy/custom-location/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.25.0
+version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   'npm:marked:20170907':

--- a/test/acceptance/workspaces/npm-with-dep-missing-policy/.snyk
+++ b/test/acceptance/workspaces/npm-with-dep-missing-policy/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.25.0
+version: v1.25.1
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 patch:

--- a/test/jest/unit/iac/cli-share-results.fixtures.ts
+++ b/test/jest/unit/iac/cli-share-results.fixtures.ts
@@ -173,7 +173,7 @@ export const expectedEnvelopeFormatterResultsWithPolicy = expectedEnvelopeFormat
     return {
       ...result,
       policy: `# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.25.0
+version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-CC-TF-4:


### PR DESCRIPTION
#### What does this PR do?

This updates snyk-policy to the latest version, to remove an error
with ignores failing because of ID casing.

Ignores are not meant to be case sensitive, but the IDs were being
interpreted as though they were, leading to ignores that didn't work.

This has already been updated in app.snyk.io, but is still an issue
in the CLI.


https://snyksec.atlassian.net/browse/NARW-2259