### PR TITLE
chore: increase timeout to avoid flaky tests

### DIFF
--- a/test/jest/acceptance/snyk-test/app-vuln-container-project.spec.ts
+++ b/test/jest/acceptance/snyk-test/app-vuln-container-project.spec.ts
@@ -11,7 +11,7 @@ describe('container test projects behavior with --app-vulns, --file and --exclud
     const jsonOutput = JSON.parse(stdout);
     expect(jsonOutput.ok).toEqual(true);
     expect(code).toEqual(0);
-  }, 10000);
+  }, 30000);
   it('should find all vulns including app vulns', async () => {
     const { code, stdout } = await runSnykCLI(
       `container test docker-archive:test/fixtures/container-projects/os-packages-and-app-vulns.tar --json --experimental`,
@@ -23,7 +23,7 @@ describe('container test projects behavior with --app-vulns, --file and --exclud
     expect(jsonOutput[1].ok).toEqual(false);
     expect(jsonOutput[1].uniqueCount).toBeGreaterThan(0);
     expect(code).toEqual(1);
-  }, 10000);
+  }, 30000);
   it('should find nothing when app-vulns are explicitly disabled', async () => {
     const { code, stdout } = await runSnykCLI(
       `container test docker-archive:test/fixtures/container-projects/os-packages-and-app-vulns.tar --json --exclude-app-vulns`,
@@ -34,7 +34,7 @@ describe('container test projects behavior with --app-vulns, --file and --exclud
     expect(jsonOutput.ok).toEqual(false);
     expect(jsonOutput.uniqueCount).toBeGreaterThan(0);
     expect(code).toEqual(1);
-  }, 10000);
+  }, 30000);
   it('should find nothing on conflicting app-vulns flags', async () => {
     // if both flags are set, --exclude-app-vulns should take precedence and
     // disable it.
@@ -47,7 +47,7 @@ describe('container test projects behavior with --app-vulns, --file and --exclud
     expect(jsonOutput.ok).toEqual(false);
     expect(jsonOutput.uniqueCount).toBeGreaterThan(0);
     expect(code).toEqual(1);
-  }, 10000);
+  }, 30000);
 
   it('should show app vulns tip when available', async () => {
     const { stdout } = await runSnykCLI(
@@ -55,7 +55,7 @@ describe('container test projects behavior with --app-vulns, --file and --exclud
     );
 
     expect(stdout).toContain(`Testing docker-archive:test`);
-  }, 10000);
+  }, 30000);
 
   it('should find all vulns without experimental flag', async () => {
     const { code, stdout } = await runSnykCLI(
@@ -70,7 +70,7 @@ describe('container test projects behavior with --app-vulns, --file and --exclud
     expect(applications[0].uniqueCount).toBeGreaterThan(0);
     expect(applications[0].ok).toEqual(false);
     expect(code).toEqual(1);
-  }, 10000);
+  }, 30000);
   it('should return only dockerfile instructions vulnerabilities when excluding base image vulns', async () => {
     const dockerfilePath = path.normalize(
       'test/fixtures/container-projects/Dockerfile-vulns',
@@ -84,7 +84,7 @@ describe('container test projects behavior with --app-vulns, --file and --exclud
     expect(jsonOutput.ok).toEqual(false);
     expect(jsonOutput.uniqueCount).toBeGreaterThan(0);
     expect(code).toEqual(1);
-  }, 10000);
+  }, 30000);
 
   it('finds dockerfile instructions and app vulns when excluding base image vulns', async () => {
     const dockerfilePath = path.normalize(
@@ -101,7 +101,7 @@ describe('container test projects behavior with --app-vulns, --file and --exclud
     expect(jsonOutput.applications[0].ok).toEqual(false);
     expect(jsonOutput.applications[0].uniqueCount).toBeGreaterThan(0);
     expect(code).toEqual(1);
-  }, 10000);
+  }, 30000);
 });
 
 describe('container test projects behavior with --json flag', () => {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Increased timeout from 10s to 30s, to avoid test flakiness.
