### PR TITLE
chore: upgrade snyk-iac-test to latest (latest rules bundle and policy engine)

### DIFF
--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -2,11 +2,11 @@ import * as os from 'os';
 
 // TODO: update!
 const policyEngineChecksums = `
-1577b258cbdd083b232f5a4d6e579f57678a42bf17cf5cec812e50aa9f400f35  snyk-iac-test_0.47.2_Darwin_arm64
-4e76a831c087e1e9dacf278a4b4c3b01f4ffeb49c15ce1192fd36c580ece30fc  snyk-iac-test_0.47.2_Linux_x86_64
-a420d4655be8fde67652461d1c311c912f1fa99a07989f752a1e9fd54303b5b9  snyk-iac-test_0.47.2_Darwin_x86_64
-b4e68106d88b7e28d089289b9ee73abe6025df0307e189397f17d88002029d9e  snyk-iac-test_0.47.2_Windows_x86_64.exe
-c1ca5fbf2fb09e99b95bef456e0f360fbe5a5068d9b5a6dcfd4efea16add6681  snyk-iac-test_0.47.2_Linux_arm64
+20626360388524d227bdf81879c68c7f8ad0dd2bba4c7e42c349743852b0b2b9  snyk-iac-test_0.47.3_Windows_x86_64.exe
+74543f6531114be163d29cb94df97eea3e7dd339215d4bf916cef6e5602e70b3  snyk-iac-test_0.47.3_Linux_x86_64
+b241a20badec080b2e22def46dd0aa7e5d9d2141724f6829e289f12eb4274fd7  snyk-iac-test_0.47.3_Linux_arm64
+b7391c1db40da0a280a97f45bc3734f7e7f2502458bd66a48c5338e0f2bb1f54  snyk-iac-test_0.47.3_Darwin_x86_64
+b97aa3e5ef2bc1cfd282f6db6189e137be31f9847b61e57c4b9f525588fe95d5  snyk-iac-test_0.47.3_Darwin_arm64
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();

--- a/test/jest/acceptance/iac/test-cloudformation.spec.ts
+++ b/test/jest/acceptance/iac/test-cloudformation.spec.ts
@@ -40,12 +40,7 @@ describe('CloudFormation single file scan', () => {
     expect(stdout).toContain(
       'File:    ./iac/cloudformation/fargate-valid.json',
     );
-    expect(stdout).toContain('S3 restrict public bucket control is disabled');
-    expect(stdout).toContain(
-      '  Path:    Resources[CodePipelineArtifactBucket] > Properties >' +
-        EOL +
-        '           PublicAccessBlockConfiguration > RestrictPublicBuckets',
-    );
+    expect(stdout).toContain('SNYK-CC-TF-124');
     expect(exitCode).toBe(1);
   });
 


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Upgrades `snyk-iac-test` to latest that has the latest rules bundle and policy engine

#### Where should the reviewer start?

The checksums are from here: https://github.com/snyk/snyk-iac-test/releases/tag/v0.47.3

#### How should this be manually tested?

Have an org with integrated IaC and try `snyk iac test` for it.

#### Any background context you want to provide?

-

#### What are the relevant tickets?

-

#### Screenshots

-

#### Additional questions

-