### PR TITLE
fix: restore ability for snyk fix to make network requests [FIX-138]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,7 @@ commands:
           name: Installing sdks and tools
           command: |
             brew install go gradle python elixir composer gradle@6 maven sbt
+            python3 -m pip install pipenv --user
 
   install_sdks_linux:
     steps:
@@ -108,6 +109,7 @@ commands:
             jq
 
             pip install awscli --upgrade --user
+            pip install pipenv --user
 
             echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
             echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
@@ -249,6 +251,7 @@ jobs:
           name: Installing Node.js + other test dependencies
           command: |
             apk add --update nodejs npm bash maven git go gradle python3 py3-pip elixir composer
+            pip3 install pipenv
       - run:
           name: Configuring artifact
           command: << parameters.test_snyk_command >> config set "api=${SNYK_API_KEY}"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 *  @snyk/hammerhead @snyk/snyk-open-source
 
 # monorepo packages
-packages/snyk-fix/ @snyk/tech-services
+packages/snyk-fix/ @snyk/fix
 packages/snyk-protect/ @snyk/hammerhead
 packages/cli-alert/ @snyk/hammerhead
 packages/iac-cli-alert/ @snyk/cloud-dev-ex

--- a/package-lock.json
+++ b/package-lock.json
@@ -2004,17 +2004,22 @@
       }
     },
     "node_modules/@snyk/child-process": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@snyk/child-process/-/child-process-0.3.3.tgz",
-      "integrity": "sha512-EXSiKYAKvYCBUtIcPwkn1Q8/8LpfYGKsABkLsoTlHom7wYAfvklqbjSfHE16IRkZqDkfPU/t/ck3vRXTxNRXcQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@snyk/child-process/-/child-process-0.4.1.tgz",
+      "integrity": "sha512-iu8gfPqp1YT8qjtIqerG7aRiKuzsH0tOeA+uY6m6gvnSXf1SgYEUTPuhfN4/vOikQ+wQb6SQlTBxkr6yIWBx+Q==",
       "dependencies": {
-        "debug": "^4.1.1",
-        "source-map-support": "^0.5.16",
-        "tslib": "^1.10.0"
+        "debug": "^4.3.4",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.6.0"
       },
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@snyk/child-process/node_modules/tslib": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/@snyk/cli-alert": {
       "resolved": "packages/cli-alert",
@@ -2290,48 +2295,42 @@
       "link": true
     },
     "node_modules/@snyk/fix-pipenv-pipfile": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@snyk/fix-pipenv-pipfile/-/fix-pipenv-pipfile-0.6.0.tgz",
-      "integrity": "sha512-6iA0rMZcOyBUFGkhzVk7Snd3JubenGRjB8sAkips7baNTL1aVKuAsaMhldQvNj5eWUrNO8r1bB91cbISW9nHfQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@snyk/fix-pipenv-pipfile/-/fix-pipenv-pipfile-0.7.1.tgz",
+      "integrity": "sha512-lE13h/Xwz5/M7OmpZAoDTrBU1UllF+J4JizksJoOITa8X9gowSuV4csvz9vF1C/Ik8bfDWFMsEgtjYBdfb4vTw==",
       "dependencies": {
-        "@snyk/child-process": "^0.3.3",
-        "bottleneck": "2.19.5",
-        "debug": "4.3.1",
-        "tslib": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@snyk/fix-pipenv-pipfile/node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@snyk/fix-poetry": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@snyk/fix-poetry/-/fix-poetry-0.8.3.tgz",
-      "integrity": "sha512-bRtRZhz0vVisPPHP19Is4nM8Zugz5nQlLyUTWaY+rpCOlnKlffMY/0uS9rVb3AbCpxuNfhslrT+TNJFAbGLWQg==",
-      "dependencies": {
-        "@snyk/child-process": "^0.3.3",
+        "@snyk/child-process": "^0.4.1",
         "bottleneck": "2.19.5",
         "debug": "4.3.4",
-        "tslib": "^1.10.0"
+        "tslib": "^2.6.0"
       },
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@snyk/fix-pipenv-pipfile/node_modules/tslib": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+    },
+    "node_modules/@snyk/fix-poetry": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@snyk/fix-poetry/-/fix-poetry-0.9.1.tgz",
+      "integrity": "sha512-bs+sDe8M8gGjaRWgzNsHSH0Tywy6wFIvfF2M1SbKFy24jWvqij6iFBbtWeMpuLk7iC3/uAyIjFcjJqxAuKBung==",
+      "dependencies": {
+        "@snyk/child-process": "^0.4.1",
+        "bottleneck": "2.19.5",
+        "debug": "4.3.4",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@snyk/fix-poetry/node_modules/tslib": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/@snyk/gemfile": {
       "version": "1.2.0",
@@ -18148,9 +18147,9 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -20814,8 +20813,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@snyk/dep-graph": "^1.21.0",
-        "@snyk/fix-pipenv-pipfile": "0.6.0",
-        "@snyk/fix-poetry": "0.8.3",
+        "@snyk/fix-pipenv-pipfile": "^0.7.1",
+        "@snyk/fix-poetry": "^0.9.1",
         "chalk": "4.1.1",
         "debug": "^4.3.1",
         "lodash.groupby": "4.6.0",
@@ -22405,13 +22404,20 @@
       }
     },
     "@snyk/child-process": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@snyk/child-process/-/child-process-0.3.3.tgz",
-      "integrity": "sha512-EXSiKYAKvYCBUtIcPwkn1Q8/8LpfYGKsABkLsoTlHom7wYAfvklqbjSfHE16IRkZqDkfPU/t/ck3vRXTxNRXcQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@snyk/child-process/-/child-process-0.4.1.tgz",
+      "integrity": "sha512-iu8gfPqp1YT8qjtIqerG7aRiKuzsH0tOeA+uY6m6gvnSXf1SgYEUTPuhfN4/vOikQ+wQb6SQlTBxkr6yIWBx+Q==",
       "requires": {
-        "debug": "^4.1.1",
-        "source-map-support": "^0.5.16",
-        "tslib": "^1.10.0"
+        "debug": "^4.3.4",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.6.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+        }
       }
     },
     "@snyk/cli-alert": {
@@ -22656,8 +22662,8 @@
       "version": "file:packages/snyk-fix",
       "requires": {
         "@snyk/dep-graph": "^1.21.0",
-        "@snyk/fix-pipenv-pipfile": "0.6.0",
-        "@snyk/fix-poetry": "0.8.3",
+        "@snyk/fix-pipenv-pipfile": "0.7.1",
+        "@snyk/fix-poetry": "0.9.1",
         "chalk": "4.1.1",
         "debug": "^4.3.1",
         "lodash.groupby": "4.6.0",
@@ -22774,35 +22780,39 @@
       }
     },
     "@snyk/fix-pipenv-pipfile": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@snyk/fix-pipenv-pipfile/-/fix-pipenv-pipfile-0.6.0.tgz",
-      "integrity": "sha512-6iA0rMZcOyBUFGkhzVk7Snd3JubenGRjB8sAkips7baNTL1aVKuAsaMhldQvNj5eWUrNO8r1bB91cbISW9nHfQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@snyk/fix-pipenv-pipfile/-/fix-pipenv-pipfile-0.7.1.tgz",
+      "integrity": "sha512-lE13h/Xwz5/M7OmpZAoDTrBU1UllF+J4JizksJoOITa8X9gowSuV4csvz9vF1C/Ik8bfDWFMsEgtjYBdfb4vTw==",
       "requires": {
-        "@snyk/child-process": "^0.3.3",
+        "@snyk/child-process": "^0.4.1",
         "bottleneck": "2.19.5",
-        "debug": "4.3.1",
-        "tslib": "^1.10.0"
+        "debug": "4.3.4",
+        "tslib": "^2.6.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "requires": {
-            "ms": "2.1.2"
-          }
+        "tslib": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
         }
       }
     },
     "@snyk/fix-poetry": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@snyk/fix-poetry/-/fix-poetry-0.8.3.tgz",
-      "integrity": "sha512-bRtRZhz0vVisPPHP19Is4nM8Zugz5nQlLyUTWaY+rpCOlnKlffMY/0uS9rVb3AbCpxuNfhslrT+TNJFAbGLWQg==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@snyk/fix-poetry/-/fix-poetry-0.9.1.tgz",
+      "integrity": "sha512-bs+sDe8M8gGjaRWgzNsHSH0Tywy6wFIvfF2M1SbKFy24jWvqij6iFBbtWeMpuLk7iC3/uAyIjFcjJqxAuKBung==",
       "requires": {
-        "@snyk/child-process": "^0.3.3",
+        "@snyk/child-process": "^0.4.1",
         "bottleneck": "2.19.5",
         "debug": "4.3.4",
-        "tslib": "^1.10.0"
+        "tslib": "^2.6.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+          "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+        }
       }
     },
     "@snyk/gemfile": {
@@ -35160,9 +35170,9 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"

--- a/packages/snyk-fix/package.json
+++ b/packages/snyk-fix/package.json
@@ -37,8 +37,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@snyk/dep-graph": "^1.21.0",
-    "@snyk/fix-pipenv-pipfile": "0.6.0",
-    "@snyk/fix-poetry": "0.8.3",
+    "@snyk/fix-pipenv-pipfile": "^0.7.1",
+    "@snyk/fix-poetry": "^0.9.1",
     "chalk": "4.1.1",
     "debug": "^4.3.1",
     "lodash.groupby": "4.6.0",

--- a/test/fixtures/snyk-fix-pipenv/Pipfile
+++ b/test/fixtures/snyk-fix-pipenv/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple/"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+pylint = "==2.6.0"
+toml = "==0.10.1"
+
+[dev-packages]
+
+[requires]

--- a/test/fixtures/snyk-fix-pipenv/Pipfile.lock
+++ b/test/fixtures/snyk-fix-pipenv/Pipfile.lock
@@ -1,0 +1,106 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "b66ab649798a1b8b7f33801ae968d1a6ef0e73db3ef22b47361511074cb8cdf9"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple/",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "astroid": {
+            "hashes": [
+                "sha256:87ae7f2398b8a0ae5638ddecf9987f081b756e0e9fc071aeebdca525671fc4dc",
+                "sha256:b31c92f545517dcc452f284bc9c044050862fbe6d93d2b3de4a215a6b384bf0d"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.5"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504",
+                "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"
+            ],
+            "markers": "python_full_version >= '3.8.0'",
+            "version": "==5.12.0"
+        },
+        "lazy-object-proxy": {
+            "hashes": [
+                "sha256:09763491ce220c0299688940f8dc2c5d05fd1f45af1e42e636b2e8b2303e4382",
+                "sha256:0a891e4e41b54fd5b8313b96399f8b0e173bbbfc03c7631f01efbe29bb0bcf82",
+                "sha256:189bbd5d41ae7a498397287c408617fe5c48633e7755287b21d741f7db2706a9",
+                "sha256:18b78ec83edbbeb69efdc0e9c1cb41a3b1b1ed11ddd8ded602464c3fc6020494",
+                "sha256:1aa3de4088c89a1b69f8ec0dcc169aa725b0ff017899ac568fe44ddc1396df46",
+                "sha256:212774e4dfa851e74d393a2370871e174d7ff0ebc980907723bb67d25c8a7c30",
+                "sha256:2d0daa332786cf3bb49e10dc6a17a52f6a8f9601b4cf5c295a4f85854d61de63",
+                "sha256:5f83ac4d83ef0ab017683d715ed356e30dd48a93746309c8f3517e1287523ef4",
+                "sha256:659fb5809fa4629b8a1ac5106f669cfc7bef26fbb389dda53b3e010d1ac4ebae",
+                "sha256:660c94ea760b3ce47d1855a30984c78327500493d396eac4dfd8bd82041b22be",
+                "sha256:66a3de4a3ec06cd8af3f61b8e1ec67614fbb7c995d02fa224813cb7afefee701",
+                "sha256:721532711daa7db0d8b779b0bb0318fa87af1c10d7fe5e52ef30f8eff254d0cd",
+                "sha256:7322c3d6f1766d4ef1e51a465f47955f1e8123caee67dd641e67d539a534d006",
+                "sha256:79a31b086e7e68b24b99b23d57723ef7e2c6d81ed21007b6281ebcd1688acb0a",
+                "sha256:81fc4d08b062b535d95c9ea70dbe8a335c45c04029878e62d744bdced5141586",
+                "sha256:8fa02eaab317b1e9e03f69aab1f91e120e7899b392c4fc19807a8278a07a97e8",
+                "sha256:9090d8e53235aa280fc9239a86ae3ea8ac58eff66a705fa6aa2ec4968b95c821",
+                "sha256:946d27deaff6cf8452ed0dba83ba38839a87f4f7a9732e8f9fd4107b21e6ff07",
+                "sha256:9990d8e71b9f6488e91ad25f322898c136b008d87bf852ff65391b004da5e17b",
+                "sha256:9cd077f3d04a58e83d04b20e334f678c2b0ff9879b9375ed107d5d07ff160171",
+                "sha256:9e7551208b2aded9c1447453ee366f1c4070602b3d932ace044715d89666899b",
+                "sha256:9f5fa4a61ce2438267163891961cfd5e32ec97a2c444e5b842d574251ade27d2",
+                "sha256:b40387277b0ed2d0602b8293b94d7257e17d1479e257b4de114ea11a8cb7f2d7",
+                "sha256:bfb38f9ffb53b942f2b5954e0f610f1e721ccebe9cce9025a38c8ccf4a5183a4",
+                "sha256:cbf9b082426036e19c6924a9ce90c740a9861e2bdc27a4834fd0a910742ac1e8",
+                "sha256:d9e25ef10a39e8afe59a5c348a4dbf29b4868ab76269f81ce1674494e2565a6e",
+                "sha256:db1c1722726f47e10e0b5fdbf15ac3b8adb58c091d12b3ab713965795036985f",
+                "sha256:e7c21c95cae3c05c14aafffe2865bbd5e377cfc1348c4f7751d9dc9a48ca4bda",
+                "sha256:e8c6cfb338b133fbdbc5cfaa10fe3c6aeea827db80c978dbd13bc9dd8526b7d4",
+                "sha256:ea806fd4c37bf7e7ad82537b0757999264d5f70c45468447bb2b91afdbe73a6e",
+                "sha256:edd20c5a55acb67c7ed471fa2b5fb66cb17f61430b7a6b9c3b4a1e40293b1671",
+                "sha256:f0117049dd1d5635bbff65444496c90e0baa48ea405125c088e93d9cf4525b11",
+                "sha256:f0705c376533ed2a9e5e97aacdbfe04cecd71e0aa84c7c0595d02ef93b6e4455",
+                "sha256:f12ad7126ae0c98d601a7ee504c1122bcef553d1d5e0c3bfa77b16b3968d2734",
+                "sha256:f2457189d8257dd41ae9b434ba33298aec198e30adf2dcdaaa3a28b9994f6adb",
+                "sha256:f699ac1c768270c9e384e4cbd268d6e67aebcfae6cd623b4d7c3bfde5a35db59"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.9.0"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "pylint": {
+            "hashes": [
+                "sha256:bb4a908c9dadbc3aac18860550e870f58e1a02c9f2c204fdf5693d73be061210",
+                "sha256:bfe68f020f8a0fece830a22dd4d5dddb4ecc6137db04face4c3420a46a52239f"
+            ],
+            "index": "pypi",
+            "version": "==2.6.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f",
+                "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"
+            ],
+            "index": "pypi",
+            "version": "==0.10.1"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"
+            ],
+            "version": "==1.12.1"
+        }
+    },
+    "develop": {}
+}

--- a/test/jest/acceptance/snyk-fix/dep-graph-response.json
+++ b/test/jest/acceptance/snyk-fix/dep-graph-response.json
@@ -1,0 +1,515 @@
+{
+  "result": {
+    "affectedPkgs": {
+      "pylint@2.6.0": {
+        "pkg": {
+          "name": "pylint",
+          "version": "2.6.0"
+        },
+        "issues": {
+          "SNYK-PYTHON-PYLINT-1089548": {
+            "issueId": "SNYK-PYTHON-PYLINT-1089548",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [],
+              "isRuntime": false,
+              "isPinnable": true
+            }
+          },
+          "SNYK-PYTHON-PYLINT-609883": {
+            "issueId": "SNYK-PYTHON-PYLINT-609883",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [],
+              "isRuntime": false,
+              "isPinnable": true
+            }
+          }
+        }
+      },
+      "isort@5.12.0": {
+        "pkg": {
+          "name": "isort",
+          "version": "5.12.0"
+        },
+        "issues": {
+          "snyk:lic:pip:isort:MIT": {
+            "issueId": "snyk:lic:pip:isort:MIT",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [],
+              "isRuntime": false,
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "mccabe@0.6.1": {
+        "pkg": {
+          "name": "mccabe",
+          "version": "0.6.1"
+        },
+        "issues": {
+          "snyk:lic:pip:mccabe:MIT": {
+            "issueId": "snyk:lic:pip:mccabe:MIT",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [],
+              "isRuntime": false,
+              "isPinnable": false
+            }
+          }
+        }
+      },
+      "toml@0.10.1": {
+        "pkg": {
+          "name": "toml",
+          "version": "0.10.1"
+        },
+        "issues": {
+          "snyk:lic:pip:toml:MIT": {
+            "issueId": "snyk:lic:pip:toml:MIT",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [],
+              "isRuntime": false,
+              "isPinnable": false
+            }
+          }
+        }
+      }
+    },
+    "issuesData": {
+      "SNYK-PYTHON-PYLINT-1089548": {
+        "id": "SNYK-PYTHON-PYLINT-1089548",
+        "title": "Regular Expression Denial of Service (ReDoS)",
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+        "credit": ["Yeting Li"],
+        "semver": {
+          "vulnerable": ["[,2.7.0)"]
+        },
+        "exploit": "Not Defined",
+        "fixedIn": ["2.7.0"],
+        "patches": [],
+        "insights": {
+          "triageAdvice": null
+        },
+        "language": "python",
+        "severity": "medium",
+        "cvssScore": 5.3,
+        "functions": [],
+        "malicious": false,
+        "isDisputed": false,
+        "moduleName": "pylint",
+        "references": [
+          {
+            "url": "https://github.com/PyCQA/pylint/commit/5405dd5115d598fa69e49538d50ec79202b1b52e",
+            "title": "GitHub Commit"
+          },
+          {
+            "url": "https://github.com/PyCQA/pylint/issues/3811",
+            "title": "GitHub Issue"
+          },
+          {
+            "url": "https://github.com/PyCQA/pylint/releases/tag/pylint-2.7.0",
+            "title": "GitHub Release"
+          }
+        ],
+        "cvssDetails": [],
+        "description": "## Overview\n[pylint](https://github.com/PyCQA/pylint) is a Python static code analysis tool which looks for programming errors, helps enforcing a coding standard, sniffs for code smells and offers simple refactoring suggestions.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) via the `SPECIAL` and `PRIVATE` attributes in `pylint/pylint/pyreverse/utils.py`. The ReDoS is mainly due to the pattern `[^\\W_]+\\w*`, and can be exploited with an input string such as `\"__\"+\"1\"*5000 + \"!\"`.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `pylint` to version 2.7.0 or higher.\n## References\n- [GitHub Commit](https://github.com/PyCQA/pylint/commit/5405dd5115d598fa69e49538d50ec79202b1b52e)\n- [GitHub Issue](https://github.com/PyCQA/pylint/issues/3811)\n- [GitHub Release](https://github.com/PyCQA/pylint/releases/tag/pylint-2.7.0)\n",
+        "epssDetails": null,
+        "identifiers": {
+          "CVE": [],
+          "CWE": ["CWE-400"]
+        },
+        "packageName": "pylint",
+        "proprietary": false,
+        "creationTime": "2021-03-29T16:03:09.945565Z",
+        "functions_new": [],
+        "alternativeIds": [],
+        "disclosureTime": "2021-03-29T16:00:18Z",
+        "packageManager": "pip",
+        "publicationTime": "2021-03-30T14:57:05.188672Z",
+        "modificationTime": "2021-03-30T14:57:05.190970Z",
+        "socialTrendAlert": false,
+        "severityWithCritical": "medium"
+      },
+      "SNYK-PYTHON-PYLINT-609883": {
+        "id": "SNYK-PYTHON-PYLINT-609883",
+        "title": "Regular Expression Denial of Service (ReDoS)",
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:U/RC:C",
+        "credit": ["Yeting Li"],
+        "semver": {
+          "vulnerable": ["[0,2.6.1)"]
+        },
+        "exploit": "Unproven",
+        "fixedIn": ["2.6.1"],
+        "patches": [],
+        "insights": {
+          "triageAdvice": null
+        },
+        "language": "python",
+        "severity": "high",
+        "cvssScore": 8.1,
+        "functions": [],
+        "malicious": false,
+        "isDisputed": false,
+        "moduleName": "pylint",
+        "references": [
+          {
+            "url": "https://github.com/PyCQA/pylint/commit/5405dd5115d598fa69e49538d50ec79202b1b52e",
+            "title": "GitHub Commit"
+          },
+          {
+            "url": "https://github.com/PyCQA/pylint/issues/3811",
+            "title": "GitHub Issue"
+          },
+          {
+            "url": "https://github.com/PyCQA/pylint/pull/3816",
+            "title": "GitHub PR 1"
+          },
+          {
+            "url": "https://github.com/PyCQA/pylint/pull/3828",
+            "title": "GitHub PR 2"
+          }
+        ],
+        "cvssDetails": [],
+        "description": "## Overview\n[pylint](https://github.com/PyCQA/pylint) is a Python static code analysis tool which looks for programming errors, helps enforcing a coding standard, sniffs for code smells and offers simple refactoring suggestions.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). A regular expression denial of service issue exists in `pyreverse`. The ambiguities of vulnerable regular expressions are removed, making the repaired regular expressions safer and faster matching.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `pylint` to version 2.6.1 or higher.\n## References\n- [GitHub Commit](https://github.com/PyCQA/pylint/commit/5405dd5115d598fa69e49538d50ec79202b1b52e)\n- [GitHub Issue](https://github.com/PyCQA/pylint/issues/3811)\n- [GitHub PR 1](https://github.com/PyCQA/pylint/pull/3816)\n- [GitHub PR 2](https://github.com/PyCQA/pylint/pull/3828)\n",
+        "epssDetails": null,
+        "identifiers": {
+          "CVE": [],
+          "CWE": ["CWE-400"]
+        },
+        "packageName": "pylint",
+        "proprietary": false,
+        "creationTime": "2020-09-07T11:58:25.375388Z",
+        "functions_new": [],
+        "alternativeIds": [],
+        "disclosureTime": "2020-09-07T11:55:06Z",
+        "packageManager": "pip",
+        "publicationTime": "2020-09-11T14:06:02Z",
+        "modificationTime": "2021-02-17T12:37:31.052056Z",
+        "socialTrendAlert": false,
+        "severityWithCritical": "high"
+      },
+      "snyk:lic:pip:isort:MIT": {
+        "id": "snyk:lic:pip:isort:MIT",
+        "type": "license",
+        "title": "MIT license",
+        "semver": {
+          "vulnerable": ["[1.0.1,)"]
+        },
+        "license": "MIT",
+        "language": "python",
+        "description": "MIT license",
+        "packageName": "isort",
+        "creationTime": "2023-06-14T20:28:08.363Z",
+        "packageManager": "pip",
+        "publicationTime": "2023-06-14T20:28:08.363Z",
+        "severity": "high",
+        "severityWithCritical": "high"
+      },
+      "snyk:lic:pip:mccabe:MIT": {
+        "id": "snyk:lic:pip:mccabe:MIT",
+        "type": "license",
+        "title": "MIT license",
+        "semver": {
+          "vulnerable": ["[0,)"]
+        },
+        "license": "MIT",
+        "language": "python",
+        "description": "MIT license",
+        "packageName": "mccabe",
+        "creationTime": "2023-06-14T22:21:05.042Z",
+        "packageManager": "pip",
+        "publicationTime": "2023-06-14T22:21:05.042Z",
+        "severity": "high",
+        "severityWithCritical": "high"
+      },
+      "snyk:lic:pip:toml:MIT": {
+        "id": "snyk:lic:pip:toml:MIT",
+        "type": "license",
+        "title": "MIT license",
+        "semver": {
+          "vulnerable": ["[0,)"]
+        },
+        "license": "MIT",
+        "language": "python",
+        "description": "MIT license",
+        "packageName": "toml",
+        "creationTime": "2023-06-15T08:33:31.008Z",
+        "packageManager": "pip",
+        "publicationTime": "2023-06-15T08:33:31.008Z",
+        "severity": "high",
+        "severityWithCritical": "high"
+      }
+    },
+    "remediation": {
+      "unresolved": [
+        {
+          "id": "SNYK-PYTHON-PYLINT-1089548",
+          "title": "Regular Expression Denial of Service (ReDoS)",
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+          "credit": ["Yeting Li"],
+          "semver": {
+            "vulnerable": ["[,2.7.0)"]
+          },
+          "exploit": "Not Defined",
+          "fixedIn": ["2.7.0"],
+          "patches": [],
+          "insights": {
+            "triageAdvice": null
+          },
+          "language": "python",
+          "severity": "medium",
+          "cvssScore": 5.3,
+          "functions": [],
+          "malicious": false,
+          "isDisputed": false,
+          "moduleName": "pylint",
+          "references": [
+            {
+              "url": "https://github.com/PyCQA/pylint/commit/5405dd5115d598fa69e49538d50ec79202b1b52e",
+              "title": "GitHub Commit"
+            },
+            {
+              "url": "https://github.com/PyCQA/pylint/issues/3811",
+              "title": "GitHub Issue"
+            },
+            {
+              "url": "https://github.com/PyCQA/pylint/releases/tag/pylint-2.7.0",
+              "title": "GitHub Release"
+            }
+          ],
+          "cvssDetails": [],
+          "description": "## Overview\n[pylint](https://github.com/PyCQA/pylint) is a Python static code analysis tool which looks for programming errors, helps enforcing a coding standard, sniffs for code smells and offers simple refactoring suggestions.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) via the `SPECIAL` and `PRIVATE` attributes in `pylint/pylint/pyreverse/utils.py`. The ReDoS is mainly due to the pattern `[^\\W_]+\\w*`, and can be exploited with an input string such as `\"__\"+\"1\"*5000 + \"!\"`.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `pylint` to version 2.7.0 or higher.\n## References\n- [GitHub Commit](https://github.com/PyCQA/pylint/commit/5405dd5115d598fa69e49538d50ec79202b1b52e)\n- [GitHub Issue](https://github.com/PyCQA/pylint/issues/3811)\n- [GitHub Release](https://github.com/PyCQA/pylint/releases/tag/pylint-2.7.0)\n",
+          "epssDetails": null,
+          "identifiers": {
+            "CVE": [],
+            "CWE": ["CWE-400"]
+          },
+          "packageName": "pylint",
+          "proprietary": false,
+          "creationTime": "2021-03-29T16:03:09.945565Z",
+          "functions_new": [],
+          "alternativeIds": [],
+          "disclosureTime": "2021-03-29T16:00:18Z",
+          "packageManager": "pip",
+          "publicationTime": "2021-03-30T14:57:05.188672Z",
+          "modificationTime": "2021-03-30T14:57:05.190970Z",
+          "socialTrendAlert": false,
+          "packagePopularityRank": 99,
+          "from": ["snyk-fix-pyenv@0.0.0", "pylint@2.6.0"],
+          "upgradePath": [],
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": true,
+          "isRuntime": false,
+          "name": "pylint",
+          "version": "2.6.0",
+          "severityWithCritical": "medium"
+        },
+        {
+          "id": "SNYK-PYTHON-PYLINT-609883",
+          "title": "Regular Expression Denial of Service (ReDoS)",
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:U/RC:C",
+          "credit": ["Yeting Li"],
+          "semver": {
+            "vulnerable": ["[0,2.6.1)"]
+          },
+          "exploit": "Unproven",
+          "fixedIn": ["2.6.1"],
+          "patches": [],
+          "insights": {
+            "triageAdvice": null
+          },
+          "language": "python",
+          "severity": "high",
+          "cvssScore": 8.1,
+          "functions": [],
+          "malicious": false,
+          "isDisputed": false,
+          "moduleName": "pylint",
+          "references": [
+            {
+              "url": "https://github.com/PyCQA/pylint/commit/5405dd5115d598fa69e49538d50ec79202b1b52e",
+              "title": "GitHub Commit"
+            },
+            {
+              "url": "https://github.com/PyCQA/pylint/issues/3811",
+              "title": "GitHub Issue"
+            },
+            {
+              "url": "https://github.com/PyCQA/pylint/pull/3816",
+              "title": "GitHub PR 1"
+            },
+            {
+              "url": "https://github.com/PyCQA/pylint/pull/3828",
+              "title": "GitHub PR 2"
+            }
+          ],
+          "cvssDetails": [],
+          "description": "## Overview\n[pylint](https://github.com/PyCQA/pylint) is a Python static code analysis tool which looks for programming errors, helps enforcing a coding standard, sniffs for code smells and offers simple refactoring suggestions.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). A regular expression denial of service issue exists in `pyreverse`. The ambiguities of vulnerable regular expressions are removed, making the repaired regular expressions safer and faster matching.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `pylint` to version 2.6.1 or higher.\n## References\n- [GitHub Commit](https://github.com/PyCQA/pylint/commit/5405dd5115d598fa69e49538d50ec79202b1b52e)\n- [GitHub Issue](https://github.com/PyCQA/pylint/issues/3811)\n- [GitHub PR 1](https://github.com/PyCQA/pylint/pull/3816)\n- [GitHub PR 2](https://github.com/PyCQA/pylint/pull/3828)\n",
+          "epssDetails": null,
+          "identifiers": {
+            "CVE": [],
+            "CWE": ["CWE-400"]
+          },
+          "packageName": "pylint",
+          "proprietary": false,
+          "creationTime": "2020-09-07T11:58:25.375388Z",
+          "functions_new": [],
+          "alternativeIds": [],
+          "disclosureTime": "2020-09-07T11:55:06Z",
+          "packageManager": "pip",
+          "publicationTime": "2020-09-11T14:06:02Z",
+          "modificationTime": "2021-02-17T12:37:31.052056Z",
+          "socialTrendAlert": false,
+          "packagePopularityRank": 99,
+          "from": ["snyk-fix-pyenv@0.0.0", "pylint@2.6.0"],
+          "upgradePath": [],
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": true,
+          "isRuntime": false,
+          "name": "pylint",
+          "version": "2.6.0",
+          "severityWithCritical": "high"
+        },
+        {
+          "id": "snyk:lic:pip:isort:MIT",
+          "type": "license",
+          "title": "MIT license",
+          "semver": {
+            "vulnerable": ["[1.0.1,)"]
+          },
+          "license": "MIT",
+          "language": "python",
+          "description": "MIT license",
+          "packageName": "isort",
+          "creationTime": "2023-06-14T20:28:08.363Z",
+          "packageManager": "pip",
+          "publicationTime": "2023-06-14T20:28:08.363Z",
+          "severity": "high",
+          "from": ["snyk-fix-pyenv@0.0.0", "pylint@2.6.0", "isort@5.12.0"],
+          "upgradePath": [],
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "isRuntime": false,
+          "name": "isort",
+          "version": "5.12.0",
+          "severityWithCritical": "high"
+        },
+        {
+          "id": "snyk:lic:pip:mccabe:MIT",
+          "type": "license",
+          "title": "MIT license",
+          "semver": {
+            "vulnerable": ["[0,)"]
+          },
+          "license": "MIT",
+          "language": "python",
+          "description": "MIT license",
+          "packageName": "mccabe",
+          "creationTime": "2023-06-14T22:21:05.042Z",
+          "packageManager": "pip",
+          "publicationTime": "2023-06-14T22:21:05.042Z",
+          "severity": "high",
+          "from": ["snyk-fix-pyenv@0.0.0", "pylint@2.6.0", "mccabe@0.6.1"],
+          "upgradePath": [],
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "isRuntime": false,
+          "name": "mccabe",
+          "version": "0.6.1",
+          "severityWithCritical": "high"
+        },
+        {
+          "id": "snyk:lic:pip:toml:MIT",
+          "type": "license",
+          "title": "MIT license",
+          "semver": {
+            "vulnerable": ["[0,)"]
+          },
+          "license": "MIT",
+          "language": "python",
+          "description": "MIT license",
+          "packageName": "toml",
+          "creationTime": "2023-06-15T08:33:31.008Z",
+          "packageManager": "pip",
+          "publicationTime": "2023-06-15T08:33:31.008Z",
+          "severity": "high",
+          "from": ["snyk-fix-pyenv@0.0.0", "pylint@2.6.0", "toml@0.10.1"],
+          "upgradePath": [],
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "isRuntime": false,
+          "name": "toml",
+          "version": "0.10.1",
+          "severityWithCritical": "high"
+        }
+      ],
+      "upgrade": {},
+      "patch": {},
+      "ignore": {},
+      "pin": {
+        "pylint@2.6.0": {
+          "upgradeTo": "pylint@2.7.0",
+          "vulns": ["SNYK-PYTHON-PYLINT-1089548", "SNYK-PYTHON-PYLINT-609883"],
+          "isTransitive": false
+        }
+      }
+    }
+  },
+  "meta": {
+    "isPrivate": true,
+    "isLicensesEnabled": true,
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\nignore: {}\npatch: {}\n",
+    "ignoreSettings": {
+      "adminOnly": false,
+      "reasonRequired": false,
+      "disregardFilesystemIgnores": false
+    },
+    "org": "aron.carroll-ac3",
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {
+        "AAL": {
+          "licenseType": "AAL",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "AFL-1.1": {
+          "licenseType": "AFL-1.1",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MIT": {
+          "licenseType": "MIT",
+          "severity": "high",
+          "instructions": ""
+        },
+        "Apache-1.0": {
+          "licenseType": "Apache-1.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "Apache-1.1": {
+          "licenseType": "Apache-1.1",
+          "severity": "high",
+          "instructions": ""
+        },
+        "Apache-2.0": {
+          "licenseType": "Apache-2.0",
+          "severity": "high",
+          "instructions": ""
+        }
+      }
+    }
+  },
+  "alerts": [],
+  "filesystemPolicy": false
+}


### PR DESCRIPTION
Currently the `snyk fix` command fails to run due to the subshell running `poetry` and `pipenv` being unable to make network requests to pypy. This is due to the proxy configuration used by the Go wrapper. We've now updated the `@snyk/child-process` library in snyk/python-fix to reset these environment variables before invoking the subshell. This fixes the issue.

The change here is to bump the sub dependencies in the `snyk-fix` package to use the latest @snyk/child-process library (see: https://github.com/snyk/python-fix/pull/68).

This was tested on the above pipenv project and with the changes we can now successfully run `snyk fix` with no errors.

NOTE: We also update the CODEOWNERS to move ownership of snyk-fix from Tech Services over to Team Fix.
