### PR TITLE
chore: add deprecation notice for managed drift detection

### DIFF
--- a/src/lib/iac/drift/driftctl.ts
+++ b/src/lib/iac/drift/driftctl.ts
@@ -239,6 +239,24 @@ export const runDriftCTL = async ({
 }): Promise<DriftctlExecutionResult> => {
   const path = await findOrDownload();
   await validateArgs(options);
+
+  if (options.kind === 'describe') {
+    const descOptions = options as DescribeOptions;
+
+    if (
+      descOptions.deep ||
+      descOptions.all ||
+      descOptions['only-managed'] ||
+      descOptions.drift
+    ) {
+      process.stderr.write(
+        `DEPRECATION NOTICE: Drift detection of managed resources,\n` +
+          `including --only-managed and --drift has been deprecated.\n` +
+          `The end-of-life date for drift detection of managed resources is September 30. 2023.\n\n`,
+      );
+    }
+  }
+
   const args = await generateArgs(options, driftIgnore);
 
   if (!stdio) {

--- a/test/jest/acceptance/iac/describe.spec.ts
+++ b/test/jest/acceptance/iac/describe.spec.ts
@@ -172,7 +172,7 @@ describe('iac describe', () => {
       );
 
       expect(stdout).toBe('');
-      expect(stderr).toBe('');
+      expect(stderr).toContain('DEPRECATION NOTICE');
       expect(exitCode).toBe(0);
 
       const output = fs.readFileSync(outputFile).toString();


### PR DESCRIPTION
#### What does this PR do?

We are deprecating managed drift detection for `snyk iac describe`, this adds the warning when the relevant flags are used.

#### How should this be manually tested?

Run these to see the message:
* `snyk iac describe --all`
* `snyk iac describe --only-managed`
* `snyk iac describe --drift`

And with this flag we shouldn't get the deprecation message:
* `snyk iac describe --only-unmanaged`


#### Any background context you want to provide?
https://snyk.slack.com/archives/CGBMBD484/p1689091028880929