### PR TITLE
test: disable integrated IaC's smoke test schedule

### DIFF
--- a/.github/workflows/iac-smoke-tests.yml
+++ b/.github/workflows/iac-smoke-tests.yml
@@ -1,8 +1,6 @@
 name: Infrastructure as Code Smoke Tests
 
 on:
-  schedule:
-    - cron: '0 23 * * *'
   release:
     types: [published]
   workflow_call:


### PR DESCRIPTION
#### What does this PR do?

We now have an environment-testing setup for the integrated IaC CLI functionality, so we are disabling the schedule trigger, but still keep the release and PR triggers.

* [IAC-2505](https://snyksec.atlassian.net/browse/IAC-2505)
* snyk/environment-testing#394

[IAC-2505]: https://snyksec.atlassian.net/browse/IAC-2505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ