### PR TITLE
fix: do not use generic bearer_token naming

### DIFF
--- a/cliv2/cmd/cliv2/main.go
+++ b/cliv2/cmd/cliv2/main.go
@@ -90,7 +90,7 @@ func main() {
 // Initialize the given configuration with CLI specific aspects
 func initApplicationConfiguration(config configuration.Configuration) {
 	config.AddAlternativeKeys(configuration.AUTHENTICATION_TOKEN, []string{"snyk_cfg_api", "api"})
-	config.AddAlternativeKeys(configuration.AUTHENTICATION_BEARER_TOKEN, []string{"snyk_oauth_token", "snyk_docker_token"})
+	config.AddAlternativeKeys(configuration.AUTHENTICATION_BEARER_TOKEN, []string{"snyk_docker_token"})
 	config.AddAlternativeKeys(configuration.API_URL, []string{"endpoint"})
 	config.AddAlternativeKeys(configuration.ADD_TRUSTED_CA_FILE, []string{"NODE_EXTRA_CA_CERTS"})
 	config.AddAlternativeKeys(configuration.ANALYTICS_DISABLED, []string{"snyk_analytics_disabled", "snyk_cfg_disable_analytics", "disable-analytics", "disable_analytics"})

--- a/cliv2/cmd/cliv2/main.go
+++ b/cliv2/cmd/cliv2/main.go
@@ -99,6 +99,7 @@ func initApplicationConfiguration(config configuration.Configuration) {
 	_, ok := os.LookupEnv(auth.CONFIG_KEY_OAUTH_TOKEN)
 	if !ok {
 		alternativeBearerKeys := config.GetAlternativeKeys(configuration.AUTHENTICATION_BEARER_TOKEN)
+		alternativeBearerKeys = append(alternativeBearerKeys, configuration.AUTHENTICATION_BEARER_TOKEN)
 		for _, key := range alternativeBearerKeys {
 			hasPrefix := strings.HasPrefix(key, "snyk_")
 			if hasPrefix {

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/rs/zerolog v1.29.1
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20230601153200-c572cfce46ce
 	github.com/snyk/cli-extension-sbom v0.0.0-20230608154310-6573cedca977
-	github.com/snyk/go-application-framework v0.0.0-20230714085540-37d34ad405bc
+	github.com/snyk/go-application-framework v0.0.0-20230721092955-9308110a35a6
 	github.com/snyk/go-httpauth v0.0.0-20230512081507-800aedece3cb
 	github.com/snyk/snyk-iac-capture v0.6.0
 	github.com/spf13/cobra v1.7.0

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -578,8 +578,8 @@ github.com/snyk/cli-extension-iac-rules v0.0.0-20230601153200-c572cfce46ce h1:Wc
 github.com/snyk/cli-extension-iac-rules v0.0.0-20230601153200-c572cfce46ce/go.mod h1:5/IYYTgf32pST7St4GhS3KNz32WE17Ys+Hdb5Pqxex0=
 github.com/snyk/cli-extension-sbom v0.0.0-20230608154310-6573cedca977 h1:kW8XGQ3hseTP6WbGrO4Q6ssqGejT02hleNzxfWga72E=
 github.com/snyk/cli-extension-sbom v0.0.0-20230608154310-6573cedca977/go.mod h1:O/cjwCbKhJQWyXHPmNbZ7ToQKnhyw0VUp1Qhim3WEcw=
-github.com/snyk/go-application-framework v0.0.0-20230714085540-37d34ad405bc h1:kyL68unMn+lw5azA+AUr+UcOLsfN8NQ+GXHz6d5VJu0=
-github.com/snyk/go-application-framework v0.0.0-20230714085540-37d34ad405bc/go.mod h1:Aun65T/AmzxjZe9jZZBqia6RHwoS7oq8QB2UfQIcPjU=
+github.com/snyk/go-application-framework v0.0.0-20230721092955-9308110a35a6 h1:tsJz7KAg9S7F9Hh15LUoHroU9Bs7lYOdXg3IPXGQzm8=
+github.com/snyk/go-application-framework v0.0.0-20230721092955-9308110a35a6/go.mod h1:Aun65T/AmzxjZe9jZZBqia6RHwoS7oq8QB2UfQIcPjU=
 github.com/snyk/go-httpauth v0.0.0-20230512081507-800aedece3cb h1:UwbUBfe1u5MYLhtCNOsFEM98tfEUWqgmaXam/UxU88Q=
 github.com/snyk/go-httpauth v0.0.0-20230512081507-800aedece3cb/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v0.22.0 h1:od9pduGrXyfWO791X+8M1qmnvWUxaIXh0gBzGKqeseA=


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
This PR should avoid potential env var collisions by not using the generic env var name `BEARER_TOKEN`.
