### PR TITLE
fix: update code-client version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@sentry/node": "^7.34.0",
         "@snyk/cli-interface": "2.12.0",
         "@snyk/cloud-config-parser": "^1.14.5",
-        "@snyk/code-client": "^4.19.0",
+        "@snyk/code-client": "^4.19.1",
         "@snyk/dep-graph": "^2.6.1",
         "@snyk/docker-registry-v2-client": "^2.10.0",
         "@snyk/fix": "file:packages/snyk-fix",
@@ -2133,9 +2133,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@snyk/code-client": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.19.0.tgz",
-      "integrity": "sha512-IB/oYSCROGY04h74UYSs+nhCpNVPqWDZ7DO5nuzLun8YfNiUMh98V3OdUl+DMrYBxKUUE2HoLEr+GfPkPUpVzA==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.19.1.tgz",
+      "integrity": "sha512-ORhxJJx5AOb7xZWPheegLDusdf1toEXiX4mqanziWA1xQanMyIVC7jTSAllj7LjEITUxm3WUD2e18kALiDIFjQ==",
       "dependencies": {
         "@deepcode/dcignore": "^1.0.4",
         "@types/flat-cache": "^2.0.0",
@@ -22582,9 +22582,9 @@
       }
     },
     "@snyk/code-client": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.19.0.tgz",
-      "integrity": "sha512-IB/oYSCROGY04h74UYSs+nhCpNVPqWDZ7DO5nuzLun8YfNiUMh98V3OdUl+DMrYBxKUUE2HoLEr+GfPkPUpVzA==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.19.1.tgz",
+      "integrity": "sha512-ORhxJJx5AOb7xZWPheegLDusdf1toEXiX4mqanziWA1xQanMyIVC7jTSAllj7LjEITUxm3WUD2e18kALiDIFjQ==",
       "requires": {
         "@deepcode/dcignore": "^1.0.4",
         "@types/flat-cache": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@sentry/node": "^7.34.0",
     "@snyk/cli-interface": "2.12.0",
     "@snyk/cloud-config-parser": "^1.14.5",
-    "@snyk/code-client": "^4.19.0",
+    "@snyk/code-client": "^4.19.1",
     "@snyk/dep-graph": "^2.6.1",
     "@snyk/docker-registry-v2-client": "^2.10.0",
     "@snyk/fix": "file:packages/snyk-fix",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Updates package version for `code-client`.

Updated version removes project-name length limit for Code Report flow.

More context [here](https://snyk.slack.com/archives/C01DGQ3AT09/p1689238829165069).