### PR TITLE
fix: make IaC issue resource file optional

### DIFF
--- a/src/lib/formatters/iac-output/text/issues-list/index.ts
+++ b/src/lib/formatters/iac-output/text/issues-list/index.ts
@@ -41,8 +41,8 @@ export function getIacDisplayedIssues(
       const issuesOutput = severityResults
         .sort(
           (severityResult1, severityResult2) =>
-            severityResult1.targetFile.localeCompare(
-              severityResult2.targetFile,
+            severityResult1.targetFile?.localeCompare(
+              severityResult2.targetFile as string,
             ) ||
             severityResult1.issue.id.localeCompare(severityResult2.issue.id),
         )

--- a/src/lib/formatters/iac-output/text/types.ts
+++ b/src/lib/formatters/iac-output/text/types.ts
@@ -16,8 +16,8 @@ export type FormattedOutputResultsBySeverity = {
 
 export type FormattedOutputResult = {
   issue: Issue;
-  targetFile: string;
   projectType: IacProjectType | State.InputTypeEnum;
+  targetFile?: string;
 };
 
 export interface IacTestCounts {

--- a/src/lib/iac/test/v2/analytics/iac-type.ts
+++ b/src/lib/iac/test/v2/analytics/iac-type.ts
@@ -75,7 +75,9 @@ function getFilesCountByPackageManager(
         acc[packageManager] = new Set();
       }
 
-      acc[packageManager].add(resource.file);
+      if (resource.file) {
+        acc[packageManager].add(resource.file);
+      }
 
       return acc;
     }, {} as { [packageManager in PackageManager]: Set<string> }),

--- a/src/lib/iac/test/v2/scan/results.ts
+++ b/src/lib/iac/test/v2/scan/results.ts
@@ -112,10 +112,10 @@ export interface Rule {
 export interface Resource {
   id: string;
   type: string;
-  path?: any[];
-  formattedPath: string;
-  file: string;
   kind: ResourceKind;
+  formattedPath: string;
+  path?: any[];
+  file?: string;
   line?: number;
   column?: number;
 }


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

- Defines the file path for resources associated with IaC+ test issues as optional.

#### How should this be manually tested?

- Test an IaC file that generates issues without an associated file origin, e.g., an issue for a non-existing resource that needs to be added.
- Ensure the test output for the CLI test is generated as expected.

#### Any background context you want to provide?

- [A support thread](https://snyk.slack.com/archives/C034QFM0DH8/p1690280367869079) revealed that we currently incorrectly assume that all the resources associated with a generated IaC+ issue have a file origin.
- Looking at the [CLI code](https://github.com/snyk/cli/blob/bc7ecc2a5552e92c12b514c3ef37341ac0106eb4/src/lib/iac/test/v2/scan/results.ts#L117-L118), we currently assume the file path is required for resources.
The resource file paths for issues are retrieved from `snyk-iac-test`, after being propagated from policy-engine [here](https://github.com/snyk/snyk-iac-test/blob/064ddf70f2c243df9c71b897a0bdeb9b53c32d69/pkg/results/results.go#L163-L169).

#### What are the relevant tickets?

- [Zendesk ticket 55895](https://snyk.zendesk.com/agent/tickets/55895)

#### Additional information

- [Slack thread from #ask-cloud](https://snyk.slack.com/archives/C04CQ0D2VFH/p1690722526092069)
- [Slack thread from #team-cloud-engines](https://snyk.slack.com/archives/C034QFM0DH8/p1690280367869079)