### PR TITLE
fix: assertions for the iac output formats test to be more generic

### DIFF
--- a/test/jest/acceptance/iac/output-formats/text.spec.ts
+++ b/test/jest/acceptance/iac/output-formats/text.spec.ts
@@ -90,14 +90,14 @@ describe('iac test text output', () => {
         EOL +
         '  Project name: fixtures' +
         EOL.repeat(2) +
-        '✔ Files without issues: 0' +
-        EOL +
-        '✗ Files with issues: 3' +
-        EOL +
-        '  Ignored issues: 12' +
-        EOL +
-        '  Total issues: ',
+        '✔ Files without issues: ',
     );
+
+    expect(stdout).toContain(EOL + '✗ Files with issues: ');
+
+    expect(stdout).toContain(EOL + '  Ignored issues: ');
+
+    expect(stdout).toContain(EOL + '  Total issues: ');
   });
 
   describe('with multiple test results', () => {


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Fixes an IaC test that from time to time fails when rules change. In order for this to not happen again - the assertions were changed to be more generic and only care about the format of the output and not the actual output.

#### Where should the reviewer start?

See a recent failure: [here](https://app.circleci.com/pipelines/github/snyk/cli/19045/workflows/10172117-6b97-4eea-a556-22d3b2482d66/jobs/282447)
See an ask for this: [here](https://snyk.slack.com/archives/C02JMMTLUF9/p1691564705804269)

#### How should this be manually tested?
`npm run test:acceptance` (test/jest/acceptance/iac/output-formats/text.spec.ts)

#### Any background context you want to provide?

-

#### What are the relevant tickets?

-

#### Screenshots

<img width="787" alt="image" src="https://github.com/snyk/cli/assets/119867733/683c2f6a-708c-4475-9f7a-cf0657e92d7c">