### PR TITLE
fix: refactor to make filterIgnoredIssues match vuln ids case insensitively

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "snyk-nodejs-lockfile-parser": "1.52.1",
         "snyk-nuget-plugin": "1.31.0",
         "snyk-php-plugin": "1.9.2",
-        "snyk-policy": "^1.25.0",
+        "snyk-policy": "^2.0.8",
         "snyk-python-plugin": "^1.25.3",
         "snyk-resolve-deps": "4.7.3",
         "snyk-sbt-plugin": "2.17.1",
@@ -17806,15 +17806,14 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/snyk-policy": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-1.25.0.tgz",
-      "integrity": "sha512-naAoqjlspwioBDlrSk5/pPGlSX2dMG42XDhoUdU/41NPS57jsifpENgiT83HEJDbTRGHOPTmQ1B4lvRupb70hQ==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-2.0.8.tgz",
+      "integrity": "sha512-kTLtcPpJVvczreZfTqZdTPpqb19GAIWUd5pY8Y2NDrdHMXuUJY5QKFzMuT/UppJ79sxM0Ozra3M7CLH9WeJViQ==",
       "dependencies": {
         "debug": "^4.1.1",
         "email-validator": "^2.0.4",
         "js-yaml": "^3.13.1",
         "lodash.clonedeep": "^4.5.0",
-        "promise-fs": "^2.1.1",
         "semver": "^7.3.4",
         "snyk-module": "^3.0.0",
         "snyk-resolve": "^1.1.0",
@@ -34831,15 +34830,14 @@
       }
     },
     "snyk-policy": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-1.25.0.tgz",
-      "integrity": "sha512-naAoqjlspwioBDlrSk5/pPGlSX2dMG42XDhoUdU/41NPS57jsifpENgiT83HEJDbTRGHOPTmQ1B4lvRupb70hQ==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-2.0.8.tgz",
+      "integrity": "sha512-kTLtcPpJVvczreZfTqZdTPpqb19GAIWUd5pY8Y2NDrdHMXuUJY5QKFzMuT/UppJ79sxM0Ozra3M7CLH9WeJViQ==",
       "requires": {
         "debug": "^4.1.1",
         "email-validator": "^2.0.4",
         "js-yaml": "^3.13.1",
         "lodash.clonedeep": "^4.5.0",
-        "promise-fs": "^2.1.1",
         "semver": "^7.3.4",
         "snyk-module": "^3.0.0",
         "snyk-resolve": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "snyk-nodejs-lockfile-parser": "1.52.1",
     "snyk-nuget-plugin": "1.31.0",
     "snyk-php-plugin": "1.9.2",
-    "snyk-policy": "^1.25.0",
+    "snyk-policy": "^2.0.8",
     "snyk-python-plugin": "^1.25.3",
     "snyk-resolve-deps": "4.7.3",
     "snyk-sbt-plugin": "2.17.1",

--- a/test/acceptance/workspaces/npm-package-policy/.snyk
+++ b/test/acceptance/workspaces/npm-package-policy/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.25.0
+version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   'npm:marked:20170907':

--- a/test/acceptance/workspaces/npm-package-policy/custom-location/.snyk
+++ b/test/acceptance/workspaces/npm-package-policy/custom-location/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.25.0
+version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   'npm:marked:20170907':

--- a/test/acceptance/workspaces/npm-with-dep-missing-policy/.snyk
+++ b/test/acceptance/workspaces/npm-with-dep-missing-policy/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.25.0
+version: v1.25.1
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 patch:

--- a/test/fixtures/npm/case-insesitive-ignore/.snyk
+++ b/test/fixtures/npm/case-insesitive-ignore/.snyk
@@ -2,7 +2,7 @@
 version: v1.24.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  SNYK-JS-LODASH-590103:
+  SNYK-js-LODASH-590103:
     - '*':
         reason: None Given
         expires: 2021-11-21T21:55:08.466Z

--- a/test/fixtures/npm/case-insesitive-ignore/package-lock.json
+++ b/test/fixtures/npm/case-insesitive-ignore/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "case-insensitive-ignore",
+  "version": "1.2.3",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "version": "1.2.3",
+      "license": "ISC",
+      "dependencies": {
+        "lodash": "4.17.15"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    }
+  },
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    }
+  }
+}

--- a/test/fixtures/npm/case-insesitive-ignore/package.json
+++ b/test/fixtures/npm/case-insesitive-ignore/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "case-insensitive-ignore",
+  "version": "1.2.3",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "license": "ISC",
+  "dependencies": {
+    "lodash": "4.17.15"
+  }
+}

--- a/test/fixtures/npm/case-insesitive-ignore/test-dep-graph-result.json
+++ b/test/fixtures/npm/case-insesitive-ignore/test-dep-graph-result.json
@@ -1,0 +1,518 @@
+{
+  "result": {
+    "affectedPkgs": {
+      "lodash@4.17.15": {
+        "pkg": {
+          "name": "lodash",
+          "version": "4.17.15"
+        },
+        "issues": {
+          "SNYK-JS-LODASH-1018905": {
+            "issueId": "SNYK-JS-LODASH-1018905",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "case-insensitive-ignore",
+                      "version": "1.2.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.17.15",
+                      "newVersion": "4.17.21"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-1040724": {
+            "issueId": "SNYK-JS-LODASH-1040724",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "case-insensitive-ignore",
+                      "version": "1.2.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.17.15",
+                      "newVersion": "4.17.21"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-567746": {
+            "issueId": "SNYK-JS-LODASH-567746",
+            "fixInfo": {
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "case-insensitive-ignore",
+                      "version": "1.2.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.17.15",
+                      "newVersion": "4.17.16"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-lodash-590103": {
+            "issueId": "SNYK-JS-lodash-590103",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "case-insensitive-ignore",
+                      "version": "1.2.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.17.15",
+                      "newVersion": "4.17.20"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          },
+          "SNYK-JS-LODASH-608086": {
+            "issueId": "SNYK-JS-LODASH-608086",
+            "fixInfo": {
+              "isPatchable": false,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "case-insensitive-ignore",
+                      "version": "1.2.3"
+                    },
+                    {
+                      "name": "lodash",
+                      "version": "4.17.15",
+                      "newVersion": "4.17.17"
+                    }
+                  ]
+                }
+              ],
+              "isPinnable": false
+            }
+          }
+        }
+      }
+    },
+    "issuesData": {
+      "SNYK-JS-LODASH-1018905": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P",
+        "alternativeIds": [],
+        "creationTime": "2020-10-16T16:48:40.985673Z",
+        "credit": [
+          "Liyuan Chen"
+        ],
+        "cvssScore": 5.3,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) via the `toNumber`, `trim` and `trimEnd` functions.\r\n\r\n### POC\r\n```\r\nvar lo = require('lodash');\r\n\r\nfunction build_blank (n) {\r\nvar ret = \"1\"\r\nfor (var i = 0; i < n; i++) {\r\nret += \" \"\r\n}\r\n\r\nreturn ret + \"1\";\r\n}\r\n\r\nvar s = build_blank(50000)\r\nvar time0 = Date.now();\r\nlo.trim(s)\r\nvar time_cost0 = Date.now() - time0;\r\nconsole.log(\"time_cost0: \" + time_cost0)\r\n\r\nvar time1 = Date.now();\r\nlo.toNumber(s)\r\nvar time_cost1 = Date.now() - time1;\r\nconsole.log(\"time_cost1: \" + time_cost1)\r\n\r\nvar time2 = Date.now();\r\nlo.trimEnd(s)\r\nvar time_cost2 = Date.now() - time2;\r\nconsole.log(\"time_cost2: \" + time_cost2)\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `lodash` to version 4.17.21 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/c4847ebe7d14540bb28a8b932a9ce1b9ecbfee1a)\n- [GitHub Fix PR](https://github.com/lodash/lodash/pull/5065)\n",
+        "disclosureTime": "2020-10-16T16:47:34Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.17.21"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-LODASH-1018905",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-28500"
+          ],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2021-02-22T09:58:41.562106Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2021-02-15T11:50:49Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/lodash/lodash/commit/c4847ebe7d14540bb28a8b932a9ce1b9ecbfee1a"
+          },
+          {
+            "title": "GitHub Fix PR",
+            "url": "https://github.com/lodash/lodash/pull/5065"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.21"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "SNYK-JS-LODASH-1040724": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H/E:P/RL:U/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-11-17T14:07:17.048472Z",
+        "credit": [
+          "Marc Hassan"
+        ],
+        "cvssScore": 7.2,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Command Injection via `template`.\r\n\r\n### PoC\r\n```\r\nvar _ = require('lodash');\r\n\r\n_.template('', { variable: '){console.log(process.env)}; with(obj' })()\r\n```\n## Remediation\nUpgrade `lodash` to version 4.17.21 or higher.\n## References\n- [GitHub Commit](https://github.com/lodash/lodash/commit/3469357cff396a26c363f8c1b5a91dde28ba4b1c)\n- [Vulnerable Code](https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js#L14851)\n",
+        "disclosureTime": "2020-11-17T13:02:10Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.17.21"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-LODASH-1040724",
+        "identifiers": {
+          "CVE": [
+            "CVE-2021-23337"
+          ],
+          "CWE": [
+            "CWE-78"
+          ],
+          "GHSA": [
+            "GHSA-35jh-r3h4-6jhm"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2021-02-22T09:58:04.543992Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2021-02-15T11:50:50Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/lodash/lodash/commit/3469357cff396a26c363f8c1b5a91dde28ba4b1c"
+          },
+          {
+            "title": "Vulnerable Code",
+            "url": "https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js%23L14851"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.21"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Command Injection"
+      },
+      "SNYK-JS-LODASH-567746": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P/RL:U/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-04-28T14:32:13.683154Z",
+        "credit": [
+          "posix"
+        ],
+        "cvssScore": 6.3,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The function `zipObjectDeep` can be tricked into adding or modifying properties of the Object prototype. These properties will be present on all objects.\r\n\r\n## PoC\r\n```\r\nconst _ = require('lodash');\r\n_.zipObjectDeep(['__proto__.z'],[123])\r\nconsole.log(z) // 123\r\n```\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.16 or higher.\n## References\n- [GitHub PR](https://github.com/lodash/lodash/pull/4759)\n- [HackerOne Report](https://hackerone.com/reports/712065)\n",
+        "disclosureTime": "2020-04-27T22:14:18Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.17.16"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-LODASH-567746",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-8203"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-p6mc-m468-83gw"
+          ],
+          "NSP": [
+            "1523"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-07-09T08:34:04.944267Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:SNYK-JS-LODASH-567746:0",
+            "modificationTime": "2020-04-30T14:28:46.729327Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/lodash/20200430/lodash_0_0_20200430_6baae67d501e4c45021280876d42efe351e77551.patch"
+            ],
+            "version": ">=4.14.2"
+          }
+        ],
+        "proprietary": false,
+        "publicationTime": "2020-04-28T14:59:14Z",
+        "references": [
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/lodash/lodash/pull/4759"
+          },
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/712065"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.16"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "snyk-JS-LODASH-590103": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2020-07-24T12:05:01.916784Z",
+        "credit": [
+          "reeser"
+        ],
+        "cvssScore": 9.8,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution in `zipObjectDeep` due to an incomplete fix for [CVE-2020-8203](https://snyk.io/vuln/SNYK-JS-LODASH-567746).\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.20 or higher.\n## References\n- [GitHub Issue](https://github.com/lodash/lodash/issues/4874)\n",
+        "disclosureTime": "2020-07-24T12:00:52Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "4.17.20"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "snyk-JS-LODASH-590103",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-16T12:11:40.402299Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-08-16T13:09:06Z",
+        "references": [
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/lodash/lodash/issues/4874"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.20"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "critical",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      },
+      "SNYK-JS-LODASH-608086": {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-08-21T12:52:58.443440Z",
+        "credit": [
+          "awarau"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution via the `setWith` and `set` functions.\r\n\r\n### PoC by awarau\r\n* Create a JS file with this contents:\r\n```\r\nlod = require('lodash')\r\nlod.setWith({}, \"__proto__[test]\", \"123\")\r\nlod.set({}, \"__proto__[test2]\", \"456\")\r\nconsole.log(Object.prototype)\r\n```\r\n* Execute it with `node`\r\n* Observe that `test` and `test2` is now in the `Object.prototype`.\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.17 or higher.\n## References\n- [HackerOne Report](https://hackerone.com/reports/864701)\n",
+        "disclosureTime": "2020-08-21T10:34:29Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "4.17.17"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-LODASH-608086",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-27T16:44:20.914177Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-08-21T12:53:03Z",
+        "references": [
+          {
+            "title": "HackerOne Report",
+            "url": "https://hackerone.com/reports/864701"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.17"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution"
+      }
+    },
+    "remediation": {
+      "unresolved": [],
+      "upgrade": {
+        "lodash@4.17.15": {
+          "upgradeTo": "lodash@4.17.21",
+          "upgrades": [
+            "lodash@4.17.15",
+            "lodash@4.17.15",
+            "lodash@4.17.15",
+            "lodash@4.17.15"
+          ],
+          "vulns": [
+            "SNYK-JS-LODASH-1018905",
+            "SNYK-JS-LODASH-1040724",
+            "SNYK-JS-LODASH-608086",
+            "SNYK-JS-LODASH-567746"
+          ]
+        }
+      },
+      "patch": {},
+      "ignore": {},
+      "pin": {}
+    }
+  },
+  "meta": {
+    "isPrivate": true,
+    "isLicensesEnabled": true,
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.22.2\n# ignores vulnerabilities until expiry date; change duration by modifying expiry date\nignore:\n  SNYK-JS-LODASH-590103:\n    - '*':\n        reason: None Given\n        expires: 2021-11-21T21:55:08.466Z\n        created: 2021-10-22T21:55:08.469Z\n        source: cli\npatch: {}\n",
+    "ignoreSettings": null,
+    "org": "demo-applications",
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {
+        "AGPL-1.0": {
+          "licenseType": "AGPL-1.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "AGPL-3.0": {
+          "licenseType": "AGPL-3.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "Artistic-1.0": {
+          "licenseType": "Artistic-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "Artistic-2.0": {
+          "licenseType": "Artistic-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "CDDL-1.0": {
+          "licenseType": "CDDL-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "CPOL-1.02": {
+          "licenseType": "CPOL-1.02",
+          "severity": "high",
+          "instructions": ""
+        },
+        "EPL-1.0": {
+          "licenseType": "EPL-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "GPL-2.0": {
+          "licenseType": "GPL-2.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "GPL-3.0": {
+          "licenseType": "GPL-3.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "LGPL-2.0": {
+          "licenseType": "LGPL-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "LGPL-2.1": {
+          "licenseType": "LGPL-2.1",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "LGPL-3.0": {
+          "licenseType": "LGPL-3.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MPL-1.1": {
+          "licenseType": "MPL-1.1",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MPL-2.0": {
+          "licenseType": "MPL-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MS-RL": {
+          "licenseType": "MS-RL",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "SimPL-2.0": {
+          "licenseType": "SimPL-2.0",
+          "severity": "high",
+          "instructions": ""
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/npm/with-vulnnerable-lodash-and-snyk-file/.snyk
+++ b/test/fixtures/npm/with-vulnnerable-lodash-and-snyk-file/.snyk
@@ -2,7 +2,7 @@
 version: v1.24.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  SNYK-JS-LODASH-590103:
+  SNYK-js-LODASH-590103:
     - '*':
         reason: None Given
         expires: 2021-11-21T21:55:08.466Z

--- a/test/fixtures/npm/with-vulnnerable-lodash-and-snyk-file/test-dep-graph-result.json
+++ b/test/fixtures/npm/with-vulnnerable-lodash-and-snyk-file/test-dep-graph-result.json
@@ -73,8 +73,8 @@
               "isPinnable": false
             }
           },
-          "SNYK-JS-LODASH-590103": {
-            "issueId": "SNYK-JS-LODASH-590103",
+          "SNYK-JS-lodash-590103": {
+            "issueId": "SNYK-JS-lodash-590103",
             "fixInfo": {
               "isPatchable": false,
               "upgradePaths": [
@@ -302,7 +302,7 @@
         "socialTrendAlert": false,
         "title": "Prototype Pollution"
       },
-      "SNYK-JS-LODASH-590103": {
+      "snyk-JS-LODASH-590103": {
         "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
         "alternativeIds": [],
         "creationTime": "2020-07-24T12:05:01.916784Z",
@@ -318,7 +318,7 @@
         ],
         "functions": [],
         "functions_new": [],
-        "id": "SNYK-JS-LODASH-590103",
+        "id": "snyk-JS-LODASH-590103",
         "identifiers": {
           "CVE": [],
           "CWE": [

--- a/test/jest/unit/iac/cli-share-results.fixtures.ts
+++ b/test/jest/unit/iac/cli-share-results.fixtures.ts
@@ -173,7 +173,7 @@ export const expectedEnvelopeFormatterResultsWithPolicy = expectedEnvelopeFormat
     return {
       ...result,
       policy: `# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.25.0
+version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-CC-TF-4:

--- a/test/jest/unit/lib/ecosystems/policy.spec.ts
+++ b/test/jest/unit/lib/ecosystems/policy.spec.ts
@@ -82,6 +82,116 @@ describe('filterIgnoredIssues fn', () => {
     });
   });
 
+  it('should be case insensitive when filtering not-expired ignored issues', () => {
+    const issues: Issue[] = [
+      {
+        pkgName: 'https://foo.bar|test1',
+        pkgVersion: '1.0.0',
+        issueId: 'snyk-TEST-1',
+        fixInfo: {
+          isPatchable: false,
+          upgradePaths: [],
+        },
+      },
+      {
+        pkgName: 'https://foo.bar|test2',
+        pkgVersion: '2.0.0',
+        issueId: 'SNYK-TEST-2',
+        fixInfo: {
+          isPatchable: false,
+          upgradePaths: [],
+        },
+      },
+      {
+        pkgName: 'https://foo.bar|test2',
+        pkgVersion: '2.0.0',
+        issueId: 'snyk-TEST-3',
+        fixInfo: {
+          isPatchable: false,
+          upgradePaths: [],
+        },
+      },
+    ];
+    const issuesData: IssuesData = {
+      'SNYK-TEST-1': {
+        title: 'Arbitrary Code Execution',
+        severity: SEVERITY.LOW,
+        id: 'SNYK-test-1',
+      },
+      'SNYK-TEST-2': {
+        title: 'Arbitrary Code Execution',
+        severity: SEVERITY.MEDIUM,
+        id: 'SNYK-TEST-2',
+      },
+      'SNyk-teST-3': {
+        title: 'Arbitrary Code Execution',
+        severity: SEVERITY.MEDIUM,
+        id: 'SnYK-TESt-3',
+      },
+      'snyk-test-4': {
+        title: 'Arbitrary Code Execution',
+        severity: SEVERITY.MEDIUM,
+        id: 'SNYK-TEST-4',
+      },
+    };
+    const policy = {
+      ignore: {
+        'SnYk-tEsT-1': [
+          {
+            '*': {
+              reason: 'None Given',
+              created: getCurrentDate(),
+              expires: getFutureDate(),
+            },
+          },
+        ],
+        'SnYk-tEsT-3': [
+          {
+            '*': {
+              reason: 'None Given',
+              created: getCurrentDate(),
+              expires: getFutureDate(),
+            },
+          },
+        ],
+        'SnYk-tEsT-4': [
+          {
+            '*': {
+              reason: 'None Given',
+              created: getCurrentDate(),
+              expires: getFutureDate(),
+            },
+          },
+        ],
+      },
+    };
+
+    const [filteredIssues, filteredIssuesData] = filterIgnoredIssues(
+      issues,
+      issuesData,
+      policy as Policy,
+    );
+
+    expect(filteredIssues).toEqual([
+      {
+        pkgName: 'https://foo.bar|test2',
+        pkgVersion: '2.0.0',
+        issueId: 'SNYK-TEST-2',
+        fixInfo: {
+          isPatchable: false,
+          upgradePaths: [],
+        },
+      },
+    ]);
+    expect(filteredIssuesData).toEqual({
+      'SNYK-TEST-2': {
+        title: 'Arbitrary Code Execution',
+        severity: SEVERITY.MEDIUM,
+        id: 'SNYK-TEST-2',
+      },
+    });
+  });
+
   it('should not filter the expired ignored issues', () => {
     const issues: Issue[] = [
       {


### PR DESCRIPTION
#### What does this PR do?

Ignored issues are not filtered out case insensitively. 
This adds a test and updates the logic to match the vulnID (named as issue?.issueId or as the key of the issuesData object), with the policy file's ignore object's keys in a case-insensitive manner.


#### Where should the reviewer start?
~~This is a draft PR~~


#### Any background context you want to provide?
Originally we thought this could be resolved by bumping the version of the policy lib (https://github.com/snyk/cli/pull/4731), however through acceptance testing, we found that the logic here means filtering is still case-sensitive so that wouldn't completely solve the problem.

~~This is still a draft PR, but when ready, we can cherry-pick the changes from this PR into #4731.~~

cherry-picked the changes from #4731 into this one 

#### What are the relevant tickets?
Support ticket here: https://snyksec.atlassian.net/browse/NARW-2259


