### PR TITLE
IAC-2550 - Remove the --cloud-context flag

### DIFF
--- a/src/cli/commands/test/iac/local-execution/assert-iac-options-flag.ts
+++ b/src/cli/commands/test/iac/local-execution/assert-iac-options-flag.ts
@@ -43,10 +43,7 @@ const keys: (keyof IaCTestFlags)[] = [
   'remote-repo-url',
   'target-name',
 ];
-const integratedKeys: (keyof IaCTestFlags)[] = [
-  'snyk-cloud-environment',
-  'cloud-context',
-];
+const integratedKeys: (keyof IaCTestFlags)[] = ['snyk-cloud-environment'];
 
 const allowed = new Set<string>(keys);
 const integratedOnlyFlags = new Set<string>(integratedKeys);

--- a/src/cli/commands/test/iac/local-execution/types.ts
+++ b/src/cli/commands/test/iac/local-execution/types.ts
@@ -215,7 +215,6 @@ export type IaCTestFlags = Pick<
   rules?: string;
   // Enables Snyk Cloud custom rules
   'custom-rules'?: boolean;
-  'cloud-context'?: string;
   'snyk-cloud-environment'?: string;
   // Tags and attributes
   'project-tags'?: string;

--- a/src/cli/commands/test/iac/v2/assert-iac-options.ts
+++ b/src/cli/commands/test/iac/v2/assert-iac-options.ts
@@ -28,7 +28,6 @@ const keys: (keyof IaCTestFlags)[] = [
   'scan',
   'var-file',
   'detectionDepth',
-  'cloud-context',
   'snyk-cloud-environment',
   'custom-rules',
   'experimental',

--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -52,7 +52,6 @@ async function prepareTestConfig(
   const policy = await findAndLoadPolicy(process.cwd(), 'iac', options);
   const scan = options.scan ?? 'resource-changes';
   const varFile = options['var-file'];
-  const cloudContext = getFlag(options, 'cloud-context');
   const snykCloudEnvironment = getFlag(options, 'snyk-cloud-environment');
   const insecure = options.insecure;
   const customRules = options['custom-rules'];
@@ -73,7 +72,6 @@ async function prepareTestConfig(
     scan,
     varFile,
     depthDetection,
-    cloudContext,
     snykCloudEnvironment,
     insecure,
     org,

--- a/src/lib/iac/test/v2/analytics/iac-cloud-context.ts
+++ b/src/lib/iac/test/v2/analytics/iac-cloud-context.ts
@@ -14,10 +14,9 @@ export function getIacCloudContext(
   testConfig: TestConfig,
   testOutput: TestOutput,
 ): IacCloudContext {
-  let iacCloudContext;
-  if (testConfig.cloudContext) {
-    iacCloudContext = 'cloud-context';
-  } else if (testConfig.snykCloudEnvironment) {
+  let iacCloudContext: string | undefined;
+
+  if (testConfig.snykCloudEnvironment) {
     iacCloudContext = 'snyk-cloud-environment';
   }
 
@@ -31,7 +30,6 @@ export function getIacCloudContext(
 
   return {
     iacCloudContext,
-    iacCloudContextCloudProvider: testConfig.cloudContext,
     iacCloudContextSuppressedIssuesCount,
   };
 }

--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -2,11 +2,11 @@ import * as os from 'os';
 
 // TODO: update!
 const policyEngineChecksums = `
-20626360388524d227bdf81879c68c7f8ad0dd2bba4c7e42c349743852b0b2b9  snyk-iac-test_0.47.3_Windows_x86_64.exe
-74543f6531114be163d29cb94df97eea3e7dd339215d4bf916cef6e5602e70b3  snyk-iac-test_0.47.3_Linux_x86_64
-b241a20badec080b2e22def46dd0aa7e5d9d2141724f6829e289f12eb4274fd7  snyk-iac-test_0.47.3_Linux_arm64
-b7391c1db40da0a280a97f45bc3734f7e7f2502458bd66a48c5338e0f2bb1f54  snyk-iac-test_0.47.3_Darwin_x86_64
-b97aa3e5ef2bc1cfd282f6db6189e137be31f9847b61e57c4b9f525588fe95d5  snyk-iac-test_0.47.3_Darwin_arm64
+255a687bd2e5e6e6426ec3a6f45692b2005760a17a07c1ad793c47bbc0ba3c06  snyk-iac-test_0.48.1_Linux_arm64
+36819fafec6ed17a2428f184d89fd210662e5382570f05540177e715c7797d60  snyk-iac-test_0.48.1_Darwin_arm64
+3e7c2640790ef1c46c5df4c7b77c921b56e3f74c22dceeb7725fb486e3791e0f  snyk-iac-test_0.48.1_Linux_x86_64
+586ecba78dc8a788a5f94db4d42b53bea1d7a1e0e4792d592013a457e7f8d05d  snyk-iac-test_0.48.1_Windows_x86_64.exe
+9aa14f8f8136cf5000a622e5f7c60f66da031d793cac10440edc22adda59f388  snyk-iac-test_0.48.1_Darwin_x86_64
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();

--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -113,14 +113,7 @@ function processFlags(
   outputPath: string,
   policyPath: string,
 ) {
-  const flags = [
-    '-cache-dir',
-    systemCachePath,
-    '-bundle',
-    rulesBundlePath,
-    '-policy',
-    policyPath,
-  ];
+  const flags = ['-bundle', rulesBundlePath, '-policy', policyPath];
 
   flags.push('-output', outputPath);
 
@@ -154,10 +147,6 @@ function processFlags(
 
   if (options.varFile) {
     flags.push('-var-file', options.varFile);
-  }
-
-  if (options.cloudContext) {
-    flags.push('-cloud-context', options.cloudContext);
   }
 
   if (options.snykCloudEnvironment) {

--- a/src/lib/iac/test/v2/types.ts
+++ b/src/lib/iac/test/v2/types.ts
@@ -15,7 +15,6 @@ export interface TestConfig {
   scan: string;
   varFile?: string;
   depthDetection?: number;
-  cloudContext?: string;
   snykCloudEnvironment?: string;
   insecure?: boolean;
   org?: string;

--- a/test/jest/unit/iac/assert-iac-options-flag.spec.ts
+++ b/test/jest/unit/iac/assert-iac-options-flag.spec.ts
@@ -39,13 +39,6 @@ describe('assertIntegratedIaCOnlyOptions()', () => {
     ).not.toThrow();
   });
 
-  it('Refuses cloud-context flag', () => {
-    const options = ['--cloud-context', 'aws'];
-    expect(() =>
-      assertIntegratedIaCOnlyOptions(org, [...command, ...options, ...files]),
-    ).toThrow(new IntegratedFlagError('cloud-context', org.meta.org));
-  });
-
   it('Refuses snyk-cloud-environment flag', () => {
     const options = ['--snyk-cloud-environment', 'envid'];
     expect(() =>

--- a/test/jest/unit/lib/iac/test/v2/analytics/fixtures/iac-analytics.json
+++ b/test/jest/unit/lib/iac/test/v2/analytics/fixtures/iac-analytics.json
@@ -1,7 +1,4 @@
 {
-    "iac-cloud-context": "cloud-context",
-    "iac-cloud-context-cloud-provider": "aws",
-    "iac-cloud-context-suppressed-issues-count": 0,
     "iac-type": {
       "terraformconfig": {
         "count": 2,

--- a/test/jest/unit/lib/iac/test/v2/analytics/index.spec.ts
+++ b/test/jest/unit/lib/iac/test/v2/analytics/index.spec.ts
@@ -57,9 +57,7 @@ describe('computeIacAnalytics', () => {
       addedAnalytics[key] = value;
     });
 
-    const testConfig = {
-      cloudContext: 'aws',
-    } as TestConfig;
+    const testConfig = {} as TestConfig;
     const testOutput = clonedeep(snykIacTestOutputFixture);
     const expectedAnalytics = clonedeep(iacAnalyticsFixture);
 


### PR DESCRIPTION
This PR removes the `--cloud-context` flag, as it was deprecated and scheduled for removal before releasing IaC+ to a wider public.