### PR TITLE
feat: upgrade snyk-iac-test

### DIFF
--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -2,11 +2,11 @@ import * as os from 'os';
 
 // TODO: update!
 const policyEngineChecksums = `
-255a687bd2e5e6e6426ec3a6f45692b2005760a17a07c1ad793c47bbc0ba3c06  snyk-iac-test_0.48.1_Linux_arm64
-36819fafec6ed17a2428f184d89fd210662e5382570f05540177e715c7797d60  snyk-iac-test_0.48.1_Darwin_arm64
-3e7c2640790ef1c46c5df4c7b77c921b56e3f74c22dceeb7725fb486e3791e0f  snyk-iac-test_0.48.1_Linux_x86_64
-586ecba78dc8a788a5f94db4d42b53bea1d7a1e0e4792d592013a457e7f8d05d  snyk-iac-test_0.48.1_Windows_x86_64.exe
-9aa14f8f8136cf5000a622e5f7c60f66da031d793cac10440edc22adda59f388  snyk-iac-test_0.48.1_Darwin_x86_64
+1b248c51c82e9a2270ff4b3c7e066a1a964b0538a3877d8113d466f12199188c  snyk-iac-test_0.48.2_Linux_arm64
+25c8ccb5416272dd5d0eea91a58b63f6fdd042c0b6f27350018127777716969d  snyk-iac-test_0.48.2_Darwin_arm64
+36b3226a0656a5e17d8992e40e70f34d547df191569da6ec04ef716d7b19372a  snyk-iac-test_0.48.2_Linux_x86_64
+79c2bd86506398ecc4f17c68dda67ea9fe8254a25b7854f9e4f526764b384b81  snyk-iac-test_0.48.2_Darwin_x86_64
+a78c4daf800d3b81fe8e2d4b2e867123b62d34d59395dd8c382edaa7af3c8158  snyk-iac-test_0.48.2_Windows_x86_64.exe
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();


### PR DESCRIPTION
Upgrades `snyk-iac-test` to the latest version. This fixes a bug where CloudFormation templates with non-string tags could not be scanned and silently failed the whole scan.