### PR TITLE
test: unexpected-error test expects non-colored output

### DIFF
--- a/test/jest/unit/lib/unexpected-error.spec.ts
+++ b/test/jest/unit/lib/unexpected-error.spec.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { runCommand } from '../../util/runCommand';
+import { RunCommandOptions, runCommand } from '../../util/runCommand';
 import { getFixturePath } from '../../util/getFixturePath';
 
 /**
@@ -15,7 +15,13 @@ import { getFixturePath } from '../../util/getFixturePath';
 describe('callHandlingUnexpectedErrors', () => {
   async function runScript(filename: string) {
     const file = path.resolve(getFixturePath('unexpected-error'), filename);
-    return runCommand('node', ['-r', 'ts-node/register', file]);
+    const options: RunCommandOptions = {
+      env: {
+        FORCE_COLOR: '0',
+        PATH: process.env.PATH,
+      },
+    };
+    return runCommand('node', ['-r', 'ts-node/register', file], options);
   }
 
   it('calls the provided callable', async () => {


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

The assertions in unexpected-error.spec.ts expect the output being tested to not contain ANSI color codes. To ensure that is always the case, set `FORCE_COLOR="0"` so node doesn't output colors.

Without this change, this test will pass or fail depending upon the terminal being used to run the tests. With this change, the test runs consistently.

#### Where should the reviewer start?

The diff for the PR is small so I'd start with the diff.

#### How should this be manually tested?

Run the test with `TERM` unset, `TERM=dumb`, `TERM=xterm`, `TERM=xterm-256color`, and any other desired values. Note that with this change, the `unexpected-error` tests consistently pass.

#### Any background context you want to provide?

Relevant node documentation: https://nodejs.org/dist/latest-v18.x/docs/api/cli.html#force_color1-2-3

#### What are the relevant tickets?

No, but I can make one if that would be helpful - just point me to the instructions to do so :)

#### Screenshots

n/a

#### Additional questions
