### PR TITLE
feat: trigger GHA workflow via CircleCI [HEAD-350]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1042,20 +1042,6 @@ jobs:
     steps:
       - prepare-workspace
       - run:
-          name: Dispatch build-and-publish workflow at snyk-images
-          command: |
-            RESPONSE=$(curl -L \
-              -X POST \
-              -H "Accept: application/vnd.github+json" \
-              -H "Authorization: Bearer $HAMMERHEAD_GITHUB_PAT" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              https://api.github.com/repos/snyk/snyk-images/dispatches \
-              -d '{"event_type":"build_and_push_images"}' \
-              -w "%{http_code}" \
-              -o /dev/null)
-            if [ "$RESPONSE" -eq 204 ]; then
-              echo "Successfully triggered the workflow."
-            else
-              echo "Failed to trigger the workflow. HTTP response code: $RESPONSE."
-              exit 1
-            fi
+          name: Trigger build-and-publish workflow at snyk-images
+          command: ./release-scripts/upload-artifacts.sh
+      - failed-release-notification

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1043,5 +1043,5 @@ jobs:
       - prepare-workspace
       - run:
           name: Trigger build-and-publish workflow at snyk-images
-          command: ./release-scripts/upload-artifacts.sh
+          command: ./release-scripts/upload-artifacts.sh trigger-snyk-images
       - failed-release-notification

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -652,8 +652,8 @@ workflows:
               only:
                 - master
 
-      - build-and-publish-snyk-images:
-          name: build and publish snyk images
+      - trigger-building-snyk-images:
+          name: Trigger building snyk-images
           context: team-hammerhead-common-deploy-tokens
           requires:
             - upload npm
@@ -1037,7 +1037,7 @@ jobs:
           command: ./release-scripts/upload-artifacts.sh npm
       - failed-release-notification
 
-  build-and-publish-snyk-images:
+  trigger-building-snyk-images:
     executor: docker-amd64
     steps:
       - prepare-workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -652,6 +652,16 @@ workflows:
               only:
                 - master
 
+      - build-and-publish-snyk-images:
+          name: build and publish snyk images
+          context: team-hammerhead-common-deploy-tokens
+          requires:
+            - upload npm
+          filters:
+            branches:
+              only:
+                - master
+
 ####################################################################################################
 # JOBS
 ####################################################################################################
@@ -1026,3 +1036,26 @@ jobs:
           name: Publish to npm
           command: ./release-scripts/upload-artifacts.sh npm
       - failed-release-notification
+
+  build-and-publish-snyk-images:
+    executor: docker-amd64
+    steps:
+      - prepare-workspace
+      - run:
+          name: Dispatch build-and-publish workflow at snyk-images
+          command: |
+            RESPONSE=$(curl -L \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $HAMMERHEAD_GITHUB_PAT" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/snyk/snyk-images/dispatches \
+              -d '{"event_type":"build_and_push_images"}' \
+              -w "%{http_code}" \
+              -o /dev/null)
+            if [ "$RESPONSE" -eq 204 ]; then
+              echo "Successfully triggered the workflow."
+            else
+              echo "Failed to trigger the workflow. HTTP response code: $RESPONSE."
+              exit 1
+            fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,7 +288,6 @@ You may see some "Docker Hub" checks on your merge commit fail. This is normal a
 
 After the `release-npm` job successfully completes, an automated process generates the Docker images for Snyk CLI. These images are then published to DockerHub under the repository [`snyk/snyk`](https://hub.docker.com/r/snyk/snyk).
 
-
 ---
 
 Questions? Ask Hammerhead 🔨

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,6 +284,11 @@ If your release pipeline fails at any step, notify Hammerhead.
 
 You may see some "Docker Hub" checks on your merge commit fail. This is normal and safe to ignore.
 
+## Snyk CLI Docker Images
+
+After the `release-npm` job successfully completes, an automated process generates the Docker images for Snyk CLI. These images are then published to DockerHub under the repository [`snyk/snyk`](https://hub.docker.com/r/snyk/snyk).
+
+
 ---
 
 Questions? Ask Hammerhead 🔨


### PR DESCRIPTION
#### What does this PR do?

This PR adds a CircleCI job to trigger a GitHub Actions workflow in the `snyk/snyk-images` repository using `repository_dispatch` [event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows). This will build and push Snyk Docker images after Upload NPM job is completed.

#### Where should the reviewer start?
This new job is triggered when Upload NPM job is completed. 

#### How should this be manually tested?
`cURL` the same command written in `build-and-publish-snyk-images`

#### What are the relevant tickets?
HEAD-350

#### Screenshots

|CICD to GHA|
|-|
|![cicd-to-gha](https://github.com/snyk/cli/assets/1948377/7ed57696-6713-4333-9f66-1fd94d701219)|



#### Additional questions
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules