### PR TITLE
fix: bump snyk-docker-plugin to fix the snyk container tag and digest handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.22.2",
-        "snyk-docker-plugin": "6.5.7",
+        "snyk-docker-plugin": "6.5.9",
         "snyk-go-plugin": "1.23.0",
         "snyk-gradle-plugin": "3.27.0",
         "snyk-module": "3.1.0",
@@ -17050,9 +17050,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "6.5.7",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.5.7.tgz",
-      "integrity": "sha512-OR2+A/bR3bax9fY5pNNuo9/M1hkO0Ne5GsTMgcRyKiGLXM9KIewxVIjPNiBMiBUSGVn6JAvYdoeTRzuisrCRDQ==",
+      "version": "6.5.9",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.5.9.tgz",
+      "integrity": "sha512-+htd0OFckcluij2w1/hJthMPF3GSYCo25KT7YRtb6rg3+tU8k/IPxZkoOFPvjPTsKQfFfVCWQ5c9xQr9VRWGpg==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.7.1",
@@ -17070,7 +17070,7 @@
         "mkdirp": "^1.0.4",
         "packageurl-js": "^1.0.2",
         "semver": "^7.5.4",
-        "shescape": "^1.7.2",
+        "shescape": "^1.7.4",
         "snyk-nodejs-lockfile-parser": "^1.52.1",
         "snyk-poetry-lockfile-parser": "^1.3.0",
         "tar-stream": "^2.1.0",
@@ -17134,9 +17134,9 @@
       }
     },
     "node_modules/snyk-docker-plugin/node_modules/shescape": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/shescape/-/shescape-1.7.2.tgz",
-      "integrity": "sha512-Q1yKKLdn+jO6g/tlsxrXr/yE4mPX0KwB2JYAVC+w3RsunAhrtu0E1DsZS5n4oUpmzUJXhWw/fdxffg8eFkx20Q==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/shescape/-/shescape-1.7.4.tgz",
+      "integrity": "sha512-6eaKkGvkiR86VmRfFaT1RYP0DtYnOj3u3WR41ItGqADBZMtr0lI4iTnqakE65gnRwHIF7XNvqA9oaE31EZsB7Q==",
       "dependencies": {
         "which": "^2.0.0"
       },
@@ -34222,9 +34222,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "6.5.7",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.5.7.tgz",
-      "integrity": "sha512-OR2+A/bR3bax9fY5pNNuo9/M1hkO0Ne5GsTMgcRyKiGLXM9KIewxVIjPNiBMiBUSGVn6JAvYdoeTRzuisrCRDQ==",
+      "version": "6.5.9",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.5.9.tgz",
+      "integrity": "sha512-+htd0OFckcluij2w1/hJthMPF3GSYCo25KT7YRtb6rg3+tU8k/IPxZkoOFPvjPTsKQfFfVCWQ5c9xQr9VRWGpg==",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.7.1",
@@ -34242,7 +34242,7 @@
         "mkdirp": "^1.0.4",
         "packageurl-js": "^1.0.2",
         "semver": "^7.5.4",
-        "shescape": "^1.7.2",
+        "shescape": "^1.7.4",
         "snyk-nodejs-lockfile-parser": "^1.52.1",
         "snyk-poetry-lockfile-parser": "^1.3.0",
         "tar-stream": "^2.1.0",
@@ -34282,9 +34282,9 @@
           }
         },
         "shescape": {
-          "version": "1.7.2",
-          "resolved": "https://registry.npmjs.org/shescape/-/shescape-1.7.2.tgz",
-          "integrity": "sha512-Q1yKKLdn+jO6g/tlsxrXr/yE4mPX0KwB2JYAVC+w3RsunAhrtu0E1DsZS5n4oUpmzUJXhWw/fdxffg8eFkx20Q==",
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/shescape/-/shescape-1.7.4.tgz",
+          "integrity": "sha512-6eaKkGvkiR86VmRfFaT1RYP0DtYnOj3u3WR41ItGqADBZMtr0lI4iTnqakE65gnRwHIF7XNvqA9oaE31EZsB7Q==",
           "requires": {
             "which": "^2.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.22.2",
-    "snyk-docker-plugin": "6.5.7",
+    "snyk-docker-plugin": "6.5.9",
     "snyk-go-plugin": "1.23.0",
     "snyk-gradle-plugin": "3.27.0",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
#### What does this PR do?

This PR updates the version of the snyk-docker-plugin dependency.

The snyk-docker-plugin did not handle correctly in the previous version the case when the docker daemon is unavailable, and both the image digest and tag are passed as arguments. The bug is fixed in the new version.


#### Any background context you want to provide?

Snyk-docker-plugin PR: https://github.com/snyk/snyk-docker-plugin/pull/527
