### PR TITLE
fix: strip CWD from paths before using them

### DIFF
--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -44,6 +44,15 @@ async function prepareTestConfig(
 ): Promise<TestConfig> {
   const iacCachePath = pathLib.join(systemCachePath, 'iac');
 
+  // When running in a case-insensitive file system (for example, in macOS),
+  // Node consider the current working directory to be the `realpath`, while Go
+  // consider it to be the `pwd`. To prevent confusion when passing the path of
+  // the current working directory as an input path, let's make every path
+  // relative and let snyk-iac-test figure them out according to what it
+  // considers the current working directory to be.
+
+  const relativePaths = paths.map((p) => pathLib.relative(process.cwd(), p));
+
   const org = (options.org as string) || config.org;
   const targetName = getFlag(options, 'target-name');
   const remoteRepoUrl = getFlag(options, 'remote-repo-url');
@@ -58,7 +67,7 @@ async function prepareTestConfig(
   const experimental = options.experimental;
 
   return {
-    paths,
+    paths: relativePaths,
     iacCachePath,
     userRulesBundlePath: config.IAC_BUNDLE_PATH,
     userPolicyEnginePath: config.IAC_POLICY_ENGINE_PATH,


### PR DESCRIPTION
When running in a case-insensitive file system (like in macOS), Node and Go use different strategies for obtaining the current working directory. The current working directory in Node is the same returned by `realpath` or `getcwd(3)`. Instead, the current working directory in Go is the same returned by `pwd` or `$PWD`. The former strategy is consistent with the case of the directory when it was created, while the latter is consistent with the case of the directory the user changed into.

For example, let's say you are in `/Users/me/src`. Because you are on macOS, you can run `cd /Users/me/SRC` and actually end up in the same directory, because the file system is not case sensitive. In this case, though, Node believes that the current working directory is `/Users/me/src`, while Go believes that it is `/Users/me/SRC`. 

To prevent confusion when Node executes `snyk-iac-test`, every input path is first made relative to the current working directory (according to Node), so that `snyk-iac-test` can make them absolute again, if needed, according to the current directory seen by Go.