### PR TITLE
fix: release validation

### DIFF
--- a/release-scripts/validate-repository.sh
+++ b/release-scripts/validate-repository.sh
@@ -9,9 +9,10 @@ if [ "${TAG_FOUND}" != "" ]; then
     exit 1
 fi
 
-aws s3 ls s3://"${PUBLIC_S3_BUCKET}"/cli/"${VERSION_TAG}"/
-if [ "${?}" -eq "0" ]; then
-    echo "Version ${VERSION_TAG} has already been released."
+npm view snyk versions | grep '${VERSION_TAG}'
+retVal=$?
+if [ $retVal -ne 1 ]; then
+    echo "Version ${VERSION_TAG} has already been released to npm."
     exit 1
 fi
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Check if a release is already published to npm instead of static.snyk.io

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
