### PR TITLE
chore: removes SCLE URL validation [nebula-1372]

### DIFF
--- a/src/lib/plugins/sast/analysis.ts
+++ b/src/lib/plugins/sast/analysis.ts
@@ -27,7 +27,6 @@ import * as debugLib from 'debug';
 import { getCodeClientProxyUrl } from '../../code-config';
 import {
   isLocalCodeEngine,
-  validateLocalCodeEngineUrl,
   logLocalCodeEngineVersion,
 } from './localCodeEngine';
 
@@ -68,7 +67,6 @@ export async function getCodeTestResults(
   const isLocalCodeEngineEnabled = isLocalCodeEngine(sastSettings);
   if (isLocalCodeEngineEnabled) {
     baseURL = sastSettings.localCodeEngine.url;
-    validateLocalCodeEngineUrl(baseURL);
     if (options.debug) {
       await logLocalCodeEngineVersion(baseURL);
     }

--- a/src/lib/plugins/sast/localCodeEngine.ts
+++ b/src/lib/plugins/sast/localCodeEngine.ts
@@ -1,7 +1,6 @@
 import * as debugLib from 'debug';
 import chalk from 'chalk';
 
-import { MissingConfigurationError } from './errors';
 import { makeRequest } from '../../request';
 import { Global } from '../../../cli/args';
 import { SastSettings } from './types';
@@ -13,14 +12,6 @@ export function isLocalCodeEngine(sastSettings: SastSettings): boolean {
   const { sastEnabled, localCodeEngine } = sastSettings;
 
   return sastEnabled && localCodeEngine.enabled;
-}
-
-export function validateLocalCodeEngineUrl(localCodeEngineUrl: string): void {
-  if (localCodeEngineUrl.length === 0) {
-    throw new MissingConfigurationError(
-      'Snyk Code Local Engine. Refer to our docs on https://docs.snyk.io/products/snyk-code/deployment-options/snyk-code-local-engine/cli-and-ide to learn more',
-    );
-  }
 }
 
 export async function logLocalCodeEngineVersion(lceUrl = ''): Promise<void> {

--- a/test/jest/unit/snyk-code/snyk-code-test.spec.ts
+++ b/test/jest/unit/snyk-code/snyk-code-test.spec.ts
@@ -910,31 +910,6 @@ describe('Test snyk code', () => {
     );
   });
 
-  it('Local code engine - should throw error, when enabled and url is missing', async () => {
-    const sastSettings = {
-      sastEnabled: true,
-      localCodeEngine: {
-        url: '',
-        allowCloudUpload: true,
-        enabled: true,
-      },
-    };
-
-    await expect(
-      getCodeTestResults(
-        '.',
-        {
-          path: '',
-          code: true,
-        },
-        sastSettings,
-        'test-id',
-      ),
-    ).rejects.toThrowError(
-      'Missing configuration for Snyk Code Local Engine. Refer to our docs on https://docs.snyk.io/products/snyk-code/deployment-options/snyk-code-local-engine/cli-and-ide to learn more',
-    );
-  });
-
   it('Local code engine - makes GET /status to get SCLE version', async () => {
     const sastSettings = {
       sastEnabled: true,


### PR DESCRIPTION
SCLE URL validation was added on the [server](https://github.com/snyk/registry/pull/32946) and hence, is not needed anymore on the clients.