### PR TITLE
fix: fix project name override with sub projects

### DIFF
--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -280,7 +280,11 @@ export default async function monitor(...args0: MethodArgs): Promise<any> {
           const res: MonitorResult = await promiseOrCleanup(
             snykMonitor(
               path,
-              generateMonitorMeta(options, extractedPackageManager),
+              generateMonitorMeta(
+                options,
+                extractedPackageManager,
+                projectName,
+              ),
               projectDeps,
               options,
               projectDeps.plugin as PluginMetadata,
@@ -346,12 +350,17 @@ export default async function monitor(...args0: MethodArgs): Promise<any> {
   throw new Error(output);
 }
 
-function generateMonitorMeta(options, packageManager?): MonitorMeta {
+function generateMonitorMeta(
+  options,
+  packageManager?,
+  projectName?,
+): MonitorMeta {
   return {
     method: 'cli',
     packageManager,
     'policy-path': options['policy-path'],
-    'project-name': options['project-name'] || config.PROJECT_NAME,
+    'project-name':
+      options['project-name'] || projectName || config.PROJECT_NAME,
     isDocker: !!options.docker,
     prune: !!options.pruneRepeatedSubdependencies,
     'remote-repo-url': options['remote-repo-url'],


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

When we scan a mono repo where in the root dir there's no project config but only sub dirs containing sub projects, e.g. like following
```
my-mono-repo
- project-a
  - settings.gradle
  - build.gradle 
- project-b
  - settings.gradle
  - build.gradle
```

We noticed that when doing `snyk monitor` instead of creating two projects, it creates one `my-mono-repo` project and the vulnerabilities found in the sub projects are overriding, and the `Explore this snapshot at` message printed out locally points to exactly the same remote URL.

We found that this issue is caused by that the `project-name` is missing as part of the meta data.

This PR supplies that missing `project-name`. The fixing has been tested locally and works well.

#### Screenshots

Before: 
![Screenshot 2023-09-05 at 17 29 28](https://github.com/snyk/cli/assets/102186579/2b09442d-500d-419e-a552-dd8e5fac13d7)

After:
![Screenshot 2023-09-05 at 17 29 34](https://github.com/snyk/cli/assets/102186579/26cdba63-cd35-460b-adf1-a09606626c16)