### PR TITLE
fix: [OSM-347] Bump `snyk-nuget-plugin`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "3.1.0",
         "snyk-nodejs-lockfile-parser": "1.52.1",
-        "snyk-nuget-plugin": "1.31.0",
+        "snyk-nuget-plugin": "1.34.0",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.25.0",
         "snyk-python-plugin": "^2.0.1",
@@ -17719,9 +17719,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-nuget-plugin": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.31.0.tgz",
-      "integrity": "sha512-uv25vE3aQ5JlRon+SwbU63AZT5BSlcLQC13U4Mc6+1ensuQkfb8BddXwnhkK/mMhFANgqpGQKwn8/DkgcNvS4A==",
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.34.0.tgz",
+      "integrity": "sha512-WODOZ2Nv3xB3n1A8HgFjwJZexGHZDpurk07wQ7DdTiY/Xmh2DzQmuC/0rknyIQxATVxt9KBrwaw1QObRW+aUOQ==",
       "dependencies": {
         "@snyk/dep-graph": "^2.7.1",
         "debug": "^4.3.4",
@@ -34632,9 +34632,9 @@
       }
     },
     "snyk-nuget-plugin": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.31.0.tgz",
-      "integrity": "sha512-uv25vE3aQ5JlRon+SwbU63AZT5BSlcLQC13U4Mc6+1ensuQkfb8BddXwnhkK/mMhFANgqpGQKwn8/DkgcNvS4A==",
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.34.0.tgz",
+      "integrity": "sha512-WODOZ2Nv3xB3n1A8HgFjwJZexGHZDpurk07wQ7DdTiY/Xmh2DzQmuC/0rknyIQxATVxt9KBrwaw1QObRW+aUOQ==",
       "requires": {
         "@snyk/dep-graph": "^2.7.1",
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "3.1.0",
     "snyk-nodejs-lockfile-parser": "1.52.1",
-    "snyk-nuget-plugin": "1.31.0",
+    "snyk-nuget-plugin": "1.34.0",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.25.0",
     "snyk-python-plugin": "^2.0.1",

--- a/test/jest/acceptance/snyk-test/basic-test-all-languages.spec.ts
+++ b/test/jest/acceptance/snyk-test/basic-test-all-languages.spec.ts
@@ -186,6 +186,29 @@ describe('`snyk test` of basic projects for each language/ecosystem', () => {
     expect(code).toEqual(0);
   });
 
+  test('run `snyk test` on a nuget project using v2 dotnet runtime resolution logic with explicit target framework', async () => {
+    const prerequisite = await runCommand('dotnet', ['--version']).catch(
+      function() {
+        return { code: 1, stderr: '', stdout: '' };
+      },
+    );
+
+    if (prerequisite.code !== 0 && !dontSkip) {
+      return;
+    }
+
+    const project = await createProjectFromWorkspace('nuget-app-6');
+
+    const { code } = await runSnykCLI(
+      'test -d --dotnet-runtime-resolution --target-framework=net6.0',
+      {
+        cwd: project.path(),
+      },
+    );
+
+    expect(code).toEqual(0);
+  });
+
   test('run `snyk test` on an unmanaged project', async () => {
     const project = await createProjectFromWorkspace('unmanaged');
 


### PR DESCRIPTION
#### What does this PR do?

Bumps the Snyk Nuget (.NET) plugin, which enables the specification of a `--target-framework` flag, that will scan for vulnerabilities against a specific runtime version.
