### PR TITLE
fix: update go version to 1.21.4

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM golang:1.20-bullseye
+FROM --platform=$TARGETPLATFORM golang:1.21-bullseye
 
 # install "normal" stuff
 

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM golang:1.21-bullseye
+FROM --platform=$TARGETPLATFORM golang:1.21.4-bullseye
 
 # install "normal" stuff
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
   go_version:
     type: string
     # https://go.dev/doc/devel/release
-    default: '1.20.6'
+    default: '1.21.1'
   aws_version:
     type: string
     # https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
   go_version:
     type: string
     # https://go.dev/doc/devel/release
-    default: '1.21.1'
+    default: '1.21.4'
   aws_version:
     type: string
     # https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -794,7 +794,7 @@ jobs:
           go_target_os: linux
           go_arch: amd64
           base_url: << pipeline.parameters.go_download_base_url >>
-          extraction_path: '.'
+          extraction_path: '/tmp'
       - run:
           name: Linting project
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,6 +462,10 @@ workflows:
           requires:
             - build linux amd64
           executor: docker-amd64
+          go_target_os: linux
+          go_os: linux
+          go_arch: amd64
+          go_download_base_url: << pipeline.parameters.go_download_base_url >>
           test_snyk_command: ./binary-releases/snyk-linux
 
       - acceptance-tests:
@@ -475,6 +479,10 @@ workflows:
           requires:
             - build linux arm64
           executor: docker-arm64
+          go_target_os: linux
+          go_os: linux
+          go_arch: arm64
+          go_download_base_url: << pipeline.parameters.go_download_base_url >>
           test_snyk_command: ./binary-releases/snyk-linux-arm64
 
       - acceptance-tests:
@@ -482,6 +490,10 @@ workflows:
           executor: docker-arm64
           test_snyk_command: ./binary-releases/fips/snyk-linux-arm64
           fips: 1
+          go_target_os: linux
+          go_os: linux
+          go_arch: arm64
+          go_download_base_url: << pipeline.parameters.fips_go_download_base_url >>
           context:
             - nodejs-install
             - team_hammerhead-cli
@@ -502,6 +514,10 @@ workflows:
           requires:
             - build alpine amd64
           executor: alpine
+          go_target_os: alpine
+          go_os: linux
+          go_arch: amd64
+          go_download_base_url: << pipeline.parameters.go_download_base_url >>
           test_snyk_command: ./binary-releases/snyk-alpine
           install_deps_extension: alpine-full
           dont_skip_tests: 0
@@ -518,6 +534,10 @@ workflows:
             - build macOS arm64
           executor: macos-arm64
           test_snyk_command: ./binary-releases/snyk-macos-arm64
+          go_target_os: darwin
+          go_os: darwin
+          go_arch: arm64
+          go_download_base_url: << pipeline.parameters.go_download_base_url >>
           install_deps_extension: macos-full
 
       - acceptance-tests:
@@ -534,6 +554,10 @@ workflows:
           test_snyk_command: binary-releases\\snyk-win.exe
           install_deps_extension: windows-full
           dont_skip_tests: 0
+          go_target_os: windows
+          go_os: windows
+          go_arch: amd64
+          go_download_base_url: << pipeline.parameters.go_download_base_url >>
           pre_test_cmds: Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1; RefreshEnv
 
       - sign:
@@ -930,6 +954,17 @@ jobs:
 
   acceptance-tests:
     parameters:
+      go_os:
+        type: string
+      go_target_os:
+        type: string
+      go_arch:
+        type: string
+      go_download_base_url:
+        type: string
+      install_path:
+        type: string
+        default: '.'
       test_snyk_command:
         type: string
       executor:
@@ -950,6 +985,12 @@ jobs:
     steps:
       - prepare-workspace
       - install-deps-<< parameters.install_deps_extension >>
+      - install-go:
+          go_os: << parameters.go_os >>
+          go_target_os: << parameters.go_target_os >>
+          go_arch: << parameters.go_arch >>
+          base_url: << parameters.go_download_base_url >>
+          extraction_path: << parameters.install_path >>
       - run:
           command: npm install
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -872,7 +872,7 @@ jobs:
       - run:
           name: Running Go unit tests
           working_directory: ./cliv2
-          command: make whiteboxtest
+          command: make openboxtest
       - run:
           name: Running Tap tests
           no_output_timeout: '30m' # the whole set of tests regularly takes 25+ minutes.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -789,6 +789,12 @@ jobs:
     executor: docker-amd64
     steps:
       - prepare-workspace
+      - install-go:
+          go_os: linux
+          go_target_os: linux
+          go_arch: amd64
+          base_url: << pipeline.parameters.go_download_base_url >>
+          extraction_path: '.'
       - run:
           name: Linting project
           command: |
@@ -830,6 +836,19 @@ jobs:
       - run:
           name: Configuring artifact
           command: node ./bin/snyk config set "api=${TEST_SNYK_TOKEN}" # many tests require the token to be in the config
+      - run:
+          name: Running TS unit tests
+          command: npm run test:unit
+      - install-go:
+          go_os: linux
+          go_target_os: linux
+          go_arch: amd64
+          base_url: << pipeline.parameters.go_download_base_url >>
+          extraction_path: '.'
+      - run:
+          name: Running Go unit tests
+          working_directory: ./cliv2
+          command: make whiteboxtest
       - run:
           name: Running Tap tests
           no_output_timeout: '30m' # the whole set of tests regularly takes 25+ minutes.

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -1,6 +1,8 @@
 module github.com/snyk/cli/cliv2
 
-go 1.18
+go 1.21
+
+toolchain go1.21.4
 
 require (
 	github.com/elazarl/goproxy v0.0.0-20231031074852-3ec07828be7a


### PR DESCRIPTION
### What does this PR do?

This PR updates Go version to 1.21.1 https://go.dev/doc/devel/release

- This version is compatible with Microsoft Go version https://github.com/microsoft/go/releases

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules