### PR TITLE
feat: updated integrated iac naming

### DIFF
--- a/packages/iac-cli-alert/src/index.ts
+++ b/packages/iac-cli-alert/src/index.ts
@@ -44,7 +44,7 @@ async function sendSlackAlert() {
   console.log('IaC smoke tests failed. Sending Slack alert...');
   const args: IncomingWebhookDefaultArguments = {
     text:
-      'Infrastructure as Code Smoke Tests jobs failed. \n Core functionality in the Integrated IaC CLI flows may not be working as expected. \n <https://github.com/snyk/cli/actions/workflows/iac-smoke-tests.yml?query=workflow%3A|Infrastructure as Code Smoke Tests Results> \n <https://www.notion.so/snyk/Alert-Infrastructure-as-Code-Smoke-Tests-jobs-failed-ad6a89ea7fb74cc4aab4763c5ac59cbc|View the runbook for this alert>',
+      'Infrastructure as Code Smoke Tests jobs failed. \n Core functionality in the IaC+ CLI flows may not be working as expected. \n <https://github.com/snyk/cli/actions/workflows/iac-smoke-tests.yml?query=workflow%3A|Infrastructure as Code Smoke Tests Results> \n <https://www.notion.so/snyk/Alert-Infrastructure-as-Code-Smoke-Tests-jobs-failed-ad6a89ea7fb74cc4aab4763c5ac59cbc|View the runbook for this alert>',
   };
   await slackWebhook.send(args);
   console.log('Slack alert sent.');

--- a/src/cli/commands/test/iac/local-execution/assert-iac-options-flag.ts
+++ b/src/cli/commands/test/iac/local-execution/assert-iac-options-flag.ts
@@ -8,6 +8,7 @@ import {
   TerraformPlanScanMode,
 } from './types';
 import { Options, TestOptions } from '../../../../../lib/types';
+import { IacV2Name } from '../../../../../lib/iac/constants';
 
 const keys: (keyof IaCTestFlags)[] = [
   'org',
@@ -72,7 +73,7 @@ export class FlagError extends CustomError {
 export class IntegratedFlagError extends CustomError {
   constructor(key: string, org: string) {
     const flag = getFlagName(key);
-    const msg = `Flag "${flag}" is only supported when using Integrated IaC. To enable it for your organisation "${org}", please contact Snyk support.`;
+    const msg = `Flag "${flag}" is only supported when using ${IacV2Name}. To enable it for your organisation "${org}", please contact Snyk support.`;
     super(msg);
     this.code = IaCErrorCodes.FlagError;
     this.strCode = getErrorStringCode(this.code);
@@ -160,7 +161,7 @@ export function assertIaCOptionsFlags(argv: string[]): void {
 
 /**
  * Check that the flags used for the v1 flow do not contain any flag that are
- * only usable with the new integrated iac (v2) flow
+ * only usable with the new IaC+ flow
  * @param settings organisation settings, used to get the org name
  * @param argv command line args
  */

--- a/src/lib/iac/constants.ts
+++ b/src/lib/iac/constants.ts
@@ -33,3 +33,5 @@ export const iacRemediationTypes: { [k in IacProjectTypes]?: string } = {
   k8sconfig: 'kubernetes',
   terraformconfig: 'terraform',
 };
+
+export const IacV2Name = 'IaC+'

--- a/src/lib/iac/constants.ts
+++ b/src/lib/iac/constants.ts
@@ -34,4 +34,6 @@ export const iacRemediationTypes: { [k in IacProjectTypes]?: string } = {
   terraformconfig: 'terraform',
 };
 
-export const IacV2Name = 'IaC+'
+export const IacV2Name = 'IaC+';
+
+export const IacV2ShortLink = 'https://snyk.co/iac+';

--- a/src/lib/iac/test/v2/output.ts
+++ b/src/lib/iac/test/v2/output.ts
@@ -35,6 +35,7 @@ import {
 } from '../../../formatters/iac-output/text/utils';
 import * as wrapAnsi from 'wrap-ansi';
 import { formatIacTestWarnings } from '../../../formatters/iac-output/text/failures/list';
+import { IacV2Name } from '../../constants';
 
 export function buildOutput({
   scanResult,
@@ -207,7 +208,7 @@ function wrapWithPadding(s: string, columns: number): string {
 }
 
 function infoMessage(orgSettings: TestOutput): string {
-  return `Your organization ${orgSettings.settings.org} is using Integrated IaC. To switch to Current IaC, use --org=<ORG_ID> to select a different organization. For more information about Integrated IaC, see https://snyk.co/integrated-iac.`;
+  return `Your organization ${orgSettings.settings.org} is using ${IacV2Name}. To switch to Current IaC, use --org=<ORG_ID> to select a different organization. For more information about ${IacV2Name}, see https://snyk.co/integrated-iac.`;
 }
 
 function assertHasSuccessfulScans(

--- a/src/lib/iac/test/v2/output.ts
+++ b/src/lib/iac/test/v2/output.ts
@@ -35,7 +35,7 @@ import {
 } from '../../../formatters/iac-output/text/utils';
 import * as wrapAnsi from 'wrap-ansi';
 import { formatIacTestWarnings } from '../../../formatters/iac-output/text/failures/list';
-import { IacV2Name } from '../../constants';
+import { IacV2Name, IacV2ShortLink } from '../../constants';
 
 export function buildOutput({
   scanResult,
@@ -208,7 +208,7 @@ function wrapWithPadding(s: string, columns: number): string {
 }
 
 function infoMessage(orgSettings: TestOutput): string {
-  return `Your organization ${orgSettings.settings.org} is using ${IacV2Name}. To switch to Current IaC, use --org=<ORG_ID> to select a different organization. For more information about ${IacV2Name}, see https://snyk.co/integrated-iac.`;
+  return `Your organization ${orgSettings.settings.org} is using ${IacV2Name}. To switch to Current IaC, use --org=<ORG_ID> to select a different organization. For more information about ${IacV2Name}, see ${IacV2ShortLink}.`;
 }
 
 function assertHasSuccessfulScans(


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Updates the naming of Integrated IAC to IAC+

#### Any background context you want to provide?

[Internal announcement](https://snyk.slack.com/archives/C2GSU0FCG/p1691690350052209)
Please see [this comment](https://snyksec.atlassian.net/browse/IAC-2572?focusedCommentId=826241) for details around updating the short link. 

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/IAC-2572
