### PR TITLE
fix: upgrade snyk-iac-test to latest - contains fixes for the policy-engine

### DIFF
--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -2,11 +2,11 @@ import * as os from 'os';
 
 // TODO: update!
 const policyEngineChecksums = `
-3ec5e8ed0e17c8d3da4ef98b629b559669747982993c3e1037f14c448aa696a8  snyk-iac-test_0.49.0_Linux_x86_64
-6be11cf55bf01a90622c397d31548ed6d50ac0f317f28c969e5cbfc109eae5e1  snyk-iac-test_0.49.0_Darwin_arm64
-b965f0f672460920839efc5e889270facea5abc7d87eedb83b65277df6305b47  snyk-iac-test_0.49.0_Darwin_x86_64
-e760a4e249fd950a89c4f996c59d20971263ba4f905d62880d05cc608718158a  snyk-iac-test_0.49.0_Windows_x86_64.exe
-fb799eb5dd79a9d68f3deed9d4b5272e4e435fe31c348fef06e245790fe1069a  snyk-iac-test_0.49.0_Linux_arm64
+1f2be3e4d03459f8f14ec971f27e51668128e0c9ea087c9079c8acd6c57f7841  snyk-iac-test_0.49.1_Linux_arm64
+275e734dab56ca4c7882c2a405fb354697675fa861a7c10f4d20056832a36294  snyk-iac-test_0.49.1_Darwin_x86_64
+7d93b6a6555c4864230134527fb3b472743fea9cfdf7081679c764af74aef9cb  snyk-iac-test_0.49.1_Windows_x86_64.exe
+d62cbf8ad8bf4f966cb9a043dce0d7f64e89eb91817cca75ea0254ba0c8dd335  snyk-iac-test_0.49.1_Linux_x86_64
+fcde4a397efc687a96738f8193cec1dc6f46c5c57fc190d28192daaa16d1a83d  snyk-iac-test_0.49.1_Darwin_arm64
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Upgrades `snyk-iac-test` to latest version. This version should contain fixes for the policy-engine related to how loops and vars and errors related to that are threaded.
