### PR TITLE
chore: Make license script used in build more portable

### DIFF
--- a/cliv2/scripts/prepare_licenses.sh
+++ b/cliv2/scripts/prepare_licenses.sh
@@ -1,11 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+VENV_DIR="./venv"
+
 BASEDIR=$(dirname "$0")
-PYTHON_VERSION=""
 
-if python3 -c 'print("python3")' > /dev/null 2>&1; then
-    PYTHON_VERSION="3"
+# check to see if virtualenv is installed
+command -v virtualenv >/dev/null 2>&1
+VIRTUALENV_INSTALLED=$?
+
+# if virtualenv is installed use that to isolate the python environment
+if [ $VIRTUALENV_INSTALLED -eq 0 ]; then
+    # Create a new virtualenv if one doesn't exists
+    if [ ! -d "$VENV_DIR" ]; then
+        python -m venv $VENV_DIR
+    fi
+    source $VENV_DIR/bin/activate
+    pip install requests
+    python $BASEDIR/prepare_licenses.py
+    deactivate
+else
+    # Fall back to use a local python installation
+    PYTHON_VERSION=""
+    if python3 -c 'print("python3")' > /dev/null 2>&1; then
+        PYTHON_VERSION="3"
+    fi
+    PIP_BREAK_SYSTEM_PACKAGES=1 pip$PYTHON_VERSION install requests
+    python$PYTHON_VERSION $BASEDIR/prepare_licenses.py
 fi
-
-PIP_BREAK_SYSTEM_PACKAGES=1 pip$PYTHON_VERSION install requests
-python$PYTHON_VERSION $BASEDIR/prepare_licenses.py


### PR DESCRIPTION
The current script `cliv2/ scripts/prepare_licenses.sh` assumes it can run python directly on the host.  If someone is using python actively for development that's likely disabled. It's good practice to disable pip from installing in the global namespace using one of:

```
pip config set global.require-virtualenv True
PIP_REQUIRE_VIRTUALENV=1
```

That means when running a build it will fail like so:

```
-- Preparing 3rd Party Licenses
make[1]: *** [/Users/garethr/Documents/cli/cliv2/_cache/prepare-3rd-party-licenses] Error 3
make: *** [build] Error 
```

This PR changes the script to use `virtualenv` if it's installed. It will create a venv if needed, or reuse an existing one. If virtualenv is not installed it will fall back on the current behaviour.

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Makes the build process more portable, by using virtualenv when present to avoid clashes with the system python configuration.

#### Where should the reviewer start?

By running the script directly, followed by running a full build.

#### How should this be manually tested?

* Run a build in a previously working environment, this shouldn't change anything there
* Run the script directly, again, this should work as previously
* Install virtualenv on your path, and then run the script directly. Note the use and creation of a virtualenv
* Run a full clean build in the presense of the virtualenv