### PR TITLE
fix: fix wrong project name change

### DIFF
--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -280,11 +280,7 @@ export default async function monitor(...args0: MethodArgs): Promise<any> {
           const res: MonitorResult = await promiseOrCleanup(
             snykMonitor(
               path,
-              generateMonitorMeta(
-                options,
-                extractedPackageManager,
-                projectName,
-              ),
+              generateMonitorMeta(options, extractedPackageManager),
               projectDeps,
               options,
               projectDeps.plugin as PluginMetadata,
@@ -350,17 +346,12 @@ export default async function monitor(...args0: MethodArgs): Promise<any> {
   throw new Error(output);
 }
 
-function generateMonitorMeta(
-  options,
-  packageManager?,
-  projectName?,
-): MonitorMeta {
+function generateMonitorMeta(options, packageManager?): MonitorMeta {
   return {
     method: 'cli',
     packageManager,
     'policy-path': options['policy-path'],
-    'project-name':
-      options['project-name'] || projectName || config.PROJECT_NAME,
+    'project-name': options['project-name'] || config.PROJECT_NAME,
     isDocker: !!options.docker,
     prune: !!options.pruneRepeatedSubdependencies,
     'remote-repo-url': options['remote-repo-url'],

--- a/src/lib/monitor/utils.ts
+++ b/src/lib/monitor/utils.ts
@@ -43,6 +43,10 @@ export function getProjectName(
     return scannedProject.meta.projectName;
   }
 
+  if (scannedProject.meta?.gradleProjectName) {
+    return scannedProject.meta.gradleProjectName;
+  }
+
   return meta['project-name'];
 }
 

--- a/test/jest/unit/cli-monitor-utils.spec.ts
+++ b/test/jest/unit/cli-monitor-utils.spec.ts
@@ -114,6 +114,47 @@ describe('cli-monitor-utils test', () => {
     expect(res).toEqual('project-name-override');
   });
 
+  it('getProjectName returns gradle project name from scanned project meta', () => {
+    const scannedProject: ScannedProject = {
+      depGraph: {} as any,
+      meta: {
+        gradleProjectName: 'my-gradle-project',
+      },
+      targetFile: '/tmp/build.gradle',
+    };
+
+    const res = utils.getProjectName(scannedProject, {
+      method: 'cli',
+      packageManager: 'gradle',
+      'policy-path': '',
+      'project-name': '',
+      isDocker: false,
+      prune: false,
+    });
+    expect(res).toEqual('my-gradle-project');
+  });
+
+  it('getProjectName returns project name from scanned project meta when project-name is provided via option', () => {
+    const scannedProject: ScannedProject = {
+      depGraph: {} as any,
+      meta: {
+        gradleProjectName: 'my-gradle-project',
+        projectName: 'meta-gradle-project',
+      },
+      targetFile: '/tmp/build.gradle',
+    };
+
+    const res = utils.getProjectName(scannedProject, {
+      method: 'cli',
+      packageManager: 'gradle',
+      'policy-path': '',
+      'project-name': 'project-name-from-option',
+      isDocker: false,
+      prune: false,
+    });
+    expect(res).toEqual('meta-gradle-project');
+  });
+
   it('getTargetFile returns name from scanned project if container', () => {
     const scannedProject: ScannedProject = stubScannedProjectContainer();
     const res = utils.getTargetFile(scannedProject, getStubPluginMeta());


### PR DESCRIPTION
Due to a previous [fixing for gradle](https://github.com/snyk/cli/pull/4837/files), we accidentally also changed the name of many existing CLI projects.

That affects ecosystems such as dotnet, cocoapads, golang projects not using go module, swift and composer.

This PR reverts the name change for those projects while still preserving the expected behavior for gradle.