### PR TITLE
chore: set Node compatibility version to >=16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,7 +137,7 @@
         "webpack-merge": "^5.8.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@arcanis/slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "snyk": "bin/snyk"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
#### What does this PR do?

The main goal of this change is to add support for **Node 18**.

As a first step to make this change granular, this PR updates the minimum required Node.js version for the project to `>=16`.


#### How should this be manually tested?

Installing dependencies with a Node version older than 16 will trigger a warning the Node version not being compatible.

```
make build
```

#### Any background context you want to provide?

> Bringing forward the End-of-Life Date for Node.js 16
https://nodejs.org/en/blog/announcements/nodejs16-eol


#### What are the relevant tickets?
HEAD-497

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules