### PR TITLE
chore: pass explicit version to snyk images [HEAD-746]

### DIFF
--- a/release-scripts/upload-artifacts.sh
+++ b/release-scripts/upload-artifacts.sh
@@ -78,7 +78,7 @@ upload_github() {
       --target "${CIRCLE_SHA1}" \
       --title "${VERSION_TAG}" \
       --notes-file binary-releases/RELEASE_NOTES.md
-    
+
     echo "DRY RUN: deleting draft from GitHub..."
     gh release delete "${VERSION_TAG}" \
       --yes
@@ -115,7 +115,7 @@ trigger_build_snyk_images() {
     -H "Authorization: Bearer $HAMMERHEAD_GITHUB_PAT" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     https://api.github.com/repos/snyk/snyk-images/dispatches \
-    -d '{"event_type":"build_and_push_images"}' \
+    -d "{\"event_type\":\"build_and_push_images\", \"client_payload\": {\"version\": \"$VERSION_TAG\"}}" \
     -w "%{http_code}" \
     -o /dev/null)
   if [ "$RESPONSE" -eq 204 ]; then
@@ -207,9 +207,9 @@ for arg in "${@}"; do
   # Trigger building Snyk images in snyk-images repository
   elif [ "${arg}" == "trigger-snyk-images" ]; then
     trigger_build_snyk_images
-  
+
   # Upload files to S3 bucket
   else
     upload_s3 "${target}"
-  fi  
+  fi
 done

--- a/scripts/install-snyk.py
+++ b/scripts/install-snyk.py
@@ -51,7 +51,7 @@ def download_snyk_cli(download_version, base_url):
     filename, output_filename = get_filename(arch_type, os_type)
 
     if download_version != "latest":
-        download_version = f"v{download_version}"
+        download_version = f"v{download_version}" if download_version[0] != 'v' else download_version
 
     url = f"{base_url}/cli/{download_version}/{filename}"
 

--- a/scripts/install-snyk.py
+++ b/scripts/install-snyk.py
@@ -40,6 +40,9 @@ def get_os_arch():
 
 
 def download_snyk_cli(download_version, base_url):
+    success = 0
+    fail = 1
+
     os_type, arch_type = get_os_arch()
 
     if not os_type or not arch_type:
@@ -83,10 +86,11 @@ def download_snyk_cli(download_version, base_url):
         else:
             os.remove(downloaded_file_path)
             print("SHA256 checksum verification failed. Downloaded file deleted.")
-        return 0
+            return fail
+        return success
     else:
         print(f"Failed to download Snyk CLI {download_version}")
-        return 1
+        return fail
 
 
 def get_filename(arch_type, os_type):

--- a/scripts/install-snyk.py
+++ b/scripts/install-snyk.py
@@ -146,7 +146,14 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     for retry in range(1, args.retry + 1):
-        print("Trying to download: #" + str(retry) + " of #" + str(args.retry))
+        print(
+            "Trying to download version "
+            + str(args.version)
+            + ": #"
+            + str(retry)
+            + " of #"
+            + str(args.retry)
+        )
         ret_value = download_snyk_cli(args.version, args.base_url)
         if ret_value == 0:
             break

--- a/scripts/install-snyk.py
+++ b/scripts/install-snyk.py
@@ -12,25 +12,25 @@ def get_os_arch():
     system = platform.system()
     machine = platform.machine()
 
-    if system == 'Linux':
-        if machine == 'x86_64':
-            return 'linux', 'amd64'
-        elif machine == 'aarch64':
-            return 'linux', 'arm64'
+    if system == "Linux":
+        if machine == "x86_64":
+            return "linux", "amd64"
+        elif machine == "aarch64":
+            return "linux", "arm64"
         else:
             print("Unsupported architecture for Linux. Aborting download.")
             return None, None
-    elif system == 'Windows':
-        if machine == 'AMD64':
-            return 'windows', 'amd64'
+    elif system == "Windows":
+        if machine == "AMD64":
+            return "windows", "amd64"
         else:
             print("Unsupported architecture for Windows. Aborting download.")
             return None, None
-    elif system == 'Darwin':
-        if machine == 'x86_64':
-            return 'macos', 'amd64'
-        elif machine == 'arm64':
-            return 'macos', 'arm64'
+    elif system == "Darwin":
+        if machine == "x86_64":
+            return "macos", "amd64"
+        elif machine == "arm64":
+            return "macos", "arm64"
         else:
             print("Unsupported architecture for macOS. Aborting download.")
             return None, None
@@ -51,7 +51,8 @@ def download_snyk_cli(download_version, base_url):
     filename, output_filename = get_filename(arch_type, os_type)
 
     if download_version != "latest":
-        download_version = f"v{download_version}" if download_version[0] != 'v' else download_version
+        if download_version[0] != "v":  # Add a "v" prefix if it's missing
+            download_version = f"v{download_version}"
 
     url = f"{base_url}/cli/{download_version}/{filename}"
 
@@ -67,7 +68,7 @@ def download_snyk_cli(download_version, base_url):
 
         downloaded_file_path = filename
 
-        with open(downloaded_file_path, 'wb') as f:
+        with open(downloaded_file_path, "wb") as f:
             f.write(response.content)
 
         if verify_checksum(downloaded_file_path, sha256_checksum):
@@ -98,19 +99,19 @@ def get_filename(arch_type, os_type):
     output_filename = "snyk"
     suffix = ""
 
-    if os_type == 'linux' and arch_type == 'arm64':
+    if os_type == "linux" and arch_type == "arm64":
         filename = "snyk-linux-arm64"
-    if os_type == 'linux' and arch_type == 'amd64':
+    if os_type == "linux" and arch_type == "amd64":
         filename = "snyk-linux"
         stat_result = os.path.exists("/lib/ld-musl-x86_64.so.1")
         if stat_result:
             filename = "snyk-alpine"
-    if os_type == 'windows' and arch_type == 'amd64':
+    if os_type == "windows" and arch_type == "amd64":
         filename = "snyk-win"
         suffix = ".exe"
-    if os_type == 'macos' and arch_type == 'amd64':
+    if os_type == "macos" and arch_type == "amd64":
         filename = "snyk-macos"
-    if os_type == 'macos' and arch_type == 'arm64':
+    if os_type == "macos" and arch_type == "arm64":
         filename = "snyk-macos-arm64"
 
     filename = filename + suffix
@@ -121,7 +122,7 @@ def get_filename(arch_type, os_type):
 
 def verify_checksum(file_path, expected_checksum):
     sha256 = hashlib.sha256()
-    with open(file_path, 'rb') as f:
+    with open(file_path, "rb") as f:
         while True:
             data = f.read(65536)
             if not data:
@@ -131,9 +132,15 @@ def verify_checksum(file_path, expected_checksum):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Download and install a specific version of Snyk CLI.")
-    parser.add_argument("version", help="Version of Snyk CLI to download (e.g., 1.123.456)")
-    parser.add_argument("--base_url", help="Base URL to download from", default="https://static.snyk.io")
+    parser = argparse.ArgumentParser(
+        description="Download and install a specific version of Snyk CLI."
+    )
+    parser.add_argument(
+        "version", help="Version of Snyk CLI to download (e.g., 1.123.456)"
+    )
+    parser.add_argument(
+        "--base_url", help="Base URL to download from", default="https://static.snyk.io"
+    )
     parser.add_argument("--retry", help="number of retries", default=3)
 
     args = parser.parse_args()
@@ -145,5 +152,9 @@ if __name__ == "__main__":
             break
         else:
             sleep_time = retry * 10
-            print("Failed to download Snyk CLI. Retrying in "+str(sleep_time) +" seconds...")
+            print(
+                "Failed to download Snyk CLI. Retrying in "
+                + str(sleep_time)
+                + " seconds..."
+            )
             time.sleep(sleep_time)


### PR DESCRIPTION
This PR updates the repository dispatch event trigger to include a version field in the `client_payload`, using the `VERSION_TAG` value. 

This allows the downstream repository to build Snyk images with the specified CLI version.