### PR TITLE
chore: update Go version to 1.21.1

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,5 +1,4 @@
-FROM --platform=$TARGETPLATFORM golang:1.20-bullseye
-
+FROM --platform=$TARGETPLATFORM golang:1.21.1-bullseye
 # install "normal" stuff
 
 ARG NODEVERSION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
   go_version:
     type: string
     # https://go.dev/doc/devel/release
-    default: '1.20.6'
+    default: '1.21.1'
   aws_version:
     type: string
     # https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -1,6 +1,8 @@
 module github.com/snyk/cli/cliv2
 
-go 1.18
+go 1.21
+
+toolchain go1.21.0
 
 require (
 	github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a


### PR DESCRIPTION
#### What does this PR do?

This PR updates Go version to 1.21.1 https://go.dev/doc/devel/release

- This version is compatible with Microsoft Go version https://github.com/microsoft/go/releases


- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules