### PR TITLE
chore: replace deprecated macos circleci runner [HEAD-781]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ executors:
     macos:
       # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
       xcode: '14.3.1'
-    resource_class: macos.m1.large.gen1
+    resource_class: macos.m1.medium.gen1
   win-server2022-amd64:
     machine:
       image: windows-server-2022-gui:2023.07.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ executors:
     macos:
       # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
       xcode: '14.3.1'
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
   macos-arm64:
     macos:
       # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,6 +279,9 @@ commands:
         type: string
         default: go gradle python elixir composer gradle@6 maven sbt dotnet
     steps:
+      - run:
+          name: Installing Rosetta
+          command: softwareupdate --install-rosetta --agree-to-license
       - restore_cache:
           key: acceptance-tests-macos-<< parameters.items >>
       - run:
@@ -298,6 +301,9 @@ commands:
         type: string
         default: go gradle python elixir composer gradle@6 maven sbt dotnet
     steps:
+      - run:
+          name: Installing Rosetta
+          command: softwareupdate --install-rosetta --agree-to-license
       - install-deps-python:
           os: macos
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,11 +86,6 @@ executors:
       - image: ubuntu:focal
     working_directory: /mnt/ramdisk/snyk
     resource_class: arm.medium
-  macos-amd64:
-    macos:
-      # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
-      xcode: '14.3.1'
-    resource_class: macos.m1.medium.gen1
   macos-arm64:
     macos:
       # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
@@ -415,7 +410,7 @@ workflows:
           go_os: darwin
           go_arch: amd64
           go_download_base_url: << pipeline.parameters.go_download_base_url >>
-          executor: macos-amd64
+          executor: macos-arm64
           install_deps_extension: macos-build
           requires:
             - prepare-build
@@ -509,7 +504,7 @@ workflows:
               ignore: master
           requires:
             - build macOS amd64
-          executor: macos-amd64
+          executor: macos-arm64
           test_snyk_command: ./binary-releases/snyk-macos
           install_deps_extension: macos-full
 
@@ -552,7 +547,7 @@ workflows:
             - build macOS amd64
           go_os: darwin
           go_arch: amd64
-          executor: macos-amd64
+          executor: macos-arm64
           install_deps_extension: noop
           filters:
             branches:
@@ -606,7 +601,7 @@ workflows:
               executor:
                 - 'docker-amd64'
                 - 'win-server2019-amd64'
-                - 'macos-amd64'
+                - 'macos-arm64'
           requires:
             - upload version
           filters:
@@ -625,7 +620,7 @@ workflows:
                 - 'docker-arm64'
                 - 'win-server2019-amd64'
                 - 'win-server2022-amd64'
-                - 'macos-amd64'
+                - 'macos-arm64'
                 - 'linux-ubuntu-latest-amd64'
                 - 'linux-ubuntu-mantic-amd64'
                 - 'linux-ubuntu-jammy-amd64'
@@ -679,12 +674,12 @@ workflows:
           requires:
             - Validate NPM artifacts (docker-amd64)
             - Validate NPM artifacts (win-server2019-amd64)
-            - Validate NPM artifacts (macos-amd64)
+            - Validate NPM artifacts (macos-arm64)
             - e2e tests (docker-amd64)
             - e2e tests (docker-arm64)
             - e2e tests (win-server2019-amd64)
             - e2e tests (win-server2022-amd64)
-            - e2e tests (macos-amd64)
+            - e2e tests (macos-arm64)
             - e2e tests (linux-ubuntu-latest-amd64)
             - e2e tests (linux-ubuntu-mantic-amd64)
             - e2e tests (linux-ubuntu-jammy-amd64)


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Replace deprecated MacOS amd64 by supported MacOS arm64 runner.

#### Where should the reviewer start?
.circleci/config.yml

#### How should this be manually tested?
* Download snyk-macos executable and run `file snyk-macos` this should show 

#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
