### PR TITLE
fix: warn when using an insecure http SNYK_API URL

### DIFF
--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -54,14 +54,21 @@ async function scanWithConfig(
 ): Promise<TestOutput> {
   const env = { ...process.env };
 
+  const apiUrl = config.API_REST_URL;
+  if (apiUrl.startsWith('http://')) {
+    console.warn(
+      '\nYou configured the Snyk CLI to use an API URL with an HTTP scheme. This option is insecure and might prevent the Snyk CLI from working correctly.',
+    );
+  }
+
   env['SNYK_IAC_TEST_API_REST_URL'] =
-    process.env['SNYK_IAC_TEST_API_REST_URL'] || getApiUrl();
+    process.env['SNYK_IAC_TEST_API_REST_URL'] || apiUrl;
   env['SNYK_IAC_TEST_API_REST_TOKEN'] =
     process.env['SNYK_IAC_TEST_API_REST_TOKEN'] || getApiToken();
   env['SNYK_IAC_TEST_API_REST_OAUTH_TOKEN'] =
     process.env['SNYK_IAC_TEST_API_REST_OAUTH_TOKEN'] || getOAuthToken();
   env['SNYK_IAC_TEST_API_V1_URL'] =
-    process.env['SNYK_IAC_TEST_API_V1_URL'] || getApiUrl();
+    process.env['SNYK_IAC_TEST_API_V1_URL'] || apiUrl;
   env['SNYK_IAC_TEST_API_V1_TOKEN'] =
     process.env['SNYK_IAC_TEST_API_V1_TOKEN'] || getApiToken();
   env['SNYK_IAC_TEST_API_V1_OAUTH_TOKEN'] =
@@ -244,10 +251,6 @@ async function remove(path: string) {
       }
     });
   });
-}
-
-function getApiUrl() {
-  return config.API_REST_URL;
 }
 
 function getApiToken() {


### PR DESCRIPTION
#### What does this PR do?

Emits a warning log when the configured API URL is an insecure http one


#### What are the relevant tickets?
[IAC-2591](https://snyksec.atlassian.net/browse/IAC-2591)
and [this Slack thread](https://snyk.slack.com/archives/C02JMMTLUF9/p1695980516376749).

[IAC-2591]: https://snyksec.atlassian.net/browse/IAC-2591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ