### PR TITLE
fix: add condition to preserve project-name with gradle monitor

### DIFF
--- a/src/lib/monitor/utils.ts
+++ b/src/lib/monitor/utils.ts
@@ -43,7 +43,7 @@ export function getProjectName(
     return scannedProject.meta.projectName;
   }
 
-  if (scannedProject.meta?.gradleProjectName) {
+  if (scannedProject.meta?.gradleProjectName && !meta['project-name']) {
     return scannedProject.meta.gradleProjectName;
   }
 

--- a/test/jest/unit/cli-monitor-utils.spec.ts
+++ b/test/jest/unit/cli-monitor-utils.spec.ts
@@ -155,6 +155,24 @@ describe('cli-monitor-utils test', () => {
     expect(res).toEqual('meta-gradle-project');
   });
 
+  it('getProjectName returns project name when project-name is provided via option', () => {
+    const scannedProject: ScannedProject = {
+      depGraph: {} as any,
+      meta: { gradleProjectName: 'my-gradle-project' },
+      targetFile: '/tmp/build.gradle',
+    };
+
+    const res = utils.getProjectName(scannedProject, {
+      method: 'cli',
+      packageManager: 'gradle',
+      'policy-path': '',
+      'project-name': 'project-name-from-option',
+      isDocker: false,
+      prune: false,
+    });
+    expect(res).toEqual('project-name-from-option');
+  });
+
   it('getTargetFile returns name from scanned project if container', () => {
     const scannedProject: ScannedProject = stubScannedProjectContainer();
     const res = utils.getTargetFile(scannedProject, getStubPluginMeta());


### PR DESCRIPTION
Following on from https://github.com/snyk/cli/pull/4865 this change tightens the method to explicitly check if allProjects is set and acts accordingly, either by making use of project name or falling back to the projectName flag.