### PR TITLE
fix: [OSM-347] Showing `displayTargetFile` before `targetFile` if defined

### DIFF
--- a/src/lib/formatters/format-test-meta.ts
+++ b/src/lib/formatters/format-test-meta.ts
@@ -10,7 +10,7 @@ export function formatTestMeta(
 ): string {
   const padToLength = 19; // chars to align
   const packageManager = res.packageManager || options.packageManager;
-  const targetFile = res.targetFile || res.displayTargetFile || options.file;
+  const targetFile = res.displayTargetFile || res.targetFile || options.file;
   const openSource = res.isPrivate ? 'no' : 'yes';
   const meta = res.org
     ? [chalk.bold(rightPadWithSpaces('Organization: ', padToLength)) + res.org]


### PR DESCRIPTION
We are working on displaying multiple scan results for .NET projects, if the project targets multiple `TargetFramework`s. 

However, there isn't currently a good way to display it in the CLI's response. The user will just see multiple scan results looking identical, see attached screenshot:

![Screenshot 2023-10-18 at 18 32 34](https://github.com/snyk/cli/assets/25500117/2e6162e2-06ae-439c-838a-3c8d795c8105)

If we allow to use the `displayTargetFile` first (which also seems more like what variable name suggests it should?) I can send a overwritten `targetFile` from the plugin that will become the `displayTargetFile` while still retaining the correct `targetFile` in the final result object, as such:

<img width="1728" alt="Screenshot 2023-10-19 at 15 12 07" src="https://github.com/snyk/cli/assets/25500117/21495ef6-6e51-471e-980e-cf0717c474b8">
