### PR TITLE
fix: add `targetRuntime` meta information to monitor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "3.1.0",
         "snyk-nodejs-lockfile-parser": "1.52.1",
-        "snyk-nuget-plugin": "1.39.1",
+        "snyk-nuget-plugin": "2.0.0",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.25.0",
         "snyk-python-plugin": "^2.0.1",
@@ -2790,9 +2790,9 @@
       }
     },
     "node_modules/@snyk/error-catalog-nodejs-public": {
-      "version": "3.18.6",
-      "resolved": "https://registry.npmjs.org/@snyk/error-catalog-nodejs-public/-/error-catalog-nodejs-public-3.18.6.tgz",
-      "integrity": "sha512-SXI4X9ujBkwaCUdyvxyUO2FGKvu3q11J91k99kvxzu1RLcRwNGwmK8sxWEhAV5zcH87IMF3/r7UAGOCz0WzVBQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@snyk/error-catalog-nodejs-public/-/error-catalog-nodejs-public-4.0.4.tgz",
+      "integrity": "sha512-M+t/MNfR/qr/Rdxc3Kl2p26mIx0YdcM22CAZfNsCuldl1DIZQma8jc7zmm14AwhwmdoU6TE7mzzO33KINgB8LA==",
       "dependencies": {
         "tslib": "^2.6.2",
         "uuid": "^9.0.0"
@@ -8934,11 +8934,11 @@
       }
     },
     "node_modules/dotnet-deps-parser": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/dotnet-deps-parser/-/dotnet-deps-parser-5.5.1.tgz",
-      "integrity": "sha512-KeKUi8MNYNpHEgi5Oe+uM289ZVfunxaWxaj/9d6oqXs03m3vw/hvIth2QAz8eNra+tN/Otf9rIn/BSJleO8+Lg==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/dotnet-deps-parser/-/dotnet-deps-parser-5.5.2.tgz",
+      "integrity": "sha512-mHDP2jr0aKWPa4kT/52h1RBkVjJNKDcTkL1cIOAu6UC6WutPxYSlLJGFzHc9z2b7BcwqyX1xb4yuO0cJgHVkSQ==",
       "dependencies": {
-        "@snyk/error-catalog-nodejs-public": "^3.18.6",
+        "@snyk/error-catalog-nodejs-public": "^4.0.1",
         "lodash": "^4.17.21",
         "source-map-support": "^0.5.21",
         "xml2js": "0.6.2"
@@ -20655,14 +20655,14 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-nuget-plugin": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.39.1.tgz",
-      "integrity": "sha512-FBsLHSk+XYjgfDL3gOfEG6a+NCafkgb+BpPtJnP9iGy2aTLl/9YZoYnvIQ/BNF9l49q8j94ENOCWXDC7cRQyTQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.0.0.tgz",
+      "integrity": "sha512-3gvAz+58mPsERNRh/RKk8fGs4QVDM0V7RFMpkpTEwC1/C2D4e6Ruiym0diNESnsZA7EjZxbmmxQNYi2flhXCDA==",
       "dependencies": {
         "@snyk/cli-interface": "^2.13.0",
         "@snyk/dep-graph": "^2.7.1",
         "debug": "^4.3.4",
-        "dotnet-deps-parser": "5.5.1",
+        "dotnet-deps-parser": "5.5.2",
         "jszip": "3.10.1",
         "lodash": "^4.17.21",
         "node-cache": "^5.1.2",
@@ -26174,9 +26174,9 @@
       }
     },
     "@snyk/error-catalog-nodejs-public": {
-      "version": "3.18.6",
-      "resolved": "https://registry.npmjs.org/@snyk/error-catalog-nodejs-public/-/error-catalog-nodejs-public-3.18.6.tgz",
-      "integrity": "sha512-SXI4X9ujBkwaCUdyvxyUO2FGKvu3q11J91k99kvxzu1RLcRwNGwmK8sxWEhAV5zcH87IMF3/r7UAGOCz0WzVBQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@snyk/error-catalog-nodejs-public/-/error-catalog-nodejs-public-4.0.4.tgz",
+      "integrity": "sha512-M+t/MNfR/qr/Rdxc3Kl2p26mIx0YdcM22CAZfNsCuldl1DIZQma8jc7zmm14AwhwmdoU6TE7mzzO33KINgB8LA==",
       "requires": {
         "tslib": "^2.6.2",
         "uuid": "^9.0.0"
@@ -30963,11 +30963,11 @@
       }
     },
     "dotnet-deps-parser": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/dotnet-deps-parser/-/dotnet-deps-parser-5.5.1.tgz",
-      "integrity": "sha512-KeKUi8MNYNpHEgi5Oe+uM289ZVfunxaWxaj/9d6oqXs03m3vw/hvIth2QAz8eNra+tN/Otf9rIn/BSJleO8+Lg==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/dotnet-deps-parser/-/dotnet-deps-parser-5.5.2.tgz",
+      "integrity": "sha512-mHDP2jr0aKWPa4kT/52h1RBkVjJNKDcTkL1cIOAu6UC6WutPxYSlLJGFzHc9z2b7BcwqyX1xb4yuO0cJgHVkSQ==",
       "requires": {
-        "@snyk/error-catalog-nodejs-public": "^3.18.6",
+        "@snyk/error-catalog-nodejs-public": "^4.0.1",
         "lodash": "^4.17.21",
         "source-map-support": "^0.5.21",
         "xml2js": "0.6.2"
@@ -39844,14 +39844,14 @@
       }
     },
     "snyk-nuget-plugin": {
-      "version": "1.39.1",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.39.1.tgz",
-      "integrity": "sha512-FBsLHSk+XYjgfDL3gOfEG6a+NCafkgb+BpPtJnP9iGy2aTLl/9YZoYnvIQ/BNF9l49q8j94ENOCWXDC7cRQyTQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.0.0.tgz",
+      "integrity": "sha512-3gvAz+58mPsERNRh/RKk8fGs4QVDM0V7RFMpkpTEwC1/C2D4e6Ruiym0diNESnsZA7EjZxbmmxQNYi2flhXCDA==",
       "requires": {
         "@snyk/cli-interface": "^2.13.0",
         "@snyk/dep-graph": "^2.7.1",
         "debug": "^4.3.4",
-        "dotnet-deps-parser": "5.5.1",
+        "dotnet-deps-parser": "5.5.2",
         "jszip": "3.10.1",
         "lodash": "^4.17.21",
         "node-cache": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "3.1.0",
     "snyk-nodejs-lockfile-parser": "1.52.1",
-    "snyk-nuget-plugin": "1.39.1",
+    "snyk-nuget-plugin": "2.0.0",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.25.0",
     "snyk-python-plugin": "^2.0.1",

--- a/src/lib/monitor/index.ts
+++ b/src/lib/monitor/index.ts
@@ -73,6 +73,7 @@ interface Meta {
   dockerImageId?: string;
   dockerBaseImage?: string;
   projectName: string;
+  targetRuntime?: string;
 }
 
 export async function monitor(
@@ -351,6 +352,7 @@ export async function monitorDepGraph(
         monitorGraph: true,
         versionBuildInfo: JSON.stringify(scannedProject.meta?.versionBuildInfo),
         gradleProjectName: scannedProject.meta?.gradleProjectName,
+        targetRuntime: scannedProject.meta?.targetRuntime,
       },
       policy: policy ? policy.toString() : undefined,
       depGraphJSON: depGraph, // depGraph will be auto serialized to JSON on send

--- a/test/tap/cli-monitor.acceptance.test.ts
+++ b/test/tap/cli-monitor.acceptance.test.ts
@@ -512,6 +512,15 @@ if (!isWindows) {
     t.same(req.body.projectAttributes.lifecycle, ['production', 'sandbox']);
   });
 
+  test('`monitor nuget package with --dotnet-runtime-resolution enabled`', async (t) => {
+    chdirWorkspaces();
+    await cli.monitor('nuget-app-6', {
+      'dotnet-runtime-resolution': true,
+    });
+    const req = server.popRequest();
+    t.same(req.body.meta.targetRuntime, 'net6.0');
+  });
+
   test('`monitor npm-package with --project-tags`', async (t) => {
     chdirWorkspaces();
     await cli.monitor('npm-package', {


### PR DESCRIPTION
The entire foundation for utilizing the `targetRuntime` exists in the Snyk backend, but is not utilized by `snyk monitor`.

Adding the `targetRuntime` will decorate the `snyk monitor` results with the Target Runtime information, used in multiple language ecosystems.

Here an example from .NET, before:
<img width="595" alt="Screenshot 2023-10-24 at 21 58 53" src="https://github.com/snyk/cli/assets/25500117/8a2de091-eb4c-47b7-a988-652891a32a1d">

After:
<img width="560" alt="Screenshot 2023-10-24 at 21 58 56" src="https://github.com/snyk/cli/assets/25500117/f6df3b01-8e9b-42f1-9810-dd5d334bbb68">

This will also pave the way for support of `snyk monitor` of a single project with multiple target runtimes attached, without overwriting the same project multiple times.