### PR TITLE
fix: do not show invalidSeverityThreshold error for HTTP 400 responses

### DIFF
--- a/src/lib/errors/legacy-errors.js
+++ b/src/lib/errors/legacy-errors.js
@@ -53,7 +53,6 @@ const codes = {
   411: errors.endpoint, // try to post to a weird endpoint
   403: errors.endpoint,
   401: errors.auth,
-  400: errors.invalidSeverityThreshold,
   Unauthorized: errors.auth,
   MISSING_NODE_MODULES: errors.nodeModules,
   OLD_DOTFILE_FORMAT: errors.oldsnyk,

--- a/test/jest/unit/lib/errors/legacy-errors.spec.ts
+++ b/test/jest/unit/lib/errors/legacy-errors.spec.ts
@@ -1,0 +1,87 @@
+import * as errors from '../../../../../src/lib/errors/legacy-errors';
+import { FormattedCustomError } from '../../../../../src/lib/errors';
+
+describe('errors.message', () => {
+  it('returns the error message if it is a VULNS error', () => {
+    const errorMessage = 'This is an error message';
+    const error = new Error(errorMessage) as any;
+    (error as any).code = 'VULNS';
+
+    const result = errors.message(error);
+
+    expect(result).toBe(errorMessage);
+  });
+
+  it('returns the error message if there is a message and it is a FormattedCustomError', () => {
+    const formattedUserMessage = 'This is a formatted user error message';
+    const error = new FormattedCustomError(
+      'This is an error message',
+      formattedUserMessage,
+    );
+
+    const result = errors.message(error);
+
+    expect(result).toBe(error.formattedUserMessage);
+  });
+
+  it('returns the error message based on the error code', () => {
+    const error = new Error('Unauthorized') as any;
+    error.code = 'Unauthorized';
+
+    const result: string = errors.message(error);
+
+    // comparing with toContain because the error message is formatted to be red and bold
+    expect(result).toContain(
+      'Unauthorized: please ensure you are logged in using `snyk auth`',
+    );
+  });
+
+  it('returns the error message based on the error message (404)', () => {
+    const error = new Error('404');
+
+    const result: string = errors.message(error);
+
+    // comparing with toContain because the error message is formatted to be red and bold
+    expect(result).toContain(
+      'The package could not be found or does not exist',
+    );
+  });
+
+  it('returns the error message based on the error message (NOT_FOUND)', () => {
+    const error = new Error('NOT_FOUND');
+
+    const result: string = errors.message(error);
+
+    // comparing with toContain because the error message is formatted to be red and bold
+    expect(result).toContain(
+      'The package could not be found or does not exist',
+    );
+  });
+
+  it('returns unknown error message for unknowne error code', () => {
+    const error = new Error('Bad request') as any;
+    error.code = 400;
+
+    const result = errors.message(error);
+
+    expect(result).toBe(
+      'An unknown error occurred. Please run with `-d` and include full trace when reporting to Snyk',
+    );
+  });
+
+  it('returns the error message if it is not recognized', () => {
+    const error = new Error('This is an unknown error');
+
+    const result = errors.message(error);
+
+    expect(result).toBe<string>(error.message);
+  });
+
+  it('returns the error message if it is a string', () => {
+    const errorMessage = 'This is an error message';
+
+    const result = errors.message(errorMessage);
+
+    expect(result).toBe(errorMessage);
+  });
+});


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Fixes a misleading error message.

In c2399ae18d0c8f5c7a5cfcdf06460a4b1f29ce74 we assumed that all 400 responses returned by our backends are due to an incorrect severity threshold (eg `snyk test --severity-threshold=non-sense`).

This is incorrect - the CLI calls into many different backend services and we can't assume anything about the reason of the failure.


#### Where should the reviewer start?

First understand how error messages are parsed/formatted here:
https://github.com/snyk/cli/blob/351c7bd09071c5db69c8276173ee166021019be5/src/lib/errors/legacy-errors.js#L82-L106

Then it should be clear that this line doesn't really make sense:
https://github.com/snyk/cli/blob/351c7bd09071c5db69c8276173ee166021019be5/src/lib/errors/legacy-errors.js#L56

If we do not provide a value for `400` above, then we'll use a generic error message, which should be more appropiate.

#### How should this be manually tested?
1. Force the backend to return a 400 error
   - I did this by changing `generateMonitorDependenciesRequest` to return an invalid request
2. run `snyk container monitor node:latest`, the result is `Invalid severity threshold, please use one of low | medium | high | critical`
3. run this again, but on my branch, the result is: `An unknown error occurred. Please run with `-d` and include full trace when reporting to Snyk`
4. running again, but with `-d` gives: the following result (this is not usper nice, but is still better than giving misleading info)
  ```
An unknown error occurred. Please run with `-d` and include full trace when reporting to Snyk
gergo-papp@YFT40J7F32 cli % ./bin/snyk container monitor node:latest -d
...
  MonitorError: Server returned unexpected error for the monitor request. Status code: 400
      at monitorDependencies (/Users/gergo-papp/Development/GitHub/snyk/cli/dist/cli/webpack:/snyk/src/lib/ecosystems/monitor.ts:168:17)
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
      at selectAndExecuteMonitorStrategy (/Users/gergo-papp/Development/GitHub/snyk/cli/dist/cli/webpack:/snyk/src/lib/ecosystems/monitor.ts:98:7)
      at Object.monitorEcosystem (/Users/gergo-papp/Development/GitHub/snyk/cli/dist/cli/webpack:/snyk/src/lib/ecosystems/monitor.ts:81:36)
      at monitor (/Users/gergo-papp/Development/GitHub/snyk/cli/dist/cli/webpack:/snyk/src/cli/commands/monitor/index.ts:144:27)
      at runCommand (/Users/gergo-papp/Development/GitHub/snyk/cli/dist/cli/webpack:/snyk/src/cli/main.ts:51:25)
      at main (/Users/gergo-papp/Development/GitHub/snyk/cli/dist/cli/webpack:/snyk/src/cli/main.ts:310:11)
      at /Users/gergo-papp/Development/GitHub/snyk/cli/dist/cli/webpack:/snyk/src/cli/index.ts:13:3
      at Object.callHandlingUnexpectedErrors (/Users/gergo-papp/Development/GitHub/snyk/cli/dist/cli/webpack:/snyk/src/lib/unexpected-error.ts:28:5)
    snyk Exit code: 2 +0ms
    snyk analytics {
  ...
    "command": "bad-command",
    "metadata": {
      "policies": 1,
      "policyLocations": [
        "node:latest"
      ],
      "error-message": "Server returned unexpected error for the monitor request. Status code: 400",
      "error": "MonitorError: Server returned unexpected error for the monitor request. Status code: 400\n    at monitorDependencies (/Users/gergo-papp/Development/GitHub/snyk/cli/dist/cli/webpack:/snyk/src/lib/ecosystems/monitor.ts:168:17)\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at selectAndExecuteMonitorStrategy (/Users/gergo-papp/Development/GitHub/snyk/cli/dist/cli/webpack:/snyk/src/lib/ecosystems/monitor.ts:98:7)\n    at Object.monitorEcosystem (/Users/gergo-papp/Development/GitHub/snyk/cli/dist/cli/webpack:/snyk/src/lib/ecosystems/monitor.ts:81:36)\n    at monitor (/Users/gergo-papp/Development/GitHub/snyk/cli/dist/cli/webpack:/snyk/src/cli/commands/monitor/index.ts:144:27)\n    at runCommand (/Users/gergo-papp/Development/GitHub/snyk/cli/dist/cli/webpack:/snyk/src/cli/main.ts:51:25)\n    at main (/Users/gergo-papp/Development/GitHub/snyk/cli/dist/cli/webpack:/snyk/src/cli/main.ts:310:11)\n    at /Users/gergo-papp/Development/GitHub/snyk/cli/dist/cli/webpack:/snyk/src/cli/index.ts:13:3\n    at Object.callHandlingUnexpectedErrors (/Users/gergo-papp/Development/GitHub/snyk/cli/dist/cli/webpack:/snyk/src/lib/unexpected-error.ts:28:5)",
      "error-code": 400,
      "command": "monitor"
    },
  ```

#### Any background context you want to provide?

Part of a customer ticket - the customer uses a proxy that returns a 400 error. Instead of showing the actual error we display a totally misleading message:
```
Invalid severity threshold, please use one of low | medium | high | critical
```


#### What are the relevant tickets?

- https://snyk.zendesk.com/agent/tickets/59541
- https://snyksec.atlassian.net/browse/SUP-2006


#### Screenshots
N/A

#### Additional questions
N/A