### PR TITLE
fix: [OSM-782] Bumping `snyk-nuget-plugin`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "3.1.0",
         "snyk-nodejs-lockfile-parser": "1.52.1",
-        "snyk-nuget-plugin": "2.0.0",
+        "snyk-nuget-plugin": "2.0.1",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.25.0",
         "snyk-python-plugin": "^2.0.1",
@@ -20655,9 +20655,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-nuget-plugin": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.0.0.tgz",
-      "integrity": "sha512-3gvAz+58mPsERNRh/RKk8fGs4QVDM0V7RFMpkpTEwC1/C2D4e6Ruiym0diNESnsZA7EjZxbmmxQNYi2flhXCDA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.0.1.tgz",
+      "integrity": "sha512-ryWZEZCCUb0lK4wNOo0aCE63g7FTIvTOqABmoPhiGGdoTBYd7UFYm4B79FZBkIt2fm3SKzdEBb52erPxHw1n9Q==",
       "dependencies": {
         "@snyk/cli-interface": "^2.13.0",
         "@snyk/dep-graph": "^2.7.1",
@@ -39844,9 +39844,9 @@
       }
     },
     "snyk-nuget-plugin": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.0.0.tgz",
-      "integrity": "sha512-3gvAz+58mPsERNRh/RKk8fGs4QVDM0V7RFMpkpTEwC1/C2D4e6Ruiym0diNESnsZA7EjZxbmmxQNYi2flhXCDA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.0.1.tgz",
+      "integrity": "sha512-ryWZEZCCUb0lK4wNOo0aCE63g7FTIvTOqABmoPhiGGdoTBYd7UFYm4B79FZBkIt2fm3SKzdEBb52erPxHw1n9Q==",
       "requires": {
         "@snyk/cli-interface": "^2.13.0",
         "@snyk/dep-graph": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "3.1.0",
     "snyk-nodejs-lockfile-parser": "1.52.1",
-    "snyk-nuget-plugin": "2.0.0",
+    "snyk-nuget-plugin": "2.0.1",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.25.0",
     "snyk-python-plugin": "^2.0.1",


### PR DESCRIPTION
Fixes a bug where .NET projects with local `PackageReference`s caused a crash in the v2 beta logic.