### PR TITLE
fix: bump nodejs-parser to 1.52.4 attempt 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "snyk-gradle-plugin": "3.27.0",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "3.1.0",
-        "snyk-nodejs-lockfile-parser": "1.52.1",
+        "snyk-nodejs-lockfile-parser": "1.52.5",
         "snyk-nuget-plugin": "2.0.1",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.25.0",
@@ -20568,9 +20568,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-nodejs-lockfile-parser": {
-      "version": "1.52.1",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.52.1.tgz",
-      "integrity": "sha512-5sheRswIk9Ode6gMISLK65XBstJ+M0siGLIZeHHZgTAII/avOTk0fHLkhXsKb8+goeg5JPT+b4tYgQVlqHreTA==",
+      "version": "1.52.5",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.52.5.tgz",
+      "integrity": "sha512-1WYlKOelGSoaDAHoUcyLr085BN1Ed17kSiYqFXFOMTfHg8SH/vEHG5fFo0sjmV07INH0QFrEY+DaK6om0sblSw==",
       "dependencies": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -39776,9 +39776,9 @@
       }
     },
     "snyk-nodejs-lockfile-parser": {
-      "version": "1.52.1",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.52.1.tgz",
-      "integrity": "sha512-5sheRswIk9Ode6gMISLK65XBstJ+M0siGLIZeHHZgTAII/avOTk0fHLkhXsKb8+goeg5JPT+b4tYgQVlqHreTA==",
+      "version": "1.52.5",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.52.5.tgz",
+      "integrity": "sha512-1WYlKOelGSoaDAHoUcyLr085BN1Ed17kSiYqFXFOMTfHg8SH/vEHG5fFo0sjmV07INH0QFrEY+DaK6om0sblSw==",
       "requires": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/graphlib": "2.1.9-patch.3",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "snyk-gradle-plugin": "3.27.0",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "3.1.0",
-    "snyk-nodejs-lockfile-parser": "1.52.1",
+    "snyk-nodejs-lockfile-parser": "1.52.5",
     "snyk-nuget-plugin": "2.0.1",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.25.0",


### PR DESCRIPTION

### What does this PR do?

This bumps the snyk-nodejs-lockfile-parser to 1.52.4. Details can be found here https://github.com/snyk/nodejs-lockfile-parser/releases
