### PR TITLE
fix: allow http requests towards code local engine [NEBULA-1541]

### DIFF
--- a/src/lib/plugins/sast/localCodeEngine.ts
+++ b/src/lib/plugins/sast/localCodeEngine.ts
@@ -1,11 +1,8 @@
 import * as debugLib from 'debug';
 import chalk from 'chalk';
-
 import { makeRequest } from '../../request';
-import { Global } from '../../../cli/args';
 import { SastSettings } from './types';
 
-declare const global: Global;
 const debug = debugLib('snyk-code');
 
 export function isLocalCodeEngine(sastSettings: SastSettings): boolean {
@@ -14,23 +11,21 @@ export function isLocalCodeEngine(sastSettings: SastSettings): boolean {
   return sastEnabled && localCodeEngine.enabled;
 }
 
-export async function logLocalCodeEngineVersion(lceUrl = ''): Promise<void> {
-  const lceBaseUrl = lceUrl.replace('/api', '');
-  const isNonSecureHttp = lceBaseUrl.match(/^http:/);
-  let ignoreUnknownCAoriginalValue;
-  if (isNonSecureHttp) {
-    ignoreUnknownCAoriginalValue = global.ignoreUnknownCA;
-    // `makeRequest` function converts `http` calls to `https`. In some cases, SCLE might be running on http.
-    // This problem is fixed by setting `options.rejectUnauthorized = true`.
-    // Setting `global.ignoreUnknownCA` to true adds rejectUnauthorized=true as an option in `makeRequest`.
-    global.ignoreUnknownCA = true;
+export async function logLocalCodeEngineVersion(
+  localEngineUrl = '',
+): Promise<void> {
+  const parsedUrl = new URL(localEngineUrl);
+  const localEngineBaseUrl = parsedUrl.origin;
+  const isHttp = parsedUrl.protocol.match('http:');
+  const originalProtocolUpgrade = process.env['SNYK_HTTP_PROTOCOL_UPGRADE'];
+  if (isHttp) {
+    process.env.SNYK_HTTP_PROTOCOL_UPGRADE = '0';
   }
-
   try {
     const {
       res: { body, statusCode },
     } = await makeRequest({
-      url: `${lceBaseUrl}/status`,
+      url: `${localEngineBaseUrl}/status`,
       method: 'get',
     });
     if (body?.ok && body?.version) {
@@ -58,9 +53,6 @@ export async function logLocalCodeEngineVersion(lceUrl = ''): Promise<void> {
   } catch (err) {
     debug('Snyk Code Local Engine health check failed.', err);
   } finally {
-    if (isNonSecureHttp) {
-      // Resetting `global.ignoreUnknownCA` to whatever value it had before I changed it above.
-      global.ignoreUnknownCA = ignoreUnknownCAoriginalValue;
-    }
+    process.env.SNYK_HTTP_PROTOCOL_UPGRADE = originalProtocolUpgrade;
   }
 }


### PR DESCRIPTION
### What does this PR do?

- Allows requests made towards the Snyk Code Local Engine `/status` endpoint to respect the protocol of the Local Engine URL set on the org/group
- Fixes conditions where a Snyk Code Local Engine installation responds on both `http` and `https` and we want to query `http` only
- Allows certificate trust to remain intact

### Where should the reviewer start?

### How should this be manually tested?

### Any background context you want to provide?

### What are the relevant tickets?

### Screenshots

### Additional questions
