### PR TITLE
fix: add percent-encoded plus sign in purl version tests

### DIFF
--- a/test/jest/unit/snyk-dep-graph.spec.ts
+++ b/test/jest/unit/snyk-dep-graph.spec.ts
@@ -1,0 +1,59 @@
+import { createFromJSON } from '@snyk/dep-graph';
+
+describe('@snyk/dep-graph', () => {
+  describe('createFromJSON', () => {
+    it('supports percent-encoded plus sign in purl version', () => {
+      // Arrange
+      const json = {
+        schemaVersion: '1.3.0',
+        pkgManager: {
+          name: 'deb',
+          repositories: [
+            {
+              alias: 'repository:tag',
+            },
+          ],
+        },
+        pkgs: [
+          {
+            id: 'repository@digest',
+            info: {
+              name: 'repository',
+              version: 'digest',
+            },
+          },
+          {
+            id: 'db5.3/libdb5.3@5.3.28+dfsg1-0.6ubuntu2',
+            info: {
+              name: 'db5.3/libdb5.3',
+              version: '5.3.28+dfsg1-0.6ubuntu2',
+              purl: 'pkg:deb/libdb5.3@5.3.28%2Bdfsg1-0.6ubuntu2?upstream=db5.3',
+            },
+          },
+        ],
+        graph: {
+          rootNodeId: 'root-node',
+          nodes: [
+            {
+              nodeId: 'root-node',
+              pkgId: 'repository@digest',
+              deps: [
+                {
+                  nodeId: 'db5.3/libdb5.3@5.3.28+dfsg1-0.6ubuntu2',
+                },
+              ],
+            },
+            {
+              nodeId: 'db5.3/libdb5.3@5.3.28+dfsg1-0.6ubuntu2',
+              pkgId: 'db5.3/libdb5.3@5.3.28+dfsg1-0.6ubuntu2',
+              deps: [],
+            },
+          ],
+        },
+      };
+
+      // Act
+      createFromJSON(json);
+    });
+  });
+});


### PR DESCRIPTION
## Pull Request Submission

Please check the boxes once done.

The pull request must:

- **Reviewer Documentation**
    - [x] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/master/CONTRIBUTING.md) rules
    - [x] be accompanied by a detailed description of the changes
    - [x] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [x] highlight breaking API if applicable
    - [x] contain a link to the automatic tests that cover the updated functionality.
    - [x] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [x] link to the link to the PR for the User-facing documentation
- **User facing Documentation**
    - [x] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [x] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [x] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.

## Pull Request Review

All pull requests must undergo a thorough review process before being merged. 
The review process of the code PR should include code review, testing, and any necessary feedback or revisions. 
Pull request reviews of functionality developed in other teams only review the given documentation and test reports. 

Manual testing will not be performed by the reviewing team, and is the responsibility of the author of the PR.

For Node projects: It’s important to make sure changes in `package.json` are also affecting `package-lock.json` correctly.

****************************If a dependency is not necessary, don’t add it.**************************** 

When adding a new package as a dependency, make sure that the change is absolutely necessary. We would like to refrain from adding new dependencies when possible.
Documentation PRs in gitbook are reviewed by Snyk's content team. They will also advise on the best phrasing and structuring if needed.

## Pull Request Approval

Once a pull request has been reviewed and all necessary revisions have been made, it is approved for merging into 
the main codebase. The merging of the code PR is performed by the code owners, the merging of the documentation PR 
by our content writers.


## What does this PR do?

Adds `test/jest/unit/snyk-dep-graph.spec.ts` to tests plus sign in the purl version is percent-encoded.

## Where should the reviewer start?

Checking out the branch and verifying the instructions in [How should this be manually tested?](#How should this be manually tested?) work produces the expected outcomes.

## How should this be manually tested?

Positive test:

```
npx jest test/jest/unit/snyk-dep-graph.spec.ts
```

Negative test:

```
npm install packageurl-js@1.2.1
npx jest test/jest/unit/snyk-dep-graph.spec.ts
```

## Any background context you want to provide?

`packageurl-js` `1.2.1` introduced a regression to how PURLs are generated and validated. PURLs that were valid before are no longer valid. The maintainers of `packageurl-js` are working on a hotfix to correct the regression.

The `packageurl-js` is used as a transitive for `snyk-docker-plugin`, `@snyk/dep-graph`, and so on.  If `packageurl-js` `1.2.1` is used in the final executable, the CLI will produce dep-graphs with incorrect PURLs and transmit them to Snyk for long-term persistence when running `snyk *? monitor`.

## What are the relevant tickets?

- INC-469

## Screenshots


## Additional questions

