### PR TITLE
fix: bump nodejs-parser to 1.52.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "snyk-gradle-plugin": "4.0.0",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "3.1.0",
-        "snyk-nodejs-lockfile-parser": "1.52.6",
+        "snyk-nodejs-lockfile-parser": "1.52.7",
         "snyk-nuget-plugin": "2.3.0",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.25.0",
@@ -20568,9 +20568,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-nodejs-lockfile-parser": {
-      "version": "1.52.6",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.52.6.tgz",
-      "integrity": "sha512-B1PYRnHmNQZ5xYDb+eFflbbzKecbx+T5Gh+xqv3+UE42+F88z/IY6QqeMgrRldjGLmJ1VSAQy/Ga2wxaiUdZsg==",
+      "version": "1.52.7",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.52.7.tgz",
+      "integrity": "sha512-mjJ5zdHTLkZJko7UanjJftEe70SD0nkxMKRzCaEoRDbSsJX3N/bNpIB74CrMJwNSrOSoR3P60Q+2LI5ooxLAlA==",
       "dependencies": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -39776,9 +39776,9 @@
       }
     },
     "snyk-nodejs-lockfile-parser": {
-      "version": "1.52.6",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.52.6.tgz",
-      "integrity": "sha512-B1PYRnHmNQZ5xYDb+eFflbbzKecbx+T5Gh+xqv3+UE42+F88z/IY6QqeMgrRldjGLmJ1VSAQy/Ga2wxaiUdZsg==",
+      "version": "1.52.7",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.52.7.tgz",
+      "integrity": "sha512-mjJ5zdHTLkZJko7UanjJftEe70SD0nkxMKRzCaEoRDbSsJX3N/bNpIB74CrMJwNSrOSoR3P60Q+2LI5ooxLAlA==",
       "requires": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/graphlib": "2.1.9-patch.3",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "snyk-gradle-plugin": "4.0.0",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "3.1.0",
-    "snyk-nodejs-lockfile-parser": "1.52.6",
+    "snyk-nodejs-lockfile-parser": "1.52.7",
     "snyk-nuget-plugin": "2.3.0",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.25.0",


### PR DESCRIPTION
## What does this PR do?

This bumps the snyk-nodejs-lockfile-parser to 1.52.7. Details can be found here https://github.com/snyk/nodejs-lockfile-parser/releases
