### PR TITLE
fix: add timeout handling to legacy cli

### DIFF
--- a/cliv2/cmd/cliv2/main.go
+++ b/cliv2/cmd/cliv2/main.go
@@ -466,7 +466,7 @@ func MainWithErrorCode() int {
 
 	displayError(err)
 
-	exitCode := cliv2.DeriveExitCode(err)
+	exitCode := cliv2.DeriveExitCode(err, globalConfiguration)
 	debugLogger.Printf("Exiting with %d", exitCode)
 
 	return exitCode
@@ -479,8 +479,9 @@ func setTimeout(config configuration.Configuration, onTimeout func()) {
 	}
 	debugLogger.Printf("Command timeout set for %d seconds", timeout)
 	go func() {
-		<-time.After(time.Duration(timeout) * time.Second)
-		fmt.Fprintf(os.Stderr, "command timed out\n")
+		// we wait a bit longer than the timeout to ensure that the command has enough time to finish
+		<-time.After(time.Duration(timeout+5) * time.Second)
+		fmt.Fprintf(os.Stdout, "command timed out")
 		onTimeout()
 	}()
 }

--- a/cliv2/cmd/cliv2/main.go
+++ b/cliv2/cmd/cliv2/main.go
@@ -8,7 +8,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
 	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/snyk/cli-extension-dep-graph/pkg/depgraph"
 	"github.com/snyk/cli-extension-iac-rules/iacrules"
 	"github.com/snyk/cli-extension-sbom/pkg/sbom"
@@ -18,25 +27,15 @@ import (
 	"github.com/snyk/container-cli/pkg/container"
 	"github.com/snyk/go-application-framework/pkg/analytics"
 	"github.com/snyk/go-application-framework/pkg/app"
+	"github.com/snyk/go-application-framework/pkg/auth"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
 	"github.com/snyk/go-application-framework/pkg/networking"
 	"github.com/snyk/go-application-framework/pkg/runtimeinfo"
 	"github.com/snyk/go-application-framework/pkg/utils"
 	"github.com/snyk/go-application-framework/pkg/workflow"
-	"github.com/snyk/snyk-iac-capture/pkg/capture"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-	"io"
-	"os"
-	"os/exec"
-	"strings"
-	"time"
-)
-
-import (
-	"github.com/snyk/go-application-framework/pkg/auth"
 	"github.com/snyk/go-httpauth/pkg/httpauth"
+	"github.com/snyk/snyk-iac-capture/pkg/capture"
 	snykls "github.com/snyk/snyk-ls/ls_extension"
 )
 
@@ -486,8 +485,8 @@ func setTimeout(config configuration.Configuration, onTimeout func()) {
 	}
 	debugLogger.Printf("Command timeout set for %d seconds", timeout)
 	go func() {
-		// we wait a bit longer than the timeout to ensure that the command has enough time to finish
-		<-time.After(time.Duration(timeout+5) * time.Second)
+		const gracePeriodForSubProcesses = 3
+		<-time.After(time.Duration(timeout+gracePeriodForSubProcesses) * time.Second)
 		fmt.Fprintf(os.Stdout, "command timed out")
 		onTimeout()
 	}()

--- a/cliv2/cmd/cliv2/main_test.go
+++ b/cliv2/cmd/cliv2/main_test.go
@@ -1,16 +1,15 @@
 package main
 
 import (
-	"os"
-	"testing"
-	"time"
-
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+	"time"
 )
 
 func cleanup() {
@@ -226,7 +225,7 @@ func Test_setTimeout(t *testing.T) {
 	select {
 	case <-exitedCh:
 		break
-	case <-time.After(5 * time.Second):
+	case <-time.After(8 * time.Second):
 		t.Fatal("timeout func never executed")
 	}
 }

--- a/cliv2/cmd/cliv2/main_test.go
+++ b/cliv2/cmd/cliv2/main_test.go
@@ -1,15 +1,16 @@
 package main
 
 import (
+	"os"
+	"testing"
+	"time"
+
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"testing"
-	"time"
 )
 
 func cleanup() {
@@ -225,7 +226,7 @@ func Test_setTimeout(t *testing.T) {
 	select {
 	case <-exitedCh:
 		break
-	case <-time.After(8 * time.Second):
+	case <-time.After(4 * time.Second):
 		t.Fatal("timeout func never executed")
 	}
 }

--- a/cliv2/cmd/cliv2/main_test.go
+++ b/cliv2/cmd/cliv2/main_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/snyk/go-application-framework/pkg/configuration"
-	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
-	"github.com/snyk/go-application-framework/pkg/workflow"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
+	"github.com/snyk/go-application-framework/pkg/workflow"
 )
 
 func cleanup() {
@@ -226,7 +227,7 @@ func Test_setTimeout(t *testing.T) {
 	select {
 	case <-exitedCh:
 		break
-	case <-time.After(4 * time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("timeout func never executed")
 	}
 }

--- a/cliv2/internal/cliv2/cliv2.go
+++ b/cliv2/internal/cliv2/cliv2.go
@@ -367,8 +367,7 @@ func (c *CLI) executeV1Default(proxyInfo *proxy.ProxyInfo, passThroughArgs []str
 	if timeout == 0 {
 		ctx = context.Background()
 	} else {
-		deadline := time.Now().Add(time.Duration(timeout) * time.Second)
-		ctx, cancel = context.WithDeadline(context.Background(), deadline)
+		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(timeout) * time.Second)
 		defer cancel()
 	}
 

--- a/cliv2/internal/cliv2/cliv2.go
+++ b/cliv2/internal/cliv2/cliv2.go
@@ -348,7 +348,14 @@ func PrepareV1EnvironmentVariables(
 
 }
 
-func (c *CLI) PrepareV1Command(ctx context.Context, cmd string, args []string, proxyInfo *proxy.ProxyInfo, integrationName string, integrationVersion string) (snykCmd *exec.Cmd, err error) {
+func (c *CLI) PrepareV1Command(
+	ctx context.Context,
+	cmd string,
+	args []string,
+	proxyInfo *proxy.ProxyInfo,
+	integrationName string,
+	integrationVersion string,
+) (snykCmd *exec.Cmd, err error) {
 	proxyAddress := fmt.Sprintf("http://%s:%s@127.0.0.1:%d", proxy.PROXY_USERNAME, proxyInfo.Password, proxyInfo.Port)
 	snykCmd = exec.CommandContext(ctx, cmd, args...)
 	snykCmd.Env, err = PrepareV1EnvironmentVariables(c.env, integrationName, integrationVersion, proxyAddress, proxyInfo.CertificateLocation, c.globalConfig, args)
@@ -367,7 +374,7 @@ func (c *CLI) executeV1Default(proxyInfo *proxy.ProxyInfo, passThroughArgs []str
 	if timeout == 0 {
 		ctx = context.Background()
 	} else {
-		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(timeout) * time.Second)
+		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 		defer cancel()
 	}
 

--- a/cliv2/internal/cliv2/cliv2.go
+++ b/cliv2/internal/cliv2/cliv2.go
@@ -4,7 +4,9 @@ Entry point class for the CLIv2 version.
 package cliv2
 
 import (
+	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -13,6 +15,7 @@ import (
 	"path"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/gofrs/flock"
 	"github.com/snyk/go-application-framework/pkg/configuration"
@@ -72,6 +75,11 @@ func NewCLIv2(config configuration.Configuration, debugLogger *log.Logger) (*CLI
 	}
 
 	return &cli, nil
+}
+
+// SetV1BinaryLocation for testing purposes
+func (c *CLI) SetV1BinaryLocation(filePath string) {
+	c.v1BinaryLocation = filePath
 }
 
 func (c *CLI) Init() (err error) {
@@ -200,7 +208,7 @@ func (c *CLI) GetBinaryLocation() string {
 }
 
 func (c *CLI) printVersion() {
-	fmt.Fprintln(c.stdout, GetFullVersion())
+	_, _ = fmt.Fprintln(c.stdout, GetFullVersion())
 }
 
 func (c *CLI) commandVersion(passthroughArgs []string) error {
@@ -235,8 +243,8 @@ func (c *CLI) commandAbout(proxyInfo *proxy.ProxyInfo, passthroughArgs []string)
 			}
 
 			fmt.Printf("Package: %s \n", strings.ReplaceAll(strings.ReplaceAll(fPath, "/licenses/", ""), "/"+f.Name(), ""))
-			fmt.Fprintln(c.stdout, string(data))
-			fmt.Fprint(c.stdout, separator)
+			_, _ = fmt.Fprintln(c.stdout, string(data))
+			_, _ = fmt.Fprint(c.stdout, separator)
 		}
 	}
 
@@ -340,16 +348,9 @@ func PrepareV1EnvironmentVariables(
 
 }
 
-func (c *CLI) PrepareV1Command(
-	cmd string,
-	args []string,
-	proxyInfo *proxy.ProxyInfo,
-	integrationName string,
-	integrationVersion string,
-) (snykCmd *exec.Cmd, err error) {
+func (c *CLI) PrepareV1Command(ctx context.Context, cmd string, args []string, proxyInfo *proxy.ProxyInfo, integrationName string, integrationVersion string) (snykCmd *exec.Cmd, err error) {
 	proxyAddress := fmt.Sprintf("http://%s:%s@127.0.0.1:%d", proxy.PROXY_USERNAME, proxyInfo.Password, proxyInfo.Port)
-
-	snykCmd = exec.Command(cmd, args...)
+	snykCmd = exec.CommandContext(ctx, cmd, args...)
 	snykCmd.Env, err = PrepareV1EnvironmentVariables(c.env, integrationName, integrationVersion, proxyAddress, proxyInfo.CertificateLocation, c.globalConfig, args)
 
 	if len(c.WorkingDirectory) > 0 {
@@ -360,8 +361,18 @@ func (c *CLI) PrepareV1Command(
 }
 
 func (c *CLI) executeV1Default(proxyInfo *proxy.ProxyInfo, passThroughArgs []string) error {
+	timeout := c.globalConfig.GetInt(configuration.TIMEOUT)
+	var ctx context.Context
+	var cancel context.CancelFunc
+	if timeout == 0 {
+		ctx = context.Background()
+	} else {
+		deadline := time.Now().Add(time.Duration(timeout) * time.Second)
+		ctx, cancel = context.WithDeadline(context.Background(), deadline)
+		defer cancel()
+	}
 
-	snykCmd, err := c.PrepareV1Command(c.v1BinaryLocation, passThroughArgs, proxyInfo, c.GetIntegrationName(), GetFullVersion())
+	snykCmd, err := c.PrepareV1Command(ctx, c.v1BinaryLocation, passThroughArgs, proxyInfo, c.GetIntegrationName(), GetFullVersion())
 
 	if c.DebugLogger.Writer() != io.Discard {
 		c.DebugLogger.Println("Launching: ")
@@ -397,13 +408,16 @@ func (c *CLI) executeV1Default(proxyInfo *proxy.ProxyInfo, passThroughArgs []str
 	snykCmd.Stderr = c.stderr
 
 	if err != nil {
-		if evWarning, ok := err.(EnvironmentWarning); ok {
-			fmt.Fprintln(c.stdout, "WARNING! ", evWarning)
+		var evWarning EnvironmentWarning
+		if errors.As(err, &evWarning) {
+			_, _ = fmt.Fprintln(c.stdout, "WARNING! ", evWarning)
 		}
 	}
 
 	err = snykCmd.Run()
-
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		_, _ = fmt.Fprintln(c.stdout, "command timed out")
+	}
 	return err
 }
 
@@ -423,15 +437,16 @@ func (c *CLI) Execute(proxyInfo *proxy.ProxyInfo, passThroughArgs []string) erro
 	return err
 }
 
-func DeriveExitCode(err error) int {
+func DeriveExitCode(err error, config configuration.Configuration) int {
 	returnCode := constants.SNYK_EXIT_CODE_OK
 
 	if err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
 			returnCode = exitError.ExitCode()
-		} else {
-			// got an error but it's not an ExitError
-			returnCode = constants.SNYK_EXIT_CODE_ERROR
+			if returnCode == -1 && config.GetInt(configuration.TIMEOUT) > 0 {
+				returnCode = constants.SNYK_EXIT_CODE_EX_UNAVAILABLE
+			}
 		}
 	}
 

--- a/cliv2/internal/cliv2/cliv2.go
+++ b/cliv2/internal/cliv2/cliv2.go
@@ -416,7 +416,6 @@ func (c *CLI) executeV1Default(proxyInfo *proxy.ProxyInfo, passThroughArgs []str
 
 	err = snykCmd.Run()
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		_, _ = fmt.Fprintln(c.stdout, "command timed out")
 		return ctx.Err()
 	}
 	return err
@@ -438,7 +437,7 @@ func (c *CLI) Execute(proxyInfo *proxy.ProxyInfo, passThroughArgs []string) erro
 	return err
 }
 
-func DeriveExitCode(err error, config configuration.Configuration) int {
+func DeriveExitCode(err error) int {
 	returnCode := constants.SNYK_EXIT_CODE_OK
 
 	if err != nil {

--- a/cliv2/internal/cliv2/cliv2_test.go
+++ b/cliv2/internal/cliv2/cliv2_test.go
@@ -272,7 +272,8 @@ func Test_prepareV1Command(t *testing.T) {
 	cacheDir := getCacheDir(t)
 	config := configuration.NewInMemory()
 	config.Set(configuration.CACHE_PATH, cacheDir)
-	cli, _ := cliv2.NewCLIv2(config, discardLogger)
+	cli, err := cliv2.NewCLIv2(config, discardLogger)
+	assert.NoError(t, err)
 
 	snykCmd, err := cli.PrepareV1Command(
 		context.Background(),
@@ -300,11 +301,12 @@ func Test_extractOnlyOnce(t *testing.T) {
 	assert.NoDirExists(t, tmpDir)
 
 	// create instance under test
-	cli, _ := cliv2.NewCLIv2(config, discardLogger)
+	cli, err := cliv2.NewCLIv2(config, discardLogger)
+	assert.NoError(t, err)
+	assert.NoError(t, cli.Init())
 
 	// run once
-	assert.Nil(t, cli.Init())
-	_ = cli.Execute(getProxyInfoForTest(), []string{"--help"})
+	err = cli.Execute(getProxyInfoForTest(), []string{"--help"})
 	assert.FileExists(t, cli.GetBinaryLocation())
 	fileInfo1, _ := os.Stat(cli.GetBinaryLocation())
 
@@ -329,7 +331,8 @@ func Test_init_extractDueToInvalidBinary(t *testing.T) {
 	assert.NoDirExists(t, tmpDir)
 
 	// create instance under test
-	cli, _ := cliv2.NewCLIv2(config, discardLogger)
+	cli, err := cliv2.NewCLIv2(config, discardLogger)
+	assert.NoError(t, err)
 
 	// fill binary with invalid data
 	_ = os.MkdirAll(tmpDir, 0755)
@@ -366,8 +369,9 @@ func Test_executeRunV2only(t *testing.T) {
 	assert.NoDirExists(t, tmpDir)
 
 	// create instance under test
-	cli, _ := cliv2.NewCLIv2(config, discardLogger)
-	assert.Nil(t, cli.Init())
+	cli, err := cliv2.NewCLIv2(config, discardLogger)
+	assert.NoError(t, err)
+	assert.NoError(t, cli.Init())
 
 	actualReturnCode := cliv2.DeriveExitCode(cli.Execute(getProxyInfoForTest(), []string{"--version"}))
 	assert.Equal(t, expectedReturnCode, actualReturnCode)
@@ -383,8 +387,9 @@ func Test_executeUnknownCommand(t *testing.T) {
 	config.Set(configuration.CACHE_PATH, cacheDir)
 
 	// create instance under test
-	cli, _ := cliv2.NewCLIv2(config, discardLogger)
-	assert.Nil(t, cli.Init())
+	cli, err := cliv2.NewCLIv2(config, discardLogger)
+	assert.NoError(t, err)
+	assert.NoError(t, cli.Init())
 
 	actualReturnCode := cliv2.DeriveExitCode(cli.Execute(getProxyInfoForTest(), []string{"bogusCommand"}))
 	assert.Equal(t, expectedReturnCode, actualReturnCode)
@@ -430,8 +435,9 @@ func Test_clearCacheBigCache(t *testing.T) {
 	config.Set(configuration.CACHE_PATH, cacheDir)
 
 	// create instance under test
-	cli, _ := cliv2.NewCLIv2(config, discardLogger)
-	assert.Nil(t, cli.Init())
+	cli, err := cliv2.NewCLIv2(config, discardLogger)
+	assert.NoError(t, err)
+	assert.NoError(t, cli.Init())
 
 	// create folders and files in cache dir
 	dir1 := path.Join(cli.CacheDirectory, "dir1")
@@ -450,8 +456,8 @@ func Test_clearCacheBigCache(t *testing.T) {
 	_ = os.Mkdir(dir6, 0755)
 
 	// clear cache
-	err := cli.ClearCache()
-	assert.Nil(t, err)
+	err = cli.ClearCache()
+	assert.NoError(t, err)
 
 	// check if directories that need to be deleted don't exist
 	assert.NoDirExists(t, dir1)
@@ -476,7 +482,7 @@ func Test_setTimeout(t *testing.T) {
 
 	// sleep for 2s
 	cli.SetV1BinaryLocation("/bin/sleep")
-	err := cli.Execute(getProxyInfoForTest(), []string{"2"})
+	err = cli.Execute(getProxyInfoForTest(), []string{"2"})
 
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 

--- a/cliv2/internal/cliv2/cliv2_test.go
+++ b/cliv2/internal/cliv2/cliv2_test.go
@@ -477,9 +477,7 @@ func Test_setTimeout(t *testing.T) {
 	cli.SetV1BinaryLocation("/bin/sleep")
 	err := cli.Execute(getProxyInfoForTest(), []string{"2"})
 
-	// process should be terminated with sigkill
-	exitCode := err.(*exec.ExitError).ExitCode()
-	assert.Equal(t, -1, exitCode)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 
 	// ensure that -1 is correctly mapped if timeout is set
 	assert.Equal(t, constants.SNYK_EXIT_CODE_EX_UNAVAILABLE, cliv2.DeriveExitCode(err, config))

--- a/cliv2/internal/cliv2/cliv2_test.go
+++ b/cliv2/internal/cliv2/cliv2_test.go
@@ -369,7 +369,7 @@ func Test_executeRunV2only(t *testing.T) {
 	cli, _ := cliv2.NewCLIv2(config, discardLogger)
 	assert.Nil(t, cli.Init())
 
-	actualReturnCode := cliv2.DeriveExitCode(cli.Execute(getProxyInfoForTest(), []string{"--version"}), config)
+	actualReturnCode := cliv2.DeriveExitCode(cli.Execute(getProxyInfoForTest(), []string{"--version"}))
 	assert.Equal(t, expectedReturnCode, actualReturnCode)
 	assert.FileExists(t, cli.GetBinaryLocation())
 
@@ -386,7 +386,7 @@ func Test_executeUnknownCommand(t *testing.T) {
 	cli, _ := cliv2.NewCLIv2(config, discardLogger)
 	assert.Nil(t, cli.Init())
 
-	actualReturnCode := cliv2.DeriveExitCode(cli.Execute(getProxyInfoForTest(), []string{"bogusCommand"}), config)
+	actualReturnCode := cliv2.DeriveExitCode(cli.Execute(getProxyInfoForTest(), []string{"bogusCommand"}))
 	assert.Equal(t, expectedReturnCode, actualReturnCode)
 }
 
@@ -480,5 +480,5 @@ func Test_setTimeout(t *testing.T) {
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 
 	// ensure that -1 is correctly mapped if timeout is set
-	assert.Equal(t, constants.SNYK_EXIT_CODE_EX_UNAVAILABLE, cliv2.DeriveExitCode(err, config))
+	assert.Equal(t, constants.SNYK_EXIT_CODE_EX_UNAVAILABLE, cliv2.DeriveExitCode(err))
 }

--- a/cliv2/internal/cliv2/cliv2_test.go
+++ b/cliv2/internal/cliv2/cliv2_test.go
@@ -470,7 +470,8 @@ func Test_setTimeout(t *testing.T) {
 		t.Skip("Skipping test on windows")
 	}
 	config := configuration.NewInMemory()
-	cli, _ := cliv2.NewCLIv2(config, discardLogger)
+	cli, err := cliv2.NewCLIv2(config, discardLogger)
+	assert.NoError(t, err)
 	config.Set(configuration.TIMEOUT, 1)
 
 	// sleep for 2s


### PR DESCRIPTION
## Pull Request Submission

Please check the boxes once done.

The pull request must:

- **Reviewer Documentation**
    - [x] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/master/CONTRIBUTING.md) rules
    - [x] be accompanied by a detailed description of the changes
    - [x] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [ ] highlight breaking API if applicable
    - [x] contain a link to the automatic tests that cover the updated functionality.
    - [x] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [ ] link to the to the PR for the User-facing documentation
- **User facing Documentation**
    - [ ] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [ ] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [ ] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.

## Pull Request Review

All pull requests must undergo a thorough review process before being merged. 
The review process of the code PR should include code review, testing, and any necessary feedback or revisions. 
Pull request reviews of functionality developed in other teams only review the given documentation and test reports. 

Manual testing will not be performed by the reviewing team, and is the responsibility of the author of the PR.

For Node projects: It’s important to make sure changes in `package.json` are also affecting `package-lock.json` correctly.

****************************If a dependency is not necessary, don’t add it.**************************** 

When adding a new package as a dependency, make sure that the change is absolutely necessary. We would like to refrain from adding new dependencies when possible.
Documentation PRs in gitbook are reviewed by Snyk's content team. They will also advise on the best phrasing and structuring if needed.

## Pull Request Approval

Once a pull request has been reviewed and all necessary revisions have been made, it is approved for merging into 
the main codebase. The merging of the code PR is performed by the code owners, the merging of the documentation PR 
by our content writers.


## What does this PR do?
This PR starts commands in the TypeScript CLI with a deadline, so that timeouts are actually killing spawned sub processes.

Also, the global timeout now waits for a grace-period of 5s on top of the timeout to exit. 


https://github.com/snyk/cli/assets/20150761/c16417cf-92ad-46ab-80c3-f23c99b21839

```
macbook-basti-lan :: ~/workspace/cli ‹fix/timeout-handling*› » SNYK_CI=1 SNYK_TIMEOUT_SECS=1 binary-releases/snyk-macos test --all-projects -d                              1 ↵
2023-11-28T11:14:31Z main - Version:               1.1256.0-dev.9067b9ee7f7407151c23f2bde2742ecc1f0c4440
2023-11-28T11:14:31Z main - Platform:              darwin amd64
2023-11-28T11:14:31Z main - API:                   https://api.snyk.io
2023-11-28T11:14:31Z main - Cache:                 /Users/bdoetsch/Library/Caches/snyk/snyk-cli
2023-11-28T11:14:31Z main - Organization:          7d7ab703-3630-4b46-afed-bad53a655ca3
2023-11-28T11:14:31Z main - Insecure HTTPS:        false
2023-11-28T11:14:31Z main - Analytics:             enabled
2023-11-28T11:14:31Z main - Authorization:         6f17318a293de207b1aea1f2052153d1[...]  (type=token)
2023-11-28T11:14:31Z main - Features:
2023-11-28T11:14:31Z main -   oauth:               Disabled
2023-11-28T11:14:31Z main -   fips:                Not available
2023-11-28T11:14:31Z main - Command timeout set for 1 seconds
2023-11-28T11:14:31Z main - Using Legacy CLI to serve the command. (reason: unknown command "test" for "snyk")
2023-11-28T11:14:31Z legacycli:1 - Arguments: [test --all-projects -d]
2023-11-28T11:14:31Z legacycli:1 - Use StdIO: true
2023-11-28T11:14:31Z legacycli:1 - Working directory:
2023-11-28T11:14:31Z legacycli:1 - Init start
2023-11-28T11:14:31Z legacycli:1 - Init-Lock acquired: true (/Users/bdoetsch/Library/Caches/snyk/snyk-cli/1.1256.0-dev.9067b9ee7f7407151c23f2bde2742ecc1f0c4440.lock)
2023-11-28T11:14:31Z legacycli:1 - Validating sha256 of /Users/bdoetsch/Library/Caches/snyk/snyk-cli/1.1256.0-dev.9067b9ee7f7407151c23f2bde2742ecc1f0c4440/snyk-macos
2023-11-28T11:14:31Z legacycli:1 - open /Users/bdoetsch/Library/Caches/snyk/snyk-cli/1.1256.0-dev.9067b9ee7f7407151c23f2bde2742ecc1f0c4440/snyk-macos: no such file or directory
2023-11-28T11:14:31Z legacycli:1 - Extract cliv1 to /Users/bdoetsch/Library/Caches/snyk/snyk-cli/1.1256.0-dev.9067b9ee7f7407151c23f2bde2742ecc1f0c4440/snyk-macos
2023-11-28T11:14:31Z legacycli:1 - Validating sha256 of /Users/bdoetsch/Library/Caches/snyk/snyk-cli/1.1256.0-dev.9067b9ee7f7407151c23f2bde2742ecc1f0c4440/snyk-macos
2023-11-28T11:14:31Z legacycli:1 - expected:  14a44145b1fe71f5609ae10582bcb360f9c01ef0938ee4a8593fd1d7c5b8eac1
2023-11-28T11:14:31Z legacycli:1 - actual:    14a44145b1fe71f5609ae10582bcb360f9c01ef0938ee4a8593fd1d7c5b8eac1
2023-11-28T11:14:31Z legacycli:1 - Extracted cliv1 successfully
2023-11-28T11:14:31Z legacycli:1 - Init end
2023-11-28T11:14:31Z legacycli:1 - Temporary CertificateLocation: /Users/bdoetsch/Library/Caches/snyk/snyk-cli/1.1256.0-dev.9067b9ee7f7407151c23f2bde2742ecc1f0c4440/tmp/snyk-cli-cert-1900104616.crt
2023-11-28T11:14:31Z legacycli:1 - Enabled Proxy Authentication Mechanism: Anyauth
2023-11-28T11:14:31Z legacycli:1 - starting proxy
2023-11-28T11:14:31Z legacycli:1 - Wrapper proxy is listening on port:  60154
2023-11-28T11:14:31Z legacycli:1 - Launching:
2023-11-28T11:14:31Z legacycli:1 - /Users/bdoetsch/Library/Caches/snyk/snyk-cli/1.1256.0-dev.9067b9ee7f7407151c23f2bde2742ecc1f0c4440/snyk-macos
2023-11-28T11:14:31Z legacycli:1 - With Arguments:
2023-11-28T11:14:31Z legacycli:1 - test, --all-projects, -d
2023-11-28T11:14:31Z legacycli:1 - With Environment:
2023-11-28T11:14:31Z legacycli:1 - NODE_EXTRA_CA_CERTS = /Users/bdoetsch/Library/Caches/snyk/snyk-cli/1.1256.0-dev.9067b9ee7f7407151c23f2bde2742ecc1f0c4440/tmp/snyk-cli-cert-1900104616.crt
2023-11-28T11:14:31Z legacycli:1 - HTTPS_PROXY = http://snykcli:e5d19da8-84ab-4ae4-a756-1ab706dce114@127.0.0.1:60154
2023-11-28T11:14:31Z legacycli:1 - HTTP_PROXY = http://snykcli:e5d19da8-84ab-4ae4-a756-1ab706dce114@127.0.0.1:60154
2023-11-28T11:14:31Z legacycli:1 - NO_PROXY = localhost,127.0.0.1,::1
2023-11-28T11:14:31Z legacycli:1 - SNYK_SYSTEM_HTTPS_PROXY =
2023-11-28T11:14:31Z legacycli:1 - SNYK_SYSTEM_HTTP_PROXY =
2023-11-28T11:14:31Z legacycli:1 - SNYK_SYSTEM_NO_PROXY =
command timed out
2023-11-28T11:14:32Z legacycli:1 - Proxy successfully shut down
2023-11-28T11:14:32Z legacycli:1 - deleting temp cert file: /Users/bdoetsch/Library/Caches/snyk/snyk-cli/1.1256.0-dev.9067b9ee7f7407151c23f2bde2742ecc1f0c4440/tmp/snyk-cli-cert-1900104616.crt
2023-11-28T11:14:32Z legacycli:1 - deleted temp cert file: /Users/bdoetsch/Library/Caches/snyk/snyk-cli/1.1256.0-dev.9067b9ee7f7407151c23f2bde2742ecc1f0c4440/tmp/snyk-cli-cert-1900104616.crt
2023-11-28T11:14:32Z main - Exiting with 69
2023-11-28T11:14:32Z main - Sending Analytics
2023-11-28T11:14:33Z main - Analytics successfully send
```


## Where should the reviewer start?
`cliv2/internal/cliv2/cliv2.go`
`cliv2/cmd/cliv2/main.go`

## How should this be manually tested?
- Build with `make build`
- `SNYK_CI=1 SNYK_TIMEOUT_SECS=1 binary-releases/snyk-macos test --all-projects` should exit with exitCode 69 and "command timed out" message

## Automatic tests
- https://github.com/snyk/cli/blob/9067b9ee7f7407151c23f2bde2742ecc1f0c4440/cliv2/cmd/cliv2/main_test.go#L217
- https://github.com/snyk/cli/blob/9067b9ee7f7407151c23f2bde2742ecc1f0c4440/cliv2/internal/cliv2/cliv2_test.go#L467

## Any background context you want to provide?


## What are the relevant tickets?


## Screenshots


## Additional questions
