### PR TITLE
fix: fix the proxy tests, ensure that CONNECT method is used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@sentry/node": "^7.34.0",
         "@snyk/cli-interface": "2.12.0",
         "@snyk/cloud-config-parser": "^1.14.5",
-        "@snyk/code-client": "^4.23.3",
+        "@snyk/code-client": "^4.23.5",
         "@snyk/dep-graph": "^2.7.4",
         "@snyk/docker-registry-v2-client": "^2.11.0",
         "@snyk/fix": "file:packages/snyk-fix",
@@ -2666,9 +2666,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@snyk/code-client": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.23.3.tgz",
-      "integrity": "sha512-6ma6m3XSZVOwmw0Y+MwlSpxOQ6QlGL1AF+/UhhfBXqvaa+Dzz/4czWeAblJd91NmcawTKW45a/wYUxOeIJJgGw==",
+      "version": "4.23.5",
+      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.23.5.tgz",
+      "integrity": "sha512-M40xtFsKgK7E/bQkzzQXCmso3ImUNTI8i/tPlGiwhEk9uJfU9lO5LOHWYhKNpb0K3G7xN+Hsu9ya8WuFhB/kFg==",
       "dependencies": {
         "@deepcode/dcignore": "^1.0.4",
         "@types/flat-cache": "^2.0.1",
@@ -2683,34 +2683,10 @@
         "lodash.pick": "^4.4.0",
         "lodash.union": "^4.6.0",
         "multimatch": "^5.0.0",
-        "needle": "3.0.0",
+        "needle": "^3.3.0",
         "p-map": "^3.0.0",
         "uuid": "^8.3.2",
         "yaml": "^1.10.2"
-      }
-    },
-    "node_modules/@snyk/code-client/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/@snyk/code-client/node_modules/needle": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-3.0.0.tgz",
-      "integrity": "sha512-eGr0qnfHxAjr+Eptl1zr2lgUQUPC1SZfTkg2kFi0kxr1ChJonHUVYobkug8siBKMlyUVVp56MSkp6CSeXH/jgw==",
-      "dependencies": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "needle": "bin/needle"
-      },
-      "engines": {
-        "node": ">= 4.4.x"
       }
     },
     "node_modules/@snyk/code-client/node_modules/p-map": {
@@ -11637,6 +11613,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -26403,9 +26380,9 @@
       }
     },
     "@snyk/code-client": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.23.3.tgz",
-      "integrity": "sha512-6ma6m3XSZVOwmw0Y+MwlSpxOQ6QlGL1AF+/UhhfBXqvaa+Dzz/4czWeAblJd91NmcawTKW45a/wYUxOeIJJgGw==",
+      "version": "4.23.5",
+      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.23.5.tgz",
+      "integrity": "sha512-M40xtFsKgK7E/bQkzzQXCmso3ImUNTI8i/tPlGiwhEk9uJfU9lO5LOHWYhKNpb0K3G7xN+Hsu9ya8WuFhB/kFg==",
       "requires": {
         "@deepcode/dcignore": "^1.0.4",
         "@types/flat-cache": "^2.0.1",
@@ -26420,30 +26397,12 @@
         "lodash.pick": "^4.4.0",
         "lodash.union": "^4.6.0",
         "multimatch": "^5.0.0",
-        "needle": "3.0.0",
+        "needle": "^3.3.0",
         "p-map": "^3.0.0",
         "uuid": "^8.3.2",
         "yaml": "^1.10.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "needle": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-3.0.0.tgz",
-          "integrity": "sha512-eGr0qnfHxAjr+Eptl1zr2lgUQUPC1SZfTkg2kFi0kxr1ChJonHUVYobkug8siBKMlyUVVp56MSkp6CSeXH/jgw==",
-          "requires": {
-            "debug": "^3.2.6",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
         "p-map": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
@@ -33352,6 +33311,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "lodash.values": "^4.3.0",
         "marked": "^4.0.1",
         "micromatch": "4.0.2",
-        "needle": "3.0.0",
+        "needle": "^3.3.0",
         "open": "^7.0.3",
         "ora": "5.4.0",
         "os-name": "^5.1.0",
@@ -2689,6 +2689,30 @@
         "yaml": "^1.10.2"
       }
     },
+    "node_modules/@snyk/code-client/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@snyk/code-client/node_modules/needle": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.0.0.tgz",
+      "integrity": "sha512-eGr0qnfHxAjr+Eptl1zr2lgUQUPC1SZfTkg2kFi0kxr1ChJonHUVYobkug8siBKMlyUVVp56MSkp6CSeXH/jgw==",
+      "dependencies": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
     "node_modules/@snyk/code-client/node_modules/p-map": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
@@ -2786,41 +2810,6 @@
         "needle": "^3.2.0",
         "parse-link-header": "^2.0.0",
         "tslib": "^1.10.0"
-      }
-    },
-    "node_modules/@snyk/docker-registry-v2-client/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/@snyk/docker-registry-v2-client/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@snyk/docker-registry-v2-client/node_modules/needle": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-3.2.0.tgz",
-      "integrity": "sha512-oUvzXnyLiVyVGoianLijF9O/RecZUf7TkBfimjGrLM4eQhXyeJwM6GeAWccwfQ9aa4gMCZKqhAOuLaMIcQxajQ==",
-      "dependencies": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.6.3",
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "needle": "bin/needle"
-      },
-      "engines": {
-        "node": ">= 4.4.x"
       }
     },
     "node_modules/@snyk/error-catalog-nodejs-public": {
@@ -16461,12 +16450,11 @@
       "dev": true
     },
     "node_modules/needle": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-3.0.0.tgz",
-      "integrity": "sha512-eGr0qnfHxAjr+Eptl1zr2lgUQUPC1SZfTkg2kFi0kxr1ChJonHUVYobkug8siBKMlyUVVp56MSkp6CSeXH/jgw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.0.tgz",
+      "integrity": "sha512-Kaq820952NOrLY/LVbIhPZeXtCGDBAPVgT0BYnoT3p/Nr3nkGXdvWXXA3zgy7wpAgqRULu9p/NvKiFo6f/12fw==",
       "dependencies": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
+        "iconv-lite": "^0.6.3",
         "sax": "^1.2.4"
       },
       "bin": {
@@ -16476,12 +16464,15 @@
         "node": ">= 4.4.x"
       }
     },
-    "node_modules/needle/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+    "node_modules/needle/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dependencies": {
-        "ms": "^2.1.1"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/negotiator": {
@@ -26435,6 +26426,24 @@
         "yaml": "^1.10.2"
       },
       "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "needle": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/needle/-/needle-3.0.0.tgz",
+          "integrity": "sha512-eGr0qnfHxAjr+Eptl1zr2lgUQUPC1SZfTkg2kFi0kxr1ChJonHUVYobkug8siBKMlyUVVp56MSkp6CSeXH/jgw==",
+          "requires": {
+            "debug": "^3.2.6",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
         "p-map": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
@@ -26518,34 +26527,6 @@
         "needle": "^3.2.0",
         "parse-link-header": "^2.0.0",
         "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        },
-        "needle": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-3.2.0.tgz",
-          "integrity": "sha512-oUvzXnyLiVyVGoianLijF9O/RecZUf7TkBfimjGrLM4eQhXyeJwM6GeAWccwfQ9aa4gMCZKqhAOuLaMIcQxajQ==",
-          "requires": {
-            "debug": "^3.2.6",
-            "iconv-lite": "^0.6.3",
-            "sax": "^1.2.4"
-          }
-        }
       }
     },
     "@snyk/error-catalog-nodejs-public": {
@@ -36988,21 +36969,20 @@
       "dev": true
     },
     "needle": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-3.0.0.tgz",
-      "integrity": "sha512-eGr0qnfHxAjr+Eptl1zr2lgUQUPC1SZfTkg2kFi0kxr1ChJonHUVYobkug8siBKMlyUVVp56MSkp6CSeXH/jgw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.0.tgz",
+      "integrity": "sha512-Kaq820952NOrLY/LVbIhPZeXtCGDBAPVgT0BYnoT3p/Nr3nkGXdvWXXA3zgy7wpAgqRULu9p/NvKiFo6f/12fw==",
       "requires": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
+        "iconv-lite": "^0.6.3",
         "sax": "^1.2.4"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
           "requires": {
-            "ms": "^2.1.1"
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "@types/fs-extra": "^9.0.11",
         "@types/jest": "^27.0.1",
         "@types/lodash": "^4.14.161",
-        "@types/needle": "^2.0.4",
+        "@types/needle": "^3.3.0",
         "@types/node": "^14.14.31",
         "@types/sarif": "^2.1.2",
         "@types/sinon": "^7.5.0",
@@ -4777,9 +4777,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/needle": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@types/needle/-/needle-2.5.2.tgz",
-      "integrity": "sha512-FSckojxsXODVYE4oJ7q0OjUki27a6gsdIxp2WJHs9oEmXit/0rjzb/NK+tJnKwFMMyR6mzo+1Nyr83ELw3YT+Q==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@types/needle/-/needle-3.3.0.tgz",
+      "integrity": "sha512-UFIuc1gdyzAqeVUYpSL+cliw2MmU/ZUhVZKE7Zo4wPbgc8hbljeKSnn6ls6iG8r5jpegPXLUIhJ+Wb2kLVs8cg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -28083,9 +28083,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "@types/needle": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@types/needle/-/needle-2.5.2.tgz",
-      "integrity": "sha512-FSckojxsXODVYE4oJ7q0OjUki27a6gsdIxp2WJHs9oEmXit/0rjzb/NK+tJnKwFMMyR6mzo+1Nyr83ELw3YT+Q==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@types/needle/-/needle-3.3.0.tgz",
+      "integrity": "sha512-UFIuc1gdyzAqeVUYpSL+cliw2MmU/ZUhVZKE7Zo4wPbgc8hbljeKSnn6ls6iG8r5jpegPXLUIhJ+Wb2kLVs8cg==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@types/fs-extra": "^9.0.11",
     "@types/jest": "^27.0.1",
     "@types/lodash": "^4.14.161",
-    "@types/needle": "^2.0.4",
+    "@types/needle": "^3.3.0",
     "@types/node": "^14.14.31",
     "@types/sarif": "^2.1.2",
     "@types/sinon": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "lodash.values": "^4.3.0",
     "marked": "^4.0.1",
     "micromatch": "4.0.2",
-    "needle": "3.0.0",
+    "needle": "^3.3.0",
     "open": "^7.0.3",
     "ora": "5.4.0",
     "os-name": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@sentry/node": "^7.34.0",
     "@snyk/cli-interface": "2.12.0",
     "@snyk/cloud-config-parser": "^1.14.5",
-    "@snyk/code-client": "^4.23.3",
+    "@snyk/code-client": "^4.23.5",
     "@snyk/dep-graph": "^2.7.4",
     "@snyk/docker-registry-v2-client": "^2.11.0",
     "@snyk/fix": "file:packages/snyk-fix",

--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -106,9 +106,7 @@ function setupRequest(payload: Payload) {
     parsedUrl.protocol === 'http:'
       ? new http.Agent({ keepAlive: true })
       : new https.Agent({ keepAlive: true });
-  const options: needle.NeedleOptions & {
-    use_proxy_from_env_var: boolean | undefined; // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67880
-  } = {
+  const options: needle.NeedleOptions = {
     use_proxy_from_env_var: false,
     json: payload.json,
     parse: payload.parse,

--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -106,7 +106,10 @@ function setupRequest(payload: Payload) {
     parsedUrl.protocol === 'http:'
       ? new http.Agent({ keepAlive: true })
       : new https.Agent({ keepAlive: true });
-  const options: needle.NeedleOptions = {
+  const options: needle.NeedleOptions & {
+    use_proxy_from_env_var: boolean | undefined; // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67880
+  } = {
+    use_proxy_from_env_var: false,
     json: payload.json,
     parse: payload.parse,
     headers: payload.headers,

--- a/test/tap/proxy.test.js
+++ b/test/tap/proxy.test.js
@@ -73,6 +73,8 @@ test('request respects proxy environment variables', async (t) => {
   });
 
   t.test('https_proxy', async (t) => {
+    t.plan(3);
+
     // NO_PROXY is set in CircleCI and brakes test purpose
     const tmpNoProxy = process.env.NO_PROXY;
     delete process.env.NO_PROXY;
@@ -89,6 +91,7 @@ test('request respects proxy environment variables', async (t) => {
     proxy.setTimeout(1000);
     proxy.on('connect', (req, cltSocket) => {
       const proxiedUrl = url.parse(`https://${req.url}`);
+      t.equal(req.method, 'CONNECT', 'Proxy for HTTPS using CONNECT');
       t.equal(
         proxiedUrl.hostname,
         url.parse(httpsRequestHost).hostname,
@@ -114,7 +117,7 @@ test('request respects proxy environment variables', async (t) => {
     try {
       await makeRequest({
         method: 'post',
-        url: httpRequestHost + requestPath,
+        url: httpsRequestHost + requestPath,
       });
     } catch (e) {
       // an exception is expected
@@ -123,6 +126,8 @@ test('request respects proxy environment variables', async (t) => {
   });
 
   t.test('HTTPS_PROXY', async (t) => {
+    t.plan(3);
+
     // NO_PROXY is set in CircleCI and brakes test purpose
     const tmpNoProxy = process.env.NO_PROXY;
     delete process.env.NO_PROXY;
@@ -138,6 +143,7 @@ test('request respects proxy environment variables', async (t) => {
     proxy.setTimeout(1000);
     proxy.on('connect', (req, cltSocket) => {
       const proxiedUrl = url.parse(`https://${req.url}`);
+      t.equal(req.method, 'CONNECT', 'Proxy for HTTPS using CONNECT');
       t.equal(
         proxiedUrl.hostname,
         url.parse(httpsRequestHost).hostname,
@@ -163,7 +169,7 @@ test('request respects proxy environment variables', async (t) => {
     try {
       await makeRequest({
         method: 'post',
-        url: httpRequestHost + requestPath,
+        url: httpsRequestHost + requestPath,
       });
     } catch (e) {
       // an exception is expected


### PR DESCRIPTION
**What**

- [x] Fixes tests for proxy, properly testing for CONNECT method with needle 3.0.0 (known to work with CONNECT)
- [x] Updates needle to 3.3.0 (known to break CONNECT)
- [x] Disables proxy in needle, introduced in https://github.com/tomas/needle/pull/427
- [x] Updates `@snyk/code-client` with updated needle https://github.com/snyk/code-client/pull/224
- [x] Updates `@types/needle` to support the new option introduced in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67880

**Why**

In https://github.com/snyk/cli/pull/4953 we had to revert to an older version of needle.
We want to make sure we can continue to upgrade needle and we don't accidentally break proxy support on upgrades.
