### PR TITLE
chore: add gitleaksignore due to PR squash and merge

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -82,3 +82,4 @@ c2de35484dcad696a6ee32f2fa317d5cfaffc133:test/fixtures/code/sample-analyze-folde
 168e6f2b48bc294e558d648626a1e00ccd85decc:test/jest/unit/lib/iac/drift/fixtures/all.console:aws-access-token:98
 4c12242de73be79ebd768468e065790f0b9d23a7:test/jest/unit/lib/iac/drift/fixtures/all.console:aws-access-token:98
 25f37b4c609380452b0b96c3853b69e4dc29bb48:test/jest/unit/lib/iac/drift/fixtures/all.console:aws-access-token:98
+ccd03cce97470452766ab397f2ba770dbb2e002e:test/jest/unit/lib/iac/drift/fixtures/all.console:aws-access-token:98


### PR DESCRIPTION
## What does this PR do?
I just squash and merged #4908, which resulted in yet another gitleaks false-positive. This PR should fix this.

## Where should the reviewer start?
–

## How should this be manually tested?
–

## Any background context you want to provide?
–

## What are the relevant tickets?
–

## Screenshots
–

## Additional questions
Would it make sense to disable the squash and merge strategy for this repository to reduce the likelihood of this happening to somebody else in the future?