### PR TITLE
chore: don't checkout code if we have a prepared workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,7 +308,6 @@ commands:
         type: string
         default: linux-base-edge-amd64
     steps:
-      - checkout
       - attach_workspace:
           at: .
 
@@ -758,12 +757,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - binary-releases/*
-            - binary-releases/fips/*
-            - node_modules/*
-            - ts-binary-wrapper/*
-            - dist/*
-            - packages/*
+            - '*'
 
   code-analysis:
     executor: docker-amd64


### PR DESCRIPTION
The workspace already has the code checked out, no need to do it, then
overwrite it with the workspace data.
