### PR TITLE
chore: tap knows about typescript now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -835,7 +835,7 @@ jobs:
           no_output_timeout: '30m' # the whole set of tests regularly takes 25+ minutes.
           command: >
             npx tap -j 1 -C --timeout=300 -R junit --reporter-file=tap-junit.xml
-            --node-arg=-r --node-arg=ts-node/register --allow-incomplete-coverage
+            --allow-incomplete-coverage
             $(circleci tests glob "test/tap/*.test.*" | circleci tests split --split-by=timings)
       - store_test_results:
           path: tap-junit.xml

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,13 +7,7 @@
       "name": "Tap Current File",
       "console": "integratedTerminal",
       "program": "${workspaceFolder}/node_modules/.bin/tap",
-      "args": [
-        "${relativeFile}",
-        "-Rspec",
-        "--timeout=300",
-        "--node-arg=-r",
-        "--node-arg=ts-node/register"
-      ]
+      "args": ["${relativeFile}", "-Rspec", "--timeout=300"]
     },
     {
       "type": "node",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test": "npm run test:unit && npm run test:acceptance && npm run test:tap",
     "test:unit": "jest --runInBand --testPathPattern '/test(/jest)?/unit/'",
     "test:acceptance": "jest --runInBand --testPathPattern '/test(/jest)?/acceptance/'",
-    "test:tap": "tap -Rspec --timeout=300 --node-arg=-r --node-arg=ts-node/register test/tap/*.test.* ",
+    "test:tap": "tap -Rspec --timeout=300 test/tap/*.test.* ",
     "test:smoke": "./scripts/run-smoke-tests-locally.sh"
   },
   "keywords": [


### PR DESCRIPTION
... so we can remove the explicit import hook for it from test running
