### PR TITLE
fix: SARIF: artifactChanges property cannot be empty

### DIFF
--- a/src/lib/formatters/get-sarif-result.ts
+++ b/src/lib/formatters/get-sarif-result.ts
@@ -41,7 +41,26 @@ export function getResults(testResult: TestResult): sarif.Result[] {
                 description: {
                   text: `Upgrade to ${vuln.upgradePath[1]}`,
                 },
-                artifactChanges: [],
+                artifactChanges: [
+                  {
+                    artifactLocation: {
+                      uri: getArtifactLocationUri(
+                        testResult.displayTargetFile,
+                        testResult.path,
+                      ),
+                    },
+                    replacements: [
+                      {
+                        deletedRegion: {
+                          startLine: vuln.lineNumber || 1,
+                        },
+                        insertedContent: {
+                          text: vuln.upgradePath[1] as string,
+                        },
+                      },
+                    ],
+                  },
+                ],
               },
             ]
           : undefined,

--- a/test/jest/unit/lib/formatters/__snapshots__/open-source-sarif-output.spec.ts.snap
+++ b/test/jest/unit/lib/formatters/__snapshots__/open-source-sarif-output.spec.ts.snap
@@ -9,7 +9,23 @@ Object {
         Object {
           "fixes": Array [
             Object {
-              "artifactChanges": Array [],
+              "artifactChanges": Array [
+                Object {
+                  "artifactLocation": Object {
+                    "uri": "package.json",
+                  },
+                  "replacements": Array [
+                    Object {
+                      "deletedRegion": Object {
+                        "startLine": 1,
+                      },
+                      "insertedContent": Object {
+                        "text": "jimp@0.2.28",
+                      },
+                    },
+                  ],
+                },
+              ],
               "description": Object {
                 "text": "Upgrade to jimp@0.2.28",
               },


### PR DESCRIPTION
We received a report that `artifactChanges: []` causes an error in GitHub:
> Unable to upload "xyz.sarif" as it is not valid SARIF:
> - instance.runs[2].results[0].fixes[0].artifactChanges does not meet minimum length of 1

cf. https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141791134

This fix populates `artifactChanges` so it's not empty.