### PR TITLE
fix: SARIF: artifactChanges property cannot be empty

### DIFF
--- a/src/lib/formatters/get-sarif-result.ts
+++ b/src/lib/formatters/get-sarif-result.ts
@@ -41,7 +41,26 @@ export function getResults(testResult: TestResult): sarif.Result[] {
                 description: {
                   text: `Upgrade to ${vuln.upgradePath[1]}`,
                 },
-                artifactChanges: [],
+                artifactChanges: [
+                  {
+                    artifactLocation: {
+                      uri: getArtifactLocationUri(
+                        testResult.displayTargetFile,
+                        testResult.path,
+                      ),
+                    },
+                    replacements: [
+                      {
+                        deletedRegion: {
+                          startLine: vuln.lineNumber || 1,
+                        },
+                        insertedContent: {
+                          text: vuln.upgradePath[1] as string,
+                        },
+                      },
+                    ],
+                  },
+                ],
               },
             ]
           : undefined,

--- a/test/jest/unit/lib/formatters/__snapshots__/open-source-sarif-output.spec.ts.snap
+++ b/test/jest/unit/lib/formatters/__snapshots__/open-source-sarif-output.spec.ts.snap
@@ -9,7 +9,23 @@ Object {
         Object {
           "fixes": Array [
             Object {
-              "artifactChanges": Array [],
+              "artifactChanges": Array [
+                Object {
+                  "artifactLocation": Object {
+                    "uri": "package.json",
+                  },
+                  "replacements": Array [
+                    Object {
+                      "deletedRegion": Object {
+                        "startLine": 1,
+                      },
+                      "insertedContent": Object {
+                        "text": "jimp@0.2.28",
+                      },
+                    },
+                  ],
+                },
+              ],
               "description": Object {
                 "text": "Upgrade to jimp@0.2.28",
               },


### PR DESCRIPTION
Resubmit of #5010 to get all CI checks to run (forks aren't enabled for some of them).