### PR TITLE
feat(#2439): populate CVSS scores in SARIF files

### DIFF
--- a/src/lib/formatters/open-source-sarif-output.ts
+++ b/src/lib/formatters/open-source-sarif-output.ts
@@ -87,7 +87,8 @@ ${vuln.description}`.replace(/##\s/g, '# '),
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             testResult.packageManager!,
           ],
-          cvssv3_baseScore: vuln.cvssScore,
+          cvssv3_baseScore: vuln.cvssScore, // AWS
+          'security-severity': vuln.cvssScore, // GitHub
         },
       };
     },

--- a/src/lib/formatters/sarif-output.ts
+++ b/src/lib/formatters/sarif-output.ts
@@ -82,7 +82,8 @@ export function getTool(testResult): sarif.Tool {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             testResult.packageManager!,
           ],
-          cvssv3_baseScore: vuln.cvssScore,
+          cvssv3_baseScore: vuln.cvssScore, // AWS
+          'security-severity': vuln.cvssScore, // GitHub
         },
       };
     })

--- a/test/fixtures/docker/sarif-container-result.json
+++ b/test/fixtures/docker/sarif-container-result.json
@@ -30,7 +30,8 @@
                   "security",
                   "deb"
                 ],
-                "cvssv3_baseScore": 6.5
+                "cvssv3_baseScore": 6.5,
+                "security-severity": 6.5
               }
             }
           ]

--- a/test/fixtures/docker/sarif-with-file-container-result.json
+++ b/test/fixtures/docker/sarif-with-file-container-result.json
@@ -30,7 +30,8 @@
                   "security",
                   "deb"
                 ],
-                "cvssv3_baseScore": 6.5
+                "cvssv3_baseScore": 6.5,
+                "security-severity": 6.5
               }
             }
           ]

--- a/test/jest/acceptance/snyk-test/output-formats/sarif.spec.ts
+++ b/test/jest/acceptance/snyk-test/output-formats/sarif.spec.ts
@@ -51,6 +51,7 @@ describe('snyk test --sarif', () => {
 
     expect(stdout).toContain('"artifactsScanned": 1');
     expect(stdout).toContain('"cvssv3_baseScore": 5.3');
+    expect(stdout).toContain('"security-severity": 5.3');
     expect(stdout).toContain('"fullyQualifiedName": "lodash@4.17.15"');
     expect(stdout).toContain('Upgrade to lodash@4.17.17');
   });

--- a/test/jest/unit/lib/formatters/__snapshots__/open-source-sarif-output.spec.ts.snap
+++ b/test/jest/unit/lib/formatters/__snapshots__/open-source-sarif-output.spec.ts.snap
@@ -79,6 +79,7 @@ Object {
               "id": "SNYK-JS-AJV-584908",
               "properties": Object {
                 "cvssv3_baseScore": 7.5,
+                "security-severity": 7.5,
                 "tags": Array [
                   "security",
                   "CWE-400",

--- a/test/jest/unit/lib/formatters/__snapshots__/sarif-output.spec.ts.snap
+++ b/test/jest/unit/lib/formatters/__snapshots__/sarif-output.spec.ts.snap
@@ -71,6 +71,7 @@ In libexpat in Expat before 2.2.7, XML input including XML names that contain a 
               "id": "SNYK-LINUX-EXPAT-450908",
               "properties": Object {
                 "cvssv3_baseScore": 7.5,
+                "security-severity": 7.5,
                 "tags": Array [
                   "security",
                   "CWE-611",
@@ -161,6 +162,7 @@ In libexpat in Expat before 2.2.7, XML input including XML names that contain a 
               "id": "SNYK-LINUX-EXPAT-450908",
               "properties": Object {
                 "cvssv3_baseScore": 7.5,
+                "security-severity": 7.5,
                 "tags": Array [
                   "security",
                   "npm",
@@ -250,6 +252,7 @@ In libexpat in Expat before 2.2.7, XML input including XML names that contain a 
               "id": "SNYK-LINUX-EXPAT-450908",
               "properties": Object {
                 "cvssv3_baseScore": 7.5,
+                "security-severity": 7.5,
                 "tags": Array [
                   "security",
                   "CWE-611",


### PR DESCRIPTION
Addresses #2439.

Adds `security-severity` to open source and container SARIF output.