### PR TITLE
chore: add npm dev script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ clean-prepack: clean-package-files
 	@rm -f prepack
 
 .PHONY: clean-ts
-clean-ts: 
+clean-ts:
 	@npm run clean
 	@rm -f -r $(BINARY_RELEASES_FOLDER_TS_CLI)
 
@@ -183,7 +183,7 @@ $(BINARY_WRAPPER_DIR)/src/generated/sha256sums.txt:
 build-binary-wrapper: pre-build-binary-wrapper $(BINARY_WRAPPER_DIR)/src/generated/version $(BINARY_WRAPPER_DIR)/src/generated/sha256sums.txt
 	@echo "-- Building Typescript Binary Wrapper ($(BINARY_WRAPPER_DIR)/dist/)"
 	@cd $(BINARY_WRAPPER_DIR); npm run build
-	
+
 .PHONY: clean-binary-wrapper
 clean-binary-wrapper:
 	@rm -f $(BINARY_WRAPPER_DIR)/config.default.json
@@ -273,3 +273,18 @@ format:
 ls-protocol-metadata: $(BINARY_RELEASES_FOLDER_TS_CLI)/version
 	@echo "-- Generating protocol metadata"
 	@pushd $(EXTENSIBLE_CLI_DIR) && $(MAKE) generate-ls-protocol-metadata bindir=$(WORKING_DIR)/$(BINARY_OUTPUT_FOLDER) && popd
+
+.PHONY: run
+run: build require-args
+	$(wildcard $(WORKING_DIR)/$(BINARY_OUTPUT_FOLDER)/snyk-*) $(ARGS)
+
+.PHONY: run-ts
+run-ts: require-args
+	@npm install
+	npm run dev "$(ARGS)"
+
+.PHONY: require-args
+require-args:
+ifndef ARGS
+	$(error cannot run: ARGS is undefined)
+endif

--- a/package-lock.json
+++ b/package-lock.json
@@ -14830,9 +14830,9 @@
       "dev": true
     },
     "node_modules/json-stream-stringify": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-3.1.1.tgz",
-      "integrity": "sha512-xDNNSv+JNhkdOpQ0Le8UVncj2KqBjJ2qiQbZmQUBvD1tJzt2NQKDdLCDaRHeCzAMQBg1X27KECwhX6pcRnqs1g==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-3.1.2.tgz",
+      "integrity": "sha512-AHUm3s+xmbOOEqkV5pK2ycTFdgwXNSanusvr67RTXGm4w+Z/lOrhjwyynHUgzDKIYo/6I3W9X3Wv8DCHfxFcgQ==",
       "engines": {
         "node": ">=7.10.1"
       }
@@ -35492,9 +35492,9 @@
       "dev": true
     },
     "json-stream-stringify": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-3.1.1.tgz",
-      "integrity": "sha512-xDNNSv+JNhkdOpQ0Le8UVncj2KqBjJ2qiQbZmQUBvD1tJzt2NQKDdLCDaRHeCzAMQBg1X27KECwhX6pcRnqs1g=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-3.1.2.tgz",
+      "integrity": "sha512-AHUm3s+xmbOOEqkV5pK2ycTFdgwXNSanusvr67RTXGm4w+Z/lOrhjwyynHUgzDKIYo/6I3W9X3Wv8DCHfxFcgQ=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "test:unit": "jest --runInBand --testPathPattern '/test(/jest)?/unit/'",
     "test:acceptance": "jest --runInBand --testPathPattern '/test(/jest)?/acceptance/'",
     "test:tap": "tap -Rspec --timeout=300 test/tap/*.test.* ",
-    "test:smoke": "./scripts/run-smoke-tests-locally.sh"
+    "test:smoke": "./scripts/run-smoke-tests-locally.sh",
+    "dev": "ts-node ./src/cli/index.ts"
   },
   "keywords": [
     "security",


### PR DESCRIPTION
To aid in debugging and development of the Typescript parts of the CLI, this adds an npm script entrypoint to the CLI.

This doesn't run the complete CLI but may be useful for isolating and debugging Typescript CLI issues.

This is not a user-facing change.

Usage:

`npm run dev test` to run the equivalent of `snyk test` from Typescript source.

`npm run dev -- -d` to pass the debug `-d` flag to the Typescript main entrypoint (and not `npm run`). 