### PR TITLE
fix: do not purge the code action cache in language server before the action is resolved by the client [IDE-134]

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/snyk/go-application-framework v0.0.0-20240111143643-fa847b8a9a3b
 	github.com/snyk/go-httpauth v0.0.0-20231117135515-eb445fea7530
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20240212152311-5c619762aff6
+	github.com/snyk/snyk-ls v0.0.0-20240221091704-22d907524170
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -673,8 +673,8 @@ github.com/snyk/policy-engine v0.22.0 h1:od9pduGrXyfWO791X+8M1qmnvWUxaIXh0gBzGKq
 github.com/snyk/policy-engine v0.22.0/go.mod h1:Vvy/9VMXoABS3JlLqhTlAPWkB5LgbLh7LGn3gBwAqdY=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20240212152311-5c619762aff6 h1:8kfK8OfLw+NOUGmuRxSbAJnE4+Yfp10wo9iWIUfnHkw=
-github.com/snyk/snyk-ls v0.0.0-20240212152311-5c619762aff6/go.mod h1:seSz3zGy2NPbSdNq6zq4NFnD2gPteeMDnpLpzfi3qTU=
+github.com/snyk/snyk-ls v0.0.0-20240221091704-22d907524170 h1:8E+HKO1n5Wi0xai4n7zJUcyLp3t1IoeDZWOjuwE8wM8=
+github.com/snyk/snyk-ls v0.0.0-20240221091704-22d907524170/go.mod h1:seSz3zGy2NPbSdNq6zq4NFnD2gPteeMDnpLpzfi3qTU=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/go-lsp v0.0.0-20200429204803-219e11d77f5d h1:afLbh+ltiygTOB37ymZVwKlJwWZn+86syPTbrrOAydY=


### PR DESCRIPTION
## Pull Request Submission

Please check the boxes once done.

The pull request must:

- **Reviewer Documentation**
    - [x] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) rules
    - [x] be accompanied by a detailed description of the changes
    - [x] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [x] highlight breaking API if applicable
    - [ ] contain a link to the automatic tests that cover the updated functionality.
    - [x] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [ ] link to the link to the PR for the User-facing documentation
- **User facing Documentation**
    - [ ] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [ ] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [ ] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.

## What does this PR do?

Risk: low

This PR updates Snyk Language Server to the latest version. This version provides a fix for code action handling in language server. Resolvable Code Actions are working in a two-step modus in language server: First, the action is created with a callback function stored in language server. The second step is the code action resolution. When a client calls language server with the codeaction/resolve request, the stored callback function is looked up in the cache and executed. 

Previously, this cache was purged on each code action request call. This is not working well, if code action information is retained by the IDE. Therefore, the cache entry for the callback function is now only purged when the action is resolved.

## Where should the reviewer start?
https://github.com/snyk/snyk-ls/pull/447

## How should this be manually tested?
Launch VSCode, scan with Snyk Code and autofix enabled a project that contains issues that are auto-fixable. Execute the code action to fix it.

## Any background context you want to provide?
We are integrating language server Snyk Code into IntelliJ right now. When implementing the Snyk Code ExternalAnnotator (SnykCodeAnnotatorLS), the error with too early purged code actions occurred.

## What are the relevant tickets?
IDE-134

## Screenshots


## Additional questions
