### PR TITLE
fix: upgrade go toolchain to 1.21.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
   go_version:
     type: string
     # https://go.dev/doc/devel/release
-    default: '1.20.6'
+    default: '1.21.7'
   aws_version:
     type: string
     # https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst
@@ -808,7 +808,7 @@ jobs:
       - run:
           name: Set version
           command: |
-            make binary-releases/version binary-releases/fips/version 
+            make binary-releases/version binary-releases/fips/version
             make ts-cli-binaries/version BINARY_RELEASES_FOLDER_TS_CLI=ts-cli-binaries
       - run:
           # required for one unit test (ts-binary-wrapper/test/unit/common.spec.ts:15:30)
@@ -837,7 +837,7 @@ jobs:
           name: Linting project
           command: |
             npm run lint
-            pushd cliv2 
+            pushd cliv2
             make lint
             popd
       - snyk/scan:
@@ -1156,7 +1156,7 @@ jobs:
           environment:
             SNYK_DISABLE_ANALYTICS: 1
           command: |
-            PIP_BREAK_SYSTEM_PACKAGES=1 pip install --user --upgrade requests || PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install --user --upgrade requests 
+            PIP_BREAK_SYSTEM_PACKAGES=1 pip install --user --upgrade requests || PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install --user --upgrade requests
             python scripts/install-snyk.py --base_url=<< parameters.cli_download_base_url >>  $(cat binary-releases/version) || python3 scripts/install-snyk.py --base_url=<< parameters.cli_download_base_url >> $(cat binary-releases/version)
             SNYK_TOKEN=${TEST_SNYK_TOKEN} ./snyk whoami --experimental
             SNYK_TOKEN=${TEST_SNYK_TOKEN} ./snyk woof

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/cli/cliv2
 
-go 1.18
+go 1.21
 
 require (
 	github.com/elazarl/goproxy v0.0.0-20231031074852-3ec07828be7a


### PR DESCRIPTION
## Pull Request Submission

Please check the boxes once done.

The pull request must:

- **Reviewer Documentation**
    - [x] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) rules
    - [x] be accompanied by a detailed description of the changes
    - [x] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [ ] highlight breaking API if applicable
    - [ ] contain a link to the automatic tests that cover the updated functionality.
    - [ ] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [ ] link to the link to the PR for the User-facing documentation
- **User facing Documentation**
    - [ ] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [ ] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [ ] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.

## What does this PR do?

Upgrades Go toolchain used to build the CLI to 1.21.7.

## How should this be manually tested?

Acceptance tests should suffice to catch problems with executable on multiple platforms, however unlikely.

You could manually test this by installing go 1.21.7 and building locally.

## Any background context you want to provide?

Go 1.18 released almost 2 years ago. Most developers (CLI team included) are on a newer version of Go. The world has moved on.

This change omits the `toolchain` directive from `cliv2/go.mod`. That should be OK because we tightly control the toolchain in our CircleCI pipeline. If we specified it, that would tightly couple the build with the tools image, which might use a different version of Go in various contexts. I propose it should be safe for these to drift though, since unit and acceptance tests use the same toolchain that builds the binaries.

## What are the relevant tickets?

CLI-152

## Screenshots


## Additional questions

In a followup, I'd like to bring the build image under the Snyk organization.
