### PR TITLE
chore: bump snyk-docker-plugin version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "semver": "^6.0.0",
         "snyk-config": "^5.0.0",
         "snyk-cpp-plugin": "2.24.0",
-        "snyk-docker-plugin": "^6.10.1",
+        "snyk-docker-plugin": "^6.10.2",
         "snyk-go-plugin": "1.23.0",
         "snyk-gradle-plugin": "4.1.0",
         "snyk-module": "3.1.0",
@@ -20807,9 +20807,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.10.1.tgz",
-      "integrity": "sha512-o0wa7wIQwWKoWkwZcvGM+G0CCaQC6H3+9iJHvf6Z650BCUtRomeoTX8uKAIiP+ecIVWzFyb3QxAlwbFky62F7w==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.10.2.tgz",
+      "integrity": "sha512-PiDtLp8VhIunwwe3lwoxPLQ940LhE8ZysDZJ1Xuy4Gbgv2gdXmH3O/iAQgCTsZFK80PNVzpAEt2oyz+LG7lqfA==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.8.0",
@@ -40472,9 +40472,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.10.1.tgz",
-      "integrity": "sha512-o0wa7wIQwWKoWkwZcvGM+G0CCaQC6H3+9iJHvf6Z650BCUtRomeoTX8uKAIiP+ecIVWzFyb3QxAlwbFky62F7w==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.10.2.tgz",
+      "integrity": "sha512-PiDtLp8VhIunwwe3lwoxPLQ940LhE8ZysDZJ1Xuy4Gbgv2gdXmH3O/iAQgCTsZFK80PNVzpAEt2oyz+LG7lqfA==",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "semver": "^6.0.0",
     "snyk-config": "^5.0.0",
     "snyk-cpp-plugin": "2.24.0",
-    "snyk-docker-plugin": "^6.10.1",
+    "snyk-docker-plugin": "^6.10.2",
     "snyk-go-plugin": "1.23.0",
     "snyk-gradle-plugin": "4.1.0",
     "snyk-module": "3.1.0",


### PR DESCRIPTION

## What does this PR do?

Bump `snyk-docker-plugin ` version to 6.10.2 to contain the fix of supporting large files to fix an issue for customers. 
For more details :https://github.com/snyk/snyk-docker-plugin/pull/569