### PR TITLE
fix: project name when using assets-project-name flag

### DIFF
--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -371,6 +371,7 @@ function generateMonitorMeta(options, packageManager?): MonitorMeta {
     prune: !!options.pruneRepeatedSubdependencies,
     'remote-repo-url': options['remote-repo-url'],
     targetReference: options['target-reference'],
+    assetsProjectName: options['assets-project-name'],
   };
 }
 

--- a/src/lib/monitor/utils.ts
+++ b/src/lib/monitor/utils.ts
@@ -47,6 +47,10 @@ export function getProjectName(
     return scannedProject.meta.gradleProjectName;
   }
 
+  if (meta.assetsProjectName && !meta['project-name']) {
+    return scannedProject.depTree?.name;
+  }
+
   return meta['project-name'];
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -157,6 +157,7 @@ export interface MonitorMeta {
   prune: boolean;
   'remote-repo-url'?: string;
   targetReference?: string;
+  assetsProjectName?: boolean;
 }
 
 export interface Tag {

--- a/test/jest/unit/cli-monitor-utils.spec.ts
+++ b/test/jest/unit/cli-monitor-utils.spec.ts
@@ -114,6 +114,64 @@ describe('cli-monitor-utils test', () => {
     expect(res).toEqual('project-name-override');
   });
 
+  it('getProjectName returns nuget project name from scanned project meta when --assets-project-name is provided via options', () => {
+    const scannedProject: ScannedProject = {
+      depTree: {
+        dependencies: {
+          'Microsoft.Extensions.FileProviders.Embedded': {
+            name: 'Microsoft.Extensions.FileProviders.Embedded',
+            version: '6.0.22',
+          },
+        },
+        name: 'nuget-project-assets-name',
+        packageFormatVersion: 'nuget:0.0.0',
+        version: '0.0.1',
+        targetFile: 'project.assets.json',
+      },
+      targetFile: 'project.assets.json',
+    };
+
+    const res = utils.getProjectName(scannedProject, {
+      method: 'cli',
+      packageManager: 'nuget',
+      'policy-path': '',
+      'project-name': '',
+      isDocker: false,
+      prune: false,
+      assetsProjectName: true,
+    });
+    expect(res).toEqual('nuget-project-assets-name');
+  });
+
+  it('getProjectName overrides --assets-project-name with value from --project-name flag', () => {
+    const scannedProject: ScannedProject = {
+      depTree: {
+        dependencies: {
+          'Microsoft.Extensions.FileProviders.Embedded': {
+            name: 'Microsoft.Extensions.FileProviders.Embedded',
+            version: '6.0.22',
+          },
+        },
+        name: 'nuget-project-assets-name',
+        packageFormatVersion: 'nuget:0.0.0',
+        version: '0.0.1',
+        targetFile: 'project.assets.json',
+      },
+      targetFile: 'project.assets.json',
+    };
+
+    const res = utils.getProjectName(scannedProject, {
+      method: 'cli',
+      packageManager: 'nuget',
+      'policy-path': '',
+      'project-name': 'project-name-from-option',
+      isDocker: false,
+      prune: false,
+      assetsProjectName: true,
+    });
+    expect(res).toEqual('project-name-from-option');
+  });
+
   it('getProjectName returns gradle project name from scanned project meta', () => {
     const scannedProject: ScannedProject = {
       depGraph: {} as any,


### PR DESCRIPTION
## Pull Request Submission

The pull request must:

- **Reviewer Documentation**
    - [X] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) rules
    - [X] be accompanied by a detailed description of the changes
    - [X] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [X] highlight breaking API if applicable
    - [X] contain a link to the automatic tests that cover the updated functionality.
    - [X] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [X] link to the link to the PR for the User-facing documentation
- **User facing Documentation**
    - [X] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [X] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [X] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.

## Pull Request Review

All pull requests must undergo a thorough review process before being merged. 
The review process of the code PR should include code review, testing, and any necessary feedback or revisions. 
Pull request reviews of functionality developed in other teams only review the given documentation and test reports. 

Manual testing will not be performed by the reviewing team, and is the responsibility of the author of the PR.

For Node projects: It’s important to make sure changes in `package.json` are also affecting `package-lock.json` correctly.

****************************If a dependency is not necessary, don’t add it.**************************** 

When adding a new package as a dependency, make sure that the change is absolutely necessary. We would like to refrain from adding new dependencies when possible.
Documentation PRs in gitbook are reviewed by Snyk's content team. They will also advise on the best phrasing and structuring if needed.

## Pull Request Approval

Once a pull request has been reviewed and all necessary revisions have been made, it is approved for merging into 
the main codebase. The merging of the code PR is performed by the code owners, the merging of the documentation PR 
by our content writers.


## What does this PR do?

Fixes a bug regarding the usage of the [--assets-project-name flag](https://docs.snyk.io/snyk-cli/commands/monitor#assets-project-name)
Without this fix, when using the above flag, the name of the monitored project it's going to be: `{{ProjectNameFromAssetsJsonFile}}:{{targetFile}}`, which is the default behaviour.
With this fix, when using [--assets-project-name flag](https://docs.snyk.io/snyk-cli/commands/monitor#assets-project-name) flag, project name will be: `{{ProjectNameFromAssetsJsonFile}}`

## Risk assessment

Even though project naming is a sensible place, this PR is not imposing any risk. The flag it's only used for dotnet projects.


## Where should the reviewer start?


## How should this be manually tested?

For manual testing, [this fixture](https://github.com/snyk/cli/blob/86eed5ad07d88501418baeab3b5bbafc6f2fba77/test/fixtures/nuget-assets-name/project.assets.json#L7) can be used along with `snyk monitor --assets-project-name`

## Any background context you want to provide?

Client is complaining that `--assets-project-name` flag it's broken since CLI v.1.1225.0. That version included a [fix](https://github.com/snyk/cli/pull/4865) for project naming along multiple ecosystems, but never for the `--assets-project-name` flag

## What are the relevant tickets?

SUP-2285

## Screenshots


## Additional questions
