### PR TITLE
fix: enables multi-platform support for OCI images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "semver": "^6.0.0",
         "snyk-config": "^5.0.0",
         "snyk-cpp-plugin": "2.24.0",
-        "snyk-docker-plugin": "^6.10.2",
+        "snyk-docker-plugin": "6.10.3",
         "snyk-go-plugin": "1.23.0",
         "snyk-gradle-plugin": "4.1.0",
         "snyk-module": "3.1.0",
@@ -3071,9 +3071,9 @@
       }
     },
     "node_modules/@snyk/dep-graph": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-2.8.0.tgz",
-      "integrity": "sha512-rx1fFfVkRqNAjRWpwIPj3A9LqYuTSEpB+LnSzI0vKj65IF8gSXDPhgCN9EUXwlOTobbDN8sHbbsHVYTuzWaH6A==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-2.8.1.tgz",
+      "integrity": "sha512-bh/uAQBPboj7rDReEAiEN6ukP7dsj5pTRW3fLXVvOXuLb3PN5SC+wj80iAhCNjuiKRSoelt/GHlsngGzUMOwOg==",
       "dependencies": {
         "event-loop-spinner": "^2.1.0",
         "lodash.clone": "^4.5.0",
@@ -3091,7 +3091,7 @@
         "lodash.union": "^4.6.0",
         "lodash.values": "^4.3.0",
         "object-hash": "^3.0.0",
-        "packageurl-js": "^1.0.0",
+        "packageurl-js": "1.2.0",
         "semver": "^7.0.0",
         "tslib": "^2"
       },
@@ -20807,12 +20807,12 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.10.2.tgz",
-      "integrity": "sha512-PiDtLp8VhIunwwe3lwoxPLQ940LhE8ZysDZJ1Xuy4Gbgv2gdXmH3O/iAQgCTsZFK80PNVzpAEt2oyz+LG7lqfA==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.10.3.tgz",
+      "integrity": "sha512-q5urrXWck+tNkmzWhLY0mvHam6sIDEOZPTv+Om4MgYziR/4kuxgZfV9lgQMjblk0sAzRjC0MmpE1iOzU6vWNkw==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
-        "@snyk/dep-graph": "^2.8.0",
+        "@snyk/dep-graph": "^2.8.1",
         "@snyk/docker-registry-v2-client": "^2.11.0",
         "@snyk/rpm-parser": "3.1.0",
         "@snyk/snyk-docker-pull": "^3.11.0",
@@ -20829,7 +20829,7 @@
         "packageurl-js": "1.2.0",
         "semver": "^7.5.4",
         "shescape": "^1.7.4",
-        "snyk-nodejs-lockfile-parser": "^1.52.10",
+        "snyk-nodejs-lockfile-parser": "^1.52.11",
         "snyk-poetry-lockfile-parser": "^1.4.0",
         "tar-stream": "^2.1.0",
         "tmp": "^0.2.1",
@@ -27024,9 +27024,9 @@
       }
     },
     "@snyk/dep-graph": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-2.8.0.tgz",
-      "integrity": "sha512-rx1fFfVkRqNAjRWpwIPj3A9LqYuTSEpB+LnSzI0vKj65IF8gSXDPhgCN9EUXwlOTobbDN8sHbbsHVYTuzWaH6A==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-2.8.1.tgz",
+      "integrity": "sha512-bh/uAQBPboj7rDReEAiEN6ukP7dsj5pTRW3fLXVvOXuLb3PN5SC+wj80iAhCNjuiKRSoelt/GHlsngGzUMOwOg==",
       "requires": {
         "event-loop-spinner": "^2.1.0",
         "lodash.clone": "^4.5.0",
@@ -27044,7 +27044,7 @@
         "lodash.union": "^4.6.0",
         "lodash.values": "^4.3.0",
         "object-hash": "^3.0.0",
-        "packageurl-js": "^1.0.0",
+        "packageurl-js": "1.2.0",
         "semver": "^7.0.0",
         "tslib": "^2"
       },
@@ -40472,12 +40472,12 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.10.2.tgz",
-      "integrity": "sha512-PiDtLp8VhIunwwe3lwoxPLQ940LhE8ZysDZJ1Xuy4Gbgv2gdXmH3O/iAQgCTsZFK80PNVzpAEt2oyz+LG7lqfA==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.10.3.tgz",
+      "integrity": "sha512-q5urrXWck+tNkmzWhLY0mvHam6sIDEOZPTv+Om4MgYziR/4kuxgZfV9lgQMjblk0sAzRjC0MmpE1iOzU6vWNkw==",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
-        "@snyk/dep-graph": "^2.8.0",
+        "@snyk/dep-graph": "^2.8.1",
         "@snyk/docker-registry-v2-client": "^2.11.0",
         "@snyk/rpm-parser": "3.1.0",
         "@snyk/snyk-docker-pull": "^3.11.0",
@@ -40494,7 +40494,7 @@
         "packageurl-js": "1.2.0",
         "semver": "^7.5.4",
         "shescape": "^1.7.4",
-        "snyk-nodejs-lockfile-parser": "^1.52.10",
+        "snyk-nodejs-lockfile-parser": "^1.52.11",
         "snyk-poetry-lockfile-parser": "^1.4.0",
         "tar-stream": "^2.1.0",
         "tmp": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "semver": "^6.0.0",
     "snyk-config": "^5.0.0",
     "snyk-cpp-plugin": "2.24.0",
-    "snyk-docker-plugin": "^6.10.2",
+    "snyk-docker-plugin": "6.10.3",
     "snyk-go-plugin": "1.23.0",
     "snyk-gradle-plugin": "4.1.0",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
## What does this PR do?

Enables multi-platform support for OCI images.

## How should this be manually tested?

Using Docker engine 25.x test an OCI image with a non-standard platform...

`snyk container test busybox:latest --platform=linux/arm64`


## Any background context you want to provide?

Docker engine 25.x now creates an archive with a compliant OCI layout when running `docker save`. We previously only supported `linux/amd64` for OCI layouts.

https://github.com/snyk/snyk-docker-plugin/pull/571

## What are the relevant tickets?

https://snyksec.atlassian.net/browse/SUP-2577
https://snyksec.atlassian.net/browse/SUP-2579
https://snyksec.atlassian.net/browse/SUP-2594
https://snyksec.atlassian.net/browse/SUP-2595
https://snyksec.atlassian.net/browse/SUP-2630

