### PR TITLE
chore(ci): persist acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -984,6 +984,7 @@ jobs:
           command: npm install
       - run:
           name: Running acceptance tests
+          no_output_timeout: 30m
           command: |
             << parameters.pre_test_cmds >>
             npm run test:acceptance -- --selectProjects coreCli
@@ -991,6 +992,11 @@ jobs:
             TEST_SNYK_FIPS: << parameters.fips >>
             TEST_SNYK_COMMAND: << parameters.test_snyk_command >>
             TEST_SNYK_DONT_SKIP_ANYTHING: << parameters.dont_skip_tests >>
+            JEST_JUNIT_OUTPUT_DIR: test/reports
+      - store_test_results:
+          path: test/reports
+      - store_artifacts:
+          path: test/reports
 
   regression-tests:
     parameters:

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "watch": "npm run build-cli:dev -- --watch",
     "test": "npm run test:unit && npm run test:acceptance && npm run test:tap",
     "test:unit": "jest --runInBand --testPathPattern '/test(/jest)?/unit/' --reporters=jest-junit",
-    "test:acceptance": "jest --runInBand --testPathPattern \"/test(/jest)?/acceptance/\"",
+    "test:acceptance": "jest --runInBand --testPathPattern \"/test(/jest)?/acceptance/\" --reporters=jest-junit",
     "test:tap": "tap -Rspec --timeout=300 test/tap/*.test.* ",
     "test:smoke": "./scripts/run-smoke-tests-locally.sh",
     "dev": "ts-node ./src/cli/index.ts"


### PR DESCRIPTION
## Pull Request Submission

Please check the boxes once done.

The pull request must:

- **Reviewer Documentation**
    - [x] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) rules
    - [x] be accompanied by a detailed description of the changes
    - [ ] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [ ] highlight breaking API if applicable
    - [ ] contain a link to the automatic tests that cover the updated functionality.
    - [ ] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [ ] link to the link to the PR for the User-facing documentation
- **User facing Documentation**
    - [ ] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [ ] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [ ] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.

## What does this PR do?

Continuing the work introduced through https://github.com/snyk/cli/pull/5087, adopts junit reporter for acceptance test suites so we can collect information and gain a better understanding of how these perform. Once we have this data we can make a more informed pitch on where to spend our time to reduce CircleCI duration. 

It is worth noting that there is some delay between test reports being uploaded and being represented in the [CircleCI insights tool](https://app.circleci.com/insights/github/snyk/cli/workflows/test_and_release/tests?branch=chore/ci-persist-acceptance-tests). 

## Where should the reviewer start?

Validate that test reports are being uploaded, heres a direct link through to the results for `acceptance-tests linux arm64`
https://app.circleci.com/pipelines/github/snyk/cli/21083/workflows/be568491-f0a0-45f0-8611-9576ea668b20/jobs/314068/tests

Each of the acceptance test jobs in this run successfully exited after uploading their test report
https://app.circleci.com/pipelines/github/snyk/cli/21083/workflows/be568491-f0a0-45f0-8611-9576ea668b20


## How should this be manually tested?

You could deliberately introduce a test failure and verify that it is highlighted under the `Tests` tab in CircleCI UI.  

