### PR TITLE
chore(ci): switch to small go image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,7 +403,7 @@ workflows:
             - nodejs-install
             - team_hammerhead-cli
           requires:
-            - prepare-build
+            - secrets-scan
           filters:
             branches:
               ignore: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,10 @@ executors:
     docker:
       - image: ubuntu:latest
     resource_class: small
+  circle-go:
+    docker:
+      - image: cimg/go:1.20
+    resource_class: medium+
   docker-amd64:
     docker:
       - image: bastiandoetsch209/cli-build:20240214-145818
@@ -911,7 +915,7 @@ jobs:
           path: test/reports
 
   test-go:
-    executor: docker-amd64
+    executor: circle-go
     steps:
       - prepare-workspace
       - run:


### PR DESCRIPTION
## Pull Request Submission

Please check the boxes once done.

The pull request must:

- **Reviewer Documentation**
    - [ ] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) rules
    - [X] be accompanied by a detailed description of the changes
    - [ ] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [ ] highlight breaking API if applicable
    - [ ] contain a link to the automatic tests that cover the updated functionality.
    - [ ] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [ ] link to the link to the PR for the User-facing documentation
- **User facing Documentation**
    - [ ] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [ ] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [ ] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.

## Pull Request Review

All pull requests must undergo a thorough review process before being merged. 
The review process of the code PR should include code review, testing, and any necessary feedback or revisions. 
Pull request reviews of functionality developed in other teams only review the given documentation and test reports. 

Manual testing will not be performed by the reviewing team, and is the responsibility of the author of the PR.

For Node projects: It’s important to make sure changes in `package.json` are also affecting `package-lock.json` correctly.

****************************If a dependency is not necessary, don’t add it.**************************** 

When adding a new package as a dependency, make sure that the change is absolutely necessary. We would like to refrain from adding new dependencies when possible.
Documentation PRs in gitbook are reviewed by Snyk's content team. They will also advise on the best phrasing and structuring if needed.

## Pull Request Approval

Once a pull request has been reviewed and all necessary revisions have been made, it is approved for merging into 
the main codebase. The merging of the code PR is performed by the code owners, the merging of the documentation PR 
by our content writers.


## What does this PR do?

* Switch Docker image used to run `test-go`
* Re-order workflow jobs

### Switch image used to run Docker Tests

Context: p95 duration for this job over the last 90 days is 2m 17s

Solution: Switch from 2.3Gb image to generic 513mb image.

Fetching the `bastiandoetsch209/cli-build` image can increase
the Job time by ~60 seconds if the image is not cached.

```
Warning: No authentication provided, using CircleCI credentials
for pulls from Docker Hub.
image cache not found on this host, downloading bastiandoetsch209/cli-build:20240214-145818
…
bastiandoetsch209/cli-build:20240214-145818:
  using image bastiandoetsch209/cli-build@sha256:1504fdbb34f02aab15475c3eacf8c0fc82be83059cda435b91327e43a98cb863
pull stats: download 2.279GiB in 23.682s (98.54MiB/s), extract 2.31GiB in 58.549s (40.39MiB/s)
```

Even pipeline jobs that execute after previous jobs do not necessarily hit the same image cache.
The caching layer at use here is entirely opaque to me, but the observed affects are
that the `Spin up environment` step can take either 0 or 60 seconds.

Switching to one of the Circle CI provided images could help here by:

* Inscrutable image caching is more likely to be optimised for their own images.
* Generic images used more frequently across their network
* Smaller image size

### Re-order workflow jobs

We can report our findings on the `test-go` job before the `prepare-build` job has completed :sonic: 

**Before:**

![Screenshot 2024-03-11 at 14 32 14](https://github.com/snyk/cli/assets/472589/d2ac9790-4fd3-48a6-97f8-ba92dcfd10c3)

**After:**

![Screenshot 2024-03-11 at 14 31 41](https://github.com/snyk/cli/assets/472589/4057fe10-8df7-4e53-afcd-b2a6557a7a38)
 
 _Note:_ Also observe that these screen grabs capture the behaviour mentioned around Image loading. You can see `prepare-build`, which uses the same image, changes by a minute, this is the symptom of a cache miss when loading the image. 