### PR TITLE
test: explicitly state project version

### DIFF
--- a/test/acceptance/workspaces/composer-app/composer.json
+++ b/test/acceptance/workspaces/composer-app/composer.json
@@ -1,6 +1,7 @@
 {
   "name" : "vulnerable/project",
   "description" : "A sample vulnerable project",
+  "version": "1.0.0",
   "require" : {
     "php" : ">=5.3.2",
     "symfony/symfony": "2.3.1",


### PR DESCRIPTION
## Pull Request Submission

Please check the boxes once done.

The pull request must:

- **Reviewer Documentation**
    - [ ] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) rules
    - [ ] be accompanied by a detailed description of the changes
    - [ ] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [ ] highlight breaking API if applicable
    - [ ] contain a link to the automatic tests that cover the updated functionality.
    - [ ] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [ ] link to the link to the PR for the User-facing documentation
- **User facing Documentation**
    - [ ] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [ ] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [x] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.

## What does this PR do?

As of Composer v2.7.2 the tool will emit an error
if the version has not been defined on the root composer.json
https://github.com/composer/composer/releases/tag/2.7.2

Rather than updating the tests to expect error output we have introduced the 
`version` property, otherwise we are relying on the fallback behaviour of Composer.

> Note that relying on the default/fallback version might potentially lead to dependency resolution issues, especially when the root package depends on a package which ends up depending (directly or indirectly) [back on the root package itself](https://getcomposer.org/doc/articles/troubleshooting.md#dependencies-on-the-root-package).
https://getcomposer.org/doc/articles/troubleshooting.md#root-package-version-detection