### PR TITLE
feat: support -dverbose argument when testing maven projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "snyk-go-plugin": "1.23.0",
         "snyk-gradle-plugin": "4.1.0",
         "snyk-module": "3.1.0",
-        "snyk-mvn-plugin": "3.1.0",
+        "snyk-mvn-plugin": "3.3.1",
         "snyk-nodejs-lockfile-parser": "1.52.11",
         "snyk-nuget-plugin": "2.4.1",
         "snyk-php-plugin": "1.9.2",
@@ -21315,17 +21315,20 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-mvn-plugin": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-3.1.0.tgz",
-      "integrity": "sha512-devEs+koPeDK2U7c+txpDld2j+u4zP8/SssWJrNIJbEO3J4Ay2CGp5FkinuZpbWqQ4KVNQGPA/t9jAnY6DBcNA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-3.3.1.tgz",
+      "integrity": "sha512-Sq45+qzZmLXRuz4RSRjKBp6DN3tQpMdRwaTB7tWTI/J5HQBDiBVDmQ3NTXAb7rCuWGwxvHKL8WE3ZmBMx0Plrw==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.23.1",
-        "debug": "^4.1.1",
+        "debug": "^4.3.4",
         "glob": "^7.1.6",
         "packageurl-js": "^1.0.0",
         "shescape": "1.6.1",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18"
       }
     },
     "node_modules/snyk-mvn-plugin/node_modules/@snyk/cli-interface": {
@@ -40997,13 +41000,13 @@
       }
     },
     "snyk-mvn-plugin": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-3.1.0.tgz",
-      "integrity": "sha512-devEs+koPeDK2U7c+txpDld2j+u4zP8/SssWJrNIJbEO3J4Ay2CGp5FkinuZpbWqQ4KVNQGPA/t9jAnY6DBcNA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-3.3.1.tgz",
+      "integrity": "sha512-Sq45+qzZmLXRuz4RSRjKBp6DN3tQpMdRwaTB7tWTI/J5HQBDiBVDmQ3NTXAb7rCuWGwxvHKL8WE3ZmBMx0Plrw==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.23.1",
-        "debug": "^4.1.1",
+        "debug": "^4.3.4",
         "glob": "^7.1.6",
         "packageurl-js": "^1.0.0",
         "shescape": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "snyk-go-plugin": "1.23.0",
     "snyk-gradle-plugin": "4.1.0",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "3.1.0",
+    "snyk-mvn-plugin": "3.3.1",
     "snyk-nodejs-lockfile-parser": "1.52.11",
     "snyk-nuget-plugin": "2.4.1",
     "snyk-php-plugin": "1.9.2",


### PR DESCRIPTION
## Pull Request Submission

Please check the boxes once done.

The pull request must:

- **Reviewer Documentation**
    - [x] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) rules
    - [x] be accompanied by a detailed description of the changes
    - [x] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [ ] highlight breaking API if applicable
    - [ ] contain a link to the automatic tests that cover the updated functionality.
    - [x] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [ ] link to the link to the PR for the User-facing documentation
- **User facing Documentation**
    - [ ] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [ ] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [ ] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.

## Pull Request Review

All pull requests must undergo a thorough review process before being merged. 
The review process of the code PR should include code review, testing, and any necessary feedback or revisions. 
Pull request reviews of functionality developed in other teams only review the given documentation and test reports. 

Manual testing will not be performed by the reviewing team, and is the responsibility of the author of the PR.

For Node projects: It’s important to make sure changes in `package.json` are also affecting `package-lock.json` correctly.

****************************If a dependency is not necessary, don’t add it.**************************** 

When adding a new package as a dependency, make sure that the change is absolutely necessary. We would like to refrain from adding new dependencies when possible.
Documentation PRs in gitbook are reviewed by Snyk's content team. They will also advise on the best phrasing and structuring if needed.

## Pull Request Approval

Once a pull request has been reviewed and all necessary revisions have been made, it is approved for merging into 
the main codebase. The merging of the code PR is performed by the code owners, the merging of the documentation PR 
by our content writers.


## What does this PR do?

- feat: support verbose for maven

Support passing -Dverbose to resolve omitted dependencies using maven-dependency-plugin.

When verbose is being used execute a specific version of the maven-dependency-plugin. This is becuase on lower version of this plugin outputType=dot is not supported, and it will output a tree.

When verbose is on skip pruning and ensure all dependency lines are traversed fully, using breadth first, first in wins for version resolution.

- fix: record and use visited dependency information

In preparation for supporting -Dverbose the breadth first search needs to retain previously visited dependency information.

At the moment we record whether a dependency has been seen (true/false) based on the maven graph node id. This id contains the dependency version. For example 'com.example:my-app:jar:jdk8:1.2.3:compile'.

However when maven is determining whether a dependency has already been seen only four properties are used:

* groupId
* artifactId
* type
* classifier (optional)

These are the properties that uniquely identify a dependency in Maven.

Changing visited to be keyed by these four properties instead.

In addition we then record the parsed dependency for these visited dependencies so that we can use that information when adding and connecting the dep-graph nodes.

The effect is that if a duplicate node is found, the previously visited version is preferred regardless of what the duplicate node is set to.

This doesn't really effect the current implementation because maven-dependency-plugin hides duplicates. Another PR will start to support -Dverbose where this becomes important that we select the effective version being resolved by Maven.

## Where should the reviewer start?

## How should this be manually tested?

Create a maven project with the following pom.xml file

```
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

  <modelVersion>4.0.0</modelVersion>

  <groupId>io.snyk.example</groupId>
  <artifactId>test-project</artifactId>
  <packaging>jar</packaging>
  <version>1.0-SNAPSHOT</version>
  <name>Test project</name>
  <description>Test project for the Maven CLI plugin</description>

  <dependencies>

<dependency>
      <groupId>org.springframework.boot</groupId>
      <artifactId>spring-boot-starter</artifactId>
      <version>2.7.15</version>
    </dependency>
    <dependency>
      <groupId>com.fasterxml.jackson.dataformat</groupId>
      <artifactId>jackson-dataformat-yaml</artifactId>
      <version>2.14.2</version>
    </dependency>

  </dependencies>

</project>
```

Afterwards run `snyk test -- -Dverbose` against it.

## Any background context you want to provide?


## What are the relevant tickets?


## Screenshots


## Additional questions
