### PR TITLE
feat: bump language server protocol version to 11 [IDE-236]

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/snyk/go-application-framework v0.0.0-20240404113733-1ee20e5f3ae4
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20240408072540-75df46322994
+	github.com/snyk/snyk-ls v0.0.0-20240409081112-f3ca3f397a7b
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -725,8 +725,8 @@ github.com/snyk/policy-engine v0.22.0 h1:od9pduGrXyfWO791X+8M1qmnvWUxaIXh0gBzGKq
 github.com/snyk/policy-engine v0.22.0/go.mod h1:Vvy/9VMXoABS3JlLqhTlAPWkB5LgbLh7LGn3gBwAqdY=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20240408072540-75df46322994 h1:XK3dxElJvE/xtI51dcAZ1XJePLe9vzj8/PzJ1MCuvZI=
-github.com/snyk/snyk-ls v0.0.0-20240408072540-75df46322994/go.mod h1:jSKV+XpanDzYZ3bLHNuT4v3+b39WEy6kCh4dkkSyykc=
+github.com/snyk/snyk-ls v0.0.0-20240409081112-f3ca3f397a7b h1:zVft430r9wUecY2IlGH/mQcRpHwWg0mgtEd8NweRds8=
+github.com/snyk/snyk-ls v0.0.0-20240409081112-f3ca3f397a7b/go.mod h1:jSKV+XpanDzYZ3bLHNuT4v3+b39WEy6kCh4dkkSyykc=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=


### PR DESCRIPTION
## Pull Request Submission

Please check the boxes once done.

The pull request must:

- **Reviewer Documentation**
    - [x] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) rules
    - [x] be accompanied by a detailed description of the changes
    - [x] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [x] highlight breaking API if applicable
    - [ ] contain a link to the automatic tests that cover the updated functionality.
    - [ ] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [ ] link to the link to the PR for the User-facing documentation
- **User facing Documentation**
    - [ ] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [ ] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [ ] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.


## What does this PR do?
This PR updates the included language server to protocol version 11. 

🚨This guards & enforces an API change for IDE clients that is needed for global ignores. This version and consecutive versions of the CLI will only be downloaded from IDEs that have require the same protocol version. Older IDE plugins will stay on the previous CLI.

Risk: Low


## Where should the reviewer start?
Snyk-LS, go-releaser.yaml


## How should this be manually tested?
`make build` should display protocol version 11, the corresponding file (`ls-protocol-version-11`) in `binary-releases` should be generated.

## Any background context you want to provide?
Protocol version 11 is going to be required for global ignores, as it uses a new API call to retrieve feature flags, that is used and exposed as an LSP command. This command is NOT available in version 10, thus the update.


## What are the relevant tickets?
IDE-236

## Screenshots


## Additional questions
