### PR TITLE
chore: log errors in acceptance tests

### DIFF
--- a/test/jest/acceptance/cli-args.spec.ts
+++ b/test/jest/acceptance/cli-args.spec.ts
@@ -380,6 +380,7 @@ describe('cli args', () => {
       {
         env,
         cwd: project.path(),
+        logErrors: true,
       },
     );
 
@@ -401,6 +402,7 @@ describe('cli args', () => {
       {
         env,
         cwd: project.path(),
+        logErrors: true,
       },
     );
 
@@ -419,6 +421,7 @@ describe('cli args', () => {
       {
         env,
         cwd: project.path(),
+        logErrors: true,
       },
     );
 
@@ -436,6 +439,7 @@ describe('cli args', () => {
       {
         env,
         cwd: project.path(),
+        logErrors: true,
       },
     );
 
@@ -458,6 +462,7 @@ describe('cli args', () => {
         {
           env,
           cwd: project.path(),
+          logErrors: true,
         },
       );
       const jsonOutput = JSON.parse(stdout);

--- a/test/jest/util/runCommand.ts
+++ b/test/jest/util/runCommand.ts
@@ -11,7 +11,10 @@ type RunCommandResult = {
 
 // bufferOutput sets the RunCommandResult stdoutBuffer and stderrBuffer
 // useful if the stdout or stderr string output is too large for the v8 engine
-type RunCommandOptions = SpawnOptionsWithoutStdio & { bufferOutput?: boolean };
+type RunCommandOptions = SpawnOptionsWithoutStdio & {
+  bufferOutput?: boolean;
+  logErrors?: boolean;
+};
 
 const runCommand = (
   command: string,
@@ -48,6 +51,10 @@ const runCommand = (
       } else {
         result.stdout = Buffer.concat(stdout).toString('utf-8');
         result.stderr = Buffer.concat(stderr).toString('utf-8');
+      }
+
+      if (options?.logErrors && result.code !== 0) {
+        console.log('stderr:', result.stderr);
       }
 
       resolve(result);


### PR DESCRIPTION
## What does this PR do?

When a Snyk CLI command is expected to exit 0 in acceptance tests, it would be useful for debugging to see the stderr from the process.

This adds an option to runSnykCLI (logErrors) to do this, opt-in. That way we don't pollute the log with expected non-zero exits in tests that expect them.

## Pull Request Submission

Please check the boxes once done.

The pull request must:

- **Reviewer Documentation**
    - [ ] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) rules
    - [ ] be accompanied by a detailed description of the changes
    - [ ] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [ ] highlight breaking API if applicable
    - [ ] contain a link to the automatic tests that cover the updated functionality.
    - [ ] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [ ] link to the link to the PR for the User-facing documentation
- **User facing Documentation**
    - [ ] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [ ] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [ ] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.