### PR TITLE
fix: create_deployment_artifacts needs go installed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -674,6 +674,10 @@ workflows:
 
       - create_deployment_artifacts:
           name: create deployment artifacts
+          go_target_os: linux
+          go_os: linux
+          go_arch: amd64
+          go_download_base_url: << pipeline.parameters.go_download_base_url >>
           context: snyk-cli-pgp-signing
           requires:
             - sign macos amd64
@@ -1202,9 +1206,27 @@ jobs:
             - binary-releases/fips/snyk-*
 
   create_deployment_artifacts:
+    parameters:
+      go_os:
+        type: string
+      go_target_os:
+        type: string
+      go_arch:
+        type: string
+      go_download_base_url:
+        type: string
+      install_path:
+        type: string
+        default: '.'
     executor: docker-amd64
     steps:
       - prepare-workspace
+      - install-go:
+          go_os: << parameters.go_os >>
+          go_target_os: << parameters.go_target_os >>
+          go_arch: << parameters.go_arch >>
+          base_url: << parameters.go_download_base_url >>
+          extraction_path: << parameters.install_path >>
       - run:
           name: Creating all shasums
           command: find binary-releases -name "snyk-*" -exec make {}.sha256 \;

--- a/release-scripts/write-ls-protocol-version.go
+++ b/release-scripts/write-ls-protocol-version.go
@@ -11,9 +11,9 @@ import (
 )
 
 func getGoreleaserYAML(commit string) (int, error) {
-	err := exec.Command("go", "install", "github.com/snyk/snyk-ls@"+commit).Run()
+	installOutput, err := exec.Command("go", "install", "github.com/snyk/snyk-ls@"+commit).CombinedOutput()
 	if err != nil {
-		return -3, fmt.Errorf("go install failed: %w", err)
+		return -3, fmt.Errorf("go install failed: %w: %q", err, string(installOutput))
 	}
 	modCacheDir, err := goModCache()
 	if err != nil {


### PR DESCRIPTION
In #5285 the script which extracts the LS protocol version from snyk-ls was changed to use the Go module cache. `go install` is used as an alternative to fetching directly from Github.

This requires Go to be installed during the deployment release build.

## Pull Request Submission

Please check the boxes once done.

The pull request must:

- **Reviewer Documentation**
    - [x] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) rules
    - [x] be accompanied by a detailed description of the changes
    - [x] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [ ] highlight breaking API if applicable
    - [ ] contain a link to the automatic tests that cover the updated functionality.
    - [ ] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [ ] link to the link to the PR for the User-facing documentation
- **User facing Documentation**
    - [ ] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [ ] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [ ] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.

## Pull Request Review

All pull requests must undergo a thorough review process before being merged. 
The review process of the code PR should include code review, testing, and any necessary feedback or revisions. 
Pull request reviews of functionality developed in other teams only review the given documentation and test reports. 

Manual testing will not be performed by the reviewing team, and is the responsibility of the author of the PR.

For Node projects: It’s important to make sure changes in `package.json` are also affecting `package-lock.json` correctly.

****************************If a dependency is not necessary, don’t add it.**************************** 

When adding a new package as a dependency, make sure that the change is absolutely necessary. We would like to refrain from adding new dependencies when possible.
Documentation PRs in gitbook are reviewed by Snyk's content team. They will also advise on the best phrasing and structuring if needed.

## Pull Request Approval

Once a pull request has been reviewed and all necessary revisions have been made, it is approved for merging into 
the main codebase. The merging of the code PR is performed by the code owners, the merging of the documentation PR 
by our content writers.


## What does this PR do?

See top posting

## Where should the reviewer start?

Failure in Circle CI addressed by this change, during create_deployment_artifacts:

```
make ls-protocol-metadata
```

```
-- Generating protocol metadata
/mnt/ramdisk/snyk/cliv2 /mnt/ramdisk/snyk
make[1]: Entering directory '/mnt/ramdisk/snyk/cliv2'
exit status 1
-- Determining LS protocol version
-- Writing protocol version file to /mnt/ramdisk/snyk/binary-releases
-- LS protocol version: Failed to retrieve LS_PROTOCOL_VERSION: go install failed: exit status 1
make[1]: Leaving directory '/mnt/ramdisk/snyk/cliv2'
/mnt/ramdisk/snyk
cp: cannot stat 'binary-releases/ls-protocol-version-*': No such file or directory

Exited with code exit status 1
```

## How should this be manually tested?

I tried a `go install` in the circleci build image and found that while Go is installed, it's an older version that fails to install snyk-ls:

```
circleci@9357af28696e:/$ go install github.com/snyk/snyk-ls@latest
go: downloading github.com/snyk/snyk-ls v0.0.0-20240603144138-b7b4b7626a10
...
go/pkg/mod/github.com/snyk/go-application-framework@v0.0.0-20240528105122-fac0dc7970b1/internal/presenters/components.go:6:2: package slices is not in GOROOT (/usr/local/go/src/slices)
note: imported by a module that requires go 1.21
circleci@9357af28696e:/$ go version
go version go1.20.14 linux/amd64
```

While we could fix this by updating the version of Go in the build image, I think it's better to use the same Go toolchain that we use to build the CLI in other steps. IIUC the purpose of Go and other tools being in the build image is not really to control the build toolchain, but so that ecosystem tooling is available for integration tests.

## Any background context you want to provide?

This was a tricky edge case. Dumping stderr from the LS protocol script in case this doesn't get at it, we'll be more likely to see what's going on.

## What are the relevant tickets?


## Screenshots


## Additional questions
