### PR TITLE
fix(sbom test): fix issues in JSON output

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/rs/zerolog v1.32.0
 	github.com/snyk/cli-extension-dep-graph v0.0.0-20240426125928-8d56ac52821e
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20240422133948-ae17a4306672
-	github.com/snyk/cli-extension-sbom v0.0.0-20240523084359-a2830fadb001
+	github.com/snyk/cli-extension-sbom v0.0.0-20240619142341-3b3fe79e862c
 	github.com/snyk/container-cli v0.0.0-20240322120441-6d9b9482f9b1
 	github.com/snyk/error-catalog-golang-public v0.0.0-20240605115201-8461850930e6
 	github.com/snyk/go-application-framework v0.0.0-20240614132431-77ccf7f7ec6b

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -736,8 +736,8 @@ github.com/snyk/cli-extension-dep-graph v0.0.0-20240426125928-8d56ac52821e h1:j1
 github.com/snyk/cli-extension-dep-graph v0.0.0-20240426125928-8d56ac52821e/go.mod h1:QF3v8HBpOpyudYNCuR8LqfULutO76c91sBdLzD+pBJU=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20240422133948-ae17a4306672 h1:AkLej8Lk//vFex1fiygSYFrQTUd0xP+GyRbsI+m2kwQ=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20240422133948-ae17a4306672/go.mod h1:2vKTUsW73sVbDcyD19iNLfN0so2GSu9BE3k/fqG0mjA=
-github.com/snyk/cli-extension-sbom v0.0.0-20240523084359-a2830fadb001 h1:EP9cL93+Lqw/wP/C80Sx+pyMYrqQY2NiuLDrad0lZ9w=
-github.com/snyk/cli-extension-sbom v0.0.0-20240523084359-a2830fadb001/go.mod h1:lqmQT+QdzLdfi7qsqIH4qvCsSWu+P09GDFwQcmFfC0g=
+github.com/snyk/cli-extension-sbom v0.0.0-20240619142341-3b3fe79e862c h1:nqFKbstv5PqnRKP4CgW2/Egmbjq6Ej89GzgYFaj+cZ0=
+github.com/snyk/cli-extension-sbom v0.0.0-20240619142341-3b3fe79e862c/go.mod h1:lqmQT+QdzLdfi7qsqIH4qvCsSWu+P09GDFwQcmFfC0g=
 github.com/snyk/code-client-go v1.8.0 h1:6H883KAn7ybiSIxhvL2QR9yEyHgAwA2+9WVHMDNEKa8=
 github.com/snyk/code-client-go v1.8.0/go.mod h1:orU911flV1kJQOlxxx0InUQkAfpBrcERsb2olfnlI8s=
 github.com/snyk/container-cli v0.0.0-20240322120441-6d9b9482f9b1 h1:9RKY9NdX5DrJAoVXDP0JiqrXT+4Nb9NH8pjEcA0NsLA=

--- a/test/jest/acceptance/snyk-sbom-test/all-projects.spec.ts
+++ b/test/jest/acceptance/snyk-sbom-test/all-projects.spec.ts
@@ -103,6 +103,8 @@ describe('snyk sbom test (mocked server only)', () => {
     );
     expect(stdout).toContain('"version":"3.0.4",');
     expect(stdout).toContain('"name":"minimatch"');
+    expect(stdout).toContain('"CWE":["CWE-1333"]');
+    expect(stdout).toContain('"semver":{"vulnerable":["3.0.4"]}');
 
     expect(code).toEqual(1);
 


### PR DESCRIPTION
This fixes two issues in the JSON output of `snyk sbom test --json`:

* the `CWE` of a vulnerability was wrongly attributed to the `CVE` field
* the casing of `@.vulnerabilities[].semver.vulnerable` was wrong