### PR TITLE
fix: align auth failure error messages for oauth

### DIFF
--- a/src/lib/ecosystems/resolve-test-facts.ts
+++ b/src/lib/ecosystems/resolve-test-facts.ts
@@ -43,9 +43,14 @@ export async function resolveAndTestFacts(
   try {
     return await resolveAndTestFactsUnmanagedDeps(scans, options);
   } catch (error) {
-    const unauthorized = error.code === 401 || error.code === 403;
+    const unauthorizedErrorCode = error.code === 401 || error.code === 403;
+    const missingApiToken = error.isMissingApiToken;
 
-    if (unauthorized) {
+    // Decide if the error is an authorization error other than being
+    // unauthenticated (missing or invalid API token). An account lacking
+    // permission, for example.
+    const otherUnauthorized = unauthorizedErrorCode && !missingApiToken;
+    if (otherUnauthorized) {
       throw AuthFailedError(
         'Unauthorized request to unmanaged service',
         error.code,

--- a/src/lib/errors/missing-api-token.ts
+++ b/src/lib/errors/missing-api-token.ts
@@ -6,6 +6,17 @@ export class MissingApiTokenError extends CustomError {
   private static ERROR_MESSAGE =
     '`snyk` requires an authenticated account. Please run `snyk auth` and try again.';
 
+  /**
+   * isMissingApiToken returns whether the error instance is a missing API token
+   * error.
+   *
+   * Defined as a property so that the same expression resolves as "falsy"
+   * (undefined) when other error types are tested.
+   */
+  public get isMissingApiToken(): boolean {
+    return this.strCode === MissingApiTokenError.ERROR_STRING_CODE;
+  }
+
   constructor() {
     super(MissingApiTokenError.ERROR_MESSAGE);
     this.code = MissingApiTokenError.ERROR_CODE;

--- a/src/lib/request/constants.ts
+++ b/src/lib/request/constants.ts
@@ -1,0 +1,1 @@
+export const headerSnykAuthFailed = 'snyk-auth-failed';

--- a/src/lib/request/promise.ts
+++ b/src/lib/request/promise.ts
@@ -1,4 +1,6 @@
 import { getAuthHeader } from '../api-token';
+import { MissingApiTokenError } from '../errors';
+import { headerSnykAuthFailed } from './constants';
 import * as request from './index';
 
 export async function makeRequest<T>(payload: any): Promise<T> {
@@ -35,6 +37,9 @@ export async function makeRequestRest<T>(payload: any): Promise<T> {
     request.makeRequest(payload, (error, res, body) => {
       if (error) {
         return reject(error);
+      }
+      if (res?.headers?.[headerSnykAuthFailed] === 'true') {
+        return reject(new MissingApiTokenError());
       }
       if (res.statusCode === 400) {
         return reject({

--- a/test/jest/unit/lib/ecosystems/resolve-test-facts.oauth.spec.ts
+++ b/test/jest/unit/lib/ecosystems/resolve-test-facts.oauth.spec.ts
@@ -1,0 +1,39 @@
+const mockMakeRequest = jest.fn();
+
+import { Options } from '../../../../../src/lib/types';
+import { MissingApiTokenError } from '../../../../../src/lib/errors';
+
+import { resolveAndTestFacts } from '../../../../../src/lib/ecosystems/resolve-test-facts';
+
+jest.mock('../../../../../src/lib/request/request', () => {
+  return {
+    makeRequest: mockMakeRequest,
+  };
+});
+
+describe('oauth failure', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('rethrows same error for missing api token', async () => {
+    mockMakeRequest.mockRejectedValue(new MissingApiTokenError());
+    await expect(resolveAndTestFacts('cpp', {}, {} as Options)).rejects.toThrow(
+      expect.objectContaining({
+        message:
+          '`snyk` requires an authenticated account. Please run `snyk auth` and try again.',
+      }),
+    );
+  });
+
+  it('rethrows general error for other api auth failures', async () => {
+    const err: any = new Error('nope');
+    err.code = 403;
+    mockMakeRequest.mockRejectedValue(err);
+    await expect(resolveAndTestFacts('cpp', {}, {} as Options)).rejects.toThrow(
+      expect.objectContaining({
+        message: 'Unauthorized request to unmanaged service',
+      }),
+    );
+  });
+});

--- a/test/jest/unit/lib/request/request.spec.ts
+++ b/test/jest/unit/lib/request/request.spec.ts
@@ -1,0 +1,30 @@
+const mockNeedleRequest = jest.fn();
+
+import { makeRequest } from '../../../../../src/lib/request/request';
+import { Payload } from '../../../../../src/lib/request/types';
+
+jest.mock('needle', () => {
+  return {
+    request: mockNeedleRequest,
+  };
+});
+
+describe('needle header auth failed', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('throws missing api token on auth failed marker header', async () => {
+    mockNeedleRequest.mockImplementation((method, url, data, options, fn) => {
+      fn(null, { headers: { 'snyk-auth-failed': 'true' } }, {});
+    });
+    await expect(
+      makeRequest({ url: 'https://example.com' } as Payload),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        message:
+          '`snyk` requires an authenticated account. Please run `snyk auth` and try again.',
+      }),
+    );
+  });
+});


### PR DESCRIPTION
In the Typescript CLI, when OAuth fails due to an invalid or expired token, throw the same "missing auth" error that one would get if not logged in (no auth token).

The resulting error message will prompt the user to re-authenticate.

This has to be mediated by the legacycli http proxy because the Typescript side of the CLI is not involved in the OAuth flow at all; it is handled transparently by the go-application-framework's networking middleware.

A special HTTP request and response header is used by the legacycli proxy to indicate whether that middleware auth has failed. If it has, the functions which perform HTTP client requests with needle will throw an error that indicates "unauthenticated", resulting in an experience consistent with the legacy token auth flow in the CLI.

Outstanding TODOs on this:

- [x] Improve the header names
- [x] Improve the middleware auth error checking -- a specific error match would be better here 
- [x] Review the approach with the team
- [x] Tests?

---

## Pull Request Submission

Please check the boxes once done.

The pull request must:

- **Reviewer Documentation**
    - [ ] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) rules
    - [ ] be accompanied by a detailed description of the changes
    - [ ] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [ ] highlight breaking API if applicable
    - [ ] contain a link to the automatic tests that cover the updated functionality.
    - [ ] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [ ] link to the link to the PR for the User-facing documentation
- **User facing Documentation**
    - [ ] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [ ] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [ ] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.

## Pull Request Review

All pull requests must undergo a thorough review process before being merged. 
The review process of the code PR should include code review, testing, and any necessary feedback or revisions. 
Pull request reviews of functionality developed in other teams only review the given documentation and test reports. 

Manual testing will not be performed by the reviewing team, and is the responsibility of the author of the PR.

For Node projects: It’s important to make sure changes in `package.json` are also affecting `package-lock.json` correctly.

****************************If a dependency is not necessary, don’t add it.**************************** 

When adding a new package as a dependency, make sure that the change is absolutely necessary. We would like to refrain from adding new dependencies when possible.
Documentation PRs in gitbook are reviewed by Snyk's content team. They will also advise on the best phrasing and structuring if needed.

## Pull Request Approval

Once a pull request has been reviewed and all necessary revisions have been made, it is approved for merging into 
the main codebase. The merging of the code PR is performed by the code owners, the merging of the documentation PR 
by our content writers.


## What does this PR do?

See top posting.

## Where should the reviewer start?


## How should this be manually tested?

- Build this branch locally.
- Authenticate with OAuth.
- "Damage" the token as follows:
  - Set `expired` in the past
  - Flip some characters in the refresh token, making it invalid.
- Observe that with this binary, all test commands will fail with the same error message as legacy token auth. Other than Code and SBOM, they'll tell you to `snyk auth` (that's a pre-existing issue that will be fixed in a followup).

## Any background context you want to provide?


## What are the relevant tickets?

CLI-392

## Screenshots


## Additional questions
