### PR TITLE
fix: make dotnet acceptance test resilient to system lib vulns

### DIFF
--- a/test/jest/acceptance/snyk-test/basic-test-all-languages.spec.ts
+++ b/test/jest/acceptance/snyk-test/basic-test-all-languages.spec.ts
@@ -240,19 +240,32 @@ describe('`snyk test` of basic projects for each language/ecosystem', () => {
       }
 
       const { code, stderr, stdout } = await runSnykCLI(
-        'test -d --dotnet-runtime-resolution',
+        'test --dotnet-runtime-resolution --json',
         {
           cwd: project.path(),
         },
       );
 
-      if (code !== 0) {
+      // Debug output on an unexpected exit code
+      if (code !== 0 && code !== 1) {
         console.debug(stderr);
         console.debug('---------------------------');
         console.debug(stdout);
       }
 
-      expect(code).toEqual(0);
+      // Expect an exit code of 0 or 1. Exit code 1 is possible if a new
+      // vulnerability is discovered in the installed version of dotnet's system
+      // libraries.
+      expect([0, 1]).toContain(code);
+
+      // Note: dotnet plugin can print a warning about runtime resolution, which breaks JSON output.
+      // This replacement regex is a temporary workaround until the dotnet plugin can be fixed.
+      const sanitizedStdout = stdout.replace(/^[\s\S]*?{/, '{');
+      const result = JSON.parse(sanitizedStdout);
+      expect(result?.ok).toBeDefined();
+
+      // Expect 'ok' to be true if exit 0, false if exit 1.
+      expect(result.ok).toBe(code === 0);
     },
   );
 


### PR DESCRIPTION
A dotnet 8.0.0 vulnerability was discovered on 2024-07-09 which caused dotnet acceptance tests to fail on platforms with the vulnerable version installed.

While the toolchain could be updated, the test can be made more robust to future reoccurances of dotnet system vulns.

For this test we care more about the operation of the test command rather than its findings, so we can test for consistency between exit code and test output instead.

In updating this test, a defect was discovered in the dotnet plugin which corrupts json output. The test works around this, but it will require a dotnet plugin upgrade as a followup to mitigate user impact.

## Pull Request Submission

Please check the boxes once done.

The pull request must:

- **Reviewer Documentation**
    - [X] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) rules
    - [X] be accompanied by a detailed description of the changes
    - [X] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [X] highlight breaking API if applicable
    - [X] contain a link to the automatic tests that cover the updated functionality.
    - [X] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [X] link to the link to the PR for the User-facing documentation
- **User facing Documentation**
    - [X] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [X] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [X] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.

## Pull Request Review

All pull requests must undergo a thorough review process before being merged. 
The review process of the code PR should include code review, testing, and any necessary feedback or revisions. 
Pull request reviews of functionality developed in other teams only review the given documentation and test reports. 

Manual testing will not be performed by the reviewing team, and is the responsibility of the author of the PR.

For Node projects: It’s important to make sure changes in `package.json` are also affecting `package-lock.json` correctly.

****************************If a dependency is not necessary, don’t add it.**************************** 

When adding a new package as a dependency, make sure that the change is absolutely necessary. We would like to refrain from adding new dependencies when possible.
Documentation PRs in gitbook are reviewed by Snyk's content team. They will also advise on the best phrasing and structuring if needed.

## Pull Request Approval

Once a pull request has been reviewed and all necessary revisions have been made, it is approved for merging into 
the main codebase. The merging of the code PR is performed by the code owners, the merging of the documentation PR 
by our content writers.


## What does this PR do?

See top posting

## Where should the reviewer start?

Recent Circle CI failures; test failures related to dotnet version 8.0.0 installed, which has a vuln:

```
    Issues with no direct upgrade or patch:
      ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-DOTNET-SYSTEMTEXTJSON-7433719] in System.Text.Json@8.0.0
        introduced by Microsoft.NET.Sdk.Functions@4.3.0 > Microsoft.Azure.WebJobs@3.0.32 > System.Memory.Data@1.0.1 > System.Text.Json@8.0.0
      This issue was fixed in versions: 8.0.4 
```

## How should this be manually tested?

Install dotnet 8.0.0, run the test in main vs this PR.

## Any background context you want to provide?

Another option would be to upgrade dotnet for all platforms, but that doesn't prevent something similar from happening again.

## What are the relevant tickets?


## Screenshots


## Additional questions
