### PR TITLE
fix: print all dep-graphs of a container scan

### DIFF
--- a/src/lib/snyk-test/assemble-payloads.ts
+++ b/src/lib/snyk-test/assemble-payloads.ts
@@ -2,15 +2,14 @@ import * as path from 'path';
 import config from '../config';
 import { isCI } from '../is-ci';
 import { getPlugin } from '../ecosystems';
-import { Ecosystem, ContainerTarget, ScanResult } from '../ecosystems/types';
+import { Ecosystem } from '../ecosystems/types';
 import { Options, PolicyOptions, TestOptions } from '../types';
 import { Payload } from './types';
-import { assembleQueryString, depGraphToOutputString } from './common';
+import { assembleQueryString } from './common';
 import { spinner } from '../spinner';
 import { findAndLoadPolicyForScanResult } from '../ecosystems/policy';
 import { getAuthHeader } from '../../lib/api-token';
 import { DockerImageNotFoundError } from '../errors';
-import { DepGraph } from '@snyk/dep-graph';
 
 export async function assembleEcosystemPayloads(
   ecosystem: Ecosystem,
@@ -53,21 +52,6 @@ export async function assembleEcosystemPayloads(
       scanResult.name =
         options['project-name'] || config.PROJECT_NAME || scanResult.name;
 
-      if (options['print-graph'] && !options['print-deps']) {
-        // not every scanResult has a 'depGraph' fact, for example the JAR
-        // fingerprints. I don't think we have another option than to skip
-        // those.
-        const dg = scanResult.facts.find((dg) => dg.type === 'depGraph');
-        if (dg) {
-          console.log(
-            depGraphToOutputString(
-              dg.data.toJSON(),
-              constructProjectName(scanResult),
-            ),
-          );
-        }
-      }
-
       payloads.push({
         method: 'POST',
         url: `${config.API}${options.testDepGraphDockerEndpoint ||
@@ -97,34 +81,4 @@ export async function assembleEcosystemPayloads(
   } finally {
     spinner.clear<void>(spinnerLbl)();
   }
-}
-
-// constructProjectName attempts to construct the project name the same way that
-// registry does. This is a bit difficult because in Registry, the code is
-// distributed over multiple functions and files that need to be kept in sync...
-function constructProjectName(sr: ScanResult): string {
-  let suffix = '';
-  if (sr.identity.targetFile) {
-    suffix = ':' + sr.identity.targetFile;
-  }
-
-  if (sr.name) {
-    return sr.name + suffix;
-  }
-
-  const targetImage = (sr.target as ContainerTarget | undefined)?.image;
-  if (targetImage) {
-    return targetImage + suffix;
-  }
-
-  const dgFact = sr.facts.find((d) => d.type === 'depGraph');
-  // not every scanResult has a depGraph, for example the JAR fingerprints.
-  if (dgFact) {
-    const name = (dgFact.data as DepGraph | undefined)?.rootPkg.name;
-    if (name) {
-      return name + suffix;
-    }
-  }
-
-  return 'no-name' + suffix;
 }

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -306,7 +306,9 @@ async function sendAndParseResults(
       options,
     );
 
-    depGraphs.set(constructProjectName(scanResult), depGraph.toJSON());
+    if (depGraph) {
+      depGraphs.set(constructProjectName(scanResult), depGraph.toJSON());
+    }
 
     const ecosystem = getEcosystem(options);
     if (ecosystem && options['print-deps']) {

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -312,7 +312,7 @@ async function sendAndParseResults(
     depGraphsAndScanResults.push({ depGraph, scanResult });
 
     const ecosystem = getEcosystem(options);
-    if (ecosystem && shouldPrintDepGraphs(options)) {
+    if (ecosystem && options['print-deps']) {
       await spinner.clear<void>(spinnerLbl)();
       await maybePrintDepGraph(options, depGraph);
     }

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -344,7 +344,7 @@ async function sendAndParseResults(
   // For a Container scan, we print the dep-graphs after we received all scan
   // results; this is because analysis can detect more dependency graphs of
   // applications within the container image.
-  if (getEcosystem(options) === 'docker' && options['print-graph']) {
+  if (getEcosystem(options) === 'docker' && shouldPrintDepGraphs(options)) {
     await spinner.clear<void>(spinnerLbl)();
     depGraphsToOutputStream(depGraphs).pipe(process.stdout);
     return [];

--- a/src/lib/stream.ts
+++ b/src/lib/stream.ts
@@ -1,0 +1,36 @@
+import { Readable } from 'stream';
+
+export class ConcatStream extends Readable {
+  private current: Readable | undefined;
+  private queue: Readable[] = [];
+
+  constructor() {
+    super({ objectMode: false }); // Adjust objectMode if needed
+  }
+
+  append(...streams: Readable[]): void {
+    this.queue.push(...streams);
+    if (!this.current) {
+      this._read();
+    }
+  }
+
+  _read(size?: number): void {
+    if (this.current) {
+      return;
+    }
+
+    this.current = this.queue.shift();
+    if (!this.current) {
+      this.push(null);
+      return;
+    }
+
+    this.current.on('data', (chunk) => this.push(chunk));
+    this.current.on('end', () => {
+      this.current = undefined;
+      this._read(size);
+    });
+    this.current.on('error', (err) => this.emit('error', err));
+  }
+}

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -349,7 +349,7 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
       return;
     }
 
-    let depGraphData = {
+    const depGraphData = {
       schemaVersion: '1.2.0',
       pkgManager: {
         name: 'rpm',
@@ -357,9 +357,9 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
       },
       pkgs: [
         {
-          id: 'docker-image|foo2@1.2.3',
+          id: 'docker-image|foo@1.2.3',
           info: {
-            name: 'docker-image|foo2',
+            name: 'docker-image|foo',
             version: '1.2.3',
           },
         },
@@ -369,7 +369,7 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
         nodes: [
           {
             nodeId: 'root-node',
-            pkgId: 'docker-image|foo2@1.2.3',
+            pkgId: 'docker-image|foo@1.2.3',
             deps: [],
           },
         ],
@@ -377,9 +377,9 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
     };
 
     // If a dep-graph can be found on the request, echo it.
-    depGraphData =
-      req.body.scanResult?.facts.find((fact) => fact.type === 'depGraph')
-        ?.data || depGraphData;
+    // depGraphData =
+    //   req.body.scanResult?.facts.find((fact) => fact.type === 'depGraph')
+    //     ?.data || depGraphData;
 
     res.send({
       result: {

--- a/test/jest/acceptance/snyk-container/container.spec.ts
+++ b/test/jest/acceptance/snyk-container/container.spec.ts
@@ -171,6 +171,7 @@ describe('snyk container', () => {
         timeout: 60 * 1000,
       });
     });
+
     it('prints dep graph with --print-graph flag', async () => {
       const { code, stdout, stderr } = await runSnykCLIWithDebug(
         `container test --print-graph ${TEST_DISTROLESS_STATIC_IMAGE}`,
@@ -188,6 +189,16 @@ DepGraph end`,
         .split('DepGraph target:')[0];
       const jsonDG = JSON.parse(jsonDGStr);
       expect(jsonDG).toMatchObject(TEST_DISTROLESS_STATIC_IMAGE_DEPGRAPH);
+    });
+
+    it('prints all dep graphs with --print-graph flag', async () => {
+      const { code, stdout, stderr } = await runSnykCLIWithDebug(
+        `container test --print-graph pasapples/snyk-boot-web@sha256:793d76003676db3390dba497c2d11a2d30840a7a37aed51b5c7e8b9d9478bcc0`,
+      );
+
+      assertCliExitCode(code, 0, stderr);
+      const jsonDGStr = stdout.split('DepGraph data:').slice(1);
+      expect(jsonDGStr).toHaveLength(14);
     });
   });
 

--- a/test/jest/unit/lib/stream.spec.ts
+++ b/test/jest/unit/lib/stream.spec.ts
@@ -1,0 +1,31 @@
+import { Readable, Writable } from 'stream';
+
+import { ConcatStream } from '../../../../src/lib/stream';
+
+describe('ConcatStream', () => {
+  it('should create a readable stream', () => {
+    const stream = new ConcatStream();
+
+    expect(stream).toBeInstanceOf(Readable);
+  });
+
+  it('should concatenate readable streams', async () => {
+    const stream = new ConcatStream();
+    const chunks = jest.fn();
+    const out = new Writable({
+      write: (chunk, enc, done) => {
+        chunks(chunk.toString());
+        done();
+      },
+    });
+
+    stream.append(Readable.from('foo'), Readable.from('bar'));
+
+    await new Promise((res) => {
+      stream.pipe(out).on('finish', res);
+    });
+
+    expect(chunks).toHaveBeenCalledWith('foo');
+    expect(chunks).toHaveBeenCalledWith('bar');
+  });
+});

--- a/test/tap/cli-test/cli-test.docker.spec.ts
+++ b/test/tap/cli-test/cli-test.docker.spec.ts
@@ -5,6 +5,13 @@ import * as path from 'path';
 import { AcceptanceTests } from '../cli-test.acceptance.test';
 import { getFixturePath } from '../../jest/util/getFixturePath';
 
+const fixedDepGraph = {
+  schemaVersion: '1.2.0',
+  pkgManager: { name: 'rpm' },
+  pkgs: [],
+  graph: { nodes: [] },
+};
+
 export const DockerTests: AcceptanceTests = {
   language: 'Docker',
   tests: {
@@ -15,7 +22,7 @@ export const DockerTests: AcceptanceTests = {
           scanResults: [
             {
               facts: [
-                { type: 'depGraph', data: {} },
+                { type: 'depGraph', data: fixedDepGraph },
                 { type: 'dockerfileAnalysis', data: {} },
               ],
               identity: {
@@ -47,7 +54,7 @@ export const DockerTests: AcceptanceTests = {
         {
           scanResult: {
             facts: [
-              { type: 'depGraph', data: {} },
+              { type: 'depGraph', data: fixedDepGraph },
               { type: 'dockerfileAnalysis', data: {} },
             ],
             identity: {
@@ -86,7 +93,7 @@ export const DockerTests: AcceptanceTests = {
           scanResults: [
             {
               facts: [
-                { type: 'depGraph', data: {} },
+                { type: 'depGraph', data: fixedDepGraph },
                 { type: 'dockerfileAnalysis', data: {} },
               ],
               identity: {
@@ -121,7 +128,7 @@ export const DockerTests: AcceptanceTests = {
         {
           scanResult: {
             facts: [
-              { type: 'depGraph', data: {} },
+              { type: 'depGraph', data: fixedDepGraph },
               { type: 'dockerfileAnalysis', data: {} },
             ],
             identity: {
@@ -161,7 +168,7 @@ export const DockerTests: AcceptanceTests = {
           scanResults: [
             {
               facts: [
-                { type: 'depGraph', data: {} },
+                { type: 'depGraph', data: fixedDepGraph },
                 { type: 'dockerfileAnalysis', data: {} },
               ],
               identity: {
@@ -210,7 +217,7 @@ export const DockerTests: AcceptanceTests = {
           scanResults: [
             {
               facts: [
-                { type: 'depGraph', data: {} },
+                { type: 'depGraph', data: fixedDepGraph },
                 {
                   type: 'dockerfileAnalysis',
                   data: {
@@ -260,7 +267,7 @@ export const DockerTests: AcceptanceTests = {
         {
           scanResult: {
             facts: [
-              { type: 'depGraph', data: {} },
+              { type: 'depGraph', data: fixedDepGraph },
               {
                 type: 'dockerfileAnalysis',
                 data: {
@@ -316,7 +323,7 @@ export const DockerTests: AcceptanceTests = {
           scanResults: [
             {
               facts: [
-                { type: 'depGraph', data: {} },
+                { type: 'depGraph', data: fixedDepGraph },
                 { type: 'dockerfileAnalysis', data: {} },
               ],
               identity: {
@@ -360,7 +367,7 @@ export const DockerTests: AcceptanceTests = {
           scanResults: [
             {
               facts: [
-                { type: 'depGraph', data: {} },
+                { type: 'depGraph', data: fixedDepGraph },
                 { type: 'dockerfileAnalysis', data: {} },
               ],
               identity: {
@@ -392,7 +399,7 @@ export const DockerTests: AcceptanceTests = {
         {
           scanResult: {
             facts: [
-              { type: 'depGraph', data: {} },
+              { type: 'depGraph', data: fixedDepGraph },
               { type: 'dockerfileAnalysis', data: {} },
             ],
             identity: {
@@ -439,7 +446,7 @@ export const DockerTests: AcceptanceTests = {
           scanResults: [
             {
               facts: [
-                { type: 'depGraph', data: {} },
+                { type: 'depGraph', data: fixedDepGraph },
                 { type: 'dockerfileAnalysis', data: {} },
               ],
               identity: {
@@ -467,7 +474,7 @@ export const DockerTests: AcceptanceTests = {
         {
           scanResult: {
             facts: [
-              { type: 'depGraph', data: {} },
+              { type: 'depGraph', data: fixedDepGraph },
               { type: 'dockerfileAnalysis', data: {} },
             ],
             identity: {
@@ -506,7 +513,7 @@ export const DockerTests: AcceptanceTests = {
           scanResults: [
             {
               facts: [
-                { type: 'depGraph', data: {} },
+                { type: 'depGraph', data: fixedDepGraph },
                 { type: 'dockerfileAnalysis', data: {} },
                 {
                   type: 'keyBinariesHashes',
@@ -544,7 +551,7 @@ export const DockerTests: AcceptanceTests = {
         {
           scanResult: {
             facts: [
-              { type: 'depGraph', data: {} },
+              { type: 'depGraph', data: fixedDepGraph },
               { type: 'dockerfileAnalysis', data: {} },
               {
                 type: 'keyBinariesHashes',
@@ -589,7 +596,7 @@ export const DockerTests: AcceptanceTests = {
           scanResults: [
             {
               facts: [
-                { type: 'depGraph', data: {} },
+                { type: 'depGraph', data: fixedDepGraph },
                 { type: 'dockerfileAnalysis', data: {} },
                 {
                   type: 'keyBinariesHashes',
@@ -654,7 +661,7 @@ export const DockerTests: AcceptanceTests = {
           scanResults: [
             {
               facts: [
-                { type: 'depGraph', data: {} },
+                { type: 'depGraph', data: fixedDepGraph },
                 {
                   type: 'dockerfileAnalysis',
                   data: {
@@ -704,7 +711,7 @@ export const DockerTests: AcceptanceTests = {
           scanResults: [
             {
               facts: [
-                { type: 'depGraph', data: {} },
+                { type: 'depGraph', data: fixedDepGraph },
                 {
                   type: 'autoDetectedUserInstructions',
                   data: {
@@ -836,7 +843,7 @@ async function testSarif(t, utils, params, flags) {
       scanResults: [
         {
           facts: [
-            { type: 'depGraph', data: {} },
+            { type: 'depGraph', data: fixedDepGraph },
             { type: 'dockerfileAnalysis', data: {} },
             {
               type: 'keyBinariesHashes',


### PR DESCRIPTION
## What does this PR do?

When printing the dep-graph results from Snyk container SCA, the code would escape early and omit all the dep-graphs that might have been found during remote analysis. This commit moves the dep-graph printing during container SCA to after the remote analysis call, this way including additional dep-graphs of applications within the container image.