### PR TITLE
fix: write dep-graph payloads to stdout stream

### DIFF
--- a/src/lib/stream.ts
+++ b/src/lib/stream.ts
@@ -1,0 +1,37 @@
+import { Readable } from 'stream';
+
+export class ConcatStream extends Readable {
+  private current: Readable | undefined;
+  private queue: Readable[] = [];
+
+  constructor(...streams: Readable[]) {
+    super({ objectMode: false }); // Adjust objectMode if needed
+    this.queue.push(...streams);
+  }
+
+  append(...streams: Readable[]): void {
+    this.queue.push(...streams);
+    if (!this.current) {
+      this._read();
+    }
+  }
+
+  _read(size?: number): void {
+    if (this.current) {
+      return;
+    }
+
+    this.current = this.queue.shift();
+    if (!this.current) {
+      this.push(null);
+      return;
+    }
+
+    this.current.on('data', (chunk) => this.push(chunk));
+    this.current.on('end', () => {
+      this.current = undefined;
+      this._read(size);
+    });
+    this.current.on('error', (err) => this.emit('error', err));
+  }
+}

--- a/test/jest/unit/lib/ecosystems/__snapshots__/common.spec.ts.snap
+++ b/test/jest/unit/lib/ecosystems/__snapshots__/common.spec.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`printUnmanagedDepGraph fn should print the dep-graph 1`] = `
+"DepGraph data:
+{"schemaVersion":"1.2.0","pkgManager":{"name":"cpp"},"pkgs":[{"id":"root-node@0.0.0","info":{"name":"root-node","version":"0.0.0"}},{"id":"https://ftp.gnu.org|cpio@2.12","info":{"name":"https://ftp.gnu.org|cpio","version":"2.12"}}],"graph":{"rootNodeId":"root-node","nodes":[{"nodeId":"root-node","pkgId":"root-node@0.0.0","deps":[{"nodeId":"https://ftp.gnu.org|cpio@2.12"}]},{"nodeId":"https://ftp.gnu.org|cpio@2.12","pkgId":"https://ftp.gnu.org|cpio@2.12","deps":[]}]}}
+DepGraph target:
+foo/bar
+DepGraph end
+
+"
+`;

--- a/test/jest/unit/lib/stream.spec.ts
+++ b/test/jest/unit/lib/stream.spec.ts
@@ -1,0 +1,31 @@
+import { Readable, Writable } from 'stream';
+
+import { ConcatStream } from '../../../../src/lib/stream';
+
+describe('ConcatStream', () => {
+  it('should create a readable stream', () => {
+    const stream = new ConcatStream();
+
+    expect(stream).toBeInstanceOf(Readable);
+  });
+
+  it('should concatenate readable streams', async () => {
+    const stream = new ConcatStream();
+    const chunks = jest.fn();
+    const out = new Writable({
+      write: (chunk, enc, done) => {
+        chunks(chunk.toString());
+        done();
+      },
+    });
+
+    stream.append(Readable.from('foo'), Readable.from('bar'));
+
+    await new Promise((res) => {
+      stream.pipe(out).on('finish', res);
+    });
+
+    expect(chunks).toHaveBeenCalledWith('foo');
+    expect(chunks).toHaveBeenCalledWith('bar');
+  });
+});


### PR DESCRIPTION
## What does this PR do?

This PR changes the way we output dep-graph payloads from `console.log` to NodeJS Streams, writing to `process.stdout`. This way we can replace `jsonStringifyLargeObject` with `JsonStreamStringify`.

This PR is a precursor to https://github.com/snyk/cli/pull/5399, which had too much happening all at once.

## How should this be manually tested?

Can be tested with `snyk test --print-graph`, `snyk container test --print-graph`, and `snyk test --unmanaged --print-graph`.