### PR TITLE
Feat: Adding support for GH Advanced Security SARIF Upload

### DIFF
--- a/src/lib/formatters/open-source-sarif-output.ts
+++ b/src/lib/formatters/open-source-sarif-output.ts
@@ -27,6 +27,7 @@ export function createSarifOutputForOpenSource(
       'https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json',
     version: '2.1.0',
     runs: testResults.map(replaceLockfileWithManifest).map((testResult) => ({
+      automationDetails : getAutomationDetails(testResult),
       tool: {
         driver: {
           name: 'Snyk Open Source',
@@ -41,6 +42,19 @@ export function createSarifOutputForOpenSource(
       },
       results: getResults(testResult),
     })),
+  };
+}
+
+// Github anncouned changes to their SARIF upload -- https://github.blog/changelog/2024-05-06-code-scanning-will-stop-combining-runs-from-a-single-upload/
+// the impact is when a SARIF that is being uploaded, each run must have unique category, as defined by GitHub here, https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#runautomationdetails-object
+// This presents a new problem of when a file is removed from source since GH will not have an empty result to close any previously opened items since GH open/closes
+// based on the SARIF tool.driver.name + Category. Open source's solution is the most obvious, inlcude the targetFile. Snyk-iac, is using this field set to a static "snyk-iac". Combing what
+// was being done there with the file name to generate the unique value. Using | as a separator to make it easier to parse out tool vs targetFile. 
+function getAutomationDetails(testResult: TestResult)
+{
+  let automationId = !!process.env.SET_AUTOMATION_DETAILS_ID ? `snyk-sca|${testResult.displayTargetFile || testResult.targetFile }/` : ""
+  return {
+    id : automationId,
   };
 }
 

--- a/src/lib/formatters/sarif-output.ts
+++ b/src/lib/formatters/sarif-output.ts
@@ -17,6 +17,7 @@ export function createSarifOutputForContainers(
 
   testResults.forEach((testResult) => {
     sarifRes.runs.push({
+      automationDetails : getAutomationDetails(testResult),
       tool: getTool(testResult),
       results: getResults(testResult),
     });
@@ -93,4 +94,17 @@ export function getTool(testResult): sarif.Tool {
     })
     .filter(Boolean);
   return tool;
+}
+
+// Github anncouned changes to their SARIF upload -- https://github.blog/changelog/2024-05-06-code-scanning-will-stop-combining-runs-from-a-single-upload/
+// the impact is when a SARIF that is being uploaded, each run must have unique category, as defined by GitHub here, https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#runautomationdetails-object
+// This presents a new problem of when a file is removed from source since GH will not have an empty result to close any previously opened items since GH open/closes
+// based on the SARIF tool.driver.name + Category. Open source's solution is the most obvious, inlcude the targetFile. Snyk-iac, is using this field set to a static "snyk-iac". Combing what
+// was being done there with the file name to generate the unique value. Using | as a separator to make it easier to parse out tool vs targetFile. 
+function getAutomationDetails(testResult: TestResult)
+{
+  let automationId = !!process.env.SET_AUTOMATION_DETAILS_ID ? `snyk-container|${testResult.displayTargetFile || testResult.targetFile }/` : ""
+  return {
+    id : automationId,
+  };
 }

--- a/test/jest/unit/lib/formatters/__snapshots__/open-source-sarif-output.spec.ts.snap
+++ b/test/jest/unit/lib/formatters/__snapshots__/open-source-sarif-output.spec.ts.snap
@@ -5,6 +5,9 @@ exports[`createSarifOutputForOpenSource general 1`] = `
   "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
+      "automationDetails": {
+        "id": "",
+      },
       "results": [
         {
           "fixes": [

--- a/test/jest/unit/lib/formatters/__snapshots__/sarif-output.spec.ts.snap
+++ b/test/jest/unit/lib/formatters/__snapshots__/sarif-output.spec.ts.snap
@@ -5,6 +5,9 @@ exports[`createSarifOutputForContainers general with critical severity issue wit
   "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
+      "automationDetails": {
+        "id": "",
+      },
       "results": [
         {
           "fixes": undefined,
@@ -99,6 +102,9 @@ exports[`createSarifOutputForContainers general with critical severity issue wit
   "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
+      "automationDetails": {
+        "id": "",
+      },
       "results": [
         {
           "fixes": undefined,
@@ -192,6 +198,9 @@ exports[`createSarifOutputForContainers general with high severity issue 1`] = `
   "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
   "runs": [
     {
+      "automationDetails": {
+        "id": "",
+      },
       "results": [
         {
           "fixes": undefined,

--- a/test/jest/unit/lib/formatters/test/format-test-results.spec.ts
+++ b/test/jest/unit/lib/formatters/test/format-test-results.spec.ts
@@ -1,10 +1,12 @@
 import { Options } from '../../../../../../src/lib/types';
 import * as fs from 'fs';
 import { extractDataToSendFromResults } from '../../../../../../src/lib/formatters/test/format-test-results';
+//import exp from 'constants';
 
 describe('extractDataToSendFromResults', () => {
   afterEach(() => {
     jest.restoreAllMocks();
+    process.env.SET_AUTOMATION_DETAILS_ID = "";
   });
 
   describe('open source results', () => {
@@ -116,6 +118,29 @@ describe('extractDataToSendFromResults', () => {
       expect(res.stringifiedData).not.toBe('');
       expect(res.stringifiedJsonData).toBe('');
       expect(res.stringifiedSarifData).not.toBe('');
+      var sarif = JSON.parse(res.stringifiedSarifData);
+      expect(sarif.runs[0].automationDetails.id).toBe('');
+    });
+
+    it('should create SARIF JSON and only SARIF JSON if `--sarif` is set in the options and SET_AUTOMATION_DETAILS_ID is set', () => {
+      const options = {
+        sarif: true,
+      } as Options;
+      process.env.SET_AUTOMATION_DETAILS_ID = "true";
+
+      const jsonStringifySpy = jest.spyOn(JSON, 'stringify');
+      const res = extractDataToSendFromResults(
+        resultsFixture,
+        mappedResultsFixture,
+        options,
+      );
+
+      expect(jsonStringifySpy).toHaveBeenCalledTimes(1);
+      expect(res.stringifiedData).not.toBe('');
+      expect(res.stringifiedJsonData).toBe('');
+      expect(res.stringifiedSarifData).not.toBe('');
+      var sarif = JSON.parse(res.stringifiedSarifData);
+      expect(sarif.runs[0].automationDetails.id).not.toBe('');
     });
 
     it('should create SARIF JSON and only SARIF JSON if `--sarif-file-output` is set in the options', () => {


### PR DESCRIPTION
A POC on what supporting GitHub advanced security changes could look like. I'm not married to the specific implementation but I do this this covers the bases. 

## Pull Request Submission

Please check the boxes once done.

The pull request must:

- **Reviewer Documentation**
    - [x] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) rules
    - [x] be accompanied by a detailed description of the changes
    - [ ] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [ ] highlight breaking API if applicable
    - [ ] contain a link to the automatic tests that cover the updated functionality.
    - [ ] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [ ] link to the link to the PR for the User-facing documentation
- **User facing Documentation**
    - [ ] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [ ] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [ ] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.

## Pull Request Review

All pull requests must undergo a thorough review process before being merged. 
The review process of the code PR should include code review, testing, and any necessary feedback or revisions. 
Pull request reviews of functionality developed in other teams only review the given documentation and test reports. 

Manual testing will not be performed by the reviewing team, and is the responsibility of the author of the PR.

For Node projects: It’s important to make sure changes in `package.json` are also affecting `package-lock.json` correctly.

****************************If a dependency is not necessary, don’t add it.**************************** 

When adding a new package as a dependency, make sure that the change is absolutely necessary. We would like to refrain from adding new dependencies when possible.
Documentation PRs in gitbook are reviewed by Snyk's content team. They will also advise on the best phrasing and structuring if needed.

## Pull Request Approval

Once a pull request has been reviewed and all necessary revisions have been made, it is approved for merging into 
the main codebase. The merging of the code PR is performed by the code owners, the merging of the documentation PR 
by our content writers.


## What does this PR do?

Changes the SARIF output to it will comply with GH's changes to GHAS, the changes are behind a environment variable `SET_AUTOMATION_DETAILS_ID`

When false or not set the `run[].automationDetails.id` is aded for open source and container with a black value; however, when a truthy then `run[].automationDetails.id` is set so the file scanned file and the type of scan is part of the value.  

## Where should the reviewer start?


## How should this be manually tested?


## Any background context you want to provide?

Github announced changes to their SARIF [upload](https://github.blog/changelog/2024-05-06-code-scanning-will-stop-combining-runs-from-a-single-upload/) the impact is when a SARIF that is being uploaded, each run must have unique "category", as defined by GitHub [here](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#runautomationdetails-object)

GH's new requirement presents a new problem for when a file is removed from source because GH will not have an empty result for the previous file to close any previously opened items as would happen with `--all-projects` previously since GH would merge all results into a single result and closed items no longer present, but now that the closure is  based on tool.driver.name + Category and we have unique files, this will be more problematic.

"Open source's" solution is the most obvious, include the targetFile. Since Snyk-iac, is already populating the field with the static value of "snyk-iac".  It seemed wise to combine riff off that and use "snyk-sca" for OpenSource. Then I separated those values with a pipe and included the `targetFile`

This pattern was then applied to "snyk-iac" and added to "snyk-container". I wasn't able to find unit tests for SARIF output for "snyk-iac" or "snyk-container" or flags to test the output; however, given their similarities in the implementation to "snyk-sca" I felt it was worth submitting.

## What are the relevant tickets?

Support Ticket - 85296

## Screenshots


## Additional questions
