### PR TITLE
fix: Missing entitlements when signing bundled TS binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,12 +133,12 @@ $(BINARY_RELEASES_FOLDER_TS_CLI)/snyk-linux-arm64: prepack | $(BINARY_RELEASES_F
 
 $(BINARY_RELEASES_FOLDER_TS_CLI)/snyk-macos: prepack | $(BINARY_RELEASES_FOLDER_TS_CLI)
 	$(PKG) -t node$(PKG_NODE_VERSION)-macos-x64 -o $(BINARY_RELEASES_FOLDER_TS_CLI)/snyk-macos
-	$(SHELL) $(WORKING_DIR)/cliv2/scripts/sign_darwin.sh $(BINARY_RELEASES_FOLDER_TS_CLI) snyk-macos skip-notarize
+	$(SHELL) $(WORKING_DIR)/cliv2/scripts/sign_darwin.sh $(BINARY_RELEASES_FOLDER_TS_CLI) snyk-macos --sign-nodejs-cli
 	$(MAKE) $(BINARY_RELEASES_FOLDER_TS_CLI)/snyk-macos.sha256
 
 $(BINARY_RELEASES_FOLDER_TS_CLI)/snyk-macos-arm64: prepack | $(BINARY_RELEASES_FOLDER_TS_CLI)
 	$(PKG) -t node$(PKG_NODE_VERSION)-macos-arm64 -o $(BINARY_RELEASES_FOLDER_TS_CLI)/snyk-macos-arm64 --no-bytecode
-	$(SHELL) $(WORKING_DIR)/cliv2/scripts/sign_darwin.sh $(BINARY_RELEASES_FOLDER_TS_CLI) snyk-macos-arm64 skip-notarize
+	$(SHELL) $(WORKING_DIR)/cliv2/scripts/sign_darwin.sh $(BINARY_RELEASES_FOLDER_TS_CLI) snyk-macos-arm64 --sign-nodejs-cli
 	$(MAKE) $(BINARY_RELEASES_FOLDER_TS_CLI)/snyk-macos-arm64.sha256
 
 $(BINARY_RELEASES_FOLDER_TS_CLI)/snyk-win.exe: prepack | $(BINARY_RELEASES_FOLDER_TS_CLI)

--- a/cliv2/scripts/osx-entitlements.plist
+++ b/cliv2/scripts/osx-entitlements.plist
@@ -1,0 +1,19 @@
+<!-- This is used to sign the TS binary with a hardened runtime. The file comes from https://github.com/nodejs/node/blob/main/tools/osx-entitlements.plist -->
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.get-task-allow</key>
+    <true/>
+</dict>
+</plist>

--- a/cliv2/scripts/sign_darwin.sh
+++ b/cliv2/scripts/sign_darwin.sh
@@ -9,9 +9,10 @@ set -euo pipefail
 #APPLE_SIGNING_SECRETS_BINARY=EEE....
 #APPLE_SIGNING_SECRETS_PASSWORD=FFF
 
+SCRIPTDIR=$(dirname "$0")
 EXPORT_PATH=${1:-./bin}
 PRODUCT_NAME=${2:-snyk_darwin_amd64}
-SKIP_NOTARIZE=${3:-0}
+SIGN_NODEJS_CLI=${3:-0}
 KEYCHAIN_PROFILE=AC_PASSWORD
 APP_PATH="$EXPORT_PATH/$PRODUCT_NAME"
 ZIP_PATH="$EXPORT_PATH/$PRODUCT_NAME.zip"
@@ -21,6 +22,11 @@ KEYCHAIN_NAME=CodeSigningChain
 KEYCHAIN_PASSWORD=123456
 KEYCHAIN_FILE="$HOME/Library/Keychains/$KEYCHAIN_NAME-db"
 OLD_KEYCHAIN_NAMES=$(security list-keychains | sed -E -e ':a' -e 'N' -e '$!ba' -e 's/\n//g' -e 's/ //g' -e 's/""/" "/g')
+CODESIGN_ENTITLEMENTS=""
+
+if [[ "$SIGN_NODEJS_CLI" = "--sign-nodejs-cli" ]]; then
+  CODESIGN_ENTITLEMENTS="--entitlements ${SCRIPTDIR}/osx-entitlements.plist"
+fi
 
 LOG_PREFIX="--- $(basename "$0"):"
 
@@ -58,13 +64,15 @@ security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD"
 sleep 10
 
 echo "$LOG_PREFIX Signing binary $APP_PATH"
-codesign -f -s "$APPLE_SIGNING_IDENTITY" -v "$APP_PATH" --timestamp --options runtime
+
+
+codesign -f -s "$APPLE_SIGNING_IDENTITY" -v "$APP_PATH" --timestamp --options runtime $CODESIGN_ENTITLEMENTS
 
 #
 # notarization
 #
 
-if [[ "$SKIP_NOTARIZE" = "skip-notarize" ]]; then
+if [[ "$SIGN_NODEJS_CLI" = "--sign-nodejs-cli" ]]; then
   exit 0
 fi
 


### PR DESCRIPTION
## Pull Request Submission

Please check the boxes once done.

The pull request must:

- **Reviewer Documentation**
    - [x] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) rules
    - [x] be accompanied by a detailed description of the changes
    - [x] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [ ] highlight breaking API if applicable
    - [ ] contain a link to the automatic tests that cover the updated functionality.
    - [ ] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [ ] link to the link to the PR for the User-facing documentation
- **User facing Documentation**
    - [ ] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [ ] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [ ] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.

## Pull Request Review

All pull requests must undergo a thorough review process before being merged. 
The review process of the code PR should include code review, testing, and any necessary feedback or revisions. 
Pull request reviews of functionality developed in other teams only review the given documentation and test reports. 

Manual testing will not be performed by the reviewing team, and is the responsibility of the author of the PR.

For Node projects: It’s important to make sure changes in `package.json` are also affecting `package-lock.json` correctly.

****************************If a dependency is not necessary, don’t add it.**************************** 

When adding a new package as a dependency, make sure that the change is absolutely necessary. We would like to refrain from adding new dependencies when possible.
Documentation PRs in gitbook are reviewed by Snyk's content team. They will also advise on the best phrasing and structuring if needed.

## Pull Request Approval

Once a pull request has been reviewed and all necessary revisions have been made, it is approved for merging into 
the main codebase. The merging of the code PR is performed by the code owners, the merging of the documentation PR 
by our content writers.


## What does this PR do?
This PR adds missing entitlements while signing the bundled macos binary. It uses the same entitlements used when signing the [nodejs binary](https://github.com/nodejs/node/blob/main/tools/osx-entitlements.plist) as the bundled binary is a nodejs single application binary.

Risk: In a previous attempt to sign, we learned that the missing requirements are problematic and our test runners won't uncover this. For now, we have a clear way to manually validate the binary. This should reduce the risk.

## Where should the reviewer start?


## How should this be manually tested?

**Reproduce the failure in 1.1292.3**
```
curl --compressed https://downloads.snyk.io/cli/v1.1292.3/snyk-macos-arm64 -o snyk-macos-arm64
chmod +x snyk-macos-arm64
./snyk-macos-arm64 auth --auth-type=token -d  
codesign -vvd /Users/<User>/Library/Caches/snyk/snyk-cli/1.1292.3/snyk-macos-arm64
codesign -vvd ./snyk-macos-arm64
```
The above invocation `snyk-macos-arm64` will fail ❌ 

**Test a signed dev version**
```
rm snyk-macos-arm64
curl --compressed https://downloads.snyk.io/cli/v1.1293.0-dev.a4dbc7938a510e7c63e1c7da26c4d19a86aeac9a/snyk-macos-arm64 -o snyk-macos-arm64
chmod +x snyk-macos-arm64
./snyk-macos-arm64 auth --auth-type=token -d
codesign -vvd /Users/<User>/Library/Caches/snyk/snyk-cli/1.1293.0-dev.a4dbc7938a510e7c63e1c7da26c4d19a86aeac9a/snyk-macos-arm64
codesign -vvd ./snyk-macos-arm64
```
The above invocation `snyk-macos-arm64` will succeed ✅ 

## Any background context you want to provide?


## What are the relevant tickets?


## Screenshots


## Additional questions
