### PR TITLE
fix: oauth refresh interprocess race conditions

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -1,11 +1,13 @@
 module github.com/snyk/cli/cliv2
 
-go 1.21
+go 1.22
+
+toolchain go1.22.5
 
 require (
 	github.com/elazarl/goproxy v0.0.0-20231031074852-3ec07828be7a
 	github.com/elazarl/goproxy/ext v0.0.0-20230808193330-2592e75ae04a
-	github.com/gofrs/flock v0.8.1
+	github.com/gofrs/flock v0.12.1
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
 	github.com/pkg/errors v0.9.1
@@ -15,10 +17,10 @@ require (
 	github.com/snyk/cli-extension-sbom v0.0.0-20240722082449-69a631da39ad
 	github.com/snyk/container-cli v0.0.0-20240322120441-6d9b9482f9b1
 	github.com/snyk/error-catalog-golang-public v0.0.0-20240809094525-c48d19c27edb
-	github.com/snyk/go-application-framework v0.0.0-20240809101931-3de5b6fbaf62
+	github.com/snyk/go-application-framework v0.0.0-20240814101709-b335a1ce00ac
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20240724110216-fff14d6d09e0
+	github.com/snyk/snyk-ls v0.0.0-20240814110458-759bec2da65d
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -394,6 +394,8 @@ github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJA
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
 github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
+github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
+github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -746,6 +748,8 @@ github.com/snyk/error-catalog-golang-public v0.0.0-20240809094525-c48d19c27edb h
 github.com/snyk/error-catalog-golang-public v0.0.0-20240809094525-c48d19c27edb/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
 github.com/snyk/go-application-framework v0.0.0-20240809101931-3de5b6fbaf62 h1:6eKlDS6tr7zu7BX54soy3JwNIC14JLv63JYi4ZydwLo=
 github.com/snyk/go-application-framework v0.0.0-20240809101931-3de5b6fbaf62/go.mod h1:N+guURPRaP+etwUYuPzS8jPRBXQWfuRxj/eXDwuxYIc=
+github.com/snyk/go-application-framework v0.0.0-20240814101709-b335a1ce00ac h1:Dr+hPN5kI4CDjHxsCHkonI4tJDYrAfoG4QvqHCMhrKY=
+github.com/snyk/go-application-framework v0.0.0-20240814101709-b335a1ce00ac/go.mod h1:zgYTVG71nX7zTb3ELeRlnwE/uKQxeOyQmAHtg6bC4uU=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v0.30.11 h1:wUy5LMar2vccMbNM62MSBRdjAQAhAbIm7aNXXO+g2tk=
@@ -754,6 +758,8 @@ github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRX
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
 github.com/snyk/snyk-ls v0.0.0-20240724110216-fff14d6d09e0 h1:9g5iv54hEMXAo3i8f0bfSNUOEoHF3CzwxmVmRFI/kOM=
 github.com/snyk/snyk-ls v0.0.0-20240724110216-fff14d6d09e0/go.mod h1:LJ9AOeLduu7sehimJjMcGxGwe6+MM/nYNPkHkIhXov0=
+github.com/snyk/snyk-ls v0.0.0-20240814110458-759bec2da65d h1:l4BMiLN+T6eUsAO8wN/RU3Iea7tU6J1/6HYYoaAVJMk=
+github.com/snyk/snyk-ls v0.0.0-20240814110458-759bec2da65d/go.mod h1:q3kfkxQ+FBQG3VXlilAbZlodhDBmkcbyK9Hq+m1RWng=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=


### PR DESCRIPTION
Update GAF and LS dependencies with recent fixes for an oauth refresh race condition that can occur when multiple CLI or LS processes attempt to refresh the oauth token at the same time.

This is likely to occur when running multiple CLI processes or having multiple IDE windows open (some IDEs will spawn an LS per window). The clients with a stale OAuth token will all attempt to use it to make API requests, and the authenticator will attempt to automatically rotate the tokens. Only one refresh token is valid at a given time though (with some potential grace period that we'll ignore because depending on this would be fragile), so without coordination, one process can "steal" the OAuth refresh from the others, causing some processes to fail and requiring an interactive re-auth to recover in some cases.

Relevant PRs included in these dependency updates:

- https://github.com/snyk/go-application-framework/pull/223
- https://github.com/snyk/go-application-framework/pull/225
- https://github.com/snyk/snyk-ls/pull/623

CLI-469

## Pull Request Submission

Please check the boxes once done.

The pull request must:

- **Reviewer Documentation**
    - [ ] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) rules
    - [ ] be accompanied by a detailed description of the changes
    - [ ] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [ ] highlight breaking API if applicable
    - [ ] contain a link to the automatic tests that cover the updated functionality.
    - [ ] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [ ] link to the link to the PR for the User-facing documentation
- **User facing Documentation**
    - [ ] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [ ] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [ ] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.

## Pull Request Review

All pull requests must undergo a thorough review process before being merged. 
The review process of the code PR should include code review, testing, and any necessary feedback or revisions. 
Pull request reviews of functionality developed in other teams only review the given documentation and test reports. 

Manual testing will not be performed by the reviewing team, and is the responsibility of the author of the PR.

For Node projects: It’s important to make sure changes in `package.json` are also affecting `package-lock.json` correctly.

****************************If a dependency is not necessary, don’t add it.**************************** 

When adding a new package as a dependency, make sure that the change is absolutely necessary. We would like to refrain from adding new dependencies when possible.
Documentation PRs in gitbook are reviewed by Snyk's content team. They will also advise on the best phrasing and structuring if needed.

## Pull Request Approval

Once a pull request has been reviewed and all necessary revisions have been made, it is approved for merging into 
the main codebase. The merging of the code PR is performed by the code owners, the merging of the documentation PR 
by our content writers.


## What does this PR do?

See top posting.

## Where should the reviewer start?

See dependency PRs above.

## How should this be manually tested?

### CLI

- Build this branch
- Do a `./binary-releases/snyk-macos-arm64 auth` with it, sign in with oAuth
- Do a `./binary-releases/snyk-macos-arm64 test`, demonstrating the client and refresh tokens are fresh and valid.
- Edit the "expiry" RFC3339 timestamp in the `INTERNAL_OAUTH_TOKEN_STORAGE` value in `~/.config/configstore/snyk.json` with a text editor, putting the date in the past.
- Hammer on the automatic oAuth refresh flow with 10 concurrent CLI processes: `for i in {1..10}; do ./binary-releases/snyk-macos-arm64 test & done`

All processes should test successfully. If you see some "unauthenticated" error messages prompting you to `snyk auth` again, then the race condition still exists (try it with a build that lacks this PR change).

### IDE

Multiple VSCode windows are said to exhibit the same issue, when the LS is configured to use a CLI that does oAuth by default. Using a build of this branch as the LS should fix this.

## Any background context you want to provide?

Chatter in `#feat-oauth-cli-and-ide`

## What are the relevant tickets?


## Screenshots


## Additional questions
