### PR TITLE
feat: enable cocoapods to send graphs for cli monitor

### DIFF
--- a/src/lib/package-managers.ts
+++ b/src/lib/package-managers.ts
@@ -85,6 +85,7 @@ export const GRAPH_SUPPORTED_PACKAGE_MANAGERS: SupportedPackageManagers[] = [
   'yarn',
   'rubygems',
   'poetry',
+  'cocoapods',
 ];
 // For ecosystems with a flat set of libraries (e.g. Python, JVM), one can
 // "pin" a transitive dependency

--- a/test/tap/cli-monitor.acceptance.test.ts
+++ b/test/tap/cli-monitor.acceptance.test.ts
@@ -1475,6 +1475,62 @@ if (!isWindows) {
     );
   });
 
+  test('`monitor cocoapods-app with just Podfile.lock`', async (t) => {
+    chdirWorkspaces('cocoapods-app');
+    const plugin = {
+      async inspect() {
+        return {
+          plugin: {
+            targetFile: 'Podfile.lock',
+            name: 'snyk-cocoapods-plugin',
+            runtime: 'cocoapods',
+          },
+          package: {},
+        };
+      },
+    };
+    console.log(plugin);
+    const spyPlugin = sinon.spy(plugin, 'inspect');
+
+    const loadPlugin = sinon.stub(plugins, 'loadPlugin');
+    t.teardown(loadPlugin.restore);
+    loadPlugin.withArgs('cocoapods').returns(plugin);
+
+    await cli.monitor('./', {
+      file: 'Podfile.lock',
+    });
+    const req = server.popRequest();
+    t.equal(req.method, 'PUT', 'makes PUT request');
+    t.equal(
+      req.headers['x-snyk-cli-version'],
+      versionNumber,
+      'sends version number',
+    );
+    const depGraphJSON = req.body.depGraphJSON;
+    t.ok(depGraphJSON);
+    t.match(req.url, '/monitor/cocoapods/graph', 'puts at correct url');
+    t.equal(
+      req.body.targetFile,
+      'Podfile.lock',
+      'sends the targetFile (Podfile.lock)',
+    );
+    t.same(
+      spyPlugin.getCall(0).args,
+      [
+        './',
+        'Podfile.lock',
+        {
+          args: null,
+          file: 'Podfile.lock',
+          packageManager: 'cocoapods',
+          path: './',
+        },
+        snykHttpClient,
+      ],
+      'calls CocoaPods plugin',
+    );
+  });
+
   test('`monitor large-mono-repo --file=bundler-app/Gemfile` suggest to use --all-projects', async (t) => {
     chdirWorkspaces('large-mono-repo');
     const res = await cli.monitor({ file: 'bundler-app/Gemfile' });


### PR DESCRIPTION
## Pull Request Submission

Please check the boxes once done.

The pull request must:

- **Reviewer Documentation**
    - [x] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) rules
    - [x] be accompanied by a detailed description of the changes
    - [ ] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [ ] highlight breaking API if applicable
    - [ ] contain a link to the automatic tests that cover the updated functionality.
    - [ ] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [ ] link to the link to the PR for the User-facing documentation
- **User facing Documentation**
    - [ ] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [ ] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [ ] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.

## Pull Request Review

All pull requests must undergo a thorough review process before being merged. 
The review process of the code PR should include code review, testing, and any necessary feedback or revisions. 
Pull request reviews of functionality developed in other teams only review the given documentation and test reports. 

Manual testing will not be performed by the reviewing team, and is the responsibility of the author of the PR.

For Node projects: It’s important to make sure changes in `package.json` are also affecting `package-lock.json` correctly.

****************************If a dependency is not necessary, don’t add it.**************************** 

When adding a new package as a dependency, make sure that the change is absolutely necessary. We would like to refrain from adding new dependencies when possible.
Documentation PRs in gitbook are reviewed by Snyk's content team. They will also advise on the best phrasing and structuring if needed.

## Pull Request Approval

Once a pull request has been reviewed and all necessary revisions have been made, it is approved for merging into 
the main codebase. The merging of the code PR is performed by the code owners, the merging of the documentation PR 
by our content writers.


## What does this PR do?

Enables Cocoapods projects to always send `depGraph` when used with `snyk monitor` instead of `depTrees`.

Relevant registry PR linked [here](https://github.com/snyk/registry/pull/37312) for reference, as they do not work without both being in tandem.

Risk Assessment [LOW]

## Where should the reviewer start?

`depGraph` has always been supported by `snyk test` and `snyk monitor` when used with `-p` to `pruneSubrepeatedDependencies`, where a conversion from `depTree` to `depGraph` is configured. This just forces this to always come as a `depGraph`. The reviewer can check both the registry PR and also this CLI PR.

## How should this be manually tested?

This can be tested by using an older version of registry + cli combination where you can see that any default Cocoapods scan is always sent as a `depTree` first. 

## Any background context you want to provide?

This was adjusted to help solve the issues in regards to 'Invalid String Length' issues where a `depTree` for some Cocoapods projects would provide this JSON error, but `depGraphs` more workable and do not provide this potential error.
