### PR TITLE
feat: conditionally write data to file instead of keeping it in memory

### DIFF
--- a/cliv2/internal/proxy/proxy_test.go
+++ b/cliv2/internal/proxy/proxy_test.go
@@ -74,6 +74,8 @@ func setup(t *testing.T, baseCache string, version string) configuration.Configu
 	assert.Nil(t, err)
 	config := configuration.NewInMemory()
 	config.Set(configuration.CACHE_PATH, baseCache)
+	config.Set(basic_workflows.ConfigurationCleanupGlobalTempDirectory, true)
+	config.Set(basic_workflows.ConfigurationCleanupGlobalCertAuthority, true)
 	caData, err = basic_workflows.GetGlobalCertAuthority(config, &debugLogger)
 	assert.Nil(t, err)
 	return config
@@ -82,7 +84,9 @@ func setup(t *testing.T, baseCache string, version string) configuration.Configu
 func teardown(t *testing.T, baseCache string) {
 	t.Helper()
 	err := os.RemoveAll(baseCache)
-	basic_workflows.CleanupGlobalCertAuthority(&debugLogger)
+	config := setup(t, "testcache", "1.1.1")
+
+	basic_workflows.CleanupGlobalCertAuthority(config, &debugLogger)
 	assert.Nil(t, err)
 }
 
@@ -96,7 +100,7 @@ func Test_CleanupCertFile(t *testing.T) {
 
 	assert.FileExistsf(t, caData.CertFile, "CertFile exist")
 
-	basic_workflows.CleanupGlobalCertAuthority(&debugLogger)
+	basic_workflows.CleanupGlobalCertAuthority(config, &debugLogger)
 
 	assert.NoFileExists(t, caData.CertFile, "CertFile does not exist anymore")
 }

--- a/test/jest/acceptance/analytics.spec.ts
+++ b/test/jest/acceptance/analytics.spec.ts
@@ -405,7 +405,11 @@ describe('analytics module', () => {
 
     expect(code).toBe(0);
 
-    const lastRequest = server.popRequest();
+    const requests = server.getRequests().filter((value) => {
+      return value.url == '/api/v1/analytics/cli';
+    });
+    const lastRequest = requests.at(-1);
+
     expect(lastRequest).toMatchObject({
       headers: {
         host: `localhost:${port}`,

--- a/test/jest/acceptance/cli-in-memory-threshold-bytes.spec.ts
+++ b/test/jest/acceptance/cli-in-memory-threshold-bytes.spec.ts
@@ -1,0 +1,142 @@
+import * as os from 'os';
+import * as path from 'path';
+import { resolve } from 'path';
+
+import { runSnykCLI } from '../util/runSnykCLI';
+import { matchers } from 'jest-json-schema';
+import * as fs from 'fs';
+
+const projectRoot = resolve(__dirname, '../../..');
+
+expect.extend(matchers);
+
+// For golang implementation only
+describe('conditionally write data to disk', () => {
+  const projectWithCodeIssues = resolve(
+    projectRoot,
+    'test/fixtures/sast/with_code_issues',
+  );
+
+  const env = {
+    // Use an org with consistent ignores enabled - uses golang/native workflow
+    SNYK_API: process.env.TEST_SNYK_API_DEV,
+    SNYK_TOKEN: process.env.TEST_SNYK_TOKEN_DEV,
+    SNYK_LOG_LEVEL: 'trace',
+    INTERNAL_CLEANUP_GLOBAL_TEMP_DIR_ENABLED: 'false', // disable cleanup of temp dir for testing
+  };
+
+  jest.setTimeout(60000);
+
+  // GAF automatically creates the temp dir
+  // GAF will also automatically deletes it
+  // but we disable this for testing
+  const tempDirName = `tempDir-${Date.now()}`;
+  const tempDirPath = path.join(os.tmpdir(), tempDirName);
+
+  afterEach(async () => {
+    // delete tempDirPath
+    try {
+      await fs.promises.rm(tempDirPath, { recursive: true, force: true });
+    } catch {
+      console.warn('teardown failed');
+    }
+  });
+
+  describe('when temp dir and threshold are set', () => {
+    const tempDirVars = {
+      SNYK_TMP_PATH: tempDirPath,
+      INTERNAL_IN_MEMORY_THRESHOLD_BYTES: '1',
+    };
+
+    it('should write to temp dir if payload is bigger than threshold', async () => {
+      await runSnykCLI(`code test ${projectWithCodeIssues}`, {
+        env: {
+          ...process.env,
+          ...env,
+          ...tempDirVars,
+        },
+      });
+
+      // assert that tempDirPath exists
+      await expect(
+        fs.promises.access(tempDirPath, fs.constants.F_OK),
+      ).resolves.toBeUndefined();
+
+      // assert that tempDirPath contains workflow files
+      const files = await fs.promises.readdir(tempDirPath);
+      const workflowFiles = files.filter((file) => file.includes('workflow.'));
+      expect(workflowFiles.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('when only threshold is set', () => {
+    const tempDirVars = {
+      INTERNAL_IN_MEMORY_THRESHOLD_BYTES: '1',
+      INTERNAL_CLEANUP_GLOBAL_TEMP_DIR_ENABLED: 'true', // re-enable as we're not setting the temp dir, and we want to ensure we cleanup
+    };
+
+    it('should write to default temp dir if payload is bigger than threshold', async () => {
+      await runSnykCLI(`code test ${projectWithCodeIssues}`, {
+        env: {
+          ...process.env,
+          ...env,
+          ...tempDirVars,
+        },
+      });
+
+      // note we can't determine whether we write to disk or memory without inspecting logs
+      // GAF uses the default OS cache dir to write to, which we cannot access in the test
+
+      // assert that tempDirPath does not exist
+      await expect(
+        fs.promises.access(tempDirPath, fs.constants.F_OK),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('when temp dir and threshold are NOT set', () => {
+    const tempDirVars = {
+      INTERNAL_CLEANUP_GLOBAL_TEMP_DIR_ENABLED: 'true', // re-enable as we're not setting the temp dir, and we want to ensure we cleanup
+    };
+
+    it('should use 512MB as default threshold', async () => {
+      await runSnykCLI(`code test ${projectWithCodeIssues}`, {
+        env: {
+          ...process.env,
+          ...env,
+          ...tempDirVars,
+        },
+      });
+
+      // note we can't determine whether we write to disk or memory without inspecting logs
+      // GAF uses the default OS cache dir to write to, which we cannot access in the test
+
+      // assert that tempDirPath does not exist
+      await expect(
+        fs.promises.access(tempDirPath, fs.constants.F_OK),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('when feature is disabled', () => {
+    const tempDirVars = {
+      INTERNAL_IN_MEMORY_THRESHOLD_BYTES: '-1',
+      INTERNAL_CLEANUP_GLOBAL_TEMP_DIR_ENABLED: 'true', // re-enable as we're not setting the temp dir, and we want to ensure we cleanup
+    };
+
+    it('should keep payload memory', async () => {
+      await runSnykCLI(`code test ${projectWithCodeIssues}`, {
+        env: {
+          ...process.env,
+          ...env,
+          ...tempDirVars,
+        },
+      });
+
+      // assert that tempDirPath does not exist
+      await expect(
+        fs.promises.access(tempDirPath, fs.constants.F_OK),
+      ).rejects.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Pull Request Submission
Risk assessment is low as this feature is only enabled for GAF workflows larger than 512MB by default and can be manually disabled

Please check the boxes once done.

The pull request must:

- **Reviewer Documentation**
    - [x] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) rules
    - [ ] be accompanied by a detailed description of the changes
    - [ ] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [ ] highlight breaking API if applicable
    - [ ] contain a link to the automatic tests that cover the updated functionality.
    - [ ] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [ ] link to the link to the PR for the User-facing documentation
- **User facing Documentation**
    - [ ] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [ ] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [ ] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.

## Pull Request Review

All pull requests must undergo a thorough review process before being merged. 
The review process of the code PR should include code review, testing, and any necessary feedback or revisions. 
Pull request reviews of functionality developed in other teams only review the given documentation and test reports. 

Manual testing will not be performed by the reviewing team, and is the responsibility of the author of the PR.

For Node projects: It’s important to make sure changes in `package.json` are also affecting `package-lock.json` correctly.

****************************If a dependency is not necessary, don’t add it.**************************** 

When adding a new package as a dependency, make sure that the change is absolutely necessary. We would like to refrain from adding new dependencies when possible.
Documentation PRs in gitbook are reviewed by Snyk's content team. They will also advise on the best phrasing and structuring if needed.

## Pull Request Approval

Once a pull request has been reviewed and all necessary revisions have been made, it is approved for merging into 
the main codebase. The merging of the code PR is performed by the code owners, the merging of the documentation PR 
by our content writers.


## What does this PR do?
This PR adds a new capability to set a threshold in bytes which determines whether to keep GAF workflow data items in memory, or write to disk.

It also fixes a bug that arises from this where the analytics are being sent after cleaning up temp directories.

## Where should the reviewer start?
See related GAF [changes](https://github.com/snyk/go-application-framework/compare/0ac46beed30a60ab132e7bfcbb8981b2c73128d3...718daf6e97a296f75db8d554488d3d0a3e4bb5ed).

2 new parameters are considered when conditionally writing data to disk:
- `SNYK_TMP_PATH` - determines the temp path to write data to, will use the OS specific cache dir if not defined
- `INTERNAL_IN_MEMORY_THRESHOLD_BYTES` - threshold in bytes to determine whether to write data to disk or keep in memory. Defaults to 512MB if not defined; a value of `-1` disables this feature.


## How should this be manually tested?

1. Checkout this branch
2. run `make clean build`
3. run `SNYK_LOG_LEVEL=trace ./binary-releases/snyk-<ARCH> code test -d`
  a. include the env vars `SNYK_TMP_DIR_PATH` and `INTERNAL_IN_MEMORY_THRESHOLD_BYTES` as appropriate for each test case

### Test case 1 - Set SNYK_TMP_DIR_PATH, do not set INTERNAL_IN_MEMORY_THRESHOLD_BYTES
#### Expected behaviour

native code workflow passes the configuration when creating new data so should take into account the SNYK_TMP_DIR_PATH and use the default 512MB memory threshold

all other workflows do not pass the configuration when creating new data so should have this feature disabled. i.e. they should all read from memory

#### Validation
Look for the log messages:
a. `internal.cleanup:4 - Deleted temporary directory: <SNYK_TMP_DIR_PATH>`
b. `code.test:1 - payload is []byte, comparing payload size (<SIZE> bytes) to threshold (536870912 bytes)` 
c. `output:2 - memory threshold feature disabled, keeping payload in memory`

### Test case 2 - Set INTERNAL_IN_MEMORY_THRESHOLD_BYTES, do not set SNYK_TMP_DIR_PATH
#### Expected behaviour

native code workflow uses the INTERNAL_IN_MEMORY_THRESHOLD_BYTES value and uses the default SNYK_TMP_DIR_PATH value

all other workflows should have this feature disabled. i.e. they should all read from memory

#### Validation
Look for the log messages:
a. `internal.cleanup:4 - Deleted temporary directory: <OS_SPECIFIC_CACHE_DIR>`
b. `code.test:1 - payload is []byte, comparing payload size (<SIZE> bytes) to threshold (<INTERNAL_IN_MEMORY_THRESHOLD_BYTES> bytes)` 
c. `output:2 - memory threshold feature disabled, keeping payload in memory`

### Test case 3 - Set SNYK_TMP_DIR_PATH and INTERNAL_IN_MEMORY_THRESHOLD_BYTES
#### Expected behaviour

native code workflow passes the configuration when creating new data so should take into account both SNYK_TMP_DIR_PATH and INTERNAL_IN_MEMORY_THRESHOLD_BYTES

all other workflows should have this feature disabled. i.e. they should all read from memory

#### Validation
Look for the log messages:
a. `internal.cleanup:4 - Deleted temporary directory: <SNYK_TMP_DIR_PATH>`
b. `code.test:1 - payload is []byte, comparing payload size (<SIZE> bytes) to threshold (<INTERNAL_IN_MEMORY_THRESHOLD_BYTES> bytes)` 
c. `output:2 - memory threshold feature disabled, keeping payload in memory`

### Test case 4 - do not set SNYK_TMP_DIR_PATH or INTERNAL_IN_MEMORY_THRESHOLD_BYTES
#### Expected behaviour

native code workflow passes the configuration when creating new data so should use the default SNYK_TMP_DIR_PATH and INTERNAL_IN_MEMORY_THRESHOLD

all other workflows should have this feature disabled. i.e. they should all read from memory

#### Validation
Look for the log messages:
a. `internal.cleanup:4 - Deleted temporary directory: <OS_SPECIFIC_CACHE_DIR>`
b. `code.test:1 - payload is []byte, comparing payload size (<SIZE> bytes) to threshold (536870912 bytes)` 
c. `output:2 - memory threshold feature disabled, keeping payload in memory`

### Test case 5 - Set INTERNAL_IN_MEMORY_THRESHOLD_BYTES=-1
#### Expected behaviour

all workflows should have feature disabled. i.e. they should all read from memory

#### Validation
Look for the log messages:
a. `internal.cleanup:4 - Deleted temporary directory: <OS_SPECIFIC_CACHE_DIR>`
b. `code.test:1 - memory threshold feature disabled, keeping payload in memory` 
c. `output:2 - memory threshold feature disabled, keeping payload in memory`

## Any background context you want to provide?


## What are the relevant tickets?
[CLI-508](https://snyksec.atlassian.net/browse/CLI-508)

## Screenshots


## Additional questions


[CLI-508]: https://snyksec.atlassian.net/browse/CLI-508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ