### PR TITLE
feat(iac): check iacNewEngine FF and pass it to snyk-iac-test [IAC-3059]

### DIFF
--- a/src/cli/commands/test/iac/local-execution/types.ts
+++ b/src/cli/commands/test/iac/local-execution/types.ts
@@ -221,6 +221,9 @@ export type IaCTestFlags = Pick<
   'project-environment'?: string;
   'project-lifecycle'?: string;
   'project-business-criticality'?: string;
+  // Temporary flag needed for the IaCv2 migration.
+  // The value of it is set internally by an API call.
+  'iac-new-engine'?: boolean;
 } & TerraformPlanFlags;
 
 // Flags specific for Terraform plan scanning

--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -65,6 +65,7 @@ async function prepareTestConfig(
   const insecure = options.insecure;
   const customRules = options['custom-rules'];
   const experimental = options.experimental;
+  const iacNewEngine = options['iac-new-engine'];
 
   return {
     paths: relativePaths,
@@ -86,5 +87,6 @@ async function prepareTestConfig(
     org,
     customRules,
     experimental,
+    iacNewEngine,
   };
 }

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -64,10 +64,19 @@ export default async function test(
   const { options: originalOptions, paths } = processCommandArgs(...args);
 
   const options = setDefaultTestOptions(originalOptions);
+  const iacNewEngine = await hasFeatureFlag('iacNewEngine', options);
+  const iacIntegratedExperience = await hasFeatureFlag(
+    'iacIntegratedExperience',
+    options,
+  );
+
   if (originalOptions.iac) {
     // temporary placeholder for the "new" flow that integrates with UPE
-    if (await hasFeatureFlag('iacIntegratedExperience', options)) {
-      return await iacTestCommandV2.test(paths, originalOptions);
+    if (iacIntegratedExperience || iacNewEngine) {
+      return await iacTestCommandV2.test(paths, {
+        ...originalOptions,
+        'iac-new-engine': iacNewEngine,
+      });
     } else {
       return await iacTestCommand(...args);
     }

--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -182,6 +182,10 @@ function processFlags(
     flags.push('-rulesClientURL', rulesClientURL);
   }
 
+  if (options.iacNewEngine) {
+    flags.push('-iac-new-engine');
+  }
+
   return flags;
 }
 

--- a/src/lib/iac/test/v2/types.ts
+++ b/src/lib/iac/test/v2/types.ts
@@ -20,4 +20,5 @@ export interface TestConfig {
   org?: string;
   customRules?: boolean;
   experimental?: boolean;
+  iacNewEngine?: boolean;
 }


### PR DESCRIPTION
## Pull Request Submission

Please check the boxes once done.

The pull request must:

- **Reviewer Documentation**
    - [ ] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) rules
    - [ ] be accompanied by a detailed description of the changes
    - [ ] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [ ] highlight breaking API if applicable
    - [ ] contain a link to the automatic tests that cover the updated functionality.
    - [ ] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [ ] link to the link to the PR for the User-facing documentation
- **User facing Documentation**
    - [ ] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [ ] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [ ] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.

## Pull Request Review

All pull requests must undergo a thorough review process before being merged. 
The review process of the code PR should include code review, testing, and any necessary feedback or revisions. 
Pull request reviews of functionality developed in other teams only review the given documentation and test reports. 

Manual testing will not be performed by the reviewing team, and is the responsibility of the author of the PR.

For Node projects: It’s important to make sure changes in `package.json` are also affecting `package-lock.json` correctly.

****************************If a dependency is not necessary, don’t add it.**************************** 

When adding a new package as a dependency, make sure that the change is absolutely necessary. We would like to refrain from adding new dependencies when possible.
Documentation PRs in gitbook are reviewed by Snyk's content team. They will also advise on the best phrasing and structuring if needed.

## Pull Request Approval

Once a pull request has been reviewed and all necessary revisions have been made, it is approved for merging into 
the main codebase. The merging of the code PR is performed by the code owners, the merging of the documentation PR 
by our content writers.


## What does this PR do?
This PR depends on https://github.com/snyk/snyk-iac-test/pull/249 ⚠️
We need to have access to the information of whether or not the callee has `iacNewEngine` FF enabled inside the `snyk-iac-test`. For that we will use the `cli-config/feature-flags` endpoint in the CLI directly and pass it as a flag to `snyk-iac-test`. Based on this flag that we pass, we will need to change some downstream behaviour, like where to report the vulns found during the scan and other things.

## Where should the reviewer start?


## How should this be manually tested?
Take a look at the screenshot attached below. It can be tested by switching on and off the `iacNewEngine` FF on the org.

## Any background context you want to provide?


## What are the relevant tickets?
[IAC-3059](https://snyksec.atlassian.net/browse/IAC-3059)

## Screenshots
This is how it looks when you run the CLI with `--report`, while having the `iacNewEngine` FF enabled.
Note that this uses a local version of `snyk-iac-test` just to simulate the flag already exists there. We need to wait for the [PR](https://github.com/snyk/snyk-iac-test/pull/249) in order to have the same behaviour.
![image](https://github.com/user-attachments/assets/142f74a7-65c2-444c-96ae-8ff8b7635446)

## Additional questions


[IAC-3059]: https://snyksec.atlassian.net/browse/IAC-3059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ