### PR TITLE
fix(iac): check iacNewEngine FF and pass it to snyk-iac-test [IAC-3059]

### DIFF
--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -15,9 +15,10 @@ import { assertIacV2Options } from './assert-iac-options';
 export async function test(
   paths: string[],
   options: IaCTestFlags,
+  iacNewEngine?: boolean,
 ): Promise<TestCommandResult> {
   assertIacV2Options(options);
-  const testConfig = await prepareTestConfig(paths, options);
+  const testConfig = await prepareTestConfig(paths, options, iacNewEngine);
 
   const testSpinner = buildSpinner(options);
 
@@ -41,6 +42,7 @@ export async function test(
 async function prepareTestConfig(
   paths: string[],
   options: IaCTestFlags,
+  iacNewEngine?: boolean,
 ): Promise<TestConfig> {
   const iacCachePath = pathLib.join(systemCachePath, 'iac');
 
@@ -86,5 +88,6 @@ async function prepareTestConfig(
     org,
     customRules,
     experimental,
+    iacNewEngine,
   };
 }

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -64,10 +64,16 @@ export default async function test(
   const { options: originalOptions, paths } = processCommandArgs(...args);
 
   const options = setDefaultTestOptions(originalOptions);
+
   if (originalOptions.iac) {
+    const iacNewEngine = await hasFeatureFlag('iacNewEngine', options);
+    const iacIntegratedExperience = await hasFeatureFlag(
+      'iacIntegratedExperience',
+      options,
+    );
     // temporary placeholder for the "new" flow that integrates with UPE
-    if (await hasFeatureFlag('iacIntegratedExperience', options)) {
-      return await iacTestCommandV2.test(paths, originalOptions);
+    if (iacIntegratedExperience || iacNewEngine) {
+      return await iacTestCommandV2.test(paths, originalOptions, iacNewEngine);
     } else {
       return await iacTestCommand(...args);
     }

--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -1,11 +1,11 @@
 import * as os from 'os';
 
 const policyEngineChecksums = `
-64d72e61b1b39ae74c069667b9ada4edfe6343df1fceeef49fbee54b60d8013d  snyk-iac-test_0.55.1_Darwin_arm64
-86b1db19a733afdf623ac5dfcb4f59f29a534997673efc94b9a0b4c14aa6abff  snyk-iac-test_0.55.1_Darwin_x86_64
-a4e30ef1e973a323a2fce72ba8dc7d507b74fd7c524b2a4e7617958980146860  snyk-iac-test_0.55.1_Linux_arm64
-e0ecebc81e619b4e7f6616c720f30150cb373548937e78f8eb42878516a087f5  snyk-iac-test_0.55.1_Linux_x86_64
-f8a8c2aa8081027baceae917dbecfacdb06c1fc8710b4d17d71ace96704112ce  snyk-iac-test_0.55.1_Windows_x86_64.exe
+020098c4dce6a7412e7aaffc379f5b668886ce1dfbcb584241985ac4de6be7f4  snyk-iac-test_0.56.0_Darwin_arm64
+07a682745d31048a1d279da53cdda2ddf75607bc90348d18d9c6b86cbeff6b81  snyk-iac-test_0.56.0_Windows_x86_64.exe
+1f46cc456e5261bf7b789a44621dfc1e1676b48679e9e89478107f40636011e6  snyk-iac-test_0.56.0_Darwin_x86_64
+4f58f39a93119a8acd74469d54f3bee53c4fb0e22a161b3311ccb9ac4cef4dad  snyk-iac-test_0.56.0_Linux_arm64
+e29ace0c3d2ac60b2aec2ed50a93c8e6ba839cecb75dc6f057d02dc21a090e96  snyk-iac-test_0.56.0_Linux_x86_64
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();

--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -182,6 +182,10 @@ function processFlags(
     flags.push('-rulesClientURL', rulesClientURL);
   }
 
+  if (options.iacNewEngine) {
+    flags.push('-iac-new-engine');
+  }
+
   return flags;
 }
 

--- a/src/lib/iac/test/v2/types.ts
+++ b/src/lib/iac/test/v2/types.ts
@@ -20,4 +20,5 @@ export interface TestConfig {
   org?: string;
   customRules?: boolean;
   experimental?: boolean;
+  iacNewEngine?: boolean;
 }

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -12,6 +12,7 @@ const featureFlagDefaults = (): Map<string, boolean> => {
   return new Map([
     ['cliFailFast', false],
     ['iacIntegratedExperience', false],
+    ['iacNewEngine', false],
     ['containerCliAppVulnsEnabled', true],
     ['enablePnpmCli', false],
   ]);

--- a/test/jest/acceptance/iac/cli-share-results.spec.ts
+++ b/test/jest/acceptance/iac/cli-share-results.spec.ts
@@ -23,11 +23,10 @@ describe('CLI Share Results', () => {
 
   afterAll(async () => teardown());
 
-  describe('feature flag is not enabled', () => {
-    beforeAll(() => {
+  describe('feature flag iacCliShareResults is not enabled', () => {
+    beforeEach(() => {
       server.setFeatureFlag('iacCliShareResults', false);
     });
-
     it('the output includes an error', async () => {
       const { stdout, exitCode } = await run(
         `snyk iac test ./iac/arm/rule_test.json --report`,
@@ -40,8 +39,8 @@ describe('CLI Share Results', () => {
     });
   });
 
-  describe('feature flag is enabled', () => {
-    beforeAll(() => {
+  describe('feature flag iacCliShareResults is enabled', () => {
+    beforeEach(() => {
       server.setFeatureFlag('iacCliShareResults', true);
     });
 
@@ -250,6 +249,23 @@ describe('CLI Share Results', () => {
         });
         expect(exitCode).toEqual(1);
       });
+    });
+  });
+
+  describe('feature flag iacNewEngine is enabled', () => {
+    beforeEach(() => {
+      server.setFeatureFlag('iacNewEngine', true);
+    });
+
+    it('the output includes an error', async () => {
+      const { stdout, exitCode } = await run(
+        `snyk iac test ./iac/arm/rule_test.json --report`,
+      );
+
+      expect(stdout).toMatch(
+        'flag --report is not yet supported when iacNewEngine flag is enabled',
+      );
+      expect(exitCode).toBe(2);
     });
   });
 });


### PR DESCRIPTION
## Pull Request Submission

Please check the boxes once done.

The pull request must:

- **Reviewer Documentation**
    - [ ] follow [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) rules
    - [ ] be accompanied by a detailed description of the changes
    - [ ] contain a risk assessment of the change (Low | Medium | High) with regards to breaking existing functionality. A change e.g. of an underlying language plugin can completely break the functionality for that language, but appearing as only a version change in the dependencies.
    - [ ] highlight breaking API if applicable
    - [ ] contain a link to the automatic tests that cover the updated functionality.
    - [ ] contain testing instructions in case that the reviewer wants to manual verify as well, to add to the manual testing done by the author.
    - [ ] link to the link to the PR for the User-facing documentation
- **User facing Documentation**
    - [ ] update any relevant documentation in gitbook by submitting a gitbook PR, and including the PR link here
    - [ ] ensure that the message of the final single commit is descriptive and prefixed with either `feat:` or `fix:` , others might be used in rare occasions as well, if there is no need to document the changes in the release notes. The changes or fixes should be described in detail in the commit message for the changelog & release notes.
- **Testing**
    - [ ] Changes, removals and additions to functionality must be covered by acceptance / integration tests or smoke tests - either already existing ones, or new ones, created by the author of the PR.

## Pull Request Review

All pull requests must undergo a thorough review process before being merged. 
The review process of the code PR should include code review, testing, and any necessary feedback or revisions. 
Pull request reviews of functionality developed in other teams only review the given documentation and test reports. 

Manual testing will not be performed by the reviewing team, and is the responsibility of the author of the PR.

For Node projects: It’s important to make sure changes in `package.json` are also affecting `package-lock.json` correctly.

****************************If a dependency is not necessary, don’t add it.**************************** 

When adding a new package as a dependency, make sure that the change is absolutely necessary. We would like to refrain from adding new dependencies when possible.
Documentation PRs in gitbook are reviewed by Snyk's content team. They will also advise on the best phrasing and structuring if needed.

## Pull Request Approval

Once a pull request has been reviewed and all necessary revisions have been made, it is approved for merging into 
the main codebase. The merging of the code PR is performed by the code owners, the merging of the documentation PR 
by our content writers.


## What does this PR do?
⚠️ This PR depends on https://github.com/snyk/snyk-iac-test/pull/249 
We need to have access to the information of whether or not the callee has `iacNewEngine` FF enabled inside the `snyk-iac-test`. For that we will use the `cli-config/feature-flags` endpoint in the CLI directly and pass it as a flag to `snyk-iac-test`. Based on this flag that we pass, we will need to change some downstream behaviour, like where to report the vulns found during the scan and other things.

It may look ugly, but instead of passing it through the `options` in the `iacTestCommandV2.test()` call, we pass it directly as a func parameter. If we pass it through the options, we need to change one more type and complicate things more in `assertIacV2Options()`. Also, this is a temporary change and the functions that have the new parameter are only called once each, so this should be the most straightforward way imo. 

## Where should the reviewer start?


## How should this be manually tested?
Take a look at the screenshot attached below. It can be tested by switching on and off the `iacNewEngine` FF on the org.

## Any background context you want to provide?


## What are the relevant tickets?
[IAC-3059](https://snyksec.atlassian.net/browse/IAC-3059)

## Screenshots
This is how it looks when you run the CLI with `--report`, while having the `iacNewEngine` FF enabled.
Note that this uses a local version of `snyk-iac-test` just to simulate the flag already exists there. We need to wait for the [PR](https://github.com/snyk/snyk-iac-test/pull/249) in order to have the same behaviour.
![image](https://github.com/user-attachments/assets/75171747-6286-4730-8761-a0118d359312)



## Additional questions


[IAC-3059]: https://snyksec.atlassian.net/browse/IAC-3059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ