### PR TITLE
fix: include CVE in JSON output of `sbom test` command

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/snyk/cli-extension-dep-graph v0.0.0-20241014075215-311d3c8a423f
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20241008152401-24c8cf03a1a3
-	github.com/snyk/cli-extension-sbom v0.0.0-20241014075233-2c0dbfc5f3b6
+	github.com/snyk/cli-extension-sbom v0.0.0-20241016065306-0df2be5b3b8f
 	github.com/snyk/container-cli v0.0.0-20240821111304-7ca1c415a5d7
 	github.com/snyk/error-catalog-golang-public v0.0.0-20240809094525-c48d19c27edb
 	github.com/snyk/go-application-framework v0.0.0-20241009095349-dc0fb55f3eb3

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -754,8 +754,8 @@ github.com/snyk/cli-extension-dep-graph v0.0.0-20241014075215-311d3c8a423f h1:xZ
 github.com/snyk/cli-extension-dep-graph v0.0.0-20241014075215-311d3c8a423f/go.mod h1:QF3v8HBpOpyudYNCuR8LqfULutO76c91sBdLzD+pBJU=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20241008152401-24c8cf03a1a3 h1:AQMi52/aevl9bBSzwxGLz9kxInojkSe/Q6j1s1s6yJg=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20241008152401-24c8cf03a1a3/go.mod h1:A/DNK3ZnUgqOKJ33Lc1z5KbbHqRSBgwCWw9KuyJu0xQ=
-github.com/snyk/cli-extension-sbom v0.0.0-20241014075233-2c0dbfc5f3b6 h1:vywmAvDiMsmsK6ehG9KpOUVdi5Gcv35R35DLuF4v+Ms=
-github.com/snyk/cli-extension-sbom v0.0.0-20241014075233-2c0dbfc5f3b6/go.mod h1:5CaY1bgvJY/uoG/1plLOf8T8o9AkwoBIGvw34RfRLZw=
+github.com/snyk/cli-extension-sbom v0.0.0-20241016065306-0df2be5b3b8f h1:dlL+f+5sjHj4JCzW/Evl1x9UREXLyc3M4KjoZvQx0Bs=
+github.com/snyk/cli-extension-sbom v0.0.0-20241016065306-0df2be5b3b8f/go.mod h1:5CaY1bgvJY/uoG/1plLOf8T8o9AkwoBIGvw34RfRLZw=
 github.com/snyk/code-client-go v1.10.0 h1:t/hBINxj4lKvoo681uGhxHBpMued/j68p2sHbB9qbfo=
 github.com/snyk/code-client-go v1.10.0/go.mod h1:orU911flV1kJQOlxxx0InUQkAfpBrcERsb2olfnlI8s=
 github.com/snyk/container-cli v0.0.0-20240821111304-7ca1c415a5d7 h1:Zn5BcV76oFAbJm5tDygU945lvoZ3yY8FoRFDC3YpwF8=

--- a/test/jest/acceptance/snyk-sbom-test/all-projects.spec.ts
+++ b/test/jest/acceptance/snyk-sbom-test/all-projects.spec.ts
@@ -98,6 +98,7 @@ describe('snyk sbom test (mocked server only)', () => {
     expect(stdout).toContain('"version":"3.0.4",');
     expect(stdout).toContain('"name":"minimatch"');
     expect(stdout).toContain('"CWE":["CWE-1333"]');
+    expect(stdout).toContain('"CVE":["CVE-2022-3517"]');
     expect(stdout).toContain('"semver":{"vulnerable":["3.0.4"]}');
 
     expect(code).toEqual(1);


### PR DESCRIPTION
## What does this PR do?

Upgrades the SBOM CLI Extension to include a fix where the CVE of a vulnerability had not been added to the JSON output of the `sbom test` command.

See https://github.com/snyk/cli-extension-sbom/pull/96.