### PR TITLE
fix: manually configure supported env vars

### DIFF
--- a/cliv2/cmd/cliv2/instrumentation_test.go
+++ b/cliv2/cmd/cliv2/instrumentation_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func Test_shallSendInstrumentation(t *testing.T) {
-	config := configuration.NewInMemory()
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	instrumentor := analytics.NewInstrumentationCollector()
 
 	// case: nothing configured

--- a/cliv2/cmd/cliv2/main.go
+++ b/cliv2/cmd/cliv2/main.go
@@ -457,7 +457,11 @@ func MainWithErrorCode() int {
 	_ = rootCommand.ParseFlags(os.Args)
 
 	// create engine
-	globalConfiguration = configuration.New()
+	globalConfiguration = configuration.NewWithOpts(
+		configuration.WithFiles("snyk"),
+		configuration.WithSupportedEnvVars("NODE_EXTRA_CA_CERTS"),
+		configuration.WithSupportedEnvVarPrefixes("snyk_", "internal_", "test_"),
+	)
 	err = globalConfiguration.AddFlagSet(rootCommand.LocalFlags())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Failed to add flags to root command", err)

--- a/cliv2/cmd/cliv2/main_test.go
+++ b/cliv2/cmd/cliv2/main_test.go
@@ -50,7 +50,7 @@ func Test_MainWithErrorCode(t *testing.T) {
 
 func Test_initApplicationConfiguration_DisablesAnalytics(t *testing.T) {
 	t.Run("via SNYK_DISABLE_ANALYTICS (true)", func(t *testing.T) {
-		c := configuration.NewInMemory()
+		c := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 		assert.False(t, c.GetBool(configuration.ANALYTICS_DISABLED))
 
 		c.Set("SNYK_DISABLE_ANALYTICS", "true")
@@ -59,7 +59,7 @@ func Test_initApplicationConfiguration_DisablesAnalytics(t *testing.T) {
 		assert.True(t, c.GetBool(configuration.ANALYTICS_DISABLED))
 	})
 	t.Run("via SNYK_DISABLE_ANALYTICS (1)", func(t *testing.T) {
-		c := configuration.NewInMemory()
+		c := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 		assert.False(t, c.GetBool(configuration.ANALYTICS_DISABLED))
 
 		c.Set("SNYK_DISABLE_ANALYTICS", "1")
@@ -68,7 +68,7 @@ func Test_initApplicationConfiguration_DisablesAnalytics(t *testing.T) {
 		assert.True(t, c.GetBool(configuration.ANALYTICS_DISABLED))
 	})
 	t.Run("via SNYK_CFG_DISABLE_ANALYTICS (true)", func(t *testing.T) {
-		c := configuration.NewInMemory()
+		c := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 		assert.False(t, c.GetBool(configuration.ANALYTICS_DISABLED))
 
 		c.Set("SNYK_CFG_DISABLE_ANALYTICS", "true")
@@ -77,7 +77,7 @@ func Test_initApplicationConfiguration_DisablesAnalytics(t *testing.T) {
 		assert.True(t, c.GetBool(configuration.ANALYTICS_DISABLED))
 	})
 	t.Run("via SNYK_CFG_DISABLE_ANALYTICS (1)", func(t *testing.T) {
-		c := configuration.NewInMemory()
+		c := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 		assert.False(t, c.GetBool(configuration.ANALYTICS_DISABLED))
 
 		c.Set("SNYK_CFG_DISABLE_ANALYTICS", "1")
@@ -86,7 +86,7 @@ func Test_initApplicationConfiguration_DisablesAnalytics(t *testing.T) {
 		assert.True(t, c.GetBool(configuration.ANALYTICS_DISABLED))
 	})
 	t.Run("via DISABLE-ANALYTICS (true)", func(t *testing.T) {
-		c := configuration.NewInMemory()
+		c := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 		assert.False(t, c.GetBool(configuration.ANALYTICS_DISABLED))
 
 		c.Set("disable-analytics", "true")
@@ -95,7 +95,7 @@ func Test_initApplicationConfiguration_DisablesAnalytics(t *testing.T) {
 		assert.True(t, c.GetBool(configuration.ANALYTICS_DISABLED))
 	})
 	t.Run("via DISABLE-ANALYTICS (1)", func(t *testing.T) {
-		c := configuration.NewInMemory()
+		c := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 		assert.False(t, c.GetBool(configuration.ANALYTICS_DISABLED))
 
 		c.Set("disable-analytics", "1")
@@ -204,7 +204,7 @@ func Test_runMainWorkflow_unknownargs(t *testing.T) {
 
 			_ = globalEngine.Init()
 
-			config := configuration.NewInMemory()
+			config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 			cmd := &cobra.Command{
 				Use: "command",
 			}
@@ -492,7 +492,7 @@ func Test_setTimeout(t *testing.T) {
 	fakeExit := func() {
 		close(exitedCh)
 	}
-	config := configuration.NewInMemory()
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	config.Set(configuration.TIMEOUT, 1)
 	setTimeout(config, fakeExit)
 	select {
@@ -511,7 +511,7 @@ func Test_displayError(t *testing.T) {
 		err := errors.New("test error")
 		userInterface.EXPECT().OutputError(err).Times(1)
 
-		config := configuration.NewInMemory()
+		config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 		displayError(err, userInterface, config)
 	})
 
@@ -531,7 +531,7 @@ func Test_displayError(t *testing.T) {
 
 	for _, scenario := range scenarios {
 		t.Run(fmt.Sprintf("%s does not display anything", scenario.name), func(t *testing.T) {
-			config := configuration.NewInMemory()
+			config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 			err := scenario.err
 			displayError(err, userInterface, config)
 		})
@@ -541,7 +541,7 @@ func Test_displayError(t *testing.T) {
 		err := &wrErr{wraps: &exec.ExitError{}}
 		userInterface.EXPECT().OutputError(err).Times(1)
 
-		config := configuration.NewInMemory()
+		config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 		displayError(err, userInterface, config)
 	})
 }

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/snyk/cli-extension-sbom v0.0.0-20241016065306-0df2be5b3b8f
 	github.com/snyk/container-cli v0.0.0-20240821111304-7ca1c415a5d7
 	github.com/snyk/error-catalog-golang-public v0.0.0-20240809094525-c48d19c27edb
-	github.com/snyk/go-application-framework v0.0.0-20241011135148-71eca49aa231
+	github.com/snyk/go-application-framework v0.0.0-20241028110230-2fd0f316365c
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20241023124225-627b73041471

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -762,8 +762,8 @@ github.com/snyk/container-cli v0.0.0-20240821111304-7ca1c415a5d7 h1:Zn5BcV76oFAb
 github.com/snyk/container-cli v0.0.0-20240821111304-7ca1c415a5d7/go.mod h1:38w+dcAQp9eG3P5t2eNS9eG0reut10AeJjLv5lJ5lpM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20240809094525-c48d19c27edb h1:w9tJhpTFxWqAhLeraGsMExDjGK9x5Dwj1NRFwb+t+QE=
 github.com/snyk/error-catalog-golang-public v0.0.0-20240809094525-c48d19c27edb/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.0.0-20241011135148-71eca49aa231 h1:mLiZHx8m36ySB+KZ9x1OR+VR84YJuOXv0/9zYsPkReU=
-github.com/snyk/go-application-framework v0.0.0-20241011135148-71eca49aa231/go.mod h1:LeMsRM1FxIfO/8QpOs9V/dI46ie/RAQl02ulAh6aKys=
+github.com/snyk/go-application-framework v0.0.0-20241028110230-2fd0f316365c h1:ZOJO1amMFSKFMo40XfMloYAp+gC5LUhjdCNQHUOdwcQ=
+github.com/snyk/go-application-framework v0.0.0-20241028110230-2fd0f316365c/go.mod h1:5aMJH42nmeZgPRXvN5fdAZVoutATPnY9yTb68Iz7zYk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v0.31.3 h1:FepCg6QN/X8uvxYjF+WwB2aiBPJB+NENDgKQeI/FwLg=

--- a/cliv2/internal/cliv2/cliv2_test.go
+++ b/cliv2/internal/cliv2/cliv2_test.go
@@ -47,7 +47,7 @@ func Test_PrepareV1EnvironmentVariables_Fill_and_Filter(t *testing.T) {
 	orgid := "orgid"
 	testapi := "https://api.snyky.io"
 
-	config := configuration.NewInMemory()
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	config.Set(configuration.ORGANIZATION, orgid)
 	config.Set(configuration.API_URL, testapi)
 	config.Set(configuration.PREVIEW_FEATURES_ENABLED, true)
@@ -95,7 +95,7 @@ func Test_PrepareV1EnvironmentVariables_DontOverrideExistingIntegration(t *testi
 	orgid := "orgid"
 	testapi := "https://api.snyky.io"
 
-	config := configuration.NewInMemory()
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	config.Set(configuration.ORGANIZATION, orgid)
 	config.Set(configuration.API_URL, testapi)
 
@@ -130,7 +130,7 @@ func Test_PrepareV1EnvironmentVariables_OverrideProxyAndCerts(t *testing.T) {
 	orgid := "orgid"
 	testapi := "https://api.snyky.io"
 
-	config := configuration.NewInMemory()
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	config.Set(configuration.ORGANIZATION, orgid)
 	config.Set(configuration.API_URL, testapi)
 
@@ -162,7 +162,7 @@ func Test_PrepareV1EnvironmentVariables_OverrideProxyAndCerts(t *testing.T) {
 }
 
 func Test_PrepareV1EnvironmentVariables_OnlyExplicitlySetValues(t *testing.T) {
-	config := configuration.NewInMemory()
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 
 	t.Run("Values not set", func(t *testing.T) {
 		input := []string{}
@@ -203,7 +203,7 @@ func Test_PrepareV1EnvironmentVariables_Fail_DontOverrideExisting(t *testing.T) 
 	orgid := "orgid"
 	testapi := "https://api.snyky.io"
 
-	config := configuration.NewInMemory()
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	config.Set(configuration.ORGANIZATION, orgid)
 	config.Set(configuration.API_URL, testapi)
 
@@ -225,7 +225,7 @@ func Test_PrepareV1EnvironmentVariables_Fail_DontOverrideExisting_Org(t *testing
 	orgid := "orgid"
 	testapi := "https://api.snyky.io"
 
-	config := configuration.NewInMemory()
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	config.Set(configuration.ORGANIZATION, orgid)
 	config.Set(configuration.API_URL, testapi)
 
@@ -275,7 +275,7 @@ func getProxyInfoForTest() *proxy.ProxyInfo {
 func Test_prepareV1Command(t *testing.T) {
 	expectedArgs := []string{"hello", "world"}
 	cacheDir := getCacheDir(t)
-	config := configuration.NewInMemory()
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	config.Set(configuration.CACHE_PATH, cacheDir)
 	cli, err := cliv2.NewCLIv2(config, discardLogger, getRuntimeInfo(t))
 	assert.NoError(t, err)
@@ -300,7 +300,7 @@ func Test_prepareV1Command(t *testing.T) {
 func Test_extractOnlyOnce(t *testing.T) {
 	cacheDir := getCacheDir(t)
 	tmpDir := utils.GetTemporaryDirectory(cacheDir, cliv2.GetFullVersion())
-	config := configuration.NewInMemory()
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	config.Set(configuration.CACHE_PATH, cacheDir)
 
 	assert.NoDirExists(t, tmpDir)
@@ -334,7 +334,7 @@ func Test_extractOnlyOnce(t *testing.T) {
 func Test_init_extractDueToInvalidBinary(t *testing.T) {
 	cacheDir := getCacheDir(t)
 	tmpDir := utils.GetTemporaryDirectory(cacheDir, cliv2.GetFullVersion())
-	config := configuration.NewInMemory()
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	config.Set(configuration.CACHE_PATH, cacheDir)
 
 	assert.NoDirExists(t, tmpDir)
@@ -372,7 +372,7 @@ func Test_executeRunV2only(t *testing.T) {
 
 	cacheDir := getCacheDir(t)
 	tmpDir := utils.GetTemporaryDirectory(cacheDir, cliv2.GetFullVersion())
-	config := configuration.NewInMemory()
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	config.Set(configuration.CACHE_PATH, cacheDir)
 
 	assert.NoDirExists(t, tmpDir)
@@ -391,7 +391,7 @@ func Test_executeUnknownCommand(t *testing.T) {
 	expectedReturnCode := constants.SNYK_EXIT_CODE_ERROR
 
 	cacheDir := getCacheDir(t)
-	config := configuration.NewInMemory()
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	config.Set(configuration.CACHE_PATH, cacheDir)
 
 	// create instance under test
@@ -486,7 +486,7 @@ func Test_setTimeout(t *testing.T) {
 	runtime.GOOS == "windows" {
 		t.Skip("Skipping test on windows")
 	}
-	config := configuration.NewInMemory()
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	cli, err := cliv2.NewCLIv2(config, discardLogger, getRuntimeInfo(t))
 	assert.NoError(t, err)
 	config.Set(configuration.TIMEOUT, 1)

--- a/cliv2/internal/proxy/proxy_test.go
+++ b/cliv2/internal/proxy/proxy_test.go
@@ -72,7 +72,7 @@ func setup(t *testing.T, baseCache string, version string) configuration.Configu
 	t.Helper()
 	err := gafUtils.CreateAllDirectories(baseCache, version)
 	assert.Nil(t, err)
-	config := configuration.NewInMemory()
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	config.Set(configuration.CACHE_PATH, baseCache)
 	config.Set(basic_workflows.ConfigurationCleanupGlobalTempDirectory, true)
 	config.Set(basic_workflows.ConfigurationCleanupGlobalCertAuthority, true)

--- a/cliv2/pkg/basic_workflows/globalresources_test.go
+++ b/cliv2/pkg/basic_workflows/globalresources_test.go
@@ -35,7 +35,7 @@ func Test_ParallelGetGobalCertAuthority(t *testing.T) {
 		return output, err
 	}
 
-	config := configuration.NewInMemory()
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	engine := workflow.NewWorkFlowEngine(config)
 	testWorkflowId := workflow.NewWorkflowIdentifier("internal.test")
 
@@ -76,7 +76,7 @@ func Test_ParallelGetGobalCertAuthority(t *testing.T) {
 }
 
 func Test_RestoreCertAuthority(t *testing.T) {
-	config := configuration.NewInMemory()
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	// set as we don't call initCleanup()
 	config.Set(ConfigurationCleanupGlobalCertAuthority, true)
 	logger := zerolog.New(os.Stderr)

--- a/test/jest/acceptance/iac/capture.spec.ts
+++ b/test/jest/acceptance/iac/capture.spec.ts
@@ -32,7 +32,7 @@ describe('iac capture', () => {
       `snyk iac capture ./iac/drift/`,
       {
         ...process.env,
-        ORG: '0d9905be-7914-42c3-ada5-9c95d6fe7eb8',
+        SNYK_CFG_ORG: '0d9905be-7914-42c3-ada5-9c95d6fe7eb8',
         SNYK_API: apiUrl,
       },
     );
@@ -56,7 +56,7 @@ describe('iac capture', () => {
       `snyk iac capture ${statePath}`,
       {
         ...process.env,
-        ORG: orgId,
+        SNYK_CFG_ORG: orgId,
         SNYK_API: apiUrl,
       },
     );


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## Risk Assessment - Medium
The existing behaviour, although not correct, may be used by clients without knowing that it's unintentional. This would lead to breaking changes for them. The fix for them would be to use the intended env var for their purpose.

## What does this PR do?
This PR updates the CLI so that it no longer automatically detects supported env vars. The automatic detection led to bugs where ambiguous environment variables (e.g. `ORG`) would be picked up and used in the CLI.

By explicitly configuring the supported env vars, we can avoid these sorts of bugs (e.g. by requiring namespace prefixes in env vars we want to support).

## Where should the reviewer start?
Review the related GAF [PR](https://github.com/snyk/go-application-framework/pull/265)

## How should this be manually tested?

<!---
## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->