### PR TITLE
fix: do not treat warnings as errors on restore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "snyk-mvn-plugin": "3.6.0",
         "snyk-nodejs-lockfile-parser": "1.58.10",
         "snyk-nodejs-plugin": "1.3.4",
-        "snyk-nuget-plugin": "2.7.8",
+        "snyk-nuget-plugin": "2.7.10",
         "snyk-php-plugin": "1.10.0",
         "snyk-policy": "^4.0.0",
         "snyk-python-plugin": "2.2.1",
@@ -21089,9 +21089,9 @@
       }
     },
     "node_modules/snyk-nuget-plugin": {
-      "version": "2.7.8",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.7.8.tgz",
-      "integrity": "sha512-FufhAyRXKky50fMpLwQ9n6MLchv0S+q4lTyvNsSd+yJWnDHLjI/AMnN8hM6cXwsJtl8DwMDWvXu0rUGNES0Brg==",
+      "version": "2.7.10",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.7.10.tgz",
+      "integrity": "sha512-Uj/u5fa+2LSE7gWJiLEaiSqEUERlzzlLsmD+5F45C+N8Ub7CYanHzyWbvyJuMIokHI8iMREBlN3YkHcZn/1rag==",
       "dependencies": {
         "@snyk/cli-interface": "^2.14.0",
         "@snyk/dep-graph": "^2.8.1",
@@ -40365,9 +40365,9 @@
       }
     },
     "snyk-nuget-plugin": {
-      "version": "2.7.8",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.7.8.tgz",
-      "integrity": "sha512-FufhAyRXKky50fMpLwQ9n6MLchv0S+q4lTyvNsSd+yJWnDHLjI/AMnN8hM6cXwsJtl8DwMDWvXu0rUGNES0Brg==",
+      "version": "2.7.10",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.7.10.tgz",
+      "integrity": "sha512-Uj/u5fa+2LSE7gWJiLEaiSqEUERlzzlLsmD+5F45C+N8Ub7CYanHzyWbvyJuMIokHI8iMREBlN3YkHcZn/1rag==",
       "requires": {
         "@snyk/cli-interface": "^2.14.0",
         "@snyk/dep-graph": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "snyk-mvn-plugin": "3.6.0",
     "snyk-nodejs-lockfile-parser": "1.58.10",
     "snyk-nodejs-plugin": "1.3.4",
-    "snyk-nuget-plugin": "2.7.8",
+    "snyk-nuget-plugin": "2.7.10",
     "snyk-php-plugin": "1.10.0",
     "snyk-policy": "^4.0.0",
     "snyk-python-plugin": "2.2.1",


### PR DESCRIPTION
## Pull Request Submission Checklist
- [X] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [X] Includes detailed description of changes
- [X] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [X] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?

Updates snyk-nuget-plugin to fix a bug regarding restoring dotnet projects that have <TreatWarningsAsErrors> turned on, and also adds a property named `SnykTest` that will be present when we run `dotnet publish`. The scope for this property is to allow customers to enable/disable properties that might interfere and break out scanning.

## Where should the reviewer start?

Looking over this PRs:
https://github.com/snyk/snyk-nuget-plugin/pull/226
https://github.com/snyk/snyk-nuget-plugin/pull/225

## How should this be manually tested?

Using this fixtures:
Treat warnings as error [issue](https://github.com/snyk/snyk-nuget-plugin/tree/main/test/fixtures/dotnetcore/dotnet_8_treat_warnings_as_errors)
[SnykTest property](https://github.com/snyk/snyk-nuget-plugin/tree/main/test/fixtures/dotnetcore/dotnet_8_with_snyk_test_property)

<!---
## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->