### PR TITLE
fix(container): support --exclude-app-vulns with oauth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -960,14 +960,14 @@ jobs:
       - restore_cache:
           name: Restore npm cache
           keys:
-            - prepare-build-npm-deps-{{ checksum "package-lock.json" }}
-            - prepare-build-npm-deps
+            - prepare-v1-build-npm-deps-{{ checksum "package-lock.json" }}
+            - prepare-v1-build-npm-deps
       - run:
           name: Installing dependencies
           command: npm ci --no-audit --no-progress --cache .npm --prefer-offline
       - save_cache:
           name: Save npm cache
-          key: prepare-build-npm-deps-{{ checksum "package-lock.json" }}
+          key: prepare-v1-build-npm-deps-{{ checksum "package-lock.json" }}
           paths:
             - .npm
       - run:

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "semver": "^6.0.0",
         "snyk-config": "^5.0.0",
         "snyk-cpp-plugin": "2.24.0",
-        "snyk-docker-plugin": "6.13.2",
+        "snyk-docker-plugin": "6.13.11",
         "snyk-go-plugin": "1.23.0",
         "snyk-gradle-plugin": "4.6.0",
         "snyk-module": "3.1.0",
@@ -5978,11 +5978,11 @@
       "dev": true
     },
     "node_modules/adm-zip": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
-      "integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
       "engines": {
-        "node": ">=6.0"
+        "node": ">=12.0"
       }
     },
     "node_modules/agent-base": {
@@ -9954,17 +9954,17 @@
       }
     },
     "node_modules/event-loop-spinner": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/event-loop-spinner/-/event-loop-spinner-2.2.0.tgz",
-      "integrity": "sha512-KB44sV4Mv7uLIkJHJ5qhiZe5um6th2g57nHQL/uqnPHKP2IswoTRWUteEXTJQL4gW++1zqWUni+H2hGkP51c9w==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/event-loop-spinner/-/event-loop-spinner-2.3.2.tgz",
+      "integrity": "sha512-O078Lkxi/yZEPPifcizDOGUeK1OFOlPC6sfCCrx10odvqX3tEi9XLaIRt9cIl9TBFcPZzuMaXbJ0b+T6D2Tnjg==",
       "dependencies": {
-        "tslib": "^2.1.0"
+        "tslib": "^2.6.3"
       }
     },
     "node_modules/event-loop-spinner/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
@@ -20280,9 +20280,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "6.13.2",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.13.2.tgz",
-      "integrity": "sha512-phUxaUm50IOiruC61Eyqwy1dEJ0KjtF+Fqs3qp7RBT4jPHYqoDxKnyHMCmxwS2+XDFigbA0r9MR5FEKfdvdL8Q==",
+      "version": "6.13.11",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.13.11.tgz",
+      "integrity": "sha512-BB1CZsrrBHib83od4wdw48l491IBkLrw7XYtppZVGd/r9OgDJ9VguhBN8Q4uyoXsLPATPF2eRFCN481Jvs/FZQ==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.8.1",
@@ -20290,40 +20290,29 @@
         "@snyk/rpm-parser": "3.1.0",
         "@snyk/snyk-docker-pull": "3.13.0",
         "@swimlane/docker-reference": "^2.0.1",
-        "adm-zip": "^0.5.5",
+        "adm-zip": "^0.5.12",
         "chalk": "^2.4.2",
         "debug": "^4.1.1",
         "docker-modem": "3.0.8",
         "dockerfile-ast": "0.6.1",
         "elfy": "^1.0.0",
-        "event-loop-spinner": "^2.0.0",
+        "event-loop-spinner": "^2.3.2",
         "gunzip-maybe": "^1.4.2",
         "mkdirp": "^1.0.4",
         "packageurl-js": "1.2.0",
-        "semver": "^7.6.0",
+        "semver": "^7.6.2",
         "shescape": "^1.7.4",
         "snyk-nodejs-lockfile-parser": "^1.57.0",
         "snyk-poetry-lockfile-parser": "^1.4.0",
         "snyk-resolve-deps": "^4.7.1",
         "tar-stream": "^2.1.0",
-        "tmp": "^0.2.1",
+        "tmp": "^0.2.2",
         "tslib": "^1",
         "uuid": "^8.2.0",
         "varint": "^6.0.0"
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/snyk-docker-plugin/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/snyk-docker-plugin/node_modules/mkdirp": {
@@ -20337,27 +20326,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/snyk-docker-plugin/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/snyk-docker-plugin/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -20377,14 +20349,11 @@
       }
     },
     "node_modules/snyk-docker-plugin/node_modules/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
       "engines": {
-        "node": ">=8.17.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/snyk-docker-plugin/node_modules/which": {
@@ -20400,11 +20369,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/snyk-docker-plugin/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-go-parser": {
       "version": "1.13.0",
@@ -29023,9 +28987,9 @@
       "dev": true
     },
     "adm-zip": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
-      "integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg=="
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ=="
     },
     "agent-base": {
       "version": "4.3.0",
@@ -31985,17 +31949,17 @@
       "dev": true
     },
     "event-loop-spinner": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/event-loop-spinner/-/event-loop-spinner-2.2.0.tgz",
-      "integrity": "sha512-KB44sV4Mv7uLIkJHJ5qhiZe5um6th2g57nHQL/uqnPHKP2IswoTRWUteEXTJQL4gW++1zqWUni+H2hGkP51c9w==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/event-loop-spinner/-/event-loop-spinner-2.3.2.tgz",
+      "integrity": "sha512-O078Lkxi/yZEPPifcizDOGUeK1OFOlPC6sfCCrx10odvqX3tEi9XLaIRt9cIl9TBFcPZzuMaXbJ0b+T6D2Tnjg==",
       "requires": {
-        "tslib": "^2.1.0"
+        "tslib": "^2.6.3"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },
@@ -39726,9 +39690,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "6.13.2",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.13.2.tgz",
-      "integrity": "sha512-phUxaUm50IOiruC61Eyqwy1dEJ0KjtF+Fqs3qp7RBT4jPHYqoDxKnyHMCmxwS2+XDFigbA0r9MR5FEKfdvdL8Q==",
+      "version": "6.13.11",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.13.11.tgz",
+      "integrity": "sha512-BB1CZsrrBHib83od4wdw48l491IBkLrw7XYtppZVGd/r9OgDJ9VguhBN8Q4uyoXsLPATPF2eRFCN481Jvs/FZQ==",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.8.1",
@@ -39736,56 +39700,37 @@
         "@snyk/rpm-parser": "3.1.0",
         "@snyk/snyk-docker-pull": "3.13.0",
         "@swimlane/docker-reference": "^2.0.1",
-        "adm-zip": "^0.5.5",
+        "adm-zip": "^0.5.12",
         "chalk": "^2.4.2",
         "debug": "^4.1.1",
         "docker-modem": "3.0.8",
         "dockerfile-ast": "0.6.1",
         "elfy": "^1.0.0",
-        "event-loop-spinner": "^2.0.0",
+        "event-loop-spinner": "^2.3.2",
         "gunzip-maybe": "^1.4.2",
         "mkdirp": "^1.0.4",
         "packageurl-js": "1.2.0",
-        "semver": "^7.6.0",
+        "semver": "^7.6.2",
         "shescape": "^1.7.4",
         "snyk-nodejs-lockfile-parser": "^1.57.0",
         "snyk-poetry-lockfile-parser": "^1.4.0",
         "snyk-resolve-deps": "^4.7.1",
         "tar-stream": "^2.1.0",
-        "tmp": "^0.2.1",
+        "tmp": "^0.2.2",
         "tslib": "^1",
         "uuid": "^8.2.0",
         "varint": "^6.0.0"
       },
       "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
         "semver": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
         },
         "shescape": {
           "version": "1.7.4",
@@ -39796,12 +39741,9 @@
           }
         },
         "tmp": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-          "requires": {
-            "rimraf": "^3.0.0"
-          }
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+          "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w=="
         },
         "which": {
           "version": "2.0.2",
@@ -39810,11 +39752,6 @@
           "requires": {
             "isexe": "^2.0.0"
           }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "semver": "^6.0.0",
     "snyk-config": "^5.0.0",
     "snyk-cpp-plugin": "2.24.0",
-    "snyk-docker-plugin": "6.13.2",
+    "snyk-docker-plugin": "6.13.11",
     "snyk-go-plugin": "1.23.0",
     "snyk-gradle-plugin": "4.6.0",
     "snyk-module": "3.1.0",

--- a/test/jest/acceptance/snyk-test/app-vuln-container-project.spec.ts
+++ b/test/jest/acceptance/snyk-test/app-vuln-container-project.spec.ts
@@ -163,7 +163,7 @@ describe('container test projects behavior with --json flag', () => {
 
     const jsonOutput = JSON.parse(stdout);
     expect(Array.isArray(jsonOutput)).toBeTruthy();
-    expect(jsonOutput).toHaveLength(3);
+    expect(jsonOutput).toHaveLength(2);
     expect(code).toEqual(0);
   });
 });


### PR DESCRIPTION
## Pull Request Submission Checklist
- [X] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [X] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?

Upgrades snyk-docker-plugin to pull in this fix: https://github.com/snyk/snyk-docker-plugin/pull/610, which ensures `--exclude-app-vulns` works correctly if you are authed with OAuth.

## How should this be manually tested?

Build locally and run the following command:

```
~/snyk/cli/binary-releases/snyk-macos container monitor --exclude-app-vulns mathiasconradt/goof
```

If it completes successfully then the fix is working as expected. 

Ref: CLI-543

Additionally this upgrade to `snyk-docker-plugin` addresses the following:

* [UNIFY-243](https://snyksec.atlassian.net/browse/UNIFY-243) - fix: dependencies detection from container removed layers
* [UNIFY-264](https://github.com/snyk/snyk-docker-plugin/pull/604) - fix: ignore npm/yarn cache directories

[UNIFY-243]: https://snyksec.atlassian.net/browse/UNIFY-243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ