### PR TITLE
fix: mismatch/off-by-one on unmanagedDependencyCount in snyk analytics UNIFY-340

### DIFF
--- a/src/lib/ecosystems/resolve-test-facts.ts
+++ b/src/lib/ecosystems/resolve-test-facts.ts
@@ -237,7 +237,7 @@ export async function resolveAndTestFactsUnmanagedDeps(
           },
           {
             name: 'unmanagedDependencyCount',
-            data: depGraphData?.pkgs.length ?? 0,
+            data: dependencyCount ?? 0,
           },
           {
             name: 'unmanagedIssuesCount',


### PR DESCRIPTION

## Pull Request Submission Checklist
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?
Fixes the reported unmanaged dependencies count in snyk analytics.
Before the change:
<img width="483" alt="Screenshot 2024-11-01 at 16 44 30" src="https://github.com/user-attachments/assets/a6452afd-cca5-4648-9772-556433e2d8be">
With the fix, the debug logs report the correct detected number of dependencies as can be seen below:
<img width="463" alt="Screenshot 2024-11-01 at 16 43 44" src="https://github.com/user-attachments/assets/ef8c664f-ebdf-47c7-86b5-082da966009d">

[](url)
## Where should the reviewer start?

## How should this be manually tested?

<!---
## Any background context you want to provide?

## What are the relevant tickets?
https://snyksec.atlassian.net/browse/UNIFY-340
## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->