### PR TITLE
fix(general): prevent snyk-policy lib from interrupting stdout to ensure valid --json --sarif output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "snyk-nodejs-plugin": "1.3.4",
         "snyk-nuget-plugin": "2.7.10",
         "snyk-php-plugin": "1.10.0",
-        "snyk-policy": "^4.0.0",
+        "snyk-policy": "4.1.2",
         "snyk-python-plugin": "2.2.1",
         "snyk-resolve-deps": "4.8.0",
         "snyk-sbt-plugin": "2.18.1",
@@ -21183,9 +21183,9 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/snyk-policy": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-4.0.0.tgz",
-      "integrity": "sha512-xkXsDhnZS2zcB/BAKVZKR09ZTkJ4M/5eVyuVrV7+BFMy7bSv2EZPDulGGsrkUhXbQwkm7eW+FtccZABRRdct2w==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-4.1.2.tgz",
+      "integrity": "sha512-xqsppScAhKR0+6dpMGLS/IOZD8kLOYvQp+v5kYBp878KH02kMMRLm/t0EyFTVQYBtsJBFiQrmVZreTMqWNknSA==",
       "dependencies": {
         "debug": "^4.1.1",
         "email-validator": "^2.0.4",
@@ -40411,9 +40411,9 @@
       }
     },
     "snyk-policy": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-4.0.0.tgz",
-      "integrity": "sha512-xkXsDhnZS2zcB/BAKVZKR09ZTkJ4M/5eVyuVrV7+BFMy7bSv2EZPDulGGsrkUhXbQwkm7eW+FtccZABRRdct2w==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-4.1.2.tgz",
+      "integrity": "sha512-xqsppScAhKR0+6dpMGLS/IOZD8kLOYvQp+v5kYBp878KH02kMMRLm/t0EyFTVQYBtsJBFiQrmVZreTMqWNknSA==",
       "requires": {
         "debug": "^4.1.1",
         "email-validator": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "snyk-nodejs-plugin": "1.3.4",
     "snyk-nuget-plugin": "2.7.10",
     "snyk-php-plugin": "1.10.0",
-    "snyk-policy": "^4.0.0",
+    "snyk-policy": "4.1.2",
     "snyk-python-plugin": "2.2.1",
     "snyk-resolve-deps": "4.8.0",
     "snyk-sbt-plugin": "2.18.1",


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?

Updates `snyk-policy` library to remove logging messages from being emitted on stdout. This was breaking Snyk CLI commands where stdout is used to build JSON documents. 

