### PR TITLE
chore: remove deprecated linters and config props

### DIFF
--- a/cliv2/.golangci.yaml
+++ b/cliv2/.golangci.yaml
@@ -3,9 +3,6 @@ run:
     - integration
   concurrency: 4
   issues-exit-code: 1
-  skip-dirs:
-    - scripts
-    - test/fixtures
   tests: true
   timeout: 5m
 
@@ -34,7 +31,6 @@ linters-settings:
   gosimple:
     checks: ['all']
   govet:
-    check-shadowing: true
     enable-all: true
     disable:
       - fieldalignment
@@ -106,7 +102,8 @@ linters:
     # TODO(errorlint): revisit
     #- errorlint
     - exhaustive
-    - exportloopref
+    # Checks for pointers to enclosing loop variables.
+    - copyloopvar
     # TODO(forbidigo): revisit
     #- forbidigo
     # TODO(forcetypeassert): revisit
@@ -167,6 +164,9 @@ linters:
     #- wrapcheck
 
 issues:
+  exclude-dirs:
+    - scripts
+    - test/fixtures
   exclude-rules:
     - path: _test\.go
       linters:


### PR DESCRIPTION
## Pull Request Submission Checklist
- [X] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [X] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?

Before:
```
WARN [config_reader] The configuration option `run.skip-dirs` is deprecated, please use `issues.exclude-dirs`.
WARN [config_reader] The configuration option `linters.govet.check-shadowing` is deprecated. Please enable `shadow` instead, if you are not using `enable-all`.
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
```


After:
🕊️ 