### PR TITLE
test: capture valid json output with policy

### DIFF
--- a/test/acceptance/workspaces/npm-package-single-ignored-vuln/.snyk
+++ b/test/acceptance/workspaces/npm-package-single-ignored-vuln/.snyk
@@ -1,0 +1,8 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.14.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'SNYK-JS-CXCT-535487':
+    - '*':
+        reason: None given
+        expires: '2100-03-01T19:48:49.699Z'

--- a/test/acceptance/workspaces/npm-package-single-ignored-vuln/package-lock.json
+++ b/test/acceptance/workspaces/npm-package-single-ignored-vuln/package-lock.json
@@ -1,0 +1,14 @@
+{
+    "name": "no-fix-app",
+    "version": "1.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+      "cxct": {
+        "version": "0.0.1-security",
+        "resolved": "https://registry.npmjs.org/cxct/-/cxct-0.0.1-security.tgz",
+        "integrity": "sha512-/ET+kx45P3MjvA/RUCFSW9aQOotUCnEzGfDbcC0HHtUGyVnv7yC/djSTL6ZZvY+NUIe3vpHRsNAYq76N+rsXKg=="
+      }
+    }
+  }
+  

--- a/test/acceptance/workspaces/npm-package-single-ignored-vuln/package.json
+++ b/test/acceptance/workspaces/npm-package-single-ignored-vuln/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "npm-package-single-ignored-vuln",
+  "version": "1.0.0",
+  "description": "application with annotated vulns",
+  "dependencies": {
+    "cxct": "0.0.1-security"
+  },
+  "devDependencies": {}
+}

--- a/test/acceptance/workspaces/npm-package-single-ignored-vuln/test-graph-results.json
+++ b/test/acceptance/workspaces/npm-package-single-ignored-vuln/test-graph-results.json
@@ -1,0 +1,104 @@
+{
+  "result": {
+    "affectedPkgs": {
+      "cxct@0.0.1-security": {
+        "pkg": { "name": "cxct", "version": "0.0.1-security" },
+        "issues": {
+          "SNYK-JS-CXCT-535487": {
+            "issueId": "SNYK-JS-CXCT-535487",
+            "fixInfo": { "isPatchable": false, "upgradePaths": [] }
+          }
+        }
+      }
+    },
+    "issuesData": {
+      "SNYK-JS-CXCT-535487": {
+        "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2019-11-24T13:10:43.888332Z",
+        "credit": ["npm 󠅮󠅰󠅭security"],
+        "cvssScore": 9.8,
+        "description": "## Overview\n\n[cxct](https://www.npmjs.com/package/cxct) is a malicious package.\n\n\nThe package finds and exfiltrates cryptocurrency wallets.\n\n## Remediation\n\nAvoid using `cxct` altogether.\n\n\n## References\n\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1344)\n",
+        "disclosureTime": "2019-11-22T00:24:41Z",
+        "exploit": "Not Defined",
+        "fixedIn": [],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-CXCT-535487",
+        "identifiers": { "CVE": [], "CWE": ["CWE-506"], "NSP": [1344] },
+        "language": "js",
+        "modificationTime": "2019-11-24T16:16:16.630345Z",
+        "moduleName": "cxct",
+        "packageManager": "npm",
+        "packageName": "cxct",
+        "patches": [],
+        "publicationTime": "2019-11-24T13:11:04Z",
+        "references": [
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1344"
+          }
+        ],
+        "semver": { "vulnerable": ["*"] },
+        "severity": "high",
+        "title": "Malicious 󠅮󠅰󠅭Package",
+        "isPinnable": false
+      }
+    },
+    "remediation": {
+      "unresolved": [
+        {
+          "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "alternativeIds": [],
+          "creationTime": "2019-11-24T13:10:43.888332Z",
+          "credit": ["npm 󠅮󠅰󠅭security"],
+          "cvssScore": 9.8,
+          "description": "## Overview\n\n[cxct](https://www.npmjs.com/package/cxct) is a malicious package.\n\n\nThe package finds and exfiltrates cryptocurrency wallets.\n\n## Remediation\n\nAvoid using `cxct` altogether.\n\n\n## References\n\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1344)\n",
+          "disclosureTime": "2019-11-22T00:24:41Z",
+          "exploit": "Not Defined",
+          "fixedIn": [],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-CXCT-535487",
+          "identifiers": { "CVE": [], "CWE": ["CWE-506"], "NSP": [1344] },
+          "language": "js",
+          "modificationTime": "2019-11-24T16:16:16.630345Z",
+          "moduleName": "cxct",
+          "packageManager": "npm",
+          "packageName": "cxct",
+          "patches": [],
+          "publicationTime": "2019-11-24T13:11:04Z",
+          "references": [
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1344"
+            }
+          ],
+          "semver": { "vulnerable": ["*"] },
+          "severity": "high",
+          "title": "Malicious 󠅮󠅰󠅭Package",
+          "isPinnable": false,
+          "from": ["no-fix-app@1.0.0", "cxct@0.0.1-security"],
+          "upgradePath": [],
+          "isUpgradable": false,
+          "isPatchable": false,
+          "name": "cxct",
+          "version": "0.0.1-security"
+        }
+      ],
+      "upgrade": {},
+      "patch": {},
+      "ignore": {},
+      "pin": {}
+    }
+  },
+  "meta": {
+    "isPrivate": true,
+    "isLicensesEnabled": false,
+    "licensesPolicy": { "severities": {}, "orgLicenseRules": {} },
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\n# ignores vulnerabilities until expiry date; change duration by modifying expiry date\nignore:\n  SNYK-JS-CXCT-535487:\n    - '*':\n        reason: None Given\n        expires: 2100-12-13T14:20:21.158Z\n        created: 2017-11-13T14:20:21.163Z\n        source: cli\npatch: {}\n",
+    "ignoreSettings": null,
+    "org": "gitphill"
+  },
+  "filesystemPolicy": false
+}

--- a/test/jest/acceptance/cli-json-output.spec.ts
+++ b/test/jest/acceptance/cli-json-output.spec.ts
@@ -164,5 +164,33 @@ describe('test --json', () => {
       expect(code).toEqual(1);
       expect(server.getRequests().length).toBeGreaterThanOrEqual(1);
     });
+
+    it('returns well structured json', async () => {
+      const project = await createProjectFromWorkspace(
+        'npm-package-single-ignored-vuln',
+      );
+      server.setCustomResponse(
+        await project.readJSON('test-graph-results.json'),
+      );
+
+      const { code, stdout } = await runSnykCLI(
+        `test -d --json --log-level=trace`,
+        {
+          cwd: project.path(),
+          env,
+        },
+      );
+
+      try {
+        const returnedJson = JSON.parse(stdout);
+
+        expect(returnedJson.vulnerabilities).toHaveLength(0);
+        expect(code).toEqual(0);
+        expect(server.getRequests().length).toBeGreaterThanOrEqual(1);
+      } catch (err) {
+        console.log(stdout);
+        throw err;
+      }
+    });
   });
 });


### PR DESCRIPTION
## Pull Request Submission Checklist
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?

Stepping back through the versions of snyk-policy the bug seems to have been introduced by adopting the vite bundler in version 3.0
[Release v3.0.0 · snyk/policy](https://github.com/snyk/policy/releases/tag/v3.0.0) 

With v2.0.8, the CLI works as expected outputting valid JSON. 

I have added an acceptance test for this behaviour with the CLI. 
Note that the first line of stdout includes: `snyk:module cxct@0.0.1-security => { name: "cxct", version: "0.0.1-security" } +0ms`

You can get the test to pass by installing an older version of the CLI and injecting that to your tests:
```
export TEST_SNYK_COMMAND=/path/to/snyk
npx jest cli-json-output.spec.ts
```
