### PR TITLE
fix: container optional python dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "semver": "^6.0.0",
         "snyk-config": "^5.0.0",
         "snyk-cpp-plugin": "2.24.0",
-        "snyk-docker-plugin": "6.13.11",
+        "snyk-docker-plugin": "6.13.15",
         "snyk-go-plugin": "1.23.0",
         "snyk-gradle-plugin": "4.6.0",
         "snyk-module": "3.1.0",
@@ -20280,9 +20280,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "6.13.11",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.13.11.tgz",
-      "integrity": "sha512-BB1CZsrrBHib83od4wdw48l491IBkLrw7XYtppZVGd/r9OgDJ9VguhBN8Q4uyoXsLPATPF2eRFCN481Jvs/FZQ==",
+      "version": "6.13.15",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.13.15.tgz",
+      "integrity": "sha512-r8Vh8EXyhF8YuU0Xda2Y9/H54PaH3P3etwLMmHsL+OA2FW2gld+K9GV2Kch4GaVDzKuZ2d+NgmW9rYlN8EkZGA==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.8.1",
@@ -39690,9 +39690,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "6.13.11",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.13.11.tgz",
-      "integrity": "sha512-BB1CZsrrBHib83od4wdw48l491IBkLrw7XYtppZVGd/r9OgDJ9VguhBN8Q4uyoXsLPATPF2eRFCN481Jvs/FZQ==",
+      "version": "6.13.15",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.13.15.tgz",
+      "integrity": "sha512-r8Vh8EXyhF8YuU0Xda2Y9/H54PaH3P3etwLMmHsL+OA2FW2gld+K9GV2Kch4GaVDzKuZ2d+NgmW9rYlN8EkZGA==",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "semver": "^6.0.0",
     "snyk-config": "^5.0.0",
     "snyk-cpp-plugin": "2.24.0",
-    "snyk-docker-plugin": "6.13.11",
+    "snyk-docker-plugin": "6.13.15",
     "snyk-go-plugin": "1.23.0",
     "snyk-gradle-plugin": "4.6.0",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
## Pull Request Submission Checklist
- [X] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [X] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [X] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?
See https://github.com/snyk/snyk-docker-plugin/pull/614

Fixing a bug in snyk-docker-plugin so that optional dependencies are properly connected in the dep-graph.

This could mean that 'snyk container monitor' commands that previously timed out or errored may now start working. The fix reduces unnecessary (optional) paths in the dep-graph and so reduce the work Snyk needs to do when scanning for vulnerabilities.

## How should this be manually tested?
`snyk container monitor` on a docker image using requirements.txt to install python dependencies.

<!---
## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->