### PR TITLE
fix: policy library logging messages to stdout instead of stderr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "snyk-nodejs-plugin": "1.3.4",
         "snyk-nuget-plugin": "2.7.12",
         "snyk-php-plugin": "1.10.0",
-        "snyk-policy": "4.1.2",
+        "snyk-policy": "4.1.4",
         "snyk-python-plugin": "2.2.1",
         "snyk-resolve-deps": "4.8.0",
         "snyk-sbt-plugin": "2.18.1",
@@ -21183,18 +21183,31 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/snyk-policy": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-4.1.2.tgz",
-      "integrity": "sha512-xqsppScAhKR0+6dpMGLS/IOZD8kLOYvQp+v5kYBp878KH02kMMRLm/t0EyFTVQYBtsJBFiQrmVZreTMqWNknSA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-4.1.4.tgz",
+      "integrity": "sha512-82CQR/wlugiBnGekS3gVm1u/E2GEwL8+bmM91gZadV2C3w7qXloXjOugjaVg8SHYDFJLFnSEq4uttJw5SnFLZw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.1.1",
         "email-validator": "^2.0.4",
         "js-yaml": "^3.13.1",
         "lodash.clonedeep": "^4.5.0",
         "semver": "^7.3.4",
-        "snyk-module": "^3.0.0",
+        "snyk-module": "^3.3.0",
         "snyk-resolve": "^1.1.0",
         "snyk-try-require": "^2.0.2"
+      }
+    },
+    "node_modules/snyk-policy/node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/snyk-policy/node_modules/lru-cache": {
@@ -21220,6 +21233,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/snyk-policy/node_modules/snyk-module": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/snyk-module/-/snyk-module-3.3.0.tgz",
+      "integrity": "sha512-XNTCmLXMmupUMYUYcRlo5h28bVbb0CHsqAS6ttiiGHaDRBqDXIbkCSoSk9/bGqezImZhmZk/l5ErXtyoFqxHDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "hosted-git-info": "^4.0.2"
       }
     },
     "node_modules/snyk-policy/node_modules/yallist": {
@@ -40411,20 +40434,28 @@
       }
     },
     "snyk-policy": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-4.1.2.tgz",
-      "integrity": "sha512-xqsppScAhKR0+6dpMGLS/IOZD8kLOYvQp+v5kYBp878KH02kMMRLm/t0EyFTVQYBtsJBFiQrmVZreTMqWNknSA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-4.1.4.tgz",
+      "integrity": "sha512-82CQR/wlugiBnGekS3gVm1u/E2GEwL8+bmM91gZadV2C3w7qXloXjOugjaVg8SHYDFJLFnSEq4uttJw5SnFLZw==",
       "requires": {
         "debug": "^4.1.1",
         "email-validator": "^2.0.4",
         "js-yaml": "^3.13.1",
         "lodash.clonedeep": "^4.5.0",
         "semver": "^7.3.4",
-        "snyk-module": "^3.0.0",
+        "snyk-module": "^3.3.0",
         "snyk-resolve": "^1.1.0",
         "snyk-try-require": "^2.0.2"
       },
       "dependencies": {
+        "hosted-git-info": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+          "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
         "lru-cache": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -40439,6 +40470,15 @@
           "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
+          }
+        },
+        "snyk-module": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/snyk-module/-/snyk-module-3.3.0.tgz",
+          "integrity": "sha512-XNTCmLXMmupUMYUYcRlo5h28bVbb0CHsqAS6ttiiGHaDRBqDXIbkCSoSk9/bGqezImZhmZk/l5ErXtyoFqxHDQ==",
+          "requires": {
+            "debug": "^4.1.1",
+            "hosted-git-info": "^4.0.2"
           }
         },
         "yallist": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "snyk-nodejs-plugin": "1.3.4",
     "snyk-nuget-plugin": "2.7.12",
     "snyk-php-plugin": "1.10.0",
-    "snyk-policy": "4.1.2",
+    "snyk-policy": "4.1.4",
     "snyk-python-plugin": "2.2.1",
     "snyk-resolve-deps": "4.8.0",
     "snyk-sbt-plugin": "2.18.1",

--- a/test/acceptance/workspaces/npm-package-single-ignored-vuln/.snyk
+++ b/test/acceptance/workspaces/npm-package-single-ignored-vuln/.snyk
@@ -1,0 +1,8 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.14.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'SNYK-JS-CXCT-535487':
+    - '*':
+        reason: None given
+        expires: '2100-03-01T19:48:49.699Z'

--- a/test/acceptance/workspaces/npm-package-single-ignored-vuln/package-lock.json
+++ b/test/acceptance/workspaces/npm-package-single-ignored-vuln/package-lock.json
@@ -1,0 +1,14 @@
+{
+    "name": "no-fix-app",
+    "version": "1.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+      "cxct": {
+        "version": "0.0.1-security",
+        "resolved": "https://registry.npmjs.org/cxct/-/cxct-0.0.1-security.tgz",
+        "integrity": "sha512-/ET+kx45P3MjvA/RUCFSW9aQOotUCnEzGfDbcC0HHtUGyVnv7yC/djSTL6ZZvY+NUIe3vpHRsNAYq76N+rsXKg=="
+      }
+    }
+  }
+  

--- a/test/acceptance/workspaces/npm-package-single-ignored-vuln/package.json
+++ b/test/acceptance/workspaces/npm-package-single-ignored-vuln/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "npm-package-single-ignored-vuln",
+  "version": "1.0.0",
+  "description": "application with annotated vulns",
+  "dependencies": {
+    "cxct": "0.0.1-security"
+  },
+  "devDependencies": {}
+}

--- a/test/acceptance/workspaces/npm-package-single-ignored-vuln/test-graph-results.json
+++ b/test/acceptance/workspaces/npm-package-single-ignored-vuln/test-graph-results.json
@@ -1,0 +1,104 @@
+{
+  "result": {
+    "affectedPkgs": {
+      "cxct@0.0.1-security": {
+        "pkg": { "name": "cxct", "version": "0.0.1-security" },
+        "issues": {
+          "SNYK-JS-CXCT-535487": {
+            "issueId": "SNYK-JS-CXCT-535487",
+            "fixInfo": { "isPatchable": false, "upgradePaths": [] }
+          }
+        }
+      }
+    },
+    "issuesData": {
+      "SNYK-JS-CXCT-535487": {
+        "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2019-11-24T13:10:43.888332Z",
+        "credit": ["npm 󠅮󠅰󠅭security"],
+        "cvssScore": 9.8,
+        "description": "## Overview\n\n[cxct](https://www.npmjs.com/package/cxct) is a malicious package.\n\n\nThe package finds and exfiltrates cryptocurrency wallets.\n\n## Remediation\n\nAvoid using `cxct` altogether.\n\n\n## References\n\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1344)\n",
+        "disclosureTime": "2019-11-22T00:24:41Z",
+        "exploit": "Not Defined",
+        "fixedIn": [],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-CXCT-535487",
+        "identifiers": { "CVE": [], "CWE": ["CWE-506"], "NSP": [1344] },
+        "language": "js",
+        "modificationTime": "2019-11-24T16:16:16.630345Z",
+        "moduleName": "cxct",
+        "packageManager": "npm",
+        "packageName": "cxct",
+        "patches": [],
+        "publicationTime": "2019-11-24T13:11:04Z",
+        "references": [
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1344"
+          }
+        ],
+        "semver": { "vulnerable": ["*"] },
+        "severity": "high",
+        "title": "Malicious 󠅮󠅰󠅭Package",
+        "isPinnable": false
+      }
+    },
+    "remediation": {
+      "unresolved": [
+        {
+          "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "alternativeIds": [],
+          "creationTime": "2019-11-24T13:10:43.888332Z",
+          "credit": ["npm 󠅮󠅰󠅭security"],
+          "cvssScore": 9.8,
+          "description": "## Overview\n\n[cxct](https://www.npmjs.com/package/cxct) is a malicious package.\n\n\nThe package finds and exfiltrates cryptocurrency wallets.\n\n## Remediation\n\nAvoid using `cxct` altogether.\n\n\n## References\n\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1344)\n",
+          "disclosureTime": "2019-11-22T00:24:41Z",
+          "exploit": "Not Defined",
+          "fixedIn": [],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-CXCT-535487",
+          "identifiers": { "CVE": [], "CWE": ["CWE-506"], "NSP": [1344] },
+          "language": "js",
+          "modificationTime": "2019-11-24T16:16:16.630345Z",
+          "moduleName": "cxct",
+          "packageManager": "npm",
+          "packageName": "cxct",
+          "patches": [],
+          "publicationTime": "2019-11-24T13:11:04Z",
+          "references": [
+            {
+              "title": "NPM Security Advisory",
+              "url": "https://www.npmjs.com/advisories/1344"
+            }
+          ],
+          "semver": { "vulnerable": ["*"] },
+          "severity": "high",
+          "title": "Malicious 󠅮󠅰󠅭Package",
+          "isPinnable": false,
+          "from": ["no-fix-app@1.0.0", "cxct@0.0.1-security"],
+          "upgradePath": [],
+          "isUpgradable": false,
+          "isPatchable": false,
+          "name": "cxct",
+          "version": "0.0.1-security"
+        }
+      ],
+      "upgrade": {},
+      "patch": {},
+      "ignore": {},
+      "pin": {}
+    }
+  },
+  "meta": {
+    "isPrivate": true,
+    "isLicensesEnabled": false,
+    "licensesPolicy": { "severities": {}, "orgLicenseRules": {} },
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.25.1\n# ignores vulnerabilities until expiry date; change duration by modifying expiry date\nignore:\n  SNYK-JS-CXCT-535487:\n    - '*':\n        reason: None Given\n        expires: 2100-12-13T14:20:21.158Z\n        created: 2017-11-13T14:20:21.163Z\n        source: cli\npatch: {}\n",
+    "ignoreSettings": null,
+    "org": "gitphill"
+  },
+  "filesystemPolicy": false
+}

--- a/test/jest/acceptance/cli-json-output.spec.ts
+++ b/test/jest/acceptance/cli-json-output.spec.ts
@@ -164,5 +164,33 @@ describe('test --json', () => {
       expect(code).toEqual(1);
       expect(server.getRequests().length).toBeGreaterThanOrEqual(1);
     });
+
+    it('returns well structured json', async () => {
+      const project = await createProjectFromWorkspace(
+        'npm-package-single-ignored-vuln',
+      );
+      server.setCustomResponse(
+        await project.readJSON('test-graph-results.json'),
+      );
+
+      const { code, stdout } = await runSnykCLI(
+        `test -d --json --log-level=trace`,
+        {
+          cwd: project.path(),
+          env,
+        },
+      );
+
+      try {
+        const returnedJson = JSON.parse(stdout);
+
+        expect(returnedJson.vulnerabilities).toHaveLength(0);
+        expect(code).toEqual(0);
+        expect(server.getRequests().length).toBeGreaterThanOrEqual(1);
+      } catch (err) {
+        console.log(stdout);
+        throw err;
+      }
+    });
   });
 });


### PR DESCRIPTION
## Pull Request Submission Checklist
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?

This pull request updates the `policy` library to `4.1.4` to fix an issue introduced in [snyk-policy version 3.0](https://github.com/snyk/policy/releases/tag/v3.0.0). In that version the [debug library ](https://github.com/debug-js/debug) began logging messages to `stdout` instead of `stderr`, causing JSON parsing to break.

The branch was created based on the [test/capture-valid-esoj-output-with-policy branch](https://github.com/snyk/cli/tree/test/capture-valid-esoj-output-with-policy), which includes an acceptance test to check if the CLI returns a well-structured json.

## What are the relevant tickets?
- [IGNR-730](https://snyksec.atlassian.net/browse/IGNR-730)
- [IGNR-786](https://snyksec.atlassian.net/browse/IGNR-786)

[IGNR-730]: https://snyksec.atlassian.net/browse/IGNR-730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ