### PR TITLE
chore(ci): remove EOL ubuntu from e2e test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,11 +65,6 @@ executors:
       - image: snyklabs/cli-build-arm64:20240814-161347
     working_directory: /mnt/ramdisk/snyk
     resource_class: arm.xlarge
-  linux-ubuntu-mantic-amd64:
-    docker:
-      - image: ubuntu:mantic
-    working_directory: /mnt/ramdisk/snyk
-    resource_class: medium
   linux-ubuntu-jammy-amd64:
     docker:
       - image: ubuntu:jammy
@@ -88,11 +83,6 @@ executors:
   linux-ubuntu-latest-arm64:
     docker:
       - image: ubuntu:latest
-    working_directory: /mnt/ramdisk/snyk
-    resource_class: arm.medium
-  linux-ubuntu-mantic-arm64:
-    docker:
-      - image: ubuntu:mantic
     working_directory: /mnt/ramdisk/snyk
     resource_class: arm.medium
   linux-ubuntu-jammy-arm64:
@@ -802,11 +792,9 @@ workflows:
                 - 'win-server2022-amd64'
                 - 'macos-arm64'
                 - 'linux-ubuntu-latest-amd64'
-                - 'linux-ubuntu-mantic-amd64'
                 - 'linux-ubuntu-jammy-amd64'
                 - 'linux-ubuntu-focal-amd64'
                 - 'linux-ubuntu-latest-arm64'
-                - 'linux-ubuntu-mantic-arm64'
                 - 'linux-ubuntu-jammy-arm64'
                 - 'linux-ubuntu-focal-arm64'
                 - 'alpine'
@@ -863,11 +851,9 @@ workflows:
             - e2e tests (win-server2022-amd64)
             - e2e tests (macos-arm64)
             - e2e tests (linux-ubuntu-latest-amd64)
-            - e2e tests (linux-ubuntu-mantic-amd64)
             - e2e tests (linux-ubuntu-jammy-amd64)
             - e2e tests (linux-ubuntu-focal-amd64)
             - e2e tests (linux-ubuntu-latest-arm64)
-            - e2e tests (linux-ubuntu-mantic-arm64)
             - e2e tests (linux-ubuntu-jammy-arm64)
             - e2e tests (linux-ubuntu-focal-arm64)
             - e2e tests (alpine)


### PR DESCRIPTION
## Pull Request Submission Checklist
- [X] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?

Removes EOL ubuntu image from e2e test matrix. The Releases for these are currently unavailable due to an ongoing maintenance incident: https://status.canonical.com/#/incident/KNms6QK9ewuzz-7xUsPsNylV20jEt5kyKsd8A-3ptQHSMVTAPVH4_LjQCYu8J9Cus3zqZwIrEn6enyZkKH6Mvg==

We should remove testing for these as they are no longer supported by ubuntu:
https://fridge.ubuntu.com/2024/07/17/ubuntu-23-10-mantic-minotaur-reached-end-of-life-on-july-11-2024/