### PR TITLE
feat: support verbose gradle graphs for sbom generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "snyk-cpp-plugin": "2.24.0",
         "snyk-docker-plugin": "6.13.15",
         "snyk-go-plugin": "1.23.0",
-        "snyk-gradle-plugin": "4.6.0",
+        "snyk-gradle-plugin": "4.7.0",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "3.6.0",
         "snyk-nodejs-lockfile-parser": "1.58.10",
@@ -20500,9 +20500,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-gradle-plugin": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-4.6.0.tgz",
-      "integrity": "sha512-Gt0m0jcpR16MxH3048BvYJnMKmJPoc6pJqvxI+WE8856yaE8EKOxrDGMhsSjAmJrJe1kzBXYysKog1xsWQ4E4g==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-4.7.0.tgz",
+      "integrity": "sha512-BtjhM6UhH4+TjOgXPdU0mPTTCLHjCysMqH0u/EYi+XMErzl7RK7kgwgFuH6nwokItK5JvX/+HpCu/Jy41IDxIQ==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",
@@ -39882,9 +39882,9 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-4.6.0.tgz",
-      "integrity": "sha512-Gt0m0jcpR16MxH3048BvYJnMKmJPoc6pJqvxI+WE8856yaE8EKOxrDGMhsSjAmJrJe1kzBXYysKog1xsWQ4E4g==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-4.7.0.tgz",
+      "integrity": "sha512-BtjhM6UhH4+TjOgXPdU0mPTTCLHjCysMqH0u/EYi+XMErzl7RK7kgwgFuH6nwokItK5JvX/+HpCu/Jy41IDxIQ==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "snyk-cpp-plugin": "2.24.0",
     "snyk-docker-plugin": "6.13.15",
     "snyk-go-plugin": "1.23.0",
-    "snyk-gradle-plugin": "4.6.0",
+    "snyk-gradle-plugin": "4.7.0",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "3.6.0",
     "snyk-nodejs-lockfile-parser": "1.58.10",

--- a/test/fixtures/gradle-with-repeated-deps/build.gradle
+++ b/test/fixtures/gradle-with-repeated-deps/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+  id 'java'
+}
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+   implementation 'org.apache.ignite:ignite-spring:2.13.0'
+   implementation 'org.apache.ignite:ignite-indexing:2.13.0'
+   implementation 'org.apache.ignite:ignite-core:2.13.0'
+}

--- a/test/fixtures/gradle-with-repeated-deps/lib/build.gradle
+++ b/test/fixtures/gradle-with-repeated-deps/lib/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id 'java-library'
+}
+
+group = 'com.example'
+version = '1.0'
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+   implementation 'org.apache.ignite:ignite-spring:2.13.0'
+   implementation 'org.apache.ignite:ignite-indexing:2.13.0'
+   implementation 'org.apache.ignite:ignite-core:2.13.0'
+}


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?
Upgrades gradle-plugin to implement a similar resolution of depgraphs as recently done for maven.
See https://github.com/snyk/snyk-gradle-plugin/pull/290.

## Where should the reviewer start?

## How should this be manually tested?
* run `snyk sbom --format=cyclonedx1.4+json` on the newly added gradle project in the cli (`cli/test/fixtures/gradle-with-repeated-deps`)
Current version of CLI will output pruned deps, while the new version will not prune any nodes.

<!---
## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->