### PR TITLE
chore: include region value in output

### DIFF
--- a/cliv2/cmd/cliv2/logheader.go
+++ b/cliv2/cmd/cliv2/logheader.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/snyk/go-application-framework/pkg/auth"
 	"github.com/snyk/go-application-framework/pkg/configuration"
+	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
 	"github.com/snyk/go-application-framework/pkg/networking"
 	"github.com/snyk/go-application-framework/pkg/networking/fips"
 
@@ -109,6 +110,12 @@ func writeLogHeader(config configuration.Configuration, networkAccess networking
 	tablePrint("Version", cliv2.GetFullVersion()+" "+buildType)
 	tablePrint("Platform", userAgent)
 	tablePrint("API", config.GetString(configuration.API_URL))
+
+	region, err := localworkflows.DetermineRegionFromUrl(config.GetString(configuration.API_URL))
+	if err == nil {
+		tablePrint("Region", region)
+	}
+
 	tablePrint("Cache", config.GetString(configuration.CACHE_PATH))
 	tablePrint("Organization", org)
 	tablePrint("Insecure HTTPS", insecureHTTPS)

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/snyk/cli-extension-sbom v0.0.0-20241016065306-0df2be5b3b8f
 	github.com/snyk/container-cli v0.0.0-20240821111304-7ca1c415a5d7
 	github.com/snyk/error-catalog-golang-public v0.0.0-20241030160523-0aa643bb7069
-	github.com/snyk/go-application-framework v0.0.0-20241121110320-ec6ffc91558a
+	github.com/snyk/go-application-framework v0.0.0-20241128111948-07c460117921
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20241121152915-97e7af8d285c

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -760,8 +760,8 @@ github.com/snyk/container-cli v0.0.0-20240821111304-7ca1c415a5d7 h1:Zn5BcV76oFAb
 github.com/snyk/container-cli v0.0.0-20240821111304-7ca1c415a5d7/go.mod h1:38w+dcAQp9eG3P5t2eNS9eG0reut10AeJjLv5lJ5lpM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20241030160523-0aa643bb7069 h1:Oj/BJAEMEuBjTAQ72UYB4tR0IZKOB2ZtdDnAnJDL1BM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20241030160523-0aa643bb7069/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.0.0-20241121110320-ec6ffc91558a h1:JBeM7V7srT5dmF7w0Y06TDxwoU+j0GG3W5YEVfKbnA0=
-github.com/snyk/go-application-framework v0.0.0-20241121110320-ec6ffc91558a/go.mod h1:GekIT38VeZQiDw/Ot9Qn0s2kxVR1TXMw6gcaaAiKsVg=
+github.com/snyk/go-application-framework v0.0.0-20241128111948-07c460117921 h1:9rBEB8Zfcgr3n8/1owhcrS+K3Ry+1XOcj7xlGojvr2s=
+github.com/snyk/go-application-framework v0.0.0-20241128111948-07c460117921/go.mod h1:GekIT38VeZQiDw/Ot9Qn0s2kxVR1TXMw6gcaaAiKsVg=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v0.31.3 h1:FepCg6QN/X8uvxYjF+WwB2aiBPJB+NENDgKQeI/FwLg=


### PR DESCRIPTION
## Pull Request Submission Checklist
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?

Introduces a Region key to our debug output to make it quicker to troubleshoot the region we are currently configured to run against.
Associated documentation: https://docs.snyk.io/working-with-snyk/regional-hosting-and-data-residency#available-snyk-regions

## How should this be manually tested?

* `snyk config environment default`
* `snyk help -d` The output will include _Region: snyk-us-01_
* `snyk config environment dev`
* `snyk help -d` will not include a Region property as we are running against a dev instance.

### Expected Output

```shell
2024-11-27T13:57:14Z main - Using a preview feature!
2024-11-27T13:57:14Z main - Version:               1.1295.0-dev
2024-11-27T13:57:14Z main - Platform:              darwin amd64
2024-11-27T13:57:14Z main - API:                   https://api.snyk.io
2024-11-27T13:57:14Z main - Region:                snyk-us-01
2024-11-27T13:57:14Z main - Cache:                 /Users/path/tocache
2024-11-27T13:57:14Z main - Organization:
2024-11-27T13:57:14Z main - Insecure HTTPS:        false
2024-11-27T13:57:14Z main - Analytics:             enabled
2024-11-27T13:57:14Z main - Authorization:
2024-11-27T13:57:14Z main - Interaction:           d1548136-5367-452a-ae7a-d8d1746833c2
2024-11-27T13:57:14Z main - Features:
2024-11-27T13:57:14Z main -   preview:             enabled
2024-11-27T13:57:14Z main -   fips:                Not available
2024-11-27T13:57:14Z main - Checks:
2024-11-27T13:57:14Z main -   Configuration:       all good
```