### PR TITLE
feat: (IaC) include evidence field in json output [IAC-3161]

### DIFF
--- a/src/lib/iac/test/v2/json.ts
+++ b/src/lib/iac/test/v2/json.ts
@@ -84,6 +84,7 @@ export interface IacSuccess {
   path: string[];
   msg: string;
   isIgnored: boolean;
+  evidence?: string;
 }
 
 export interface Remediation {
@@ -332,6 +333,7 @@ function passedVulnerabilitiesToIacSuccesses(
       // IAC-2962: This field is included in IacIssue, so adding it here as well
       msg: v.resource.formattedPath,
       isIgnored: v.ignored,
+      evidence: v.context?.evidence,
     };
   });
 }

--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -1,11 +1,11 @@
 import * as os from 'os';
 
 const policyEngineChecksums = `
-2e09361c270a1134c625c91e730d17a904f8a8c8f6607ffbe188cf0f539ed75c  snyk-iac-test_0.56.2_Darwin_x86_64
-5e74c8b4193f28e65eb512d3c881a12837685ec1a747a44a3e922d69d0ad0637  snyk-iac-test_0.56.2_Linux_x86_64
-788cb65446ff69df95db9c8791a154bba22272fb5859f3c52a8ebb757881deec  snyk-iac-test_0.56.2_Windows_x86_64.exe
-d8720484d64ecdfcadc6d0d57c339c6aa825f758724f58fc487c817e4db5199c  snyk-iac-test_0.56.2_Darwin_arm64
-da46dd35f2bed090c7ab61ad6fee23c0c6634b8d94a608681749342bac0cbdc9  snyk-iac-test_0.56.2_Linux_arm64
+124b8f9225a4ed5c244e7e1991ed26448ea8e35413a9e265cb5c4185f9af9538  snyk-iac-test_0.57.0_Darwin_x86_64
+26ae8c3cc8cc4d8a7fa5f3c0a94a9c30b043bc2c3f1c19582d5f3c4879b056c4  snyk-iac-test_0.57.0_Linux_x86_64
+9a1e25084d7ff064568f4b14ad6808e9fdee5711fbbbe3e618b51b3d5962d2cc  snyk-iac-test_0.57.0_Windows_x86_64.exe
+f2e569723e9b60cbcc02de92b9b65e15d59896d0f6bfe4de72f44c09b7fb5a95  snyk-iac-test_0.57.0_Darwin_arm64
+fe6c6f56c4acf15575c407d6fcb7e33e36f301f29f6256fdf22c9cfd7eae5cc2  snyk-iac-test_0.57.0_Linux_arm64
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();

--- a/src/lib/iac/test/v2/scan/results.ts
+++ b/src/lib/iac/test/v2/scan/results.ts
@@ -97,6 +97,9 @@ export interface Vulnerability {
   severity: SEVERITY;
   ignored: boolean;
   resource: Resource;
+  context?: {
+    evidence?: string;
+  };
 }
 
 export interface Rule {

--- a/test/jest/unit/iac/process-results/fixtures/integrated-json-output-v2.json
+++ b/test/jest/unit/iac/process-results/fixtures/integrated-json-output-v2.json
@@ -253,6 +253,7 @@
     ],
     "infrastructureAsCodeSuccesses": [
       {
+        "evidence": "cidr_block: 10.1.0.0/16",
         "id": "SNYK-CC-00328",
         "severity": "medium",
         "type": "terraformconfig",

--- a/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results-v2.json
+++ b/test/jest/unit/iac/process-results/fixtures/snyk-iac-test-results-v2.json
@@ -241,6 +241,9 @@
           "file": "vpc_group.tf",
           "line": 9,
           "column": 1
+        },
+        "context": {
+          "evidence": "cidr_block: 10.1.0.0/16"
         }
       },
       {


### PR DESCRIPTION
## Pull Request Submission Checklist
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?

IaC custom rules may include evidence to why a certain policy passed for a resource. If that evidence (string) is specified, we display it in the JSON output for the rule.

Note: this applies only for custom IaC rules, since the standard rules are not required to provide this evidence, and were not modified to include it.

There should be no concerns about output size increase, IaC custom rules are used by a small fraction of the customers, and this field should be a one line string in the majority of cases, if at all added.

## How should this be manually tested?

This functionality is fully covered by tests, so no need for a manual test, which is a bit complicated. 
I write it here nevertheless, just in case.

1. A custom rule needs to be created and pushed to Snyk using `snyk iac rules init`. See an example [here](https://github.com/snyk/policy-engine/blob/main/examples/12-context.rego#L28) of what the rule could look like.The `resources` Rego rule declares a `context`, which needs to include an `evidence` string field.

2. Publish the rule bundle using `snyk iac rules push`.

3. Define a terraform file with a resource designed to pass the custom rule.

4. Run `snyk iac test` on the Terraform file, and expect to see the `evidence` message included in the relevant `infrastructureAsCodeSuccesses` entries.

## What are the relevant tickets?
https://snyksec.atlassian.net/browse/IAC-3161

<!---
## Any background context you want to provide?


## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->