### PR TITLE
feat: dep-graph json output

### DIFF
--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -165,6 +165,7 @@ export interface LegacyVulnApiResult extends BasicResultData {
   filesystemPolicy?: boolean;
   uniqueCount?: any;
   remediation?: RemediationChanges;
+  depGraph?: depGraphLib.DepGraphData;
 }
 
 export interface BaseImageRemediation {
@@ -451,6 +452,9 @@ function convertTestDepGraphResultToLegacy(
     severityThreshold,
     remediation: result.remediation,
   };
+  if (options['print-deps']) {
+    legacyRes.depGraph = depGraph.toJSON();
+  }
 
   return legacyRes;
 }


### PR DESCRIPTION
## Pull Request Submission Checklist
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?
Changes dependency JSON output for snyk test and snyk container test. When using either `--json` or `--json-file-output` together with `--print-deps` attached a `depGraph` property to the output JSON.

Previously using `--json` and `--print-deps` together would produce invalid JSON.

Prevent any warning logs from invalidating JSON output when `--json` is being used.

## Where should the reviewer start?

## How should this be manually tested?

<!---
## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->