### PR TITLE
feat: dep-graph json output file

### DIFF
--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -165,6 +165,7 @@ export interface LegacyVulnApiResult extends BasicResultData {
   filesystemPolicy?: boolean;
   uniqueCount?: any;
   remediation?: RemediationChanges;
+  depGraph?: depGraphLib.DepGraphData;
 }
 
 export interface BaseImageRemediation {
@@ -451,6 +452,10 @@ function convertTestDepGraphResultToLegacy(
     severityThreshold,
     remediation: result.remediation,
   };
+
+  if (options['print-deps'] && options['json-file-output']) {
+    legacyRes.depGraph = depGraph.toJSON();
+  }
 
   return legacyRes;
 }

--- a/test/jest/acceptance/cli-json-file-output.spec.ts
+++ b/test/jest/acceptance/cli-json-file-output.spec.ts
@@ -4,6 +4,7 @@ import { createProjectFromWorkspace } from '../util/createProject';
 import { runSnykCLI } from '../util/runSnykCLI';
 import { humanFileSize } from '../../utils';
 import { getServerPort } from '../util/getServerPort';
+import * as depGraphLib from '@snyk/dep-graph';
 
 jest.setTimeout(1000 * 60);
 
@@ -111,5 +112,46 @@ describe('test --json-file-output', () => {
     const fileExists = fs.existsSync(outputFilename);
     expect(fileExists).toBeFalsy();
     expect(code).toEqual(0);
+  });
+
+  describe('print-deps and json-file-output', () => {
+    it('saves JSON output to file with depGraph when --print-deps and --json-file-output are being used', async () => {
+      const project = await createProjectFromWorkspace('maven-app');
+      const outputPath = 'json-file-output.json';
+
+      const { code } = await runSnykCLI(
+        `test --print-deps --json-file-output=${outputPath}`,
+        {
+          cwd: project.path(),
+          env,
+        },
+      );
+
+      expect(code).toEqual(0);
+      const json = await project.readJSON(outputPath);
+      expect(json.depGraph).toBeTruthy();
+      const depGraph = depGraphLib.createFromJSON(json.depGraph);
+      expect(depGraph.getPkgs()).toContainEqual({
+        name: 'axis:axis',
+        version: '1.4',
+      });
+    });
+
+    it('saves JSON output to file without a depGraph when --print-deps is not used', async () => {
+      const project = await createProjectFromWorkspace('maven-app');
+      const outputPath = 'json-file-output.json';
+
+      const { code } = await runSnykCLI(
+        `test --json-file-output=${outputPath}`,
+        {
+          cwd: project.path(),
+          env,
+        },
+      );
+
+      expect(code).toEqual(0);
+      const json = await project.readJSON(outputPath);
+      expect(json.depGraph).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION

## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?
When both `--print-deps` and `--json-file-output` are being used produce a depGraph object in the resulting JSON file.

Does not attempt to fix any existing `--json` output formats to reduce the potential of breaking changes.

This allows CLI users to see the dependency graph that was resolved by the plugin code and scanned.
Useful for those users that are interested in what dependencies where resolved by Snyk and for debugging.

## How should this be manually tested?

```bash
snyk test --print-deps --json-file-output=out.json
cat out.json | jq .depGraph
```