### PR TITLE
fix: error catalog messages for monitor commands

### DIFF
--- a/src/lib/request/constants.ts
+++ b/src/lib/request/constants.ts
@@ -1,1 +1,2 @@
 export const headerSnykAuthFailed = 'snyk-auth-failed';
+export const headerSnykTsCliTerminate = 'snyk-terminate';

--- a/src/lib/request/promise.ts
+++ b/src/lib/request/promise.ts
@@ -1,11 +1,16 @@
+import { EXIT_CODES } from '../../cli/exit-codes';
 import { getAuthHeader } from '../api-token';
 import { MissingApiTokenError } from '../errors';
-import { headerSnykAuthFailed } from './constants';
+import { headerSnykAuthFailed, headerSnykTsCliTerminate } from './constants';
 import * as request from './index';
 
 export async function makeRequest<T>(payload: any): Promise<T> {
   return new Promise((resolve, reject) => {
     request.makeRequest(payload, (error, res, body) => {
+      if (res.headers[headerSnykTsCliTerminate] == 'true') {
+        process.exit(EXIT_CODES.EX_TERMINATE);
+      }
+
       if (error) {
         return reject(error);
       }

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -87,6 +87,7 @@ import {
 import { PackageExpanded } from 'snyk-resolve-deps/dist/types';
 import { normalizeTargetFile } from '../normalize-target-file';
 import { EXIT_CODES } from '../../cli/exit-codes';
+import { headerSnykTsCliTerminate } from '../request/constants';
 
 const debug = debugModule('snyk:run-test');
 
@@ -533,7 +534,7 @@ function sendTestPayload(
         return reject(error);
       }
 
-      if (res?.headers?.['snyk-terminate']) {
+      if (res?.headers?.[headerSnykTsCliTerminate]) {
         process.exit(EXIT_CODES.EX_TERMINATE);
       }
 


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?

Following the previous changes to the `snyk test` and `snyk code test` of returning an error message from the Error Catalog for unsuccessful network requests, this PR adds the same functionality to the `snyk monitor` and `snyk container monitor` commands. 

## Where should the reviewer start?

## How should this be manually tested?

- Ensure a clean build of the CLI
- Clear you configuration using `snyk config clear` to ensure further request towards Snyk services will fail with a 401 unauthorized response code
- Running `snyk monitor` or `snyk container monitor <image>` (eg. image: alpine or any available Docker image) should return a nicely formatted error message from the Error Catalog. You can also include the `-d` debug flag and look for the analytics payload sent, that should contain the same ID for the error and the status code for it. 

Ticket: [CLI-644](https://snyksec.atlassian.net/browse/CLI-644)

[CLI-644]: https://snyksec.atlassian.net/browse/CLI-644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ