### PR TITLE
  feat: container test/monitor add support for --exclude-node-modules option

### DIFF
--- a/help/cli-commands/container-monitor.md
+++ b/help/cli-commands/container-monitor.md
@@ -134,6 +134,12 @@ In earlier releases, cannot be used with `--app-vulns`.
 
 For more information see [Detecting application vulnerabilities in container images](https://docs.snyk.io/scan-using-snyk/snyk-container/use-snyk-container-from-the-web-ui/detect-application-vulnerabilities-in-container-images)
 
+### `--exclude-node-modules`
+
+Allow disabling the scan of node_modules directories inside node.js container images; in CLI versions v1.1292.0 and higher, node_modules scanning is enabled by default.
+
+When the node_modules scan is disabled, snyk will report vulnerabilities for npm projects sourced from application file pairs: [package.json, package-lock.json], [package.json, yarn.lock].
+
 ### `--nested-jars-depth`
 
 When `app-vulns` is enabled, use the `--nested-jars-depth=n` option to set how many levels of nested jars Snyk is to unpack. Depth must be a number.

--- a/help/cli-commands/container-test.md
+++ b/help/cli-commands/container-test.md
@@ -116,6 +116,12 @@ Allow disabling scans for app vulnerabilities; in CLI versions 1.1090.0 (2023-01
 
 In earlier releases, cannot be used with `--app-vulns`.
 
+### `--exclude-node-modules`
+
+Allow disabling the scan of node_modules directories inside node.js container images; in CLI versions v1.1292.0 and higher, node_modules scanning is enabled by default.
+
+When the node_modules scan is disabled, snyk will report vulnerabilities for npm projects sourced from application file pairs: [package.json, package-lock.json], [package.json, yarn.lock].
+
 ### `--nested-jars-depth`
 
 When `app-vulns` is enabled, use the `--nested-jars-depth=n` option to set how many levels of nested jars Snyk is to unpack. Depth must be a number.

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "semver": "^6.0.0",
         "snyk-config": "^5.0.0",
         "snyk-cpp-plugin": "2.24.0",
-        "snyk-docker-plugin": "6.13.18",
+        "snyk-docker-plugin": "6.14.0",
         "snyk-go-plugin": "1.23.0",
         "snyk-gradle-plugin": "4.7.0",
         "snyk-module": "3.1.0",
@@ -20280,9 +20280,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "6.13.18",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.13.18.tgz",
-      "integrity": "sha512-R/eKm8qgv+F1tLifuFt+8rMW5rkuaCbA1Swqc3jBITNg9+8e4NNnOPOYJNxxwwoBfDrsvGkQJZceBOs4qWlysQ==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.14.0.tgz",
+      "integrity": "sha512-OTLQKn4RLgJVupmb3JuDOAXjglSIU0VcJufeO8D+NEghxpsxpx0srfD0O+R/vTPjYpjqYH3ZJrFWAYb55PME4A==",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.8.1",
@@ -39807,9 +39807,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "6.13.18",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.13.18.tgz",
-      "integrity": "sha512-R/eKm8qgv+F1tLifuFt+8rMW5rkuaCbA1Swqc3jBITNg9+8e4NNnOPOYJNxxwwoBfDrsvGkQJZceBOs4qWlysQ==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.14.0.tgz",
+      "integrity": "sha512-OTLQKn4RLgJVupmb3JuDOAXjglSIU0VcJufeO8D+NEghxpsxpx0srfD0O+R/vTPjYpjqYH3ZJrFWAYb55PME4A==",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "semver": "^6.0.0",
     "snyk-config": "^5.0.0",
     "snyk-cpp-plugin": "2.24.0",
-    "snyk-docker-plugin": "6.13.18",
+    "snyk-docker-plugin": "6.14.0",
     "snyk-go-plugin": "1.23.0",
     "snyk-gradle-plugin": "4.7.0",
     "snyk-module": "3.1.0",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -75,6 +75,7 @@ export interface Options {
   // Used with the Docker plugin only. Allows application scanning.
   'app-vulns'?: boolean;
   'exclude-app-vulns'?: boolean;
+  'exclude-node-modules'?: boolean;
   debug?: boolean;
   sarif?: boolean;
   'group-issues'?: boolean;
@@ -144,6 +145,7 @@ export interface MonitorOptions {
   // Used with the Docker plugin only. Allows application scanning.
   'app-vulns'?: boolean;
   'exclude-app-vulns'?: boolean;
+  'exclude-node-modules'?: boolean;
   initScript?: string;
   yarnWorkspaces?: boolean;
   'max-depth'?: number;

--- a/test/jest/acceptance/snyk-test/app-vuln-container-project.spec.ts
+++ b/test/jest/acceptance/snyk-test/app-vuln-container-project.spec.ts
@@ -167,3 +167,39 @@ describe('container test projects behavior with --json flag', () => {
     expect(code).toEqual(0);
   });
 });
+
+describe('container test projects behavior with --exclude-node-modules flag', () => {
+  // Dockerfile for node-slim-image.tar
+  // FROM node:alpine
+
+  // COPY package.json /goof1/
+  // COPY package-lock.json /goof1/
+  // COPY package.json /
+  // COPY package-lock.json /
+  // WORKDIR /goof1
+  // RUN npm install
+  // WORKDIR /
+  // RUN npm install
+  it('should scan npm projects only when package.json and package-lock.json pairs are identified in the container image', async () => {
+    const { code, stdout } = await runSnykCLI(
+      `container test docker-archive:test/fixtures/container-projects/node-slim-image.tar --exclude-node-modules --json --exclude-base-image-vulns`,
+    );
+    const jsonOutput = JSON.parse(stdout);
+    const applications = jsonOutput.applications;
+
+    expect(applications.length).toEqual(2);
+    expect(code).toEqual(1);
+  }, 30000);
+
+  it('should scan npm projects from package.json and package-lock.json pairs and node_modules dependencies', async () => {
+    const { code, stdout } = await runSnykCLI(
+      `container test docker-archive:test/fixtures/container-projects/node-slim-image.tar --json --exclude-base-image-vulns`,
+    );
+    const jsonOutput = JSON.parse(stdout);
+    const applications = jsonOutput.applications;
+
+    expect(applications.length).toEqual(3);
+
+    expect(code).toEqual(1);
+  }, 30000);
+});


### PR DESCRIPTION
## Pull Request Submission Checklist
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?
Before [v6.12.0](https://github.com/snyk/snyk-docker-plugin/releases/tag/v6.12.0), the docker cli plugin was able to scan npm projects only when [strict package.json and package-lock.json pairs](https://github.com/snyk/snyk-docker-plugin/blob/ac707fdb49a29406e61d04a26ddd6f3c91b626a1/lib/analyzer/applications/node.ts#L88-L104) of files were identified within container images. The pair of files [had to be outside](https://github.com/snyk/snyk-docker-plugin/blob/ac707fdb49a29406e61d04a26ddd6f3c91b626a1/lib/inputs/node/static.ts#L12) of a node_modules folder’s context in order to avoid creating projects out of the dependencies. Scanning container images that had the manifests/lockfiles removed was not possible and customer needs were created to remove that constraint.

The scanning of npm global and local scoped node_modules directories has been enabled as a default behavior when a node.js image is scanned.
Adding an option to opt-out from the node_modules scan allows the user to scan npm projects only when [strict package.json and package-lock.json pairs] are identified in the container image, thus re-enabling the original npm scan behavior.
## Where should the reviewer start?

## How should this be manually tested?
1.  Build a docker image with multiple npm projects and global node_modules installed in the image:
Dockerfile:
`FROM node:18-alpine

COPY package.json /goof1/
COPY package-lock.json /goof1/
COPY package.json /
COPY package-lock.json /
WORKDIR /goof1
RUN npm install
WORKDIR /
RUN npm install`
 
`docker build -t npm7-image . `
2. Run test/monitor without disabling node_modules scan on the nodejs image
`SNYK_API=https://app.pre-prod.snyk.io/api/v1 snyk container test npm7-image:latest`
Expected Results:
Global node_modules are scanned.
A log line should appear that describes the target scanned:

`Target file:       /usr/local/lib/node_modules`

3. Run test/monitor with --exclude-node-modules option enabled
`SNYK_API=https://app.pre-prod.snyk.io/api/v1 snyk container test npm7-image:latest --exclude-node-modules`

Expected Results
Global node_modules are excluded from the scan.

<!---
## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->