### PR TITLE
chore(deps): upgrade golang v1.23.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
   go_version:
     type: string
     # https://go.dev/doc/devel/release
-    default: '1.23.2'
+    default: '1.23.4'
   aws_version:
     type: string
     # https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -2,7 +2,7 @@ module github.com/snyk/cli/cliv2
 
 go 1.23
 
-toolchain go1.23.2
+toolchain go1.23.4
 
 require (
 	github.com/elazarl/goproxy v0.0.0-20231031074852-3ec07828be7a


### PR DESCRIPTION
## Pull Request Submission Checklist

- [X] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [X] Includes detailed description of changes (provided in the diff)
- [X] Contains risk assessment (Low | Medium | High) LOW
- [X] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality TODO
- [ ] Includes manual testing instructions (if necessary)

## What does this PR do?

This pull request updates the Go version and toolchain used in the cliv2 directory to version 1.23.4.

Go 1.23.4 (released 2024-12-03) includes fixes to the compiler, the runtime, the trace command, and the syscall package. You can find the full release notes here: [invalid URL removed]

## Where should the reviewer start?
The reviewer can start by reviewing the changes in the .circleci/config.yml and cliv2/go.mod files.

## How should this be manually tested?

Download the artefact built by the CI/CD process and run `snyk test`
