### PR TITLE
chore(ci): move to use keyId

### DIFF
--- a/release-scripts/sha256sums.txt.asc.sh
+++ b/release-scripts/sha256sums.txt.asc.sh
@@ -12,7 +12,7 @@ echo "${SNYK_CODE_SIGNING_PGP_PRIVATE}" \
 echo "Signing shasums file"
 gpg \
     --clear-sign \
-    --local-user=3676C4B8289C296E \
+    --default-key="${SNYK_CODE_SIGNING_PGP_KEY_ID}" \
     --passphrase="${SNYK_CODE_SIGNING_GPG_PASSPHRASE}" \
     --pinentry-mode=loopback \
     --armor \
@@ -20,7 +20,7 @@ gpg \
 
 gpg \
     --clear-sign \
-    --local-user=3676C4B8289C296E \
+    --default-key="${SNYK_CODE_SIGNING_PGP_KEY_ID}" \
     --passphrase="${SNYK_CODE_SIGNING_GPG_PASSPHRASE}" \
     --pinentry-mode=loopback \
     --armor \


### PR DESCRIPTION
## Pull Request Submission Checklist
- [X] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [X] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?

This PR updates the sha256sums.txt.asc.sh script to replace the hardcoded GPG key (3676C4B8289C296E) with a dynamic environment variable (`SNYK_CODE_SIGNING_PGP_KEY_ID`). This enhances the flexibility of the signing process by allowing different GPG keys to be used depending on the environment.

Additionally, this change introduces the use of --default-key instead of --local-user. This switch offers two key benefits:

- Dynamic Key Selection:
  - --default-key relies on the value of the GPG_KEY_ID provided at runtime, making it adaptable to different environments or pipelines.
  - --local-user is more static, requiring the exact key ID at the time of script authoring, limiting its reusability without manual code changes.
- Environment-Driven Configuration:
  - --default-key aligns with best practices by leveraging environment variables, reducing the risk of exposing sensitive information (e.g., private keys) directly in the codebase.
  - In contrast, --local-user enforces a rigid, hardcoded approach that can complicate key rotation or environment-specific signing processes.

## Where should the reviewer start?

## How should this be manually tested?

* Create an `e2e/branch` name that will exercise the full pipeline https://github.com/snyk/cli/tree/e2e/validate-deployment-artifacts. Passing check: https://app.circleci.com/pipelines/github/snyk/cli/28357/workflows/870178dd-d7e2-4ca7-abed-3b7b1c6d45c0/jobs/380858