### PR TITLE
chore(ci): include release channel in payload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -925,7 +925,29 @@ workflows:
                 - '/release.*/'
 
       - trigger-building-snyk-images:
-          name: Trigger building snyk-images
+          name: Trigger building snyk-images (preview)
+          context: team-hammerhead-common-deploy-tokens
+          deployment: preview
+          requires:
+            - upload preview
+          filters:
+            branches:
+              only:
+                - main
+
+      - trigger-building-snyk-images:
+          name: Trigger building snyk-images (rc)
+          context: team-hammerhead-common-deploy-tokens
+          deployment: rc
+          requires:
+            - upload release candidate
+          filters:
+            branches:
+              only:
+                - '/release.*/'
+
+      - trigger-building-snyk-images:
+          name: Trigger building snyk-images (stable)
           context: team-hammerhead-common-deploy-tokens
           requires:
             - upload npm
@@ -1429,11 +1451,15 @@ jobs:
       - failed-release-notification
 
   trigger-building-snyk-images:
+    parameters:
+      deployment:
+        type: string
+        default: stable
     executor: docker-amd64
     steps:
       - prepare-workspace
       - shall-deploy:
-          deployment: stable
+          deployment: << parameters.deployment >>
       - run:
           name: Trigger build-and-publish workflow at snyk-images
           command: ./release-scripts/upload-artifacts.sh trigger-snyk-images

--- a/release-scripts/upload-artifacts.sh
+++ b/release-scripts/upload-artifacts.sh
@@ -34,6 +34,7 @@ declare -a StaticFilesFIPS=(
 )
 
 VERSION_TAG="v$(cat binary-releases/version)"
+RELEASE_CHANNEL="$($(dirname "$0")/determine-release-channel.sh)"
 DRY_RUN=false
 
 if [ ${#} == 0 ]; then
@@ -117,7 +118,7 @@ trigger_build_snyk_images() {
     -H "Authorization: Bearer $HAMMERHEAD_GITHUB_PAT" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     https://api.github.com/repos/snyk/snyk-images/dispatches \
-    -d "{\"event_type\":\"build_and_push_images\", \"client_payload\": {\"version\": \"$VERSION_TAG\"}}" \
+    -d "{\"event_type\":\"build_and_push_images\", \"client_payload\": {\"version\": \"$VERSION_TAG\", \"release_channel\": \"$RELEASE_CHANNEL\"}}" \
     -w "%{http_code}" \
     -o /dev/null)
   if [ "$RESPONSE" -eq 204 ]; then


### PR DESCRIPTION
## Pull Request Submission Checklist
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?

Adds a trigger docker images task to each of the release pipelines so that we start building images for each distribution channel. The change here is intended to be straight forward by introducing a single additional property to the event payload which includes the release channel. Then it is for the receiving component to respond to the behaviour. 

Related PR, which should be merged first
https://github.com/snyk/snyk-images/pull/122