### PR TITLE
chore(deps): upgrade go proxy 1.5

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -25,4 +25,3 @@ exclude:
     - test/**
     - scripts/upgrade-snyk-go-dependencies.go
     - release-scripts/write-ls-protocol-version.go
-    - src/cli/args.ts

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -5,7 +5,7 @@ go 1.23
 toolchain go1.23.4
 
 require (
-	github.com/elazarl/goproxy v1.3.0
+	github.com/elazarl/goproxy v1.5.0
 	github.com/elazarl/goproxy/ext v0.0.0-20230808193330-2592e75ae04a
 	github.com/gofrs/flock v0.12.1
 	github.com/golang/mock v1.6.0

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -318,6 +318,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v1.3.0 h1:hpDH1r1qJgM3eusz7lP+BiMPnLiWPa6hDjIFF5WVCjE=
 github.com/elazarl/goproxy v1.3.0/go.mod h1:X/5W/t+gzDyLfHW4DrMdpjqYjpXsURlBt9lpBDxZZZQ=
+github.com/elazarl/goproxy v1.5.0 h1:YU2DM2E1piA2lvHx/Wv7AgxoE0MoYnPyKOnZhiNsopc=
+github.com/elazarl/goproxy v1.5.0/go.mod h1:X/5W/t+gzDyLfHW4DrMdpjqYjpXsURlBt9lpBDxZZZQ=
 github.com/elazarl/goproxy/ext v0.0.0-20230808193330-2592e75ae04a h1:6hp3+W5oJSkbk/m2XquFdhih2H4wxxR0Nl6GfPL8kss=
 github.com/elazarl/goproxy/ext v0.0.0-20230808193330-2592e75ae04a/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/emicklei/proto v1.13.2 h1:z/etSFO3uyXeuEsVPzfl56WNgzcvIr42aQazXaQmFZY=

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -271,7 +271,6 @@ export function args(rawArgv: string[]): Args {
 
   if (argv.insecure) {
     global.ignoreUnknownCA = true;
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
   }
 
   debug(command, obfuscateArgs(argv));


### PR DESCRIPTION
## Pull Request Submission Checklist
- [X] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?

Upgrades goproxy to v1.5.0 which removes the need for a workaround introduced here:
https://github.com/snyk/cli/commit/2aed7cb97fb36bb0a2664c7a06ef41d70a87c9d5#diff-cb98b6b0e8336713b5d56cb8986db5a61310c740a8317b9bf42bc90be49e0fb8