### PR TITLE
chore: speed up clean build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "packages/*"
   ],
   "scripts": {
-    "clean": "npx rimraf node_modules dist binary-releases test-results *.tgz tsconfig.tsbuildinfo .eslintcache pysrc packages/*/node_modules packages/*/dist packages/*/tsconfig.tsbuildinfo packages/*/*.tgz",
+    "clean": "npx rimraf dist binary-releases test-results *.tgz tsconfig.tsbuildinfo .eslintcache pysrc packages/*/node_modules packages/*/dist packages/*/tsconfig.tsbuildinfo packages/*/*.tgz",
     "format": "prettier --write '**/*.{js,ts,json,yaml,yml,md}' && npm run lint:js -- --fix",
     "format:changes": "./scripts/format/prettier-changes.sh",
     "lint": "npm-run-all --serial --continue-on-error lint:*",


### PR DESCRIPTION
## Pull Request Submission Checklist
- [X] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [X] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?

Removing the node_modules siginificantly slows down the rebuild
cycle when iterating locally as it requires reinstalling all deps

Removing the node_modules should be an optional step of last resort during debugging rather than default.