### PR TITLE
fix: remove test-compile for mavenAggregateProject with Dverbose or sbom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "snyk-go-plugin": "1.23.0",
         "snyk-gradle-plugin": "4.9.0",
         "snyk-module": "3.1.0",
-        "snyk-mvn-plugin": "3.6.1",
+        "snyk-mvn-plugin": "3.7.0",
         "snyk-nodejs-lockfile-parser": "1.58.16",
         "snyk-nodejs-plugin": "1.4.1",
         "snyk-nuget-plugin": "2.7.12",
@@ -20751,9 +20751,10 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-mvn-plugin": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-3.6.1.tgz",
-      "integrity": "sha512-k90RJvA+TZuFVbwPx8B7sjaH6aDLHNSTjsAeeJnVvBphtrHZtkjePdSn40IvsHEnyajlpo8OZ5zGHT4CV0jheA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-3.7.0.tgz",
+      "integrity": "sha512-BQUCPnPvVgl4V5Xa79FWTOU2H1XXeO7aeC7Bp1qwwifJBv1VikdohlGhSuwvrhmFIjsC9RsEGMV8LTFBLNOCGg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.23.1",
@@ -20859,6 +20860,7 @@
       "version": "1.58.16",
       "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.58.16.tgz",
       "integrity": "sha512-vSwXA47O0CFg2UM7aopC6S6hyFdA8xOsCTdq7oMxJ41kfTb8VOQ8PETYgI1dnM9FibgtXkHOXmbPvfOYqPpaHA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/error-catalog-nodejs-public": "^5.16.0",
@@ -20962,6 +20964,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/snyk-nodejs-plugin/-/snyk-nodejs-plugin-1.4.1.tgz",
       "integrity": "sha512-wqR1gRL/rrqwNxranIER0idT9wSvybSBwlUF37wQ9heY2nGBgR0Pt5E5hp5+ZP9T27/YJbf8zP/iuoPD3ITeyg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@snyk/cli-interface": "^2.13.0",
         "@snyk/dep-graph": "^2.7.4",
@@ -39996,9 +39999,9 @@
       }
     },
     "snyk-mvn-plugin": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-3.6.1.tgz",
-      "integrity": "sha512-k90RJvA+TZuFVbwPx8B7sjaH6aDLHNSTjsAeeJnVvBphtrHZtkjePdSn40IvsHEnyajlpo8OZ5zGHT4CV0jheA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-3.7.0.tgz",
+      "integrity": "sha512-BQUCPnPvVgl4V5Xa79FWTOU2H1XXeO7aeC7Bp1qwwifJBv1VikdohlGhSuwvrhmFIjsC9RsEGMV8LTFBLNOCGg==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.23.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "snyk-go-plugin": "1.23.0",
     "snyk-gradle-plugin": "4.9.0",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "3.6.1",
+    "snyk-mvn-plugin": "3.7.0",
     "snyk-nodejs-lockfile-parser": "1.58.16",
     "snyk-nodejs-plugin": "1.4.1",
     "snyk-nuget-plugin": "2.7.12",


### PR DESCRIPTION
## Pull Request Submission Checklist
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?
Fixes an issue where users trying to run snyk sbom (or test with `-- -Dverbose`) on a maven project with --maven-aggregate-project fails on the test-compile phase we invoke in case a user is using an older versions of the maven-depepndency-plugin. Since sbom forces a newer version of the plugin, there is no need to invoke that phase.

## Where should the reviewer start?

## How should this be manually tested?
Run current version and this Pr's snyk on the following pom.xml:

`snyk test --maven-aggregate-project -- -Dverbose`

```
<project xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <groupId>com.example</groupId>
    <artifactId>test-compile-failure</artifactId>
    <version>1.0-SNAPSHOT</version>
    <packaging>jar</packaging>

    <properties>
        <maven.compiler.source>1.8</maven.compiler.source>
        <maven.compiler.target>1.8</maven.compiler.target>
    </properties>

    <dependencies>
        <!-- Regular dependency for main code -->
        <dependency>
            <groupId>org.apache.commons</groupId>
            <artifactId>commons-lang3</artifactId>
            <version>3.12.0</version>
        </dependency>

    </dependencies>

    <build>
        <plugins>

            <!-- Maven Antrun Plugin to Force Failure -->
            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-antrun-plugin</artifactId>
                <version>3.0.0</version>
                <executions>
                    <execution>
                        <phase>test-compile</phase>
                        <goals>
                            <goal>run</goal>
                        </goals>
                        <configuration>
                            <tasks>
                                <fail message="Deliberate failure during test-compile phase!" />
                            </tasks>
                        </configuration>
                    </execution>
                </executions>
            </plugin>
        </plugins>
    </build>
</project>
```

<!---
## Any background context you want to provide?

## What are the relevant tickets?
https://snyksec.atlassian.net/browse/OSM-2345

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->