### PR TITLE
fix: debug logs causing CLI to quit unexpectedly [CLI-638]

### DIFF
--- a/src/cli/commands/test/iac/scan.ts
+++ b/src/cli/commands/test/iac/scan.ts
@@ -30,6 +30,7 @@ import { getErrorStringCode } from './local-execution/error-utils';
 import { getRepositoryRootForPath } from '../../../../lib/iac/git';
 import { getInfo } from '../../../../lib/project-metadata/target-builders/git';
 import { buildMeta, GitRepository, GitRepositoryFinder } from './meta';
+import { MAX_STRING_LENGTH } from '../../../../lib/constants';
 
 const debug = debugLib('snyk-iac');
 
@@ -181,7 +182,7 @@ function formatTestError(error) {
 
 function safeStringify(obj: unknown): string {
   try {
-    return JSON.stringify(obj);
+    return JSON.stringify(obj).slice(0, MAX_STRING_LENGTH);
   } catch (e) {
     if (e instanceof Error) {
       return `Error stringifying object: ${e.message}`;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -10,3 +10,7 @@ export const CALL_PATH_LEADING_ELEMENTS = 2;
 
 // Number of function names to show in the end of an abbreviated call path
 export const CALL_PATH_TRAILING_ELEMENTS = 2;
+
+// Upper limit of string length that should be allowed for output to stdrr || stdout.
+// Use when outputting strings of unknown length. e.g. response payloads
+export const MAX_STRING_LENGTH = 50000;

--- a/src/lib/plugins/sast/utils/testEmitter.ts
+++ b/src/lib/plugins/sast/utils/testEmitter.ts
@@ -1,6 +1,7 @@
 import { emitter as codeEmitter } from '@snyk/code-client';
 import { spinner } from '../../../spinner';
 import * as debugLib from 'debug';
+import { MAX_STRING_LENGTH } from '../../../constants';
 
 export function analysisProgressUpdate(): void {
   let currentMessage = '';
@@ -32,6 +33,14 @@ export function analysisProgressUpdate(): void {
   });
   codeEmitter.on('apiRequestLog', (data) => {
     const debug = debugLib('snyk-code');
-    debug('---> API request log ', data);
+    if (data.length > MAX_STRING_LENGTH) {
+      // limit the string length as truncation doesn't always happen, causing the CLI to end unexpectedly
+      debug(
+        '---> API request log ',
+        data.slice(0, MAX_STRING_LENGTH) + '...(log line truncated)',
+      );
+    } else {
+      debug('---> API request log ', data);
+    }
   });
 }

--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -14,6 +14,7 @@ import * as http from 'http';
 import { jsonStringifyLargeObject } from '../json';
 import { MissingApiTokenError } from '../errors';
 import { headerSnykAuthFailed } from './constants';
+import { MAX_STRING_LENGTH } from '../constants';
 
 const debug = debugModule('snyk:req');
 const snykDebug = debugModule('snyk');
@@ -87,7 +88,13 @@ function setupRequest(payload: Payload) {
   }
 
   try {
-    debug('request payload: ', jsonStringifyLargeObject(payload));
+    const payloadStr = jsonStringifyLargeObject(payload);
+    debug(
+      'request payload: ',
+      payloadStr.length > MAX_STRING_LENGTH
+        ? payloadStr + '...(log line truncated)'
+        : payloadStr,
+    );
   } catch (e) {
     debug('request payload is too big to log', e);
   }


### PR DESCRIPTION
## Pull Request Submission Checklist
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?
This PR should set an upper limit on the length of some logs outputted by the `debug` lib. In particular, log a log that outputs an full api response which can lead to the CLI quitting unexpectedly.

## Where should the reviewer start?

## How should this be manually tested?

<!---
## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->