### PR TITLE
feat: print legacy tree with json file output

### DIFF
--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -166,6 +166,7 @@ export interface LegacyVulnApiResult extends BasicResultData {
   uniqueCount?: any;
   remediation?: RemediationChanges;
   depGraph?: depGraphLib.DepGraphData;
+  depTree?: depGraphLib.legacy.DepTree;
 }
 
 export interface BaseImageRemediation {
@@ -336,12 +337,12 @@ export interface RemediationChanges {
   pin: DependencyPins;
 }
 
-function convertTestDepGraphResultToLegacy(
+async function convertTestDepGraphResultToLegacy(
   res: TestDepGraphResponse,
   depGraph: depGraphLib.DepGraph,
   packageManager: SupportedProjectTypes | undefined,
   options: Options & TestOptions,
-): LegacyVulnApiResult {
+): Promise<LegacyVulnApiResult> {
   const result = res.result;
 
   const upgradePathsMap = new Map<string, string[]>();
@@ -455,6 +456,13 @@ function convertTestDepGraphResultToLegacy(
 
   if (options['print-deps'] && options['json-file-output']) {
     legacyRes.depGraph = depGraph.toJSON();
+  }
+
+  if (options['print-tree'] && options['json-file-output']) {
+    legacyRes.depTree = await depGraphLib.legacy.graphToDepTree(
+      depGraph,
+      depGraph.pkgManager.name,
+    );
   }
 
   return legacyRes;

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -432,7 +432,7 @@ async function parseRes(
   // so this flow will not be applicable
   // refactor to separate
   if (depGraph && pkgManager) {
-    res = convertTestDepGraphResultToLegacy(
+    res = await convertTestDepGraphResultToLegacy(
       res as any as TestDepGraphResponse, // Double "as" required by Typescript for dodgy assertions
       depGraph,
       pkgManager,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -62,6 +62,7 @@ export interface Options {
   severityThreshold?: SEVERITY;
   dev?: boolean;
   'print-deps'?: boolean;
+  'print-tree'?: boolean;
   'print-dep-paths'?: boolean;
   'remote-repo-url'?: string;
   criticality?: string;

--- a/test/jest/acceptance/cli-json-file-output.spec.ts
+++ b/test/jest/acceptance/cli-json-file-output.spec.ts
@@ -154,4 +154,52 @@ describe('test --json-file-output', () => {
       expect(json.depGraph).toBeUndefined();
     });
   });
+
+  describe('print-tree and json-file-output', () => {
+    it('saves JSON output to file with depTree when --print-tree and --json-file-output are being used', async () => {
+      const project = await createProjectFromWorkspace('maven-app');
+      const outputPath = 'json-file-output.json';
+
+      const { code } = await runSnykCLI(
+        `test --print-tree --json-file-output=${outputPath}`,
+        {
+          cwd: project.path(),
+          env,
+        },
+      );
+
+      expect(code).toEqual(0);
+      const json = await project.readJSON(outputPath);
+      expect(json.depTree).toEqual({
+        name: 'com.mycompany.app:maven-app',
+        packageFormatVersion: 'mvn:0.0.1',
+        type: 'maven',
+        version: '1.0-SNAPSHOT',
+        dependencies: {
+          'axis:axis': {
+            name: 'axis:axis',
+            version: '1.4',
+            dependencies: expect.any(Object),
+          },
+        },
+      });
+    });
+
+    it('saves JSON output to file without a depTree when --print-tree is not used', async () => {
+      const project = await createProjectFromWorkspace('maven-app');
+      const outputPath = 'json-file-output.json';
+
+      const { code } = await runSnykCLI(
+        `test --json-file-output=${outputPath}`,
+        {
+          cwd: project.path(),
+          env,
+        },
+      );
+
+      expect(code).toEqual(0);
+      const json = await project.readJSON(outputPath);
+      expect(json.depTree).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?
To support clients that prefer our older depTree format.

When '--print-tree' and '--json-file-output' are used together a depTree object is included in the JSON file.

## How should this be manually tested?

```shell
snyk test --print-tree --json-file-output=out.json
cat out.json | jq .depTree
```

<!---
## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->