### PR TITLE
chore: add generic error catalog errors for golang Errors

### DIFF
--- a/cliv2/cmd/cliv2/errorhandling.go
+++ b/cliv2/cmd/cliv2/errorhandling.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"errors"
+	"os/exec"
+
+	"github.com/snyk/error-catalog-golang-public/cli"
+	"github.com/snyk/error-catalog-golang-public/snyk_errors"
+
+	cli_errors "github.com/snyk/cli/cliv2/internal/errors"
+)
+
+// decorate generic errors that do not contain Error-Catalog Errors
+func decorateError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if _, isExitError := err.(*exec.ExitError); isExitError {
+		return err
+	}
+
+	if _, isErrorWithCode := err.(*cli_errors.ErrorWithExitCode); isErrorWithCode {
+		return err
+	}
+
+	var errorCatalogError snyk_errors.Error
+	if !errors.As(err, &errorCatalogError) {
+		genericError := cli.NewGeneralCLIFailureError(err.Error())
+		genericError.StatusCode = 0
+		err = errors.Join(err, genericError)
+	}
+	return err
+}

--- a/cliv2/cmd/cliv2/errorhandling_test.go
+++ b/cliv2/cmd/cliv2/errorhandling_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/error-catalog-golang-public/cli"
+
+	cli_errors "github.com/snyk/cli/cliv2/internal/errors"
+)
+
+func Test_decorateError(t *testing.T) {
+	t.Run("is nil error", func(t *testing.T) {
+		assert.Nil(t, decorateError(nil))
+	})
+
+	t.Run("is ErrorWithExitCode", func(t *testing.T) {
+		err := &cli_errors.ErrorWithExitCode{
+			ExitCode: 2,
+		}
+		assert.Equal(t, err, decorateError(err))
+	})
+
+	t.Run("is ExitError", func(t *testing.T) {
+		err := &exec.ExitError{
+			ProcessState: &os.ProcessState{},
+		}
+		assert.Equal(t, err, decorateError(err))
+	})
+
+	t.Run("is already error catalog error", func(t *testing.T) {
+		err := cli.NewConnectionTimeoutError("")
+		assert.Equal(t, err, decorateError(err))
+	})
+
+	t.Run("is a generic error", func(t *testing.T) {
+		err := errors.New("generic error")
+		actualErrr := decorateError(err)
+		expectedError := cli.NewGeneralCLIFailureError("")
+		assert.ErrorIs(t, actualErrr, err)
+		assert.ErrorAs(t, actualErrr, &expectedError)
+	})
+}

--- a/cliv2/cmd/cliv2/main.go
+++ b/cliv2/cmd/cliv2/main.go
@@ -20,8 +20,6 @@ import (
 	"github.com/snyk/cli-extension-dep-graph/pkg/depgraph"
 	"github.com/snyk/cli-extension-iac-rules/iacrules"
 	"github.com/snyk/cli-extension-sbom/pkg/sbom"
-	"github.com/snyk/cli/cliv2/internal/cliv2"
-	"github.com/snyk/cli/cliv2/internal/constants"
 	"github.com/snyk/container-cli/pkg/container"
 	"github.com/snyk/go-application-framework/pkg/analytics"
 	"github.com/snyk/go-application-framework/pkg/app"
@@ -31,6 +29,9 @@ import (
 	"github.com/snyk/go-application-framework/pkg/local_workflows/output_workflow"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/snyk/cli/cliv2/internal/cliv2"
+	"github.com/snyk/cli/cliv2/internal/constants"
 
 	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/content_type"
@@ -592,6 +593,8 @@ func MainWithErrorCode() (int, []error) {
 	}
 
 	if err != nil {
+		err = decorateError(err)
+
 		errorList = append(errorList, err)
 		for _, tempError := range errorList {
 			cliAnalytics.AddError(tempError)

--- a/test/jest/acceptance/snyk-sbom-test/all-projects.spec.ts
+++ b/test/jest/acceptance/snyk-sbom-test/all-projects.spec.ts
@@ -130,7 +130,7 @@ describe('snyk sbom test (mocked server only)', () => {
       { env },
     );
 
-    expect(stdout).toMatch(
+    expect(stdout).toContainText(
       'Flag `--file` is required to execute this command. Value should point to a valid SBOM document.',
     );
 

--- a/test/jest/acceptance/snyk-sbom/npm-options.spec.ts
+++ b/test/jest/acceptance/snyk-sbom/npm-options.spec.ts
@@ -67,10 +67,10 @@ describe('snyk sbom: npm options (mocked server only)', () => {
     );
 
     expect(code).toEqual(2);
-    expect(stdout).toContain(
+    expect(stdout).toContainText(
       'An error occurred while running the underlying analysis needed to generate the SBOM.',
     );
-    expect(stderr).toContain(
+    expect(stderr).toContainText(
       'OutOfSyncError: Dependency snyk was not found in package-lock.json.',
     );
   });

--- a/test/jest/acceptance/snyk-sbom/sbom.spec.ts
+++ b/test/jest/acceptance/snyk-sbom/sbom.spec.ts
@@ -211,7 +211,7 @@ describe('snyk sbom (mocked server only)', () => {
     );
 
     expect(code).toBe(3);
-    expect(stdout).toContain(
+    expect(stdout).toContainText(
       'An error occurred while running the underlying analysis needed to generate the SBOM.',
     );
   });


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?
This PR introduces a wrapping of golang Errors returned from various places and dependencies in a generic Error Catalog Error. Exceptions are exit code errors and if there is already an Error Catalog Error.

The risk of the change is relatively low, as the changes only focus on decorating errors without altering the content itself

## Where should the reviewer start?
`decorateError()` implements the logic and is integrated in main.go

## How should this be manually tested?
Run the command below. which will show an error that tells users to add the missing format parameter.
```
snyk sbom
```

<!---
## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->