### PR TITLE
fix (iac): update project page link for iac v2 --report 

### DIFF
--- a/src/cli/commands/test/iac/output.ts
+++ b/src/cli/commands/test/iac/output.ts
@@ -32,7 +32,11 @@ import {
   shareResultsTip,
   formatTestData,
 } from '../../../../lib/formatters/iac-output/text';
-import { formatShareResultsOutputV2 } from '../../../../lib/formatters/iac-output/text/share-results';
+import {
+  formatShareResultsOutputIacV2,
+  formatShareResultsOutputIacPlus,
+  shareResultsError,
+} from '../../../../lib/formatters/iac-output/text/share-results';
 
 const SEPARATOR = '\n-------------------------------------------------------\n';
 
@@ -270,7 +274,7 @@ export function buildShareResultsSummary({
   return response;
 }
 
-export function buildShareResultsSummaryV2({
+export function buildShareResultsSummaryIacPlus({
   orgName,
   projectName,
   options,
@@ -286,7 +290,7 @@ export function buildShareResultsSummaryV2({
   let response = '';
 
   response +=
-    SEPARATOR + EOL + formatShareResultsOutputV2(orgName, projectName);
+    SEPARATOR + EOL + formatShareResultsOutputIacPlus(orgName, projectName);
 
   if (
     shouldPrintShareCustomRulesDisclaimer(
@@ -297,6 +301,21 @@ export function buildShareResultsSummaryV2({
   ) {
     response += EOL + EOL + shareCustomRulesDisclaimer;
   }
+
+  return response;
+}
+
+export function buildShareResultsSummaryIacV2({
+  orgName,
+  projectPublicId,
+}: {
+  orgName: string;
+  projectPublicId: string | undefined;
+}): string {
+  let response = SEPARATOR + EOL;
+  response += projectPublicId
+    ? formatShareResultsOutputIacV2(orgName, projectPublicId)
+    : shareResultsError;
 
   return response;
 }

--- a/src/cli/commands/test/iac/v2/index.ts
+++ b/src/cli/commands/test/iac/v2/index.ts
@@ -33,6 +33,7 @@ export async function test(
       scanResult,
       testSpinner,
       options,
+      iacNewEngine,
     });
   } finally {
     testSpinner?.stop();

--- a/src/lib/formatters/iac-output/text/share-results.ts
+++ b/src/lib/formatters/iac-output/text/share-results.ts
@@ -17,7 +17,7 @@ export function formatShareResultsOutput(orgName: string, projectName: string) {
   );
 }
 
-export function formatShareResultsOutputV2(
+export function formatShareResultsOutputIacPlus(
   orgName: string,
   projectName: string,
 ) {
@@ -37,6 +37,25 @@ export function formatShareResultsOutputV2(
   );
 }
 
+export function formatShareResultsOutputIacV2(
+  orgName: string,
+  projectPublicId: string | undefined,
+) {
+  let projectLink = ''; // empty link if projectId is undefined, will follow up on this after product decision
+  if (projectPublicId) {
+    projectLink = `${config.ROOT}/org/${orgName}/project/${encodeURIComponent(projectPublicId)}`;
+  }
+
+  return (
+    colors.title('Report Complete') +
+    EOL +
+    EOL +
+    contentPadding +
+    'Your test results are available at: ' +
+    colors.title(projectLink)
+  );
+}
+
 export const shareResultsTip =
   colors.title('Tip') +
   EOL +
@@ -50,3 +69,14 @@ export const shareCustomRulesDisclaimer =
   colors.suggestion(
     'Please note that your custom rules will not be sent to the platform, and will not be available on the projects page.',
   );
+
+export const shareResultsError =
+  colors.title('Failed to create and display results in Snyk UI') +
+  EOL +
+  EOL +
+  contentPadding +
+  'There was a problem creating the project and displaying the test results in Snyk UI.' +
+  EOL +
+  contentPadding +
+  colors.title('Need help?') +
+  ' Check the Snyk CLI for IaC doc https://docs.snyk.io/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-iac';

--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -1,11 +1,11 @@
 import * as os from 'os';
 
 const policyEngineChecksums = `
-aeb08fbecd094cdec741237f0f9f187492fa4e446f41e3dc7135426fdd721382  snyk-iac-test_0.57.4_Darwin_x86_64
-b9607371e0372b382c6e92fdbe1624364baf3b2d4856312c32567de4ed0bdc72  snyk-iac-test_0.57.4_Darwin_arm64
-c4447339c352c646bfa79bf12aef108e8c9f0263ac2440fe7e5edafa46ba433d  snyk-iac-test_0.57.4_Linux_arm64
-fa327f0909b43b59bb76dfd54f99603859a2606663390aad16abe484f6ef8765  snyk-iac-test_0.57.4_Windows_x86_64.exe
-fe0604529047aa5fcd3edffe5f1b9392bfc255f94885d745266aca768f521907  snyk-iac-test_0.57.4_Linux_x86_64
+2bece98c6602298aab72fe8be803cd48974b63766c2a53491761d0855dccef0d  snyk-iac-test_0.57.5_Darwin_x86_64
+3703de51908fb24ea11358c1f97643937b502a43afac5131d45c11a321138687  snyk-iac-test_0.57.5_Windows_x86_64.exe
+458e9debc734006ce6bb4ae530111ad0548a3d85ca43f8b4b5f0b17994e75efd  snyk-iac-test_0.57.5_Linux_arm64
+c624ddaa85851ed8c9fb54895c8834d0f04221066feb7d08afd2413ae2cf97cc  snyk-iac-test_0.57.5_Darwin_arm64
+d15e89f5933933b13693f5ee42b27799825a1abc16e0bdbd5a2c40c5b5af8f9b  snyk-iac-test_0.57.5_Linux_x86_64
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();

--- a/src/lib/iac/test/v2/scan/results.ts
+++ b/src/lib/iac/test/v2/scan/results.ts
@@ -71,6 +71,7 @@ export interface Results {
 
 export interface Metadata {
   projectName: string;
+  projectPublicId: string;
   ignoredCount: number;
 }
 


### PR DESCRIPTION
## Pull Request Submission Checklist
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?
This PR is related to the IaC V2 product (i.e. `iacNewEngine` feature flag).
Based on the project public id received from `snyk-iac-test` when the --report option is used, show the correct link (Snyk UI) to the project results. If the project is not created properly, show an error message.

## Where should the reviewer start?

## How should this be manually tested?
Make sure to have the `iacNewEngine` feature flag.
Run the snyk iac test --report command using the corresponding snyk-iac-test version (https://github.com/snyk/snyk-iac-test/pull/264).
The output should include a link to the specific project for which the results are reported.

<!---
## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->