### PR TITLE
feat: compose error catalog errors in TS custom errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@snyk/code-client": "^4.23.5",
         "@snyk/dep-graph": "^2.7.4",
         "@snyk/docker-registry-v2-client": "^2.11.0",
-        "@snyk/error-catalog-nodejs-public": "^5.37.0",
+        "@snyk/error-catalog-nodejs-public": "^5.44.0",
         "@snyk/fix": "file:packages/snyk-fix",
         "@snyk/gemfile": "1.2.0",
         "@snyk/snyk-cocoapods-plugin": "2.5.3",
@@ -142,6 +142,62 @@
       },
       "engines": {
         "node": "^18"
+      }
+    },
+    "../error-catalog": {
+      "name": "@snyk/error-catalog",
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@octokit/rest": "^21.1.0",
+        "@snyk/log": "^5.3.0",
+        "express": "^4.21.2",
+        "handlebars": "^4.7.8",
+        "http-status-codes": "^2.3.0",
+        "ts-dedent": "^2.2.0",
+        "tslib": "^2.8.1",
+        "uuid": "^11.0.5"
+      },
+      "devDependencies": {
+        "@nx/eslint-plugin": "^20.4.0",
+        "@nx/jest": "20.4.0",
+        "@nx/js": "20.4.0",
+        "@nx/linter": "19.8.4",
+        "@nx/workspace": "20.4.0",
+        "@rossmcewan/semantic-release-nx": "^0.2.0",
+        "@semantic-release/exec": "^6.0.3",
+        "@types/express": "^5.0.0",
+        "@types/jest": "29.5.14",
+        "@types/node": "^22.12.0",
+        "@types/uuid": "^10.0.0",
+        "@typescript-eslint/eslint-plugin": "^8.22.0",
+        "eslint": "9.19.0",
+        "fs-extra": "^11.3.0",
+        "jest": "29.7.0",
+        "jest-environment-jsdom": "^29.7.0",
+        "nx": "20.4.0",
+        "prettier": "^2.8.8",
+        "semantic-release": "^20.1.3",
+        "semver": "^7.7.0",
+        "simple-git": "^3.27.0",
+        "stream-buffers": "^3.0.3",
+        "ts-jest": "29.2.5",
+        "ts-node": "10.9.2",
+        "typescript": "5.7.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "../error-catalog/packages/error-catalog-nodejs-public": {
+      "name": "@snyk/error-catalog-nodejs-public",
+      "version": "0.0.1",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.1",
+        "uuid": "^11.0.5"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -3077,13 +3133,13 @@
       }
     },
     "node_modules/@snyk/error-catalog-nodejs-public": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@snyk/error-catalog-nodejs-public/-/error-catalog-nodejs-public-5.37.0.tgz",
-      "integrity": "sha512-63SNBN5XC0fD2zmFYJtMtW8jg3kf774CCCOqMikyZW1rknkxnLiTFbGgA/Xwwjse3TobGxlltfBHt0yPpcRSPw==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/@snyk/error-catalog-nodejs-public/-/error-catalog-nodejs-public-5.44.0.tgz",
+      "integrity": "sha512-lCs8k4FeRbbsBwjPopZFisb9Yv9sIMYUArOUUw0G3lO82ih8MfLUoj8ilnw9aTl91/T5cjPHmP/nX5jsWYzz4Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.1",
-        "uuid": "^11.0.5"
+        "uuid": "^11.1.0"
       }
     },
     "node_modules/@snyk/error-catalog-nodejs-public/node_modules/tslib": {
@@ -3093,9 +3149,9 @@
       "license": "0BSD"
     },
     "node_modules/@snyk/error-catalog-nodejs-public/node_modules/uuid": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
-      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -26638,12 +26694,12 @@
       }
     },
     "@snyk/error-catalog-nodejs-public": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@snyk/error-catalog-nodejs-public/-/error-catalog-nodejs-public-5.37.0.tgz",
-      "integrity": "sha512-63SNBN5XC0fD2zmFYJtMtW8jg3kf774CCCOqMikyZW1rknkxnLiTFbGgA/Xwwjse3TobGxlltfBHt0yPpcRSPw==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/@snyk/error-catalog-nodejs-public/-/error-catalog-nodejs-public-5.44.0.tgz",
+      "integrity": "sha512-lCs8k4FeRbbsBwjPopZFisb9Yv9sIMYUArOUUw0G3lO82ih8MfLUoj8ilnw9aTl91/T5cjPHmP/nX5jsWYzz4Q==",
       "requires": {
         "tslib": "^2.8.1",
-        "uuid": "^11.0.5"
+        "uuid": "^11.1.0"
       },
       "dependencies": {
         "tslib": {
@@ -26652,9 +26708,9 @@
           "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "uuid": {
-          "version": "11.0.5",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
-          "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA=="
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+          "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@snyk/code-client": "^4.23.5",
     "@snyk/dep-graph": "^2.7.4",
     "@snyk/docker-registry-v2-client": "^2.11.0",
-    "@snyk/error-catalog-nodejs-public": "^5.37.0",
+    "@snyk/error-catalog-nodejs-public": "^5.44.0",
     "@snyk/fix": "file:packages/snyk-fix",
     "@snyk/gemfile": "1.2.0",
     "@snyk/snyk-cocoapods-plugin": "2.5.3",

--- a/src/cli/commands/describe.ts
+++ b/src/cli/commands/describe.ts
@@ -17,6 +17,7 @@ import { DCTL_EXIT_CODES, runDriftCTL } from '../../lib/iac/drift/driftctl';
 import { IaCErrorCodes } from './test/iac/local-execution/types';
 import { getErrorStringCode } from './test/iac/local-execution/error-utils';
 import { DescribeOptions } from '../../lib/iac/types';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 export class FlagError extends CustomError {
   constructor(flag: string) {
@@ -25,6 +26,7 @@ export class FlagError extends CustomError {
     this.code = IaCErrorCodes.FlagError;
     this.strCode = getErrorStringCode(this.code);
     this.userMessage = msg;
+    this.errorCatalog = new CLI.InvalidFlagOptionError('');
   }
 }
 export default async (...args: MethodArgs): Promise<any> => {

--- a/src/cli/commands/test/iac/local-execution/assert-iac-options-flag.ts
+++ b/src/cli/commands/test/iac/local-execution/assert-iac-options-flag.ts
@@ -9,6 +9,7 @@ import {
 } from './types';
 import { Options, TestOptions } from '../../../../../lib/types';
 import { IacV2Name } from '../../../../../lib/iac/constants';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 const keys: (keyof IaCTestFlags)[] = [
   'org',
@@ -67,6 +68,7 @@ export class FlagError extends CustomError {
     this.code = IaCErrorCodes.FlagError;
     this.strCode = getErrorStringCode(this.code);
     this.userMessage = msg;
+    this.errorCatalog = new CLI.InvalidFlagOptionError('');
   }
 }
 
@@ -78,6 +80,7 @@ export class IntegratedFlagError extends CustomError {
     this.code = IaCErrorCodes.FlagError;
     this.strCode = getErrorStringCode(this.code);
     this.userMessage = msg;
+    this.errorCatalog = new CLI.InvalidFlagOptionError('');
   }
 }
 
@@ -94,6 +97,7 @@ export class FeatureFlagError extends CustomError {
     this.code = IaCErrorCodes.FeatureFlagError;
     this.strCode = getErrorStringCode(this.code);
     this.userMessage = msg;
+    this.errorCatalog = new CLI.InvalidFlagOptionError('');
   }
 }
 
@@ -105,29 +109,34 @@ export class FlagValueError extends CustomError {
     this.code = IaCErrorCodes.FlagValueError;
     this.strCode = getErrorStringCode(this.code);
     this.userMessage = msg;
+    this.errorCatalog = new CLI.InvalidFlagOptionError('');
   }
 }
 
 export class UnsupportedEntitlementFlagError extends CustomError {
   constructor(key: string, entitlementName: string) {
     const flag = getFlagName(key);
+    const msg = `Flag "${flag}" is currently not supported for this org. To enable it, please contact snyk support.`;
     super(
       `Unsupported flag: ${flag} - Missing the ${entitlementName} entitlement`,
     );
     this.code = IaCErrorCodes.UnsupportedEntitlementFlagError;
     this.strCode = getErrorStringCode(this.code);
-    this.userMessage = `Flag "${flag}" is currently not supported for this org. To enable it, please contact snyk support.`;
+    this.userMessage = msg;
+    this.errorCatalog = new CLI.InvalidFlagOptionError('');
   }
 }
 
 export class UnsupportedEntitlementCommandError extends CustomError {
   constructor(key: string, entitlementName: string) {
+    const usrMsg = `Command "${key}" is currently not supported for this org. To enable it, please contact snyk support.`;
     super(
       `Unsupported command: ${key} - Missing the ${entitlementName} entitlement`,
     );
     this.code = IaCErrorCodes.UnsupportedEntitlementFlagError;
     this.strCode = getErrorStringCode(this.code);
-    this.userMessage = `Command "${key}" is currently not supported for this org. To enable it, please contact snyk support.`;
+    this.userMessage = usrMsg;
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }
 
@@ -213,5 +222,6 @@ export class InvalidArgumentError extends CustomError {
     this.code = IaCErrorCodes.InvalidArgumentError;
     this.strCode = getErrorStringCode(this.code);
     this.userMessage = msg;
+    this.errorCatalog = new CLI.InvalidFlagOptionError('');
   }
 }

--- a/src/cli/commands/test/iac/local-execution/file-loader.ts
+++ b/src/cli/commands/test/iac/local-execution/file-loader.ts
@@ -4,6 +4,7 @@ import { IacFileTypes } from '../../../../../lib/iac/constants';
 import { CustomError } from '../../../../../lib/errors';
 import { getErrorStringCode } from './error-utils';
 import { getFileType } from './directory-loader';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 const DEFAULT_ENCODING = 'utf-8';
 
@@ -52,6 +53,7 @@ export class NoFilesToScanError extends CustomError {
     this.strCode = getErrorStringCode(this.code);
     this.userMessage =
       'Could not find any valid infrastructure as code files. Supported file extensions are tf, yml, yaml & json.\nMore information can be found by running `snyk iac test --help` or through our documentation:\nhttps://support.snyk.io/hc/en-us/articles/360012429477-Test-your-Kubernetes-files-with-our-CLI-tool\nhttps://support.snyk.io/hc/en-us/articles/360013723877-Test-your-Terraform-files-with-our-CLI-tool';
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }
 
@@ -63,5 +65,6 @@ export class FailedToLoadFileError extends CustomError {
     this.strCode = getErrorStringCode(this.code);
     this.filename = filename;
     this.userMessage = `We were unable to read file "${filename}" for scanning. Please ensure that it is readable.`;
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }

--- a/src/cli/commands/test/iac/local-execution/file-parser.ts
+++ b/src/cli/commands/test/iac/local-execution/file-parser.ts
@@ -24,6 +24,7 @@ import hclToJsonV2 from './parsers/hcl-to-json-v2';
 import { IacProjectType } from '../../../../../lib/iac/constants';
 
 import * as Debug from 'debug';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 const debug = Debug('snyk-test');
 
@@ -168,5 +169,6 @@ export class UnsupportedFileTypeError extends CustomError {
     this.code = IaCErrorCodes.UnsupportedFileTypeError;
     this.strCode = getErrorStringCode(this.code);
     this.userMessage = `Unable to process the file with extension ${fileType}. Supported file extensions are tf, yml, yaml & json.\nMore information can be found by running \`snyk iac test --help\` or through our documentation:\nhttps://support.snyk.io/hc/en-us/articles/360012429477-Test-your-Kubernetes-files-with-our-CLI-tool\nhttps://support.snyk.io/hc/en-us/articles/360013723877-Test-your-Terraform-files-with-our-CLI-tool`;
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }

--- a/src/cli/commands/test/iac/local-execution/file-scanner.ts
+++ b/src/cli/commands/test/iac/local-execution/file-scanner.ts
@@ -13,6 +13,7 @@ import { CustomError } from '../../../../../lib/errors';
 import { getErrorStringCode } from './error-utils';
 import { IacFileInDirectory } from '../../../../../lib/types';
 import { SEVERITIES } from '../../../../../lib/snyk-test/common';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 export async function scanFiles(parsedFiles: Array<IacFileParsed>): Promise<{
   scannedFiles: IacFileScanResult[];
@@ -170,6 +171,7 @@ export class FailedToBuildPolicyEngine extends CustomError {
     this.strCode = getErrorStringCode(this.code);
     this.userMessage =
       'We were unable to run the test. Please run the command again with the `-d` flag and contact support@snyk.io with the contents of the output';
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }
 export class FailedToExecutePolicyEngine extends CustomError {
@@ -179,5 +181,6 @@ export class FailedToExecutePolicyEngine extends CustomError {
     this.strCode = getErrorStringCode(this.code);
     this.userMessage =
       'We were unable to run the test. Please run the command again with the `-d` flag and contact support@snyk.io with the contents of the output';
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }

--- a/src/cli/commands/test/iac/local-execution/index.ts
+++ b/src/cli/commands/test/iac/local-execution/index.ts
@@ -32,6 +32,7 @@ import { CustomError } from '../../../../../lib/errors';
 import { getErrorStringCode } from './error-utils';
 import { NoFilesToScanError } from './file-loader';
 import { Tag } from '../../../../../lib/types';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 // this method executes the local processing engine and then formats the results to adapt with the CLI output.
 // this flow is the default GA flow for IAC scanning.
@@ -184,5 +185,6 @@ export class InvalidVarFilePath extends CustomError {
     this.code = IaCErrorCodes.InvalidVarFilePath;
     this.strCode = getErrorStringCode(this.code);
     this.userMessage = `We were unable to locate a variable definitions file at: "${path}". The file at the provided path does not exist`;
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }

--- a/src/cli/commands/test/iac/local-execution/local-cache.ts
+++ b/src/cli/commands/test/iac/local-execution/local-cache.ts
@@ -10,6 +10,7 @@ import { getErrorStringCode } from './error-utils';
 import config from '../../../../../lib/config';
 import { streamRequest } from '../../../../../lib/request/request';
 import envPaths from 'env-paths';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 const debug = Debug('iac-local-cache');
 
@@ -176,6 +177,7 @@ export class FailedToInitLocalCacheError extends CustomError {
     this.strCode = getErrorStringCode(this.code);
     this.userMessage =
       'We were unable to create a local directory to store the test assets, please ensure that the current working directory is writable';
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }
 
@@ -186,6 +188,7 @@ export class FailedToDownloadRulesError extends CustomError {
     this.strCode = getErrorStringCode(this.code);
     this.userMessage =
       'We were unable to download the security rules, please ensure the network can access https://downloads.snyk.io';
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }
 
@@ -195,6 +198,7 @@ export class FailedToExtractCustomRulesError extends CustomError {
     this.code = IaCErrorCodes.FailedToExtractCustomRulesError;
     this.strCode = getErrorStringCode(this.code);
     this.userMessage = `We were unable to extract the rules provided at: ${path}. The provided bundle may be corrupted or invalid. Please ensure it was generated using the 'snyk-iac-rules' SDK`;
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }
 
@@ -204,6 +208,7 @@ export class InvalidCustomRules extends CustomError {
     this.code = IaCErrorCodes.InvalidCustomRules;
     this.strCode = getErrorStringCode(this.code);
     this.userMessage = `We were unable to extract the rules provided at: ${path}. The provided bundle does not match the required structure. Please ensure it was generated using the 'snyk-iac-rules' SDK`;
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }
 
@@ -213,6 +218,7 @@ export class InvalidCustomRulesPath extends CustomError {
     this.code = IaCErrorCodes.InvalidCustomRulesPath;
     this.strCode = getErrorStringCode(this.code);
     this.userMessage = `We were unable to extract the rules provided at: ${path}. The bundle at the provided path does not exist`;
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }
 

--- a/src/cli/commands/test/iac/local-execution/org-settings/get-iac-org-settings.ts
+++ b/src/cli/commands/test/iac/local-execution/org-settings/get-iac-org-settings.ts
@@ -6,6 +6,7 @@ import { getAuthHeader } from '../../../../../../lib/api-token';
 import { makeRequest } from '../../../../../../lib/request';
 import { CustomError } from '../../../../../../lib/errors';
 import { getErrorStringCode } from '../error-utils';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 export function getIacOrgSettings(
   publicOrgId?: string,
@@ -41,5 +42,6 @@ export class FailedToGetIacOrgSettingsError extends CustomError {
     this.strCode = getErrorStringCode(this.code);
     this.userMessage =
       'We failed to fetch your organization settings, including custom severity overrides for infrastructure-as-code policies. Please run the command again with the `-d` flag and contact support@snyk.io with the contents of the output.';
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }

--- a/src/cli/commands/test/iac/local-execution/parsers/terraform-file-parser.ts
+++ b/src/cli/commands/test/iac/local-execution/parsers/terraform-file-parser.ts
@@ -1,6 +1,7 @@
 import { IaCErrorCodes } from '../types';
 import { CustomError } from '../../../../../../lib/errors';
 import { getErrorStringCode } from '../error-utils';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 export class FailedToParseTerraformFileError extends CustomError {
   public filename: string;
@@ -10,5 +11,6 @@ export class FailedToParseTerraformFileError extends CustomError {
     this.strCode = getErrorStringCode(this.code);
     this.filename = filename;
     this.userMessage = `We were unable to parse the Terraform file "${filename}", please ensure it is valid HCL2. This can be done by running it through the 'terraform validate' command.`;
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }

--- a/src/cli/commands/test/iac/local-execution/parsers/terraform-plan-parser.ts
+++ b/src/cli/commands/test/iac/local-execution/parsers/terraform-plan-parser.ts
@@ -16,6 +16,7 @@ import {
 import { CustomError } from '../../../../../../lib/errors';
 import { getErrorStringCode } from '../error-utils';
 import { IacProjectType } from '../../../../../../lib/iac/constants';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 function terraformPlanReducer(
   scanInput: TerraformScanInput,
@@ -190,5 +191,6 @@ export class FailedToExtractResourcesInTerraformPlanError extends CustomError {
     this.strCode = getErrorStringCode(this.code);
     this.userMessage =
       'We failed to extract resource changes from the Terraform plan file, please contact support@snyk.io, if possible with a redacted version of the file';
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }

--- a/src/cli/commands/test/iac/local-execution/process-results/results-formatter.ts
+++ b/src/cli/commands/test/iac/local-execution/process-results/results-formatter.ts
@@ -19,6 +19,7 @@ import {
 } from '@snyk/cloud-config-parser';
 import * as path from 'path';
 import { isLocalFolder } from '../../../../../../lib/detect';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 const severitiesArray = SEVERITIES.map((s) => s.verboseName);
 
@@ -172,6 +173,7 @@ export class FailedToFormatResults extends CustomError {
     this.strCode = getErrorStringCode(this.code);
     this.userMessage =
       'We failed printing the results, please contact support@snyk.io';
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }
 

--- a/src/cli/commands/test/iac/local-execution/rules/oci-pull.ts
+++ b/src/cli/commands/test/iac/local-execution/rules/oci-pull.ts
@@ -7,6 +7,7 @@ import { LOCAL_POLICY_ENGINE_DIR } from '../local-cache';
 import * as Debug from 'debug';
 import { createIacDir } from '../file-utils';
 import { OciRegistry } from './oci-registry';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 const debug = Debug('iac-oci-pull');
 
 export const CUSTOM_RULES_TARBALL = 'custom-bundle.tar.gz';
@@ -80,6 +81,7 @@ export class FailedToBuildOCIArtifactError extends CustomError {
     this.strCode = getErrorStringCode(this.code);
     this.userMessage =
       'We were unable to build the remote OCI Artifact locally, please ensure that the local directory is writeable.';
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }
 
@@ -89,6 +91,7 @@ export class InvalidManifestSchemaVersionError extends CustomError {
     this.code = IaCErrorCodes.InvalidRemoteRegistryURLError;
     this.strCode = getErrorStringCode(this.code);
     this.userMessage = `Invalid manifest schema version: ${message}. We currently support Image Manifest Version 2, Schema 2`;
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }
 
@@ -97,9 +100,8 @@ export class InvalidRemoteRegistryURLError extends CustomError {
     super('Invalid URL for Remote Registry');
     this.code = IaCErrorCodes.InvalidRemoteRegistryURLError;
     this.strCode = getErrorStringCode(this.code);
-    this.userMessage = `The provided remote registry URL${
-      url ? `: "${url}"` : ''
-    } is invalid. Please check it again.`;
+    this.userMessage = `The provided remote registry URL${url ? `: "${url}"` : ''} is invalid. Please check it again.`;
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }
 
@@ -109,5 +111,6 @@ export class UnsupportedEntitlementPullError extends CustomError {
     this.code = IaCErrorCodes.UnsupportedEntitlementPullError;
     this.strCode = getErrorStringCode(this.code);
     this.userMessage = `The custom rules feature is currently not supported for this org. To enable it, please contact snyk support.`;
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }

--- a/src/cli/commands/test/iac/local-execution/rules/rules.ts
+++ b/src/cli/commands/test/iac/local-execution/rules/rules.ts
@@ -25,6 +25,7 @@ import {
 import { OciRegistry, RemoteOciRegistry } from './oci-registry';
 import { isValidUrl } from '../url-utils';
 import { isFeatureFlagSupportedForOrg } from '../../../../../../lib/feature-flags';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 export async function initRules(
   buildOciRegistry: () => OciRegistry,
@@ -201,6 +202,7 @@ export class FailedToPullCustomBundleError extends CustomError {
       `${message ? message + ' ' : ''}` +
       '\nWe were unable to download the custom bundle to the disk. Please ensure access to the remote Registry and validate you have provided all the right parameters.' +
       '\nSee documentation on troubleshooting: https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/use-IaC-custom-rules-with-CLI/using-a-remote-custom-rules-bundle#troubleshooting';
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }
 
@@ -209,8 +211,8 @@ export class FailedToExecuteCustomRulesError extends CustomError {
     super(message || 'Could not execute custom rules mode');
     this.code = IaCErrorCodes.FailedToExecuteCustomRulesError;
     this.strCode = getErrorStringCode(this.code);
-    this.userMessage = `
-    Remote and local custom rules bundle can not be used at the same time.
-    Please provide a registry URL for the remote bundle, or specify local path location by using the --rules flag for the local bundle.`;
+    this.userMessage = `Remote and local custom rules bundle can not be used at the same time.
+      Please provide a registry URL for the remote bundle, or specify local path location by using the --rules flag for the local bundle.`;
+    this.errorCatalog = new CLI.InvalidFlagOptionError('');
   }
 }

--- a/src/cli/commands/test/iac/local-execution/usage-tracking.ts
+++ b/src/cli/commands/test/iac/local-execution/usage-tracking.ts
@@ -2,6 +2,7 @@ import { makeRequest } from '../../../../../lib/request';
 import config from '../../../../../lib/config';
 import { getAuthHeader } from '../../../../../lib/api-token';
 import { CustomError } from '../../../../../lib/errors';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 export async function trackUsage(
   formattedResults: TrackableResult[],
@@ -42,6 +43,7 @@ export class TestLimitReachedError extends CustomError {
     super(
       'Test limit reached! You have exceeded your infrastructure as code test allocation for this billing period.',
     );
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }
 

--- a/src/cli/commands/test/iac/local-execution/yaml-parser.ts
+++ b/src/cli/commands/test/iac/local-execution/yaml-parser.ts
@@ -1,3 +1,4 @@
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from '../../../../../lib/errors';
 import { getErrorStringCode } from './error-utils';
 import { IaCErrorCodes, IacFileData } from './types';
@@ -28,6 +29,7 @@ export class InvalidJsonFileError extends CustomError {
     this.strCode = getErrorStringCode(this.code);
     this.filename = filename;
     this.userMessage = `We were unable to parse the JSON file "${filename}". Please ensure that it contains properly structured JSON`;
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }
 
@@ -39,5 +41,6 @@ export class InvalidYamlFileError extends CustomError {
     this.strCode = getErrorStringCode(this.code);
     this.filename = filename;
     this.userMessage = `We were unable to parse the YAML file "${filename}". Please ensure that it contains properly structured YAML, without any template directives`;
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }

--- a/src/cli/commands/test/iac/output.ts
+++ b/src/cli/commands/test/iac/output.ts
@@ -37,6 +37,7 @@ import {
   formatShareResultsOutputIacPlus,
   shareResultsError,
 } from '../../../../lib/formatters/iac-output/text/share-results';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 const SEPARATOR = '\n-------------------------------------------------------\n';
 
@@ -183,6 +184,8 @@ export function buildOutput({
         ? new FormattedCustomError(
             errorResults[0].message,
             formatFailuresList(allTestFailures),
+            undefined,
+            new CLI.GeneralIACFailureError(formatFailuresList(allTestFailures)),
           )
         : new CustomError(response);
       error.code = errorResults[0].code;

--- a/src/cli/commands/test/iac/scan.ts
+++ b/src/cli/commands/test/iac/scan.ts
@@ -31,6 +31,7 @@ import { getRepositoryRootForPath } from '../../../../lib/iac/git';
 import { getInfo } from '../../../../lib/project-metadata/target-builders/git';
 import { buildMeta, GitRepository, GitRepositoryFinder } from './meta';
 import { MAX_STRING_LENGTH } from '../../../../lib/constants';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 const debug = debugLib('snyk-iac');
 
@@ -199,9 +200,10 @@ class CurrentWorkingDirectoryTraversalError extends CustomError {
     super('Path is outside the current working directory');
     this.code = IaCErrorCodes.CurrentWorkingDirectoryTraversalError;
     this.strCode = getErrorStringCode(this.code);
-    this.userMessage = `Path is outside the current working directory`;
+    this.userMessage = 'Path is outside the current working directory';
     this.filename = path;
     this.projectRoot = projectRoot;
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -142,7 +142,7 @@ async function handleError(args, error) {
    * - sarif - no error message or details are present in the payload
    * - vulnsFound - issues are treated as errors (exit code 1), this should be some nice pretty formated output for users.
    */
-  const errorSent =
+  const shouldOutputError =
     vulnsFound || args.options.sarif
       ? false
       : await sendError(error, args.options.json);
@@ -163,7 +163,7 @@ async function handleError(args, error) {
       console.log(output);
     }
     // If the IPC communication failed, we default back to the original output flow
-  } else if (!errorSent) {
+  } else if (!shouldOutputError) {
     // Debug output flow
     if (args.options.debug) {
       const output = vulnsFound ? error.message : error.stack;

--- a/src/lib/errors/authentication-failed-error.ts
+++ b/src/lib/errors/authentication-failed-error.ts
@@ -1,4 +1,5 @@
 import { CustomError } from './custom-error';
+import { Snyk } from '@snyk/error-catalog-nodejs-public';
 import config from '../config';
 
 export function AuthFailedError(
@@ -10,5 +11,6 @@ export function AuthFailedError(
   error.code = errorCode;
   error.strCode = 'authfail';
   error.userMessage = errorMessage;
+  error.errorCatalog = new Snyk.UnauthorisedError('');
   return error;
 }

--- a/src/lib/errors/bad-gateway-error.ts
+++ b/src/lib/errors/bad-gateway-error.ts
@@ -1,4 +1,5 @@
 import { CustomError } from './custom-error';
+import { Snyk } from '@snyk/error-catalog-nodejs-public';
 
 export class BadGatewayError extends CustomError {
   private static ERROR_CODE = 502;
@@ -10,5 +11,6 @@ export class BadGatewayError extends CustomError {
     this.code = BadGatewayError.ERROR_CODE;
     this.strCode = BadGatewayError.ERROR_STRING_CODE;
     this.userMessage = userMessage || BadGatewayError.ERROR_MESSAGE;
+    this.errorCatalog = new Snyk.BadGatewayError('');
   }
 }

--- a/src/lib/errors/connection-timeout-error.ts
+++ b/src/lib/errors/connection-timeout-error.ts
@@ -1,4 +1,5 @@
 import { CustomError } from './custom-error';
+import { Snyk } from '@snyk/error-catalog-nodejs-public';
 
 export class ConnectionTimeoutError extends CustomError {
   private static ERROR_MESSAGE = 'Connection timeout.';
@@ -7,5 +8,6 @@ export class ConnectionTimeoutError extends CustomError {
     super(ConnectionTimeoutError.ERROR_MESSAGE);
     this.code = 504;
     this.userMessage = ConnectionTimeoutError.ERROR_MESSAGE;
+    this.errorCatalog = new Snyk.TimeoutError('');
   }
 }

--- a/src/lib/errors/custom-error.ts
+++ b/src/lib/errors/custom-error.ts
@@ -1,8 +1,11 @@
+import { ProblemError } from '@snyk/error-catalog-nodejs-public';
+
 export class CustomError extends Error {
   public innerError;
   public code: number | undefined;
   public userMessage: string | undefined;
   public strCode: string | undefined;
+  protected _errorCatalog: ProblemError | undefined;
 
   constructor(message: string) {
     super(message);
@@ -12,5 +15,17 @@ export class CustomError extends Error {
     this.strCode = undefined;
     this.innerError = undefined;
     this.userMessage = undefined;
+    this._errorCatalog = undefined;
+  }
+
+  set errorCatalog(ec: ProblemError | undefined) {
+    this._errorCatalog = ec;
+  }
+
+  get errorCatalog(): ProblemError | undefined {
+    if (this._errorCatalog) {
+      this._errorCatalog.detail = this.userMessage ?? this.message;
+    }
+    return this._errorCatalog;
   }
 }

--- a/src/lib/errors/docker-image-not-found-error.ts
+++ b/src/lib/errors/docker-image-not-found-error.ts
@@ -1,3 +1,4 @@
+import { CustomBaseImages } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class DockerImageNotFoundError extends CustomError {
@@ -8,5 +9,6 @@ export class DockerImageNotFoundError extends CustomError {
     super(message);
     this.code = DockerImageNotFoundError.ERROR_CODE;
     this.userMessage = message;
+    this.errorCatalog = new CustomBaseImages.ImageNotFoundError('');
   }
 }

--- a/src/lib/errors/empty-sarif-output-error.ts
+++ b/src/lib/errors/empty-sarif-output-error.ts
@@ -1,3 +1,4 @@
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class SarifFileOutputEmptyError extends CustomError {
@@ -9,5 +10,6 @@ export class SarifFileOutputEmptyError extends CustomError {
     super(SarifFileOutputEmptyError.ERROR_MESSAGE);
     this.code = SarifFileOutputEmptyError.ERROR_CODE;
     this.userMessage = SarifFileOutputEmptyError.ERROR_MESSAGE;
+    this.errorCatalog = new CLI.EmptyFlagOptionError('');
   }
 }

--- a/src/lib/errors/exclude-flag-bad-input.ts
+++ b/src/lib/errors/exclude-flag-bad-input.ts
@@ -1,3 +1,4 @@
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class ExcludeFlagBadInputError extends CustomError {
@@ -9,5 +10,6 @@ export class ExcludeFlagBadInputError extends CustomError {
     super(ExcludeFlagBadInputError.ERROR_MESSAGE);
     this.code = ExcludeFlagBadInputError.ERROR_CODE;
     this.userMessage = ExcludeFlagBadInputError.ERROR_MESSAGE;
+    this.errorCatalog = new CLI.EmptyFlagOptionError('');
   }
 }

--- a/src/lib/errors/exclude-flag-invalid-input.ts
+++ b/src/lib/errors/exclude-flag-invalid-input.ts
@@ -1,3 +1,4 @@
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class ExcludeFlagInvalidInputError extends CustomError {
@@ -9,5 +10,6 @@ export class ExcludeFlagInvalidInputError extends CustomError {
     super(ExcludeFlagInvalidInputError.ERROR_MESSAGE);
     this.code = ExcludeFlagInvalidInputError.ERROR_CODE;
     this.userMessage = ExcludeFlagInvalidInputError.ERROR_MESSAGE;
+    this.errorCatalog = new CLI.InvalidFlagOptionError('');
   }
 }

--- a/src/lib/errors/fail-on-error.ts.ts
+++ b/src/lib/errors/fail-on-error.ts.ts
@@ -1,5 +1,6 @@
 import { CustomError } from './custom-error';
 import { FAIL_ON } from '../snyk-test/common';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 export class FailOnError extends CustomError {
   private static ERROR_MESSAGE =
@@ -8,5 +9,6 @@ export class FailOnError extends CustomError {
 
   constructor() {
     super(FailOnError.ERROR_MESSAGE);
+    this.errorCatalog = new CLI.InvalidFlagOptionError('');
   }
 }

--- a/src/lib/errors/failed-to-get-vulnerabilities-error.ts
+++ b/src/lib/errors/failed-to-get-vulnerabilities-error.ts
@@ -1,3 +1,4 @@
+import { Snyk } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class FailedToGetVulnerabilitiesError extends CustomError {
@@ -11,5 +12,6 @@ export class FailedToGetVulnerabilitiesError extends CustomError {
     this.strCode = FailedToGetVulnerabilitiesError.ERROR_STRING_CODE;
     this.userMessage =
       userMessage || FailedToGetVulnerabilitiesError.ERROR_MESSAGE;
+    this.errorCatalog = new Snyk.ServerError('');
   }
 }

--- a/src/lib/errors/failed-to-get-vulns-from-unavailable-resource.ts
+++ b/src/lib/errors/failed-to-get-vulns-from-unavailable-resource.ts
@@ -1,3 +1,4 @@
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 const errorNpmMessage =
@@ -9,12 +10,13 @@ export function FailedToGetVulnsFromUnavailableResource(
   root: string,
   statusCode: number,
 ): CustomError {
-  const isRepository = root.startsWith('http' || 'https');
+  const isRepository = root.startsWith('http');
   const errorMsg = `We couldn't test ${root}. ${
     isRepository ? errorRepositoryMessage : errorNpmMessage
   }`;
   const error = new CustomError(errorMsg);
   error.code = statusCode;
   error.userMessage = errorMsg;
+  error.errorCatalog = new CLI.GetVulnsFromResourceFailedError('');
   return error;
 }

--- a/src/lib/errors/failed-to-load-policy-error.ts
+++ b/src/lib/errors/failed-to-load-policy-error.ts
@@ -1,3 +1,4 @@
+import { Policies } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class FailedToLoadPolicyError extends CustomError {
@@ -10,5 +11,6 @@ export class FailedToLoadPolicyError extends CustomError {
     this.code = FailedToLoadPolicyError.ERROR_CODE;
     this.strCode = FailedToLoadPolicyError.ERROR_STRING_CODE;
     this.userMessage = FailedToLoadPolicyError.ERROR_MESSAGE;
+    this.errorCatalog = new Policies.InvalidPolicyApplyError('');
   }
 }

--- a/src/lib/errors/failed-to-run-test-error.ts
+++ b/src/lib/errors/failed-to-run-test-error.ts
@@ -1,14 +1,22 @@
+import { ProblemError } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 export class FailedToRunTestError extends CustomError {
   private static ERROR_MESSAGE = 'Failed to run a test';
   public innerError: any | undefined;
 
-  constructor(userMessage, errorCode?, innerError?: any) {
+  constructor(
+    userMessage,
+    errorCode?,
+    innerError?: any,
+    errorCatalog?: ProblemError,
+  ) {
     const code = errorCode || 500;
     super(userMessage || FailedToRunTestError.ERROR_MESSAGE);
     this.code = errorCode || code;
     this.userMessage = userMessage || FailedToRunTestError.ERROR_MESSAGE;
     this.innerError = innerError;
+    this.errorCatalog = errorCatalog ?? new CLI.GeneralCLIFailureError('');
   }
 }

--- a/src/lib/errors/file-flag-bad-input.ts
+++ b/src/lib/errors/file-flag-bad-input.ts
@@ -1,3 +1,4 @@
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class FileFlagBadInputError extends CustomError {
@@ -9,5 +10,6 @@ export class FileFlagBadInputError extends CustomError {
     super(FileFlagBadInputError.ERROR_MESSAGE);
     this.code = FileFlagBadInputError.ERROR_CODE;
     this.userMessage = FileFlagBadInputError.ERROR_MESSAGE;
+    this.errorCatalog = new CLI.EmptyFlagOptionError('');
   }
 }

--- a/src/lib/errors/formatted-custom-error.ts
+++ b/src/lib/errors/formatted-custom-error.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import { CustomError } from '.';
+import { CLI, ProblemError } from '@snyk/error-catalog-nodejs-public';
 
 export class FormattedCustomError extends CustomError {
   public formattedUserMessage: string;
@@ -8,9 +9,19 @@ export class FormattedCustomError extends CustomError {
     message: string,
     formattedUserMessage: string,
     userMessage?: string,
+    errorCatalog?: ProblemError,
   ) {
     super(message);
     this.userMessage = userMessage || chalk.reset(formattedUserMessage);
     this.formattedUserMessage = formattedUserMessage;
+    this.errorCatalog = errorCatalog ?? new CLI.GeneralCLIFailureError('');
+  }
+
+  set errorCatalog(ec: ProblemError | undefined) {
+    super.errorCatalog = ec;
+  }
+
+  get errorCatalog(): ProblemError | undefined {
+    return this._errorCatalog;
   }
 }

--- a/src/lib/errors/internal-server-error.ts
+++ b/src/lib/errors/internal-server-error.ts
@@ -1,4 +1,5 @@
 import { CustomError } from './custom-error';
+import { Snyk } from '@snyk/error-catalog-nodejs-public';
 
 export class InternalServerError extends CustomError {
   private static ERROR_CODE = 500;
@@ -10,5 +11,6 @@ export class InternalServerError extends CustomError {
     this.code = InternalServerError.ERROR_CODE;
     this.strCode = InternalServerError.ERROR_STRING_CODE;
     this.userMessage = userMessage || InternalServerError.ERROR_MESSAGE;
+    this.errorCatalog = new Snyk.ServerError('');
   }
 }

--- a/src/lib/errors/invalid-detection-depth-value.ts
+++ b/src/lib/errors/invalid-detection-depth-value.ts
@@ -1,3 +1,4 @@
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class InvalidDetectionDepthValue extends CustomError {
@@ -6,5 +7,6 @@ export class InvalidDetectionDepthValue extends CustomError {
     super(msg);
     this.code = 422;
     this.userMessage = msg;
+    this.errorCatalog = new CLI.InvalidFlagOptionError('');
   }
 }

--- a/src/lib/errors/invalid-remote-url-error.ts
+++ b/src/lib/errors/invalid-remote-url-error.ts
@@ -1,3 +1,4 @@
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class InvalidRemoteUrlError extends CustomError {
@@ -6,5 +7,6 @@ export class InvalidRemoteUrlError extends CustomError {
 
   constructor() {
     super(InvalidRemoteUrlError.ERROR_MESSAGE);
+    this.errorCatalog = new CLI.InvalidFlagOptionError('');
   }
 }

--- a/src/lib/errors/json-file-output-bad-input-error.ts
+++ b/src/lib/errors/json-file-output-bad-input-error.ts
@@ -1,3 +1,4 @@
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class JsonFileOutputBadInputError extends CustomError {
@@ -9,5 +10,6 @@ export class JsonFileOutputBadInputError extends CustomError {
     super(JsonFileOutputBadInputError.ERROR_MESSAGE);
     this.code = JsonFileOutputBadInputError.ERROR_CODE;
     this.userMessage = JsonFileOutputBadInputError.ERROR_MESSAGE;
+    this.errorCatalog = new CLI.EmptyFlagOptionError('');
   }
 }

--- a/src/lib/errors/misconfigured-auth-in-ci-error.ts
+++ b/src/lib/errors/misconfigured-auth-in-ci-error.ts
@@ -1,3 +1,4 @@
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export function MisconfiguredAuthInCI() {
@@ -9,5 +10,6 @@ export function MisconfiguredAuthInCI() {
   error.code = 401;
   error.strCode = 'noAuthInCI';
   error.userMessage = errorMsg;
+  error.errorCatalog = new CLI.AuthConfigError('');
   return error;
 }

--- a/src/lib/errors/missing-api-token.ts
+++ b/src/lib/errors/missing-api-token.ts
@@ -1,3 +1,4 @@
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class MissingApiTokenError extends CustomError {
@@ -22,5 +23,6 @@ export class MissingApiTokenError extends CustomError {
     this.code = MissingApiTokenError.ERROR_CODE;
     this.strCode = MissingApiTokenError.ERROR_STRING_CODE;
     this.userMessage = MissingApiTokenError.ERROR_MESSAGE;
+    this.errorCatalog = new CLI.AuthConfigError('');
   }
 }

--- a/src/lib/errors/missing-arg-error.ts
+++ b/src/lib/errors/missing-arg-error.ts
@@ -1,3 +1,4 @@
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class MissingArgError extends CustomError {
@@ -7,5 +8,6 @@ export class MissingArgError extends CustomError {
     super(msg);
     this.code = 422;
     this.userMessage = msg;
+    this.errorCatalog = new CLI.CommandArgsError('');
   }
 }

--- a/src/lib/errors/missing-option-error.ts
+++ b/src/lib/errors/missing-option-error.ts
@@ -1,3 +1,4 @@
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class MissingOptionError extends CustomError {
@@ -8,5 +9,6 @@ export class MissingOptionError extends CustomError {
     super(msg);
     this.code = 422;
     this.userMessage = msg;
+    this.errorCatalog = new CLI.InvalidFlagOptionError('');
   }
 }

--- a/src/lib/errors/missing-targetfile-error.ts
+++ b/src/lib/errors/missing-targetfile-error.ts
@@ -1,3 +1,4 @@
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export function MissingTargetFileError(path: string) {
@@ -8,5 +9,6 @@ export function MissingTargetFileError(path: string) {
   const error = new CustomError(errorMsg);
   error.code = 422;
   error.userMessage = errorMsg;
+  error.errorCatalog = new CLI.CommandArgsError('');
   return error;
 }

--- a/src/lib/errors/monitor-error.ts
+++ b/src/lib/errors/monitor-error.ts
@@ -1,3 +1,4 @@
+import { Snyk } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class MonitorError extends CustomError {
@@ -10,5 +11,6 @@ export class MonitorError extends CustomError {
     super(MonitorError.ERROR_MESSAGE + `Status code: ${code}${errorMessage}`);
     this.code = errorCode;
     this.userMessage = message;
+    this.errorCatalog = new Snyk.ServerError('');
   }
 }

--- a/src/lib/errors/no-supported-manifests-found.ts
+++ b/src/lib/errors/no-supported-manifests-found.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import { CustomError } from './custom-error';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 export function NoSupportedManifestsFoundError(
   atLocations: string[],
@@ -16,5 +17,6 @@ export function NoSupportedManifestsFoundError(
   const error = new CustomError(errorMsg);
   error.code = 422;
   error.userMessage = errorMsg;
+  error.errorCatalog = new CLI.NoSupportedFilesFoundError('');
   return error;
 }

--- a/src/lib/errors/no-supported-sast-files-found.ts
+++ b/src/lib/errors/no-supported-sast-files-found.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import { CustomError } from './custom-error';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 export class NoSupportedSastFiles extends CustomError {
   private static ERROR_MESSAGE =
@@ -13,5 +14,8 @@ export class NoSupportedSastFiles extends CustomError {
     super(NoSupportedSastFiles.ERROR_MESSAGE);
     this.code = 422;
     this.userMessage = NoSupportedSastFiles.ERROR_MESSAGE;
+    this.errorCatalog = new CLI.NoSupportedFilesFoundError(
+      NoSupportedSastFiles.ERROR_MESSAGE,
+    );
   }
 }

--- a/src/lib/errors/not-found-error.ts
+++ b/src/lib/errors/not-found-error.ts
@@ -1,3 +1,4 @@
+import { OpenAPI } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class NotFoundError extends CustomError {
@@ -8,5 +9,6 @@ export class NotFoundError extends CustomError {
     super(userMessage || NotFoundError.ERROR_MESSAGE);
     this.code = NotFoundError.ERROR_CODE;
     this.userMessage = userMessage || NotFoundError.ERROR_MESSAGE;
+    this.errorCatalog = new OpenAPI.NotFoundError('');
   }
 }

--- a/src/lib/errors/not-supported-by-ecosystem.ts
+++ b/src/lib/errors/not-supported-by-ecosystem.ts
@@ -1,6 +1,7 @@
 import { CustomError } from './custom-error';
 import { SupportedPackageManagers } from '../package-managers';
 import { Ecosystem } from '../ecosystems/types';
+import { Fix } from '@snyk/error-catalog-nodejs-public';
 
 export class FeatureNotSupportedByEcosystemError extends CustomError {
   public readonly feature: string;
@@ -14,5 +15,6 @@ export class FeatureNotSupportedByEcosystemError extends CustomError {
     this.feature = feature;
 
     this.userMessage = `\`${feature}\` is not supported for ecosystem '${ecosystem}'`;
+    this.errorCatalog = new Fix.UnsupportedEcosystemError('');
   }
 }

--- a/src/lib/errors/policy-not-found-error.ts
+++ b/src/lib/errors/policy-not-found-error.ts
@@ -1,3 +1,4 @@
+import { Policies } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class PolicyNotFoundError extends CustomError {
@@ -10,5 +11,6 @@ export class PolicyNotFoundError extends CustomError {
     this.code = PolicyNotFoundError.ERROR_CODE;
     this.strCode = PolicyNotFoundError.ERROR_STRING_CODE;
     this.userMessage = PolicyNotFoundError.ERROR_MESSAGE;
+    this.errorCatalog = new Policies.InvalidPolicyApplyError('');
   }
 }

--- a/src/lib/errors/service-unavailable-error.ts
+++ b/src/lib/errors/service-unavailable-error.ts
@@ -1,3 +1,4 @@
+import { Snyk } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class ServiceUnavailableError extends CustomError {
@@ -10,5 +11,6 @@ export class ServiceUnavailableError extends CustomError {
     this.code = ServiceUnavailableError.ERROR_CODE;
     this.strCode = ServiceUnavailableError.ERROR_STRING_CODE;
     this.userMessage = userMessage || ServiceUnavailableError.ERROR_MESSAGE;
+    this.errorCatalog = new Snyk.ServiceUnavailableError('');
   }
 }

--- a/src/lib/errors/token-expired-error.ts
+++ b/src/lib/errors/token-expired-error.ts
@@ -1,3 +1,4 @@
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export function TokenExpiredError() {
@@ -9,5 +10,6 @@ export function TokenExpiredError() {
   error.code = 401;
   error.strCode = 'AUTH_TIMEOUT';
   error.userMessage = errorMsg;
+  error.errorCatalog = new CLI.AuthConfigError('');
   return error;
 }

--- a/src/lib/errors/too-many-vuln-paths.ts
+++ b/src/lib/errors/too-many-vuln-paths.ts
@@ -1,3 +1,4 @@
+import { CLI } from '@snyk/error-catalog-nodejs-public/src';
 import { CustomError } from './custom-error';
 
 export class TooManyVulnPaths extends CustomError {
@@ -11,5 +12,6 @@ export class TooManyVulnPaths extends CustomError {
     this.code = TooManyVulnPaths.ERROR_CODE;
     this.strCode = TooManyVulnPaths.ERROR_STRING_CODE;
     this.userMessage = TooManyVulnPaths.ERROR_MESSAGE;
+    this.errorCatalog = new CLI.TooManyVulnerablePathsError('');
   }
 }

--- a/src/lib/errors/unsupported-entitlement-error.ts
+++ b/src/lib/errors/unsupported-entitlement-error.ts
@@ -1,3 +1,4 @@
+import { OpenAPI } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class UnsupportedEntitlementError extends CustomError {
@@ -17,5 +18,6 @@ export class UnsupportedEntitlementError extends CustomError {
     this.entitlement = entitlement;
     this.code = UnsupportedEntitlementError.ERROR_CODE;
     this.userMessage = userMessage;
+    this.errorCatalog = new OpenAPI.ForbiddenError('');
   }
 }

--- a/src/lib/errors/unsupported-feature-for-org-error.ts
+++ b/src/lib/errors/unsupported-feature-for-org-error.ts
@@ -1,3 +1,4 @@
+import { OpenAPI } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class FeatureNotSupportedForOrgError extends CustomError {
@@ -7,10 +8,10 @@ export class FeatureNotSupportedForOrgError extends CustomError {
     super(`Unsupported action for org ${org}.`);
     this.code = 422;
     this.org = org;
-
     this.userMessage =
       `${feature} is not supported for org` +
       (org ? ` ${org}` : '') +
       (additionalUserHelp ? `: ${additionalUserHelp}` : '.');
+    this.errorCatalog = new OpenAPI.ForbiddenError('');
   }
 }

--- a/src/lib/errors/unsupported-option-combination-error.ts
+++ b/src/lib/errors/unsupported-option-combination-error.ts
@@ -1,3 +1,4 @@
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class UnsupportedOptionCombinationError extends CustomError {
@@ -14,5 +15,6 @@ export class UnsupportedOptionCombinationError extends CustomError {
     this.code = 422;
     this.userMessage =
       UnsupportedOptionCombinationError.ERROR_MESSAGE + options.join(' + ');
+    this.errorCatalog = new CLI.InvalidFlagOptionError('');
   }
 }

--- a/src/lib/errors/unsupported-package-manager-error.ts
+++ b/src/lib/errors/unsupported-package-manager-error.ts
@@ -1,5 +1,6 @@
 import { CustomError } from './custom-error';
 import * as pms from '../package-managers';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 export class UnsupportedPackageManagerError extends CustomError {
   private static ERROR_MESSAGE: string =
@@ -11,12 +12,13 @@ export class UnsupportedPackageManagerError extends CustomError {
 
   constructor(packageManager) {
     super(
-      `Unsupported package manager ${packageManager}.` +
+      `Unsupported package manager '${packageManager}''. ` +
         UnsupportedPackageManagerError.ERROR_MESSAGE,
     );
     this.code = 422;
     this.userMessage =
       `Unsupported package manager '${packageManager}''. ` +
       UnsupportedPackageManagerError.ERROR_MESSAGE;
+    this.errorCatalog = new CLI.NoSupportedFilesFoundError('');
   }
 }

--- a/src/lib/errors/validation-error.ts
+++ b/src/lib/errors/validation-error.ts
@@ -1,8 +1,10 @@
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
 
 export class ValidationError extends CustomError {
   constructor(message: string) {
     super(message);
     this.userMessage = message;
+    this.errorCatalog = new CLI.ValidationFailureError('');
   }
 }

--- a/src/lib/iac/service-mappings.ts
+++ b/src/lib/iac/service-mappings.ts
@@ -1,6 +1,7 @@
 import { CustomError } from '../errors';
 import { IaCErrorCodes } from '../../cli/commands/test/iac/local-execution/types';
 import { getErrorStringCode } from '../../cli/commands/test/iac/local-execution/error-utils';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 export const services2resources = new Map<string, Array<string>>([
   // Amazon
@@ -267,5 +268,6 @@ export class InvalidServiceError extends CustomError {
     this.code = IaCErrorCodes.InvalidServiceError;
     this.strCode = getErrorStringCode(this.code);
     this.userMessage = msg;
+    this.errorCatalog = new CLI.InvalidFlagOptionError('');
   }
 }

--- a/src/lib/iac/test/v2/errors.ts
+++ b/src/lib/iac/test/v2/errors.ts
@@ -1,3 +1,4 @@
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 import { getErrorStringCode } from '../../../../cli/commands/test/iac/local-execution/error-utils';
 import { IaCErrorCodes } from '../../../../cli/commands/test/iac/local-execution/types';
 import { CustomError } from '../../../errors';
@@ -75,6 +76,7 @@ export class SnykIacTestError extends CustomError {
       },
       scanError.fields,
     );
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 
   public get path(): string {

--- a/src/lib/iac/test/v2/local-cache/policy-engine/download.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/download.ts
@@ -14,6 +14,7 @@ import {
   policyEngineReleaseVersion,
 } from './constants';
 import { saveFile } from '../../../../file-utils';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 const debugLog = createDebugLogger('snyk-iac');
 
@@ -68,6 +69,7 @@ export class FailedToDownloadPolicyEngineError extends CustomError {
     this.userMessage =
       `Could not fetch cache resource from: ${policyEngineUrl}` +
       '\nEnsure valid network connection.';
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }
 
@@ -111,5 +113,6 @@ export class FailedToCachePolicyEngineError extends CustomError {
     this.userMessage =
       `Could not write the downloaded cache resource to: ${savePath}` +
       '\nEnsure the cache directory is writable.';
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }

--- a/src/lib/iac/test/v2/local-cache/policy-engine/lookup-local.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/lookup-local.ts
@@ -5,6 +5,7 @@ import { getErrorStringCode } from '../../../../../../cli/commands/test/iac/loca
 import { TestConfig } from '../../types';
 import { policyEngineFileName } from './constants';
 import { InvalidUserPathError, lookupLocal } from '../utils';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 export class InvalidUserPolicyEnginePathError extends CustomError {
   constructor(path: string, message?: string, userMessage?: string) {
@@ -18,6 +19,7 @@ export class InvalidUserPolicyEnginePathError extends CustomError {
       userMessage ||
       `Could not find a valid Policy Engine executable in the configured path: ${path}` +
         '\nEnsure the configured path points to a valid Policy Engine executable.';
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }
 

--- a/src/lib/iac/test/v2/local-cache/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/utils.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { CustomError } from '../../../../errors';
 import { streamRequest } from '../../../../request/request';
 import { ReadableStream } from 'needle';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 const debugLogger = createDebugLogger('snyk-iac');
 
@@ -38,6 +39,7 @@ export async function lookupLocal(
 export class InvalidUserPathError extends CustomError {
   constructor(message: string) {
     super(message);
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }
 

--- a/src/lib/iac/test/v2/scan/index.ts
+++ b/src/lib/iac/test/v2/scan/index.ts
@@ -13,6 +13,7 @@ import config from '../../../../config';
 import { api, getOAuthToken } from '../../../../api-token';
 import envPaths from 'env-paths';
 import * as analytics from '../../../../analytics';
+import { CLI } from '@snyk/error-catalog-nodejs-public';
 
 const debug = newDebug('snyk-iac');
 const debugOutput = newDebug('snyk-iac:output');
@@ -343,5 +344,6 @@ class ScanError extends CustomError {
     this.code = IaCErrorCodes.PolicyEngineScanError;
     this.strCode = getErrorStringCode(this.code);
     this.userMessage = 'An error occurred when running the scan';
+    this.errorCatalog = new CLI.GeneralIACFailureError('');
   }
 }

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -23,6 +23,7 @@ import {
 import {
   AuthFailedError,
   BadGatewayError,
+  CustomError,
   DockerImageNotFoundError,
   errorMessageWithRetry,
   FailedToGetVulnerabilitiesError,
@@ -412,6 +413,7 @@ export async function runTest(
         `Failed to test ${projectType} project`,
       error.code,
       error.innerError,
+      error.errorCatalog,
     );
   } finally {
     spinner.clear<void>(spinnerLbl)();
@@ -554,7 +556,7 @@ function sendTestPayload(
 
 function handleTestHttpErrorResponse(res, body) {
   const { statusCode } = res;
-  let err;
+  let err: CustomError;
   const userMessage = body && body.userMessage;
   switch (statusCode) {
     case 401:

--- a/test/jest/acceptance/iac/iac-entitlement.spec.ts
+++ b/test/jest/acceptance/iac/iac-entitlement.spec.ts
@@ -15,10 +15,15 @@ describe('iac test with infrastructureAsCode entitlement', () => {
   afterAll(async () => teardown());
 
   it('fails to scan because the user is not entitled to infrastructureAsCode', async () => {
-    const { stdout, exitCode } = await run(
-      `snyk iac test --org=no-iac-entitlements ./iac/terraform/sg_open_ssh.tf`,
+    const { stdout, stderr, exitCode } = await run(
+      `snyk iac test -d --org=no-iac-entitlements ./iac/terraform/sg_open_ssh.tf`,
     );
+    expect(stdout).toContainText('SNYK-OPENAPI-0002');
     expect(stdout).toContainText(
+      'This feature is currently not enabled for your org. To enable it, please contact snyk support.',
+    );
+    expect(stderr).toContainText('SNYK-OPENAPI-0002');
+    expect(stderr).toContainText(
       'This feature is currently not enabled for your org. To enable it, please contact snyk support.',
     );
     expect(exitCode).toBe(2);

--- a/test/jest/acceptance/snyk-sbom/npm-options.spec.ts
+++ b/test/jest/acceptance/snyk-sbom/npm-options.spec.ts
@@ -67,11 +67,13 @@ describe('snyk sbom: npm options (mocked server only)', () => {
     );
 
     expect(code).toEqual(2);
+    expect(stdout).toContainText('SNYK-CLI-0000');
     expect(stdout).toContainText(
       'Dependency snyk was not found in package-lock.json.',
     );
+    expect(stderr).toContainText('SNYK-CLI-0000');
     expect(stderr).toContainText(
-      'OutOfSyncError: Dependency snyk was not found in package-lock.json.',
+      'Dependency snyk was not found in package-lock.json.',
     );
   });
 });

--- a/test/jest/acceptance/snyk-sbom/sbom.spec.ts
+++ b/test/jest/acceptance/snyk-sbom/sbom.spec.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { NoSupportedManifestsFoundError } from '../../../../src/lib/errors/no-supported-manifests-found';
+
 import {
   createProject,
   createProjectFromWorkspace,
@@ -202,7 +202,7 @@ describe('snyk sbom (mocked server only)', () => {
   test('`sbom` retains the exit error code of the underlying SCA process', async () => {
     const project = await createProject('empty');
 
-    const { code, stdout } = await runSnykCLI(
+    const { code, stdout, stderr } = await runSnykCLI(
       `sbom --org aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee --format cyclonedx1.5+json --debug`,
       {
         cwd: project.path(),
@@ -211,8 +211,9 @@ describe('snyk sbom (mocked server only)', () => {
     );
 
     expect(code).toBe(3);
-    expect(stdout).toContainText(
-      NoSupportedManifestsFoundError([project.path()]).message,
-    );
+    expect(stdout).toContainText('SNYK-CLI-0000');
+    expect(stdout).toContainText('Could not detect supported target files');
+    expect(stderr).toContainText('SNYK-CLI-0000');
+    expect(stderr).toContainText('Could not detect supported target files');
   });
 });

--- a/test/jest/unit/cli/ipc.spec.ts
+++ b/test/jest/unit/cli/ipc.spec.ts
@@ -1,0 +1,104 @@
+import { CLI } from '@snyk/error-catalog-nodejs-public';
+import { sendError } from '../../../../src/cli/ipc';
+import { tmpdir } from 'os';
+import { ExcludeFlagBadInputError } from '../../../../src/lib/errors';
+
+describe('sendError()', () => {
+  const backupEnv = { ...process.env };
+  afterEach(() => {
+    process.env = { ...backupEnv };
+  });
+
+  describe('returns true', () => {
+    beforeEach(() => {
+      process.env.SNYK_ERR_FILE = tmpdir() + '/tmp_err_file.txt';
+    });
+
+    it('when given a simple error', async () => {
+      const error = new Error('something went wrong');
+      expect(await sendError(error, false)).toBeTruthy();
+    });
+
+    it('when given an Error Catalog error', async () => {
+      const error = new CLI.GeneralCLIFailureError('something went wrong');
+      expect(await sendError(error, false)).toBeTruthy();
+    });
+
+    it('when given an TS custom error', async () => {
+      const error = new ExcludeFlagBadInputError();
+      expect(await sendError(error, false)).toBeTruthy();
+    });
+
+    describe('JSON formatted errors', () => {
+      const JSONerr = {
+        ok: false,
+        code: 1234,
+        error: 'err in a list',
+        path: 'somewhere/file',
+      };
+
+      it('when given a single error', async () => {
+        const error = new Error(JSON.stringify(JSONerr));
+        expect(await sendError(error, true)).toBeTruthy();
+      });
+
+      it('when given an error in a list', async () => {
+        const errMsg = [
+          {
+            meta: {
+              isPrivate: true,
+              isLicensesEnabled: false,
+              ignoreSettings: {
+                adminOnly: false,
+                reasonRequired: false,
+                disregardFilesystemIgnores: false,
+                autoApproveIgnores: false,
+              },
+              org: 'ORG',
+              orgPublicId: 'ORGID',
+              policy: '',
+            },
+            filesystemPolicy: false,
+            vulnerabilities: [],
+            dependencyCount: 0,
+            licensesPolicy: null,
+            ignoreSettings: null,
+            targetFile: 'var_deref/nested_var_deref/variables.tf',
+            projectName: 'badProject',
+            org: 'ORG',
+            policy: '',
+            isPrivate: true,
+            targetFilePath:
+              '/a/valid/path/fixtures/iac/terraform/var_deref/nested_var_deref/variables.tf',
+            packageManager: 'terraformconfig',
+            path: './path/fixtures/iac/terraform',
+            projectType: 'terraformconfig',
+            ok: true,
+            infrastructureAsCodeIssues: [],
+          },
+          JSONerr,
+        ];
+        const error = new Error(JSON.stringify(errMsg));
+        expect(await sendError(error, true)).toBeTruthy();
+      });
+    });
+  });
+
+  describe('returns false', () => {
+    it('when no error file path is specified', async () => {
+      const error = new Error('something went wrong');
+      expect(await sendError(error, false)).toBeFalsy();
+    });
+
+    it('when no error message is specified', async () => {
+      const error = new Error('');
+      expect(await sendError(error, false)).toBeFalsy();
+    });
+
+    it('when the file cannot be written', async () => {
+      process.env.SNYK_ERR_FILE = './does/not/exist';
+      const error = new Error('something went wrong');
+      expect(await sendError(error, false)).toBeFalsy();
+    });
+  });
+});


### PR DESCRIPTION
## Pull Request Submission Checklist
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?
TS CLI custom errors includes an Error Catalog error. This allows us to check for Error Catalog errors in TS CLI's custom errors without replacing the custom errors completely with Error Catalog errors.

We do not want to replace TS CLI customer errors as some business logic depends on it (e.g. `err instanceof CustomError` checks).

Composiing Error Catalog errors into TS CLI custom errors lets us add them to the analytics payload and stdout/stderr outputs without impacting the existing business logic.

## Where should the reviewer start?
`src/cli/ipc.ts` and `src/cli/main.ts` contain the changes required to check for Error Catalog errors in TS CLI custom errors.

The other changes are composing Error Catalog errors into TS CLI custom errors.

## Exceptions where we do not output structured errors
- `snyk <command> --all-projects --json` will output failures in a structured format e.g.:
```
{
  "ok": false,
  "error": "Failed to get dependencies for all 1 potential projects.\nTip: Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>\nIf the issue persists contact support@snyk.io",
  "path": "/Users/jason.luong/Documents/projects/snyk/cli/ignoreme"
}
```
- `snyk iac test <dir1> <dir2> --json` will output results, including failures in a structured format e.g.:
```
[
  {
    "meta": {
      "blah": false
      },
      "blahblah": ""
    },
    "blahblahblah": true,
    "infrastructureAsCodeIssues": [
      {
        "id": "SNYK-CC-TF-20",
        "title": "Azure Firewall Network Rule Collection allows public access",
        "severity": "medium",
        "isIgnored": false,
        "subType": "Network",
        "documentation": "https://security.snyk.io/rules/cloud/SNYK-CC-TF-20",
        "isGeneratedByCustomRule": false,
        "issue": "That inbound traffic is allowed to a resource from any source instead of a restricted range",
        "impact": "That potentially everyone can access your resource",
        "resolve": "Set `properties.networkRuleCollections.properties.rules.sourceAddresses` attribute to specific IP range only, e.g. `192.168.1.0/24`",
        "remediation": {
          "terraform": "Set source_addresses to specific IP range only, e.g. `192.168.1.0/24`",
          "arm": "Set `properties.networkRuleCollections.properties.rules.sourceAddresses` attribute to specific IP range only, e.g. `192.168.1.0/24`"
        },
        "lineNumber": 68,
        "iacDescription": {
          "issue": "That inbound traffic is allowed to a resource from any source instead of a restricted range",
          "impact": "That potentially everyone can access your resource",
          "resolve": "Set `properties.networkRuleCollections.properties.rules.sourceAddresses` attribute to specific IP range only, e.g. `192.168.1.0/24`"
        },
        "publicId": "SNYK-CC-TF-20",
        "msg": "resources[1].properties.networkRuleCollections[0].properties.rules[0].sourceAddresses",
        "references": [],
        "path": [
          "resources[1]",
          "properties",
          "networkRuleCollections[0]",
          "properties",
          "rules[0]",
          "sourceAddresses"
        ],
        "compliance": []
      }
    ]
  },
  {
    "ok": false,
    "code": 1010,
    "error": "Could not find any valid IaC files",
    "path": "non-existing-dir"
  }
]
```

Overriding the output here is a breaking change so we must keep the original output, but still send an error catalog error to analytics and the footer of the debug logs. Note that in the 2nd example, the error catalog error in the debug logs contain the message from the **first** error in the array.

## How should this be manually tested?
Try a few TS CLI custom errors that would normally result in the `GeneralCLIFailure` Error Catalog error in `stdout`; these should not be more specific Error Catalog errors:
- `./binary-releases/snyk-macos-arm64 test --sarif-file-output`
- `./binary-releases/snyk-macos-arm64 test --json-file-output`
- `./binary-releases/snyk-macos-arm64 test --exclude`

Try the commands that do not send an Error Catalog error (in the exceptions above), `stdout` should behave the same as before:
- `./binary-releases/snyk-macos-arm64 test --all-projects --json` (test something that throws an error)
- `./binary-releases/snyk-macos-arm64 iac test ./path/to/iac-exists ./path/to/does-not-exist --json`

These should now result in Error Catalog errors in debug logs and the analytics payload.

<!---
## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->