### PR TITLE
fix(code): Don't write sarif files when no results are found

### DIFF
--- a/cliv2/cmd/cliv2/main.go
+++ b/cliv2/cmd/cliv2/main.go
@@ -310,6 +310,10 @@ func runCodeTestCommand(cmd *cobra.Command, args []string) error {
 	// ensure legacy behavior, where sarif and json can be used interchangeably
 	globalConfiguration.AddAlternativeKeys(output_workflow.OUTPUT_CONFIG_KEY_SARIF, []string{output_workflow.OUTPUT_CONFIG_KEY_JSON})
 	globalConfiguration.AddAlternativeKeys(output_workflow.OUTPUT_CONFIG_KEY_SARIF_FILE, []string{output_workflow.OUTPUT_CONFIG_KEY_JSON_FILE})
+
+	// ensure legacy behavior, where sarif files with no findings are not written
+	globalConfiguration.Set(output_workflow.OUTPUT_CONFIG_WRITE_EMPTY_FILE, false)
+
 	return runCommand(cmd, args)
 }
 

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/snyk/cli-extension-sbom v0.0.0-20241016065306-0df2be5b3b8f
 	github.com/snyk/container-cli v0.0.0-20240821111304-7ca1c415a5d7
 	github.com/snyk/error-catalog-golang-public v0.0.0-20250121101159-e6a61b2bfae6
-	github.com/snyk/go-application-framework v0.0.0-20250205081247-7a253efc2b0c
+	github.com/snyk/go-application-framework v0.0.0-20250210203133-5b0f3252d77d
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20250211120001-7122ee6defea

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -778,8 +778,8 @@ github.com/snyk/container-cli v0.0.0-20240821111304-7ca1c415a5d7 h1:Zn5BcV76oFAb
 github.com/snyk/container-cli v0.0.0-20240821111304-7ca1c415a5d7/go.mod h1:38w+dcAQp9eG3P5t2eNS9eG0reut10AeJjLv5lJ5lpM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250121101159-e6a61b2bfae6 h1:qY954YMn/7TaapgatD1bn4hfGQSmu56W6EgS2m8c++I=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250121101159-e6a61b2bfae6/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.0.0-20250205081247-7a253efc2b0c h1:FAZ18Wx6iqz0w5N1CfEFq4sjL5MiMbjaCQX7ogFwDfw=
-github.com/snyk/go-application-framework v0.0.0-20250205081247-7a253efc2b0c/go.mod h1:ag3sCoHGCn534oDAnAXLcjZEZljW3oMOfKCzpmFX060=
+github.com/snyk/go-application-framework v0.0.0-20250210203133-5b0f3252d77d h1:Qhe0N1em8naODCCTXU12UHC4Te9FgwYAS32pzyRIAi8=
+github.com/snyk/go-application-framework v0.0.0-20250210203133-5b0f3252d77d/go.mod h1:ag3sCoHGCn534oDAnAXLcjZEZljW3oMOfKCzpmFX060=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v0.33.0 h1:nXH4LEVrYbEuSEq4RJBObRY2fduaXiovAJt3Kni1baY=

--- a/test/jest/acceptance/cli-json-file-output.spec.ts
+++ b/test/jest/acceptance/cli-json-file-output.spec.ts
@@ -107,12 +107,6 @@ describe('test --json-file-output', () => {
 
     const { code } = await runSnykCLI(
       `code test --json-file-output=${outputFilename} ${project.path()}`,
-      {
-        env: {
-          ...process.env,
-          INTERNAL_SNYK_CODE_IGNORES_ENABLED: 'false', // remove when CLI-711 is implemented
-        },
-      },
     );
 
     const fileExists = fs.existsSync(outputFilename);


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?
This PR implements the same behavior for the golang native code test as the legacy implementation, when scanning a code base without findings and using `--sarif-file-output`. The expected behavior based on the legacy implementation is, that if there are no code test findings, the sarif file is not created at all.

The risk of the change is low, since currently the only affected flow is code test.

## Where should the reviewer start?
The main functionality is implemented here https://github.com/snyk/go-application-framework/pull/304

This PR just configures the output workflow and re-enables a test for the golang native implementation, that previously failed due to the difference in behavior.

## How should this be manually tested?
Run `snyk code test --sarif-file-output=myfile` on a code base 

1. with findings => myfile is created
2. without findings => myfile is not created


<!---
## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->