### PR TITLE
feat: display all applicable maven unmanaged identities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "snyk-go-plugin": "1.23.0",
         "snyk-gradle-plugin": "4.9.0",
         "snyk-module": "3.1.0",
-        "snyk-mvn-plugin": "3.7.0",
+        "snyk-mvn-plugin": "3.8.0",
         "snyk-nodejs-lockfile-parser": "1.58.18",
         "snyk-nodejs-plugin": "1.4.3",
         "snyk-nuget-plugin": "2.7.15",
@@ -20447,9 +20447,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-mvn-plugin": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-3.7.0.tgz",
-      "integrity": "sha512-BQUCPnPvVgl4V5Xa79FWTOU2H1XXeO7aeC7Bp1qwwifJBv1VikdohlGhSuwvrhmFIjsC9RsEGMV8LTFBLNOCGg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-3.8.0.tgz",
+      "integrity": "sha512-q6ONviduwf/0QlJgRUha4+Lci71GYma5z9+p/WFOzmwN+NULFd9ZvROIqDDtqqd+JzGMVjBJmN7VFbkjg0qz5A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
@@ -39459,9 +39459,9 @@
       }
     },
     "snyk-mvn-plugin": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-3.7.0.tgz",
-      "integrity": "sha512-BQUCPnPvVgl4V5Xa79FWTOU2H1XXeO7aeC7Bp1qwwifJBv1VikdohlGhSuwvrhmFIjsC9RsEGMV8LTFBLNOCGg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-3.8.0.tgz",
+      "integrity": "sha512-q6ONviduwf/0QlJgRUha4+Lci71GYma5z9+p/WFOzmwN+NULFd9ZvROIqDDtqqd+JzGMVjBJmN7VFbkjg0qz5A==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.23.1",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "snyk-go-plugin": "1.23.0",
     "snyk-gradle-plugin": "4.9.0",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "3.7.0",
+    "snyk-mvn-plugin": "3.8.0",
     "snyk-nodejs-lockfile-parser": "1.58.18",
     "snyk-nodejs-plugin": "1.4.3",
     "snyk-nuget-plugin": "2.7.15",


### PR DESCRIPTION
## Pull Request Submission Checklist
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)

## What does this PR do?
Allows `snyk test --scan-all-unmananged` in a directory with jar/war/aar files, to identify all possible identities based on the sha1 hash of the files. 

It will take the file name into consideration when identifying the package. 
For example: 
- `some-maven-jar-1.0.0.jar` resolves to <some-sha1> 
    which corresponds with `group1:artifact:1.0.0` and `group2:artifact:1.0.0` 
    will result in showing both `group1:artifact:1.0.0` and `group2:artifact:1.0.0`

- `group1-artifact-1.0.0.jar` resolves to <some-sha1> 
    which corresponds with `group1:artifact:1.0.0` and `group2:artifact:1.0.0` 
    will result in only `group1:artifact:1.0.0`

After this change some users of `--scan-all-unamnaged` will potentially see more packages showing than previously.

## Where should the reviewer start?
https://github.com/snyk/snyk-mvn-plugin/pull/182

## How should this be manually tested?

1. Download the following jar file: [jakarta.annotation-api@1.3.5](https://repo1.maven.org/maven2/one/gfw/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.jar)
2. Rename the file to something else (i.e: somenameof.jar)
3. Run `snyk test --scan-all-unmanaged --print-deps` in the directory it is located.
4. The current CLI will return only one direct dependency, while the new version returns two.

## Any background context you want to provide?
This is a requirement for Citi
## What are the relevant tickets?
https://snyksec.atlassian.net/browse/OSM-2354