### PR TITLE
fix(iac): removed FeatureFlagNotEnabled error and updated snyk-iac-test [IAC-3235]

### DIFF
--- a/src/cli/commands/test/iac/local-execution/types.ts
+++ b/src/cli/commands/test/iac/local-execution/types.ts
@@ -402,7 +402,6 @@ export enum IaCErrorCodes {
   FailedToProcessResults = 2200,
   EntitlementNotEnabled = 2201,
   ReadSettings = 2202,
-  FeatureFlagNotEnabled = 2203,
 
   // snyk-iac-test non-fatal errors
   SubmoduleLoadingError = 3000,

--- a/src/lib/iac/test/v2/errors.ts
+++ b/src/lib/iac/test/v2/errors.ts
@@ -55,10 +55,6 @@ export function getErrorUserMessage(code: number, error: string): string {
     return `${error}. Please run the command again with the \`-d\` flag for more information.`;
   }
 
-  if (code == IaCErrorCodes.FeatureFlagNotEnabled) {
-    return error;
-  }
-
   return snykIacTestErrorsUserMessages[errorName];
 }
 

--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -1,11 +1,11 @@
 import * as os from 'os';
 
 const policyEngineChecksums = `
-2bece98c6602298aab72fe8be803cd48974b63766c2a53491761d0855dccef0d  snyk-iac-test_0.57.5_Darwin_x86_64
-3703de51908fb24ea11358c1f97643937b502a43afac5131d45c11a321138687  snyk-iac-test_0.57.5_Windows_x86_64.exe
-458e9debc734006ce6bb4ae530111ad0548a3d85ca43f8b4b5f0b17994e75efd  snyk-iac-test_0.57.5_Linux_arm64
-c624ddaa85851ed8c9fb54895c8834d0f04221066feb7d08afd2413ae2cf97cc  snyk-iac-test_0.57.5_Darwin_arm64
-d15e89f5933933b13693f5ee42b27799825a1abc16e0bdbd5a2c40c5b5af8f9b  snyk-iac-test_0.57.5_Linux_x86_64
+03c218b11f0e2ce2bf6e845cc0f314368900fc966f50d630da961eb7ef02aa2b  snyk-iac-test_0.57.7_Linux_arm64
+3062c2b9604412ba6f8fbb185220b656785d9f5634c800db8f0d25f62470433a  snyk-iac-test_0.57.7_Darwin_x86_64
+58da235defa00fb86c33911522e400242a461749c0738624514ce236a07e659d  snyk-iac-test_0.57.7_Windows_x86_64.exe
+61b106f260b01567b9407a2d7921a386d510d7231622b26b4bbbad630c541534  snyk-iac-test_0.57.7_Linux_x86_64
+c08b7954b6ee1605ad2caec68e3575d4a007aad831872d062a14263073bea24a  snyk-iac-test_0.57.7_Darwin_arm64
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();

--- a/test/jest/acceptance/iac/cli-share-results.spec.ts
+++ b/test/jest/acceptance/iac/cli-share-results.spec.ts
@@ -251,21 +251,4 @@ describe('CLI Share Results', () => {
       });
     });
   });
-
-  describe('feature flag iacNewEngine is enabled', () => {
-    beforeEach(() => {
-      server.setFeatureFlag('iacNewEngine', true);
-    });
-
-    it('the output includes an error', async () => {
-      const { stdout, exitCode } = await run(
-        `snyk iac test ./iac/arm/rule_test.json --report`,
-      );
-
-      expect(stdout).toMatch(
-        'flag --report is not yet supported when iacNewEngine flag is enabled',
-      );
-      expect(exitCode).toBe(2);
-    });
-  });
 });


### PR DESCRIPTION
## Pull Request Submission Checklist
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Removes the `FeatureFlagNotEnabled ` error code that was mapping an error we added in snyk-iac-test to stop the scan of an IaC project when we run `snyk iac test --report` with the FF `iacNewEngine` being enabled. As we completed the CLI flow, we can now safely create an `IaCV2 Project` in the UI therefore we can stop adding an error when we try to do a scan from the CLI with `iacNewEngine` FF enabled and the `--report` command.
Update the `snyk-iac-test` to latest version where we removed this error.

Risk: low

## Where should the reviewer start?
`<local build> iac test --org=<org_that_has_iacv2>`

## How should this be manually tested?
Run comand: `snyk iac test --report` on an IaC Project, having the FF `iacNewEngine` enabled. This command should run a complete scan your IaC Project and create a target in the UI and not the error: `flag --report is not yet supported when iacNewEngine flag is enabled`.

## Any background context you want to provide?
Changes included: https://github.com/snyk/snyk-iac-test/compare/v0.57.5...v0.57.7
## What's the product update that needs to be communicated to CLI users?

## What are the relevant tickets?
[IAC-3235](https://snyksec.atlassian.net/jira/software/c/projects/IAC/boards/301?assignee=712020%3A381a5669-a2bb-479a-abcf-aecde6290e62&selectedIssue=IAC-3235)



[IAC-3235]: https://snyksec.atlassian.net/browse/IAC-3235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ