### PR TITLE
feat: add container support for remote-repo-url UNIFY-506

### DIFF
--- a/help/cli-commands/container-monitor.md
+++ b/help/cli-commands/container-monitor.md
@@ -78,6 +78,12 @@ Specify a reference that differentiates this project, for example, a branch name
 
 For more information see [Group projects by branch or version for monitoring](https://docs.snyk.io/snyk-cli/scan-and-maintain-projects-using-the-cli/group-projects-by-branch-or-version-for-monitoring)
 
+### `--remote-repo-url=<URL>`
+
+Set or override the remote URL for the image that you would like to monitor.
+
+Groups container images under the same target with other monitored projects.
+
 ### `--project-environment=<ENVIRONMENT>[,<ENVIRONMENT>]...>`
 
 Set the project environment to one or more values (comma-separated). To clear the project environment set `--project-environment=`

--- a/help/cli-commands/container-test.md
+++ b/help/cli-commands/container-test.md
@@ -110,6 +110,12 @@ In CLI versions 1.1090.0 (2023-01-24) and higher, Snyk scans for application dep
 
 In CLI versions 1.962.0 through v1.1089.0, use the `--app-vulns` option with the the `--json` option to see the operating system as well as application vulnerabilities in JSON format in the results.
 
+### `--remote-repo-url=<URL>`
+
+Set or override the remote URL for the image that you would like to test.
+
+Groups container images under the same target with other monitored projects.
+
 ### `--exclude-app-vulns`
 
 Allow disabling scans for app vulnerabilities; in CLI versions 1.1090.0 (2023-01-24) and higher, `app-vulns` is enabled by default.

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "semver": "^6.0.0",
         "snyk-config": "^5.0.0",
         "snyk-cpp-plugin": "2.24.0",
-        "snyk-docker-plugin": "6.17.0",
+        "snyk-docker-plugin": "git+ssh://git@github.com:snyk/snyk-docker-plugin.git#feat/container-remote-repo-url",
         "snyk-go-plugin": "1.23.0",
         "snyk-gradle-plugin": "4.9.0",
         "snyk-module": "3.1.0",
@@ -19976,9 +19976,8 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.17.0.tgz",
-      "integrity": "sha512-wpthCZX/2BL4RLd7g39SjHSD4ZUgX7Bdn6MHc8r4yWf7fzoNKXiR2TSsUXSWqN3XQ6FuiTbjsYM2QSk2UcXIeQ==",
+      "resolved": "git+ssh://git@github.com/snyk/snyk-docker-plugin.git#fb8de2dfcfc45301b5d639890c9c3e2e50752aa1",
+      "license": "Apache-2.0",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.8.1",
@@ -39095,9 +39094,8 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-6.17.0.tgz",
-      "integrity": "sha512-wpthCZX/2BL4RLd7g39SjHSD4ZUgX7Bdn6MHc8r4yWf7fzoNKXiR2TSsUXSWqN3XQ6FuiTbjsYM2QSk2UcXIeQ==",
+      "version": "git+ssh://git@github.com/snyk/snyk-docker-plugin.git#fb8de2dfcfc45301b5d639890c9c3e2e50752aa1",
+      "from": "snyk-docker-plugin@git+ssh://git@github.com:snyk/snyk-docker-plugin.git#feat/container-remote-repo-url",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "semver": "^6.0.0",
     "snyk-config": "^5.0.0",
     "snyk-cpp-plugin": "2.24.0",
-    "snyk-docker-plugin": "6.17.0",
+    "snyk-docker-plugin": "git+ssh://git@github.com:snyk/snyk-docker-plugin.git#feat/container-remote-repo-url",
     "snyk-go-plugin": "1.23.0",
     "snyk-gradle-plugin": "4.9.0",
     "snyk-module": "3.1.0",

--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -92,9 +92,6 @@ export default async function monitor(...args0: MethodArgs): Promise<any> {
     checkOSSPaths(paths, options);
   }
 
-  if (options.docker && options['remote-repo-url']) {
-    throw new Error('`--remote-repo-url` is not supported for container scans');
-  }
   if (options.docker) {
     // order is important here, we want:
     // 1) exclude-app-vulns set -> no app vulns

--- a/src/lib/ecosystems/monitor.ts
+++ b/src/lib/ecosystems/monitor.ts
@@ -107,6 +107,9 @@ export async function generateMonitorDependenciesRequest(
   scanResult.name =
     options['project-name'] || config.PROJECT_NAME || scanResult.name;
   scanResult.targetReference = options['target-reference'];
+  if (scanResult.target && options['remote-repo-url']) {
+    scanResult.target.remoteUrl = options['remote-repo-url'];
+  }
   // WARNING! This mutates the payload. Policy logic should be in the plugin.
   const policy = await findAndLoadPolicyForScanResult(scanResult, options);
   if (policy !== undefined) {

--- a/src/lib/ecosystems/types.ts
+++ b/src/lib/ecosystems/types.ts
@@ -18,6 +18,7 @@ export interface GitTarget {
 
 export interface ContainerTarget {
   image: string;
+  remoteUrl?: string;
 }
 
 export interface NamedTarget extends GitTarget {


### PR DESCRIPTION
## Pull Request Submission Checklist
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
Adds support for remote-repo-url option for ContainerTarget.
Remote-repo-url allows the user to override the remote URL for the image that is monitored/tested.

Monitoring container images using remote-repo-url groups container images under the same target with other monitored projects.


## Where should the reviewer start?

## How should this be manually tested?
`snyk container monitor debian:latest --remote-repo-url=https://github.com/org/my-repo-test`
## What's the product update that needs to be communicated to CLI users?

<!---
## Any background context you want to provide?

## What are the relevant tickets?
[https://snyksec.atlassian.net/browse/UNIFY-506](url)

## Screenshots (if appropriate)
<img width="1601" alt="Screenshot 2025-02-20 at 08 46 45" src="https://github.com/user-attachments/assets/e15f5511-a9b9-4319-847e-40cd337bb968" />

Uncomment and fill in any sections above that are relevant to your PR.
--->
