### PR TITLE
feat: minimise how often countPathsToGraphRoot is called

### DIFF
--- a/test/jest/acceptance/analytics.spec.ts
+++ b/test/jest/acceptance/analytics.spec.ts
@@ -155,7 +155,6 @@ describe('analytics module', () => {
             packageManager: 'npm',
             packageName: 'with-vulnerable-lodash-dep',
             packageVersion: '1.2.3',
-            prePrunedPathsCount: 2,
             depGraph: true,
             isDocker: false,
             'vulns-pre-policy': 5,
@@ -302,7 +301,6 @@ describe('analytics module', () => {
             packageManager: 'npm',
             packageName: 'with-vulnerable-lodash-dep',
             packageVersion: '1.2.3',
-            prePrunedPathsCount: 2,
             'error-code': 403,
             'error-message': expect.stringContaining(
               'Authentication failed. Please check the API token on',


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: \_\_\_)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

This PR makes two optimisations to the `run-test` flow. These are designed so as to be transparent to users except for increased performance for projects with dense dependency graphs - "dense" defined as graphs with many cross linking dependencies leading to very many paths to the root of the graph.

Our main culprit is `countPathsToRoot()` which goes through every pkg in a graph and accumulates a count of all paths to root from all nodes. This is then compared to our prune limits to see whether we should prune, the only other thing this result is used for is analytics.

**`--pruneRepeatedSubdependencies` short circuit:**

Previously if a user passed the `--pruneRepeatedSubdependencies` flag the prune functionality still counted paths to root and calculated whether we were dealing with a dense graph. This is redundant as no matter the response, if `--pruneRepeatedSubdependencies` is set, then we start the prune logic.
Now if we see this flag we just immediately attempt the prune.

**Early exit from, `countPathsToRoot()`:**

The `countPathsToRoot()` is incredibly expensive and scales badly. The way it was previously working, going through every pkg and counting _everything_ before then comparison, is overkill in the most expensive cases and can take _hours_. Instead, we now add to an accumulator every pkg processed and as soon as we breach the limit we exit as we know we are definitely going to prune. Additionally, the dep-graph library also provides the functionality to early exit within the context of a pkg. Applying both of these optimisations saves a lot of time in the worst cases.

## Where should the reviewer start?

There is only one function that has changed.

## How should this be manually tested?

Compare against the current release version of `snyk` using a dense graph - a moderate speed up should be expected, the relative speed up shoul be inversely correlated with size and density of the graph.

## What's the product update that needs to be communicated to CLI users?

An improvement to the handling of dense, highly connected dependency graph provides a moderate performance uplift for these projects.
