### PR TITLE
fix: don't read IPC file on successful runs

### DIFF
--- a/cliv2/internal/cliv2/cliv2.go
+++ b/cliv2/internal/cliv2/cliv2.go
@@ -465,6 +465,10 @@ func (c *CLI) executeV1Default(proxyInfo *proxy.ProxyInfo, passThroughArgs []str
 		return nil
 	}
 
+	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() < 2 {
+		return err
+	}
+
 	if sentErrs, fileErr := c.getErrorFromFile(filePath); fileErr == nil {
 		err = errors.Join(err, sentErrs)
 	}


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Previously, we would try to open the IPC error file even though the legacy cli run didn't result in any errors (this would not create the file as a result). The debug logs would log `Failed to read error file:  open <err-file-path>:  no such file or directory`, which might cause confusion for users. 

## Where should the reviewer start?

If the legacy CLI run resulted in an exit error with an exit code 0 or 1, we would not attempt to read from the error file; meaning if the exit code is greater or equal to 2, the error file should be checked against.

## How should this be manually tested?

- run a commad that invokes the Typescript CLI and would exit with the exit code 0 or 1 -> the debug logs should not contain the message listed above
- run a commad that invokes the Typescript CLI and would exit with the exit code 0 or 1 -> the debug logs should contain a log about the error file being read

## What's the product update that needs to be communicated to CLI users?

None

<!---
## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
