### PR TITLE
fix: fix IPC error handling

### DIFF
--- a/cliv2/internal/cliv2/cliv2.go
+++ b/cliv2/internal/cliv2/cliv2.go
@@ -465,6 +465,10 @@ func (c *CLI) executeV1Default(proxyInfo *proxy.ProxyInfo, passThroughArgs []str
 		return nil
 	}
 
+	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() < 2 {
+		return err
+	}
+
 	if sentErrs, fileErr := c.getErrorFromFile(filePath); fileErr == nil {
 		err = errors.Join(err, sentErrs)
 	}

--- a/src/cli/ipc.ts
+++ b/src/cli/ipc.ts
@@ -1,9 +1,9 @@
-import { writeFile } from 'fs/promises';
 import { CLI, ProblemError } from '@snyk/error-catalog-nodejs-public';
 import { debug as Debug } from 'debug';
 import * as legacyErrors from '../lib/errors/legacy-errors';
 import stripAnsi = require('strip-ansi');
 import { CustomError } from '../lib/errors';
+import { writeFileSync } from 'fs';
 
 const debug = Debug('snyk:ipc');
 
@@ -14,7 +14,7 @@ const debug = Debug('snyk:ipc');
  * @param isJson {boolean} If the prameter is set, the meta field "supressJsonOutput" will also be set, supressing the Golang CLI from displaying this error.
  * @returns {Promise<boolean>} The result of the operation as a boolean value
  */
-export async function sendError(err: Error, isJson: boolean): Promise<boolean> {
+export function sendError(err: Error, isJson: boolean): boolean {
   const ERROR_FILE_PATH = process.env.SNYK_ERR_FILE;
   if (!ERROR_FILE_PATH) {
     debug('Error file path not set.');
@@ -46,7 +46,7 @@ export async function sendError(err: Error, isJson: boolean): Promise<boolean> {
   const data = (err as ProblemError).toJsonApi().body();
 
   try {
-    await writeFile(ERROR_FILE_PATH, JSON.stringify(data));
+    writeFileSync(ERROR_FILE_PATH, JSON.stringify(data));
   } catch (e) {
     debug('Failed to write data to error file: ', e);
     return false;

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -145,7 +145,7 @@ async function handleError(args, error) {
   const shouldOutputError =
     vulnsFound || args.options.sarif
       ? false
-      : await sendError(error, args.options.json);
+      : sendError(error, args.options.json);
 
   // JSON output flow
   if (

--- a/test/jest/unit/cli/ipc.spec.ts
+++ b/test/jest/unit/cli/ipc.spec.ts
@@ -16,17 +16,17 @@ describe('sendError()', () => {
 
     it('when given a simple error', async () => {
       const error = new Error('something went wrong');
-      expect(await sendError(error, false)).toBeTruthy();
+      expect(sendError(error, false)).toBeTruthy();
     });
 
     it('when given an Error Catalog error', async () => {
       const error = new CLI.GeneralCLIFailureError('something went wrong');
-      expect(await sendError(error, false)).toBeTruthy();
+      expect(sendError(error, false)).toBeTruthy();
     });
 
     it('when given an TS custom error', async () => {
       const error = new ExcludeFlagBadInputError();
-      expect(await sendError(error, false)).toBeTruthy();
+      expect(sendError(error, false)).toBeTruthy();
     });
 
     describe('JSON formatted errors', () => {
@@ -39,7 +39,7 @@ describe('sendError()', () => {
 
       it('when given a single error', async () => {
         const error = new Error(JSON.stringify(JSONerr));
-        expect(await sendError(error, true)).toBeTruthy();
+        expect(sendError(error, true)).toBeTruthy();
       });
 
       it('when given an error in a list', async () => {
@@ -79,7 +79,7 @@ describe('sendError()', () => {
           JSONerr,
         ];
         const error = new Error(JSON.stringify(errMsg));
-        expect(await sendError(error, true)).toBeTruthy();
+        expect(sendError(error, true)).toBeTruthy();
       });
     });
   });
@@ -87,18 +87,18 @@ describe('sendError()', () => {
   describe('returns false', () => {
     it('when no error file path is specified', async () => {
       const error = new Error('something went wrong');
-      expect(await sendError(error, false)).toBeFalsy();
+      expect(sendError(error, false)).toBeFalsy();
     });
 
     it('when no error message is specified', async () => {
       const error = new Error('');
-      expect(await sendError(error, false)).toBeFalsy();
+      expect(sendError(error, false)).toBeFalsy();
     });
 
     it('when the file cannot be written', async () => {
       process.env.SNYK_ERR_FILE = './does/not/exist';
       const error = new Error('something went wrong');
-      expect(await sendError(error, false)).toBeFalsy();
+      expect(sendError(error, false)).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Previously, we would try to open the IPC error file even though the legacy cli run didn't result in any errors (this would not create the file as a result). The debug logs would log `Failed to read error file:  open <err-file-path>:  no such file or directory`, which might cause confusion for users. 

## Where should the reviewer start?

If the legacy CLI run resulted in an exit error with an exit code 0 or 1, we would not attempt to read from the error file; meaning if the exit code is greater or equal to 2, the error file should be checked against.

## How should this be manually tested?

- run a commad that invokes the Typescript CLI and would exit with the exit code 0 or 1 -> the debug logs should not contain the message listed above
- run a commad that invokes the Typescript CLI and would exit with the exit code 0 or 1 -> the debug logs should contain a log about the error file being read

## What's the product update that needs to be communicated to CLI users?

None

## Other

- [CLI-755](https://snyksec.atlassian.net/browse/CLI-755)


[CLI-755]: https://snyksec.atlassian.net/browse/CLI-755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ