### PR TITLE
feat(sbom): add `--platform` flag to `container sbom` command

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/snyk/cli-extension-dep-graph v0.0.0-20250321153619-9390ab5e348e
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20250227121450-6e14346dbd1a
 	github.com/snyk/cli-extension-sbom v0.0.0-20241016065306-0df2be5b3b8f
-	github.com/snyk/container-cli v0.0.0-20240821111304-7ca1c415a5d7
+	github.com/snyk/container-cli v0.0.0-20250321132345-1e2e01681dd7
 	github.com/snyk/error-catalog-golang-public v0.0.0-20250310083934-7ac627e3451f
 	github.com/snyk/go-application-framework v0.0.0-20250325133828-3ffd1aa4f76f
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -804,8 +804,8 @@ github.com/snyk/cli-extension-sbom v0.0.0-20241016065306-0df2be5b3b8f h1:dlL+f+5
 github.com/snyk/cli-extension-sbom v0.0.0-20241016065306-0df2be5b3b8f/go.mod h1:5CaY1bgvJY/uoG/1plLOf8T8o9AkwoBIGvw34RfRLZw=
 github.com/snyk/code-client-go v1.17.1 h1:H5G4Ufe8fMkLpr9L//34S2iXdfRY7Q/+gALedIRtHXQ=
 github.com/snyk/code-client-go v1.17.1/go.mod h1:WH6lNkJc785hfXmwhixxWHix3O6z+1zwz40oK8vl/zg=
-github.com/snyk/container-cli v0.0.0-20240821111304-7ca1c415a5d7 h1:Zn5BcV76oFAbJm5tDygU945lvoZ3yY8FoRFDC3YpwF8=
-github.com/snyk/container-cli v0.0.0-20240821111304-7ca1c415a5d7/go.mod h1:38w+dcAQp9eG3P5t2eNS9eG0reut10AeJjLv5lJ5lpM=
+github.com/snyk/container-cli v0.0.0-20250321132345-1e2e01681dd7 h1:/2+2piwQtB9fEJCkXEOjboZjY+77lQfnvqBZ/60xNHk=
+github.com/snyk/container-cli v0.0.0-20250321132345-1e2e01681dd7/go.mod h1:38w+dcAQp9eG3P5t2eNS9eG0reut10AeJjLv5lJ5lpM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250310083934-7ac627e3451f h1:plWVxooZeV6rTxu5BXYCe6p9z48r5egblbYM9VW4tvY=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250310083934-7ac627e3451f/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
 github.com/snyk/go-application-framework v0.0.0-20250325133828-3ffd1aa4f76f h1:1EPrRhLQ5Bo0SmIqoAU38Et1Bv2klCbyfgLmVJfUyvM=


### PR DESCRIPTION
This PR updates the version of the `container-cli` plugin (to make use of the changes [here](https://github.com/snyk/container-cli/pull/30)), adding a `--platform` flag to the container sbom command. The value for the platform is passed through to the container test command, and results in the SBOM specifically for that platform.

## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (I will do this separately)
- [ ] Includes product update to be announced in the next stable release notes

## How should this be manually tested?

To test, build and run the CLI with the arguments

```sh
container sbom --format spdx2.3+json nginx:latest --platform=linux/amd64
```

Test with different values for `--platform`, e.g. `linux/386`, and you should see different results
