### PR TITLE
fix(code): fix backward compatibility issue in sarif driver name

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/snyk/cli-extension-sbom v0.0.0-20241016065306-0df2be5b3b8f
 	github.com/snyk/container-cli v0.0.0-20240821111304-7ca1c415a5d7
 	github.com/snyk/error-catalog-golang-public v0.0.0-20250218074309-307ad7b38a60
-	github.com/snyk/go-application-framework v0.0.0-20250312152307-f382628a3a7e
+	github.com/snyk/go-application-framework v0.0.0-20250320111922-b329abf1a58c
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20250311173630-f1a49f299c8e

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -808,8 +808,8 @@ github.com/snyk/container-cli v0.0.0-20240821111304-7ca1c415a5d7 h1:Zn5BcV76oFAb
 github.com/snyk/container-cli v0.0.0-20240821111304-7ca1c415a5d7/go.mod h1:38w+dcAQp9eG3P5t2eNS9eG0reut10AeJjLv5lJ5lpM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250218074309-307ad7b38a60 h1:iB6z2BhBpfN9p0/dEZfwWvs7fpdZk3loooAih8yspS8=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250218074309-307ad7b38a60/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.0.0-20250312152307-f382628a3a7e h1:zWUYzapqmQyzNxMqRdia/u6TVDa8aPG3eWolXCe/OcI=
-github.com/snyk/go-application-framework v0.0.0-20250312152307-f382628a3a7e/go.mod h1:A7oFVjMjNukzsMeiIWXEXjCrAf2ARvoK4aQOm9e3E/Y=
+github.com/snyk/go-application-framework v0.0.0-20250320111922-b329abf1a58c h1:HnWiT5YyPW9NCR+ZekqOS7ygoSXYNX2U9Z7UJMAMtjU=
+github.com/snyk/go-application-framework v0.0.0-20250320111922-b329abf1a58c/go.mod h1:A7oFVjMjNukzsMeiIWXEXjCrAf2ARvoK4aQOm9e3E/Y=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v0.33.2 h1:ZxD6/RQ4vqUAXa64V72SsGjZ8vmnBgZNGYQxMIqctYo=


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
This PR fixes an incompatibility between the CLI and snyk-to-html, when trying to generate an html report for `snyk code test` using consistent ignores. The inconsistency comes from a change in the Driver Name as part of the Sarif content. The Driver Name now matches `SnykCode` again and an existing USer Journey test has been extended.

The risk of the change is low, as it only affects the Driver Name written for the new native code test implementation, which is still behind a feature flag.

## Where should the reviewer start?
https://github.com/snyk/go-application-framework/pull/316

## How should this be manually tested?
Given an org that uses consistent ignores, run
```
snyk code test --sarif | snyk-to-html --output=out.html
```
inspect the file out.html to be a `Snyk Code Report`.

## What's the product update that needs to be communicated to CLI users?

<!---
## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
