### PR TITLE
chore: adding default dockerignore from node service template

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.bin/
+.circleci/
+.github/
+!/.github/CODEOWNERS
+.git
+.node-version
+**/*.md
+Dockerfile*
+coverage/
+dist/
+helm/
+node_modules/
+test/
+**/*.test.ts


### PR DESCRIPTION
Adding a default `.dockerignore` file as per best practice guidelines. Values are not explicitly for our current need, also potential future additions, took most from our service template.