### PR TITLE
chore: add a name to the workflow

### DIFF
--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -1,3 +1,5 @@
+name: Check for stale PRs
+
 on:
   schedule:
     - cron: '0 0 * * *' # Every day at midnight


### PR DESCRIPTION
All other workflows in this repo has a `name`, should have added one to the [previous PR](https://github.com/snyk/cli/pull/5796).