### PR TITLE
feat(sbom): add purls to json test results

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/snyk/cli-extension-dep-graph v0.0.0-20250321153619-9390ab5e348e
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20250227121450-6e14346dbd1a
-	github.com/snyk/cli-extension-sbom v0.0.0-20241016065306-0df2be5b3b8f
+	github.com/snyk/cli-extension-sbom v0.0.0-20250401145354-6c5f86d51796
 	github.com/snyk/container-cli v0.0.0-20250321132345-1e2e01681dd7
 	github.com/snyk/error-catalog-golang-public v0.0.0-20250310083934-7ac627e3451f
 	github.com/snyk/go-application-framework v0.0.0-20250325133828-3ffd1aa4f76f

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -800,10 +800,12 @@ github.com/snyk/cli-extension-dep-graph v0.0.0-20250321153619-9390ab5e348e h1:lY
 github.com/snyk/cli-extension-dep-graph v0.0.0-20250321153619-9390ab5e348e/go.mod h1:9Zpe+B8SCkWFjpDR3ckFJl1XuMyxysWebKhyAIj7EyI=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20250227121450-6e14346dbd1a h1:SJ+Ts7e1EYcGJXeENR5inTGwPNRlNVgmMN2itO3+yj8=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20250227121450-6e14346dbd1a/go.mod h1:IqfQCIkyC26mkwa+aM6d6yxIh5+tCm4fSQG+Ogq3Qbc=
-github.com/snyk/cli-extension-sbom v0.0.0-20241016065306-0df2be5b3b8f h1:dlL+f+5sjHj4JCzW/Evl1x9UREXLyc3M4KjoZvQx0Bs=
-github.com/snyk/cli-extension-sbom v0.0.0-20241016065306-0df2be5b3b8f/go.mod h1:5CaY1bgvJY/uoG/1plLOf8T8o9AkwoBIGvw34RfRLZw=
 github.com/snyk/code-client-go v1.17.2 h1:plXGA/SgB+FYKaQjtm7xBaIhnDGavZtHbhIY5hCuEN8=
 github.com/snyk/code-client-go v1.17.2/go.mod h1:WH6lNkJc785hfXmwhixxWHix3O6z+1zwz40oK8vl/zg=
+github.com/snyk/cli-extension-sbom v0.0.0-20250401131444-e93eb402aafe h1:aHAbacbssfOL43qHKa1SepgKEwAftPfSERe9MhlfH+Y=
+github.com/snyk/cli-extension-sbom v0.0.0-20250401131444-e93eb402aafe/go.mod h1:A5MgBJK8orWojEoEp/JDi8NPEyDApEBD7eL9XWZJA/0=
+github.com/snyk/cli-extension-sbom v0.0.0-20250401145354-6c5f86d51796 h1:4oMs0vMaGnwD2iwqlml10mv54edE3NQVlPRCOZTv1RE=
+github.com/snyk/cli-extension-sbom v0.0.0-20250401145354-6c5f86d51796/go.mod h1:A5MgBJK8orWojEoEp/JDi8NPEyDApEBD7eL9XWZJA/0=
 github.com/snyk/container-cli v0.0.0-20250321132345-1e2e01681dd7 h1:/2+2piwQtB9fEJCkXEOjboZjY+77lQfnvqBZ/60xNHk=
 github.com/snyk/container-cli v0.0.0-20250321132345-1e2e01681dd7/go.mod h1:38w+dcAQp9eG3P5t2eNS9eG0reut10AeJjLv5lJ5lpM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250310083934-7ac627e3451f h1:plWVxooZeV6rTxu5BXYCe6p9z48r5egblbYM9VW4tvY=

--- a/test/jest/acceptance/snyk-sbom-test/all-projects.spec.ts
+++ b/test/jest/acceptance/snyk-sbom-test/all-projects.spec.ts
@@ -100,6 +100,7 @@ describe('snyk sbom test (mocked server only)', () => {
     expect(stdout).toContain('"CWE":["CWE-1333"]');
     expect(stdout).toContain('"CVE":["CVE-2022-3517"]');
     expect(stdout).toContain('"semver":{"vulnerable":["3.0.4"]}');
+    expect(stdout).toContain('"purl":"pkg:npm/minimatch@3.0.4"');
 
     expect(code).toEqual(1);
 


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Upgrades `cli-extension-sbom` to the latest version. In this version, the `--json` output of the `snyk sbom test` command will also include `packageUrl` as a field on the vulnerability results.

## Where should the reviewer start?

## How should this be manually tested?

Running the `snyk sbom test --experimental --file=PATH_TO_SBOM --json` should return a list of vulnerabilities which also contain the package url of the affected package.

## What's the product update that needs to be communicated to CLI users?

<!---
## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
