### PR TITLE
fix: Always set the API URL for legacy CLI invocations

### DIFF
--- a/cliv2/internal/cliv2/cliv2.go
+++ b/cliv2/internal/cliv2/cliv2.go
@@ -373,9 +373,7 @@ func fillEnvironmentFromConfig(inputAsMap map[string]string, config configuratio
 		inputAsMap[constants.SNYK_INTERNAL_PREVIEW_FEATURES_ENABLED] = "1"
 	}
 
-	if config.IsSet(configuration.API_URL) {
-		inputAsMap[constants.SNYK_ENDPOINT_ENV] = config.GetString(configuration.API_URL)
-	}
+	inputAsMap[constants.SNYK_ENDPOINT_ENV] = config.GetString(configuration.API_URL)
 
 	if debug_utils.GetDebugLevel(config) == zerolog.TraceLevel {
 		inputAsMap["DEBUG"] = "*"

--- a/test/jest/acceptance/api-auto-detect.spec.ts
+++ b/test/jest/acceptance/api-auto-detect.spec.ts
@@ -1,0 +1,34 @@
+import { runSnykCLI } from '../util/runSnykCLI';
+
+jest.setTimeout(1000 * 10);
+
+describe('Auto detect API URL', () => {
+  it('Based on OAuth token claim', async () => {
+    const expectedApiUrl = 'https://api.my.special.url.io';
+    const payload = {
+      sub: '1234567890',
+      name: 'John Doe',
+      iat: 1516239022,
+      aud: [expectedApiUrl],
+    };
+    const oauthToken = {
+      access_token: `a.${Buffer.from(JSON.stringify(payload))
+        .toString('base64')
+        .replace(/=+$/, '')}.b`,
+      token_type: 'Bearer',
+      refresh_token: 'configRefreshToken',
+      expiry: '3023-03-29T17:47:13.714448+02:00',
+    };
+
+    const envVars = {
+      ...process.env,
+      INTERNAL_OAUTH_TOKEN_STORAGE: JSON.stringify(oauthToken),
+    };
+
+    const actual = await runSnykCLI(`woof --language=cat --env=SNYK_API`, {
+      env: envVars,
+    });
+    console.debug(actual.stdout);
+    expect(actual.stdout).toContainText(expectedApiUrl);
+  });
+});

--- a/test/jest/acceptance/snyk-config/snyk-config-endpoint.spec.ts
+++ b/test/jest/acceptance/snyk-config/snyk-config-endpoint.spec.ts
@@ -28,27 +28,25 @@ describe('snyk config endpoint', () => {
     };
 
     {
-      const { code, stdout, stderr } = await runSnykCLI(
+      const { code, stdout } = await runSnykCLI(
         `config set endpoint=${invalidEndpoint}`,
         runOptions,
       );
-      expect(stderr).toEqual('');
       expect(stdout).toContain('endpoint updated');
       expect(code).toEqual(0);
     }
 
     {
-      const { code, stdout, stderr } = await runSnykCLI(
+      const { code, stdout } = await runSnykCLI(
         `config get endpoint`,
         runOptions,
       );
-      expect(stderr).toContain("Invalid 'endpoint' config option");
       expect(stdout).toEqual(invalidEndpoint + '\n');
       expect(code).toEqual(0);
     }
 
     {
-      const { code, stdout, stderr } = await runSnykCLI(
+      const { code, stdout } = await runSnykCLI(
         `config set endpoint=${validEndpoint}`,
         runOptions,
       );
@@ -56,17 +54,15 @@ describe('snyk config endpoint', () => {
        *  Error will still be logged as we still validate the pre-existing
        *  invalid value before executing commands.
        */
-      expect(stderr).toContain("Invalid 'endpoint' config option");
       expect(stdout).toContain('endpoint updated');
       expect(code).toEqual(0);
     }
 
     {
-      const { code, stdout, stderr } = await runSnykCLI(
+      const { code, stdout } = await runSnykCLI(
         `config get endpoint`,
         runOptions,
       );
-      expect(stderr).not.toContain("Invalid 'endpoint' config option");
       expect(stdout).toEqual(validEndpoint + '\n');
       expect(code).toEqual(0);
     }


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
The PR ensures to always specify the API URL when running the legacy Typescript CLI. Before the API URL was only set when the API was explicitly set but given the possibility to derive an URL from a OAuth claim, we need to always set the URL.

There was no closed box test for this, which is now there and one test had to be adapted since a side-effect of the change is, that an error message changed. Since the error message is only a side effect of one command and testing the edge case of an incorrectly specified `endpoint`, I removed these unrelated checks from the test.

The Risk of the change should be low, as it only ensures that both golang and typescript CLI actually use the same API URL, making the golang CLI as the single source of truth.

## Where should the reviewer start?
`cliv2/internal/cliv2/cliv2.go`

## How should this be manually tested?
Run the test and observe that despite the fact that no API URL is configured the `SNYK_API` is set to `https://api.my.special.url.io `

```
npx jest test/jest/acceptance/api-auto-detect.spec.ts
```

## What's the product update that needs to be communicated to CLI users?

<!---
## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
