### PR TITLE
docs: update `container sbom` docs with platform flag

### DIFF
--- a/help/cli-commands/container-sbom.md
+++ b/help/cli-commands/container-sbom.md
@@ -10,7 +10,7 @@ The `snyk container sbom` feature requires an internet connection.
 
 ## Usage
 
-`$ snyk container sbom --format=<cyclonedx1.4+json|cyclonedx1.4+xml|cyclonedx1.5+json|cyclonedx1.5+xml|cyclonedx1.6+json|cyclonedx1.6+xml|spdx2.3+json> [--org=<ORG_ID>] [--exclude-app-vulns] <IMAGE>`
+`$ snyk container sbom --format=<cyclonedx1.4+json|cyclonedx1.4+xml|cyclonedx1.5+json|cyclonedx1.5+xml|cyclonedx1.6+json|cyclonedx1.6+xml|spdx2.3+json> [--org=<ORG_ID>] [--platform=<PLATFORM>] [--exclude-app-vulns] <IMAGE>`
 
 ## Description
 
@@ -58,6 +58,12 @@ If you have multiple organizations, you can set a default from the CLI using:
 **Note:** You can also use `--org=<orgslugname>.` The `ORG_ID` works in both the CLI and the API. The Organization slug name works in the CLI, but not in the API.
 
 For more information, see the article [How to select the Organization to use in the CLI](https://docs.snyk.io/snyk-cli/scan-and-maintain-projects-using-the-cli/how-to-select-the-organization-to-use-in-the-cli)
+
+### `--platform=<PLATFORM>`
+
+For multi-architecture images, specify the platform for the container image.
+
+Supported platforms are: `linux/amd64`, `linux/arm64`, `linux/riscv64`, `linux/ppc64le`, `linux/s390x`, `linux/386`, `linux/arm/v7`, or `linux/arm/v6`
 
 ### `[--exclude-app-vulns]`
 


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

In [this PR](https://github.com/snyk/cli/pull/5788) I updated the `container-cli` version to add a `--plugin` flag to the `container sbom` command. I was confused about the order of operations for updating docs, but it looks like I need to make the changes to the docs here so that they appear in the preview CLI help text, and then make gitbook changes later when the change is in the stable release, so this PR adds the required docs.

## How should this be manually tested?

Run `snyk container sbom --help` and you should see docs for the new `--platform` flag.

## What's the product update that needs to be communicated to CLI users?

n/a