### PR TITLE
chore: manual resync windows signing certs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,9 @@ commands:
             # Execute the MSI installer
             msiexec.exe /i smtools-windows-x64.msi /quiet /qn | Wait-Process
             & 'C:\Program Files\DigiCert\DigiCert One Signing Manager Tools\smksp_cert_sync.exe'
+
+            # Manual resync
+            & 'C:\Program Files\DigiCert\DigiCert One Signing Manager Tools\smctl.exe' windows certsync
       - save_cache:
           name: Saving DigitCert cache
           key: digicert-cache-v3-{{ arch }}-{{ checksum "~/cache_key.txt" }}


### PR DESCRIPTION
## What does this PR do?

Manual resync the signing certificates when windows code signing happens as an extra step in the build pipeline.

## Context

After recent failures in the pipelines we discovered that the code signing for Windows was not working as expected and required manual resyncing in order for the certificates to be valid. 
