### PR TITLE
fix: Add container detection for other container runtimes

### DIFF
--- a/src/lib/is-docker.ts
+++ b/src/lib/is-docker.ts
@@ -1,11 +1,21 @@
 const fs = require('fs');
 
 export function isDocker(): boolean {
-  return hasDockerEnv() || hasDockerCGroup();
+  return hasDockerEnv() || hasContainerEnv() || hasDockerCGroup();
 }
+
 function hasDockerEnv() {
   try {
     fs.statSync('/.dockerenv');
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+function hasContainerEnv() {
+  try {
+    fs.statSync('/run/.containerenv');
     return true;
   } catch (_) {
     return false;

--- a/test/jest/unit/is-docker.spec.ts
+++ b/test/jest/unit/is-docker.spec.ts
@@ -16,6 +16,25 @@ describe('isDocker', () => {
     expect(statSyncSpy).toHaveBeenLastCalledWith('/.dockerenv');
   });
 
+  it('inside other containers (.containerenv test)', async () => {
+    delete require.cache[path.join(__dirname, 'index.js')];
+    const statSyncSpy = jest.spyOn(fs, 'statSync');
+
+    statSyncSpy.mockImplementationOnce((path): any => {
+      if (path === '/.dockerenv') {
+        throw new Error("ENOENT, no such file or directory '/.dockerinit'");
+      }
+
+      if (path === '/run/.containerenv') {
+        return {} as any
+      }
+    });
+    expect(isDocker()).toBeTruthy();
+    expect(statSyncSpy).toHaveBeenCalledTimes(2);
+    expect(statSyncSpy).toHaveBeenLastCalledWith('/run/.containerenv');
+  });
+
+
   it('inside a Docker container (cgroup test)', async () => {
     delete require.cache[path.join(__dirname, 'index.js')];
 


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?
This PR enables the container detection to work in container runtimes other than docker such as Podman and cri-o by checking for an additional file `/run/.containerenv`. This is a low risk change as it follows an established pattern in the codebase and has minimal changes. 

## Where should the reviewer start?
src/lib/is-docker.ts

## How should this be manually tested?
Run the `regression-tests` tests inside a podman container

## What's the product update that needs to be communicated to CLI users?
The CLI should no longer try and open a browser automatically when run in container environments other than dockers

## Any background context you want to provide?
This relates to support request #159183 with CircleCI and should resolve issues running tests on the new container runtime. 

<!---
## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
