### PR TITLE
feat: bump gradle plugin to v4.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "snyk-cpp-plugin": "2.24.0",
         "snyk-docker-plugin": "6.18.2",
         "snyk-go-plugin": "1.23.0",
-        "snyk-gradle-plugin": "4.9.0",
+        "snyk-gradle-plugin": "4.9.2",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "3.8.0",
         "snyk-nodejs-lockfile-parser": "1.60.1",
@@ -20642,9 +20642,10 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-gradle-plugin": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-4.9.0.tgz",
-      "integrity": "sha512-yRqr2//8Jdoy3uLm7aGk3qTHjZrmK5r1FPQz7/233Vyw3ZIW1iccL+aFT49WnM+VhLsspnJQFLaxEgs0lpA9Ag==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-4.9.2.tgz",
+      "integrity": "sha512-V/2Ys4yCzSuMn2qRkkllO3XZ8fcq8U95oM6otwm3G+zk+jJjaCL7IL1+A41r1t37GQTmBj8eyXLO6hP5jnSXgw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",
@@ -40010,9 +40011,9 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-4.9.0.tgz",
-      "integrity": "sha512-yRqr2//8Jdoy3uLm7aGk3qTHjZrmK5r1FPQz7/233Vyw3ZIW1iccL+aFT49WnM+VhLsspnJQFLaxEgs0lpA9Ag==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-4.9.2.tgz",
+      "integrity": "sha512-V/2Ys4yCzSuMn2qRkkllO3XZ8fcq8U95oM6otwm3G+zk+jJjaCL7IL1+A41r1t37GQTmBj8eyXLO6hP5jnSXgw==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "snyk-cpp-plugin": "2.24.0",
     "snyk-docker-plugin": "6.18.2",
     "snyk-go-plugin": "1.23.0",
-    "snyk-gradle-plugin": "4.9.0",
+    "snyk-gradle-plugin": "4.9.2",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "3.8.0",
     "snyk-nodejs-lockfile-parser": "1.60.1",


### PR DESCRIPTION
## Pull Request Submission Checklist
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

This bumps the snyk-gradle-plugin version to 4.9.2 (https://github.com/snyk/snyk-gradle-plugin/releases/tag/v4.9.2 & https://github.com/snyk/snyk-gradle-plugin/releases/tag/v4.9.1) what contain fixes for running on windows only. Plugin has been fully tested and new tested have been added within the plugin.


## What are the relevant tickets?
https://snyksec.atlassian.net/browse/OSM-2475
https://snyksec.atlassian.net/browse/OSM-2534
