### PR TITLE
Revert "chore: upgrade to go 1.24"

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,5 +1,5 @@
 # When upgrading golang, make sure to update the docker executors that use snyklabs/cli-build in .circleci/config.yml
-FROM golang:1.24-bullseye
+FROM --platform=$TARGETPLATFORM golang:1.23-bullseye
 
 # install "normal" stuff
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
   go_version:
     type: string
     # https://go.dev/doc/devel/release
-    default: '1.24.2'
+    default: '1.23.6'
   aws_version:
     type: string
     # https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst
@@ -47,22 +47,22 @@ executors:
     resource_class: small
   docker-amd64:
     docker:
-      - image: snyklabs/cli-build:20250429-091242
+      - image: snyklabs/cli-build:20241015-082358
     working_directory: /mnt/ramdisk/snyk
     resource_class: large
   docker-amd64-xl:
     docker:
-      - image: snyklabs/cli-build:20250429-091242
+      - image: snyklabs/cli-build:20241015-082358
     working_directory: /mnt/ramdisk/snyk
     resource_class: xlarge
   docker-arm64:
     docker:
-      - image: snyklabs/cli-build-arm64:20250429-091242
+      - image: snyklabs/cli-build-arm64:20241015-082358
     working_directory: /mnt/ramdisk/snyk
     resource_class: arm.large
   docker-arm64-xl:
     docker:
-      - image: snyklabs/cli-build-arm64:20250429-091242
+      - image: snyklabs/cli-build-arm64:20241015-082358
     working_directory: /mnt/ramdisk/snyk
     resource_class: arm.xlarge
   linux-ubuntu-jammy-amd64:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 .bin/
 .circleci/
-!.circleci/awscli-publickey.pub
 .github/
 !/.github/CODEOWNERS
 .git

--- a/cliv2/Makefile
+++ b/cliv2/Makefile
@@ -19,7 +19,7 @@ export LS_PROTOCOL_VERSION=
 
 # Build tools
 GO_BIN := $(shell pwd)/.bin
-OVERRIDE_GOCI_LINT_V := v1.64.8
+OVERRIDE_GOCI_LINT_V := v1.61.0
 SHELL := env PATH=$(GO_BIN):$(PATH) $(SHELL)
 
 # Make directories per convention

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/cli/cliv2
 
-go 1.24.2
+go 1.23.6
 
 require (
 	github.com/elazarl/goproxy v1.7.2


### PR DESCRIPTION
Revert snyk/cli#5860 as it fails some of the system tests.