### PR TITLE
fix: [OSM-2584] Bump PHP plugin version to fix project scanning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "snyk-nodejs-lockfile-parser": "1.60.1",
         "snyk-nodejs-plugin": "1.4.4",
         "snyk-nuget-plugin": "2.7.15",
-        "snyk-php-plugin": "1.10.0",
+        "snyk-php-plugin": "1.12.1",
         "snyk-policy": "4.1.4",
         "snyk-python-plugin": "2.6.0",
         "snyk-resolve-deps": "4.8.0",
@@ -21191,17 +21191,17 @@
       }
     },
     "node_modules/snyk-php-plugin": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.10.0.tgz",
-      "integrity": "sha512-S3DgV/R2xQabG11WWsBp5DstW/jXP4L11yll2xp3laWIo8/Jey3hhsf0WNHqv33Uh7B7VN5dgg/eA8moKY57yw==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.12.1.tgz",
+      "integrity": "sha512-MV0G+ayYhBkbjoVY1XpsSKgY26K5/rZJYCTY+EsW62MRQYlXTOugIlg6EpQvH47H5DvrMDZbhwR+NnnbHCYJVQ==",
       "dependencies": {
         "@snyk/cli-interface": "^2.9.1",
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^1.22.0",
-        "tslib": "1.14.1"
+        "tslib": "^2.8.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       }
     },
     "node_modules/snyk-php-plugin/node_modules/@snyk/dep-graph": {
@@ -21233,6 +21233,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/snyk-php-plugin/node_modules/@snyk/dep-graph/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "node_modules/snyk-php-plugin/node_modules/object-hash": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
@@ -21251,6 +21256,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/snyk-php-plugin/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/snyk-poetry-lockfile-parser": {
       "version": "1.9.0",
@@ -40509,14 +40519,14 @@
       }
     },
     "snyk-php-plugin": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.10.0.tgz",
-      "integrity": "sha512-S3DgV/R2xQabG11WWsBp5DstW/jXP4L11yll2xp3laWIo8/Jey3hhsf0WNHqv33Uh7B7VN5dgg/eA8moKY57yw==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.12.1.tgz",
+      "integrity": "sha512-MV0G+ayYhBkbjoVY1XpsSKgY26K5/rZJYCTY+EsW62MRQYlXTOugIlg6EpQvH47H5DvrMDZbhwR+NnnbHCYJVQ==",
       "requires": {
         "@snyk/cli-interface": "^2.9.1",
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^1.22.0",
-        "tslib": "1.14.1"
+        "tslib": "^2.8.1"
       },
       "dependencies": {
         "@snyk/dep-graph": {
@@ -40543,6 +40553,13 @@
             "object-hash": "^2.0.3",
             "semver": "^7.0.0",
             "tslib": "^1.13.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
           }
         },
         "object-hash": {
@@ -40554,6 +40571,11 @@
           "version": "7.6.3",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
           "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
+        },
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "snyk-nodejs-lockfile-parser": "1.60.1",
     "snyk-nodejs-plugin": "1.4.4",
     "snyk-nuget-plugin": "2.7.15",
-    "snyk-php-plugin": "1.10.0",
+    "snyk-php-plugin": "1.12.1",
     "snyk-policy": "4.1.4",
     "snyk-python-plugin": "2.6.0",
     "snyk-resolve-deps": "4.8.0",


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [x] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?
Bumps the version of the PHP Plugin used by the CLI, which fixes Open Source scanning of PHP projects.
Previously when  `composer`/ `composer.phar` is available on the machine, the command's result `stdout` was not handled properly and resulted in `[object Object]` being parsed as JSON.

Risk is **Low** as this only affects PHP, which has low traffic and it fixes a bug rather than changing any logic.

## Where should the reviewer start?

## How should this be manually tested?
- Run the CLI on a directory containing PHP code, making sure that you have [composer](https://getcomposer.org/download/) either installed globally or the `composer.phar` file in the current working directory.
- This should output scan results as expected, while before this would have crashed with a JSON parsing error

## What's the product update that needs to be communicated to CLI users?
Scanning open source dependencies of PHP projects when composer is installed on the user machine works again.

<!---
## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
