### PR TITLE
feat(language-server): integrate LS

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/snyk/go-application-framework v0.0.0-20250505092137-65a591adf20f
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20250505124801-160b93dc2aaa
+	github.com/snyk/snyk-ls v0.0.0-20250506133358-be0352e86859
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -816,8 +816,8 @@ github.com/snyk/policy-engine v0.33.2 h1:ZxD6/RQ4vqUAXa64V72SsGjZ8vmnBgZNGYQxMIq
 github.com/snyk/policy-engine v0.33.2/go.mod h1:YTZq3GMRbXcHOXQQrFRVEg+MQiIGCGZ1met6KlpruNo=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20250505124801-160b93dc2aaa h1:RHURtxIvSuqvI8w1/ljLYM8zlUw5bGlaedExQN4PRpc=
-github.com/snyk/snyk-ls v0.0.0-20250505124801-160b93dc2aaa/go.mod h1:xbvwtDAjQuol2GI45d6awmmRQ3TYcC3jdHFGn+2bTjQ=
+github.com/snyk/snyk-ls v0.0.0-20250506133358-be0352e86859 h1:Y8h3p6XC1vhoy3qQbTzLdOyOZLIrEGYT2J8Wc1PzpsM=
+github.com/snyk/snyk-ls v0.0.0-20250506133358-be0352e86859/go.mod h1:xbvwtDAjQuol2GI45d6awmmRQ3TYcC3jdHFGn+2bTjQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit be0352e868594be116a6ed1ac8004084a1331e4f
Author: Abdelrahman Shawki Hassan <shawki.hassan@snyk.io>
Date:   Tue May 6 15:33:58 2025 +0200

    fix: use request.Host to retrieve host header (#860)
    
    fix: use r.Host to retrieve host header

:100644 100644 39b52691 039dd1f3 M	internal/mcp/llm_binding.go
:100644 100644 bb8e9460 2ffe5edf M	internal/mcp/llm_binding_test.go

commit 9e64d5a60b5b708d4b3d372722e0e9cd60b88e6c
Author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
Date:   Tue May 6 14:19:17 2025 +0200

    docs: synchronizing MCP README from snyk/user-docs (#859)
    
    Co-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

:100644 100644 d66e4aaf 0c67559a M	mcp_extension/README.md

commit 51ded6af0d4b67d4d585ec65f975658b0826cbc7
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Tue May 6 11:49:48 2025 +0200

    fix: copy auth link command should not use read locks (#858)
    
    * fix: copy auth link command should not use read locks
    
    The auth URL is only relevant during authentication. When authentication is triggered, it obtains a write-lock on the authentication service. Thus, the copy auth link command was waiting for authentication to finish until it obtained the now obsolete auth URL.
    
    This fix
    
    - adds a method to the Authentication Service interface and its implementations for retrieving the Auth URL via the provider
    - implements the retrieval without usage of any locks
    
    * fix: write test for AuthURL()
    
    * chore: add explanation to AuthURL why no lock is required
    
    * fix: ensure test cleanup

:100644 100644 21d8e48c 77a2ee96 M	.gitignore
:100644 100644 98483d94 3310cb5b M	domain/ide/command/copy_auth_link.go
:100644 100644 43a18806 9d237d69 M	infrastructure/authentication/auth_service.go
:100644 100644 a981896a 92ea38c4 M	infrastructure/authentication/auth_service_impl.go
:100644 100644 2e3250ff 8bbefe74 M	infrastructure/authentication/auth_service_impl_test.go
:100644 100644 90210095 be5851fb M	infrastructure/authentication/oauth_provider.go

commit 1e41ffb4695b8aab1a9cf6a8acdc2efd9bb79ce7
Author: Abdelrahman Shawki Hassan <shawki.hassan@snyk.io>
Date:   Tue May 6 10:51:33 2025 +0200

    fix: mcp host check [IDE-1119] (#856)
    
    * fix: add host header check in MCP middleware
    
    * fix: added tests
    
    * fix: parse host without port

:100644 100644 7f9c979f 39b52691 M	internal/mcp/llm_binding.go
:100644 100644 2d4e415d bb8e9460 M	internal/mcp/llm_binding_test.go
```

[IDE-1119]: https://snyksec.atlassian.net/browse/IDE-1119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ