### PR TITLE
chore: Add attach to CLI process debug configuration for VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -61,6 +61,13 @@
       "console": "integratedTerminal",
       "program": "node_modules/.bin/ts-node",
       "args": ["./src/cli/index.ts", "iac", "test", "--unmanaged"]
+    },
+    {
+      "name": "Attach to CLI Process",
+      "type": "go",
+      "request": "attach",
+      "mode": "local",
+      "processId": 0
     }
   ]
 }


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Small addition to the launch configuration for VSCode. The new option will open the prompt for choosing the CLI process to attach to. Note this debug option applies to the Golang binary.

## Where should the reviewer start?

- `.vscode/launch.json` - Almost the same configuration as the one listed in [the contributing guidelines](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#debugging-the-go-binary-with-vscode), but the remote path is not necessary since you would still need to choose the process to attach to (shoutout to @j-luong).

## How should this be manually tested?

Put some breakpoints, make a debug build of the CLI and run it, switch to VSCode and use the new launch config option to select the CLI process to attach to (searching for snyk make it easy to find).

## What's the product update that needs to be communicated to CLI users?

Nil

<!---
## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
