### PR TITLE
feat: [OSM-2668] introduced dfs for  maven dverbose

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,11 +69,11 @@
         "semver": "^6.0.0",
         "snyk-config": "^5.0.0",
         "snyk-cpp-plugin": "2.24.0",
-        "snyk-docker-plugin": "^7.0.1",
+        "snyk-docker-plugin": "7.0.1",
         "snyk-go-plugin": "1.23.0",
         "snyk-gradle-plugin": "5.0.1",
         "snyk-module": "3.1.0",
-        "snyk-mvn-plugin": "3.8.3",
+        "snyk-mvn-plugin": "3.9.0",
         "snyk-nodejs-lockfile-parser": "1.60.1",
         "snyk-nodejs-plugin": "1.4.4",
         "snyk-nuget-plugin": "2.7.15",
@@ -21234,9 +21234,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-mvn-plugin": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-3.8.3.tgz",
-      "integrity": "sha512-6AmAUXXXuRwSm96hXbCZ6A01+R9elzbxPIKnjpawM5s0LGCjgKtWBOa2qE/IvSdbNQy/y1f1/ST68GtCPQSfIQ==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-3.9.0.tgz",
+      "integrity": "sha512-NoSTzlOutMGfIveQdkuYnRklamP9tG4fIwJS4MyBhyTZI07Ze/25hmCrcdQLmQLwq9YhRCp5LfIv6FcSzOKNYQ==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.23.1",
@@ -40323,7 +40323,7 @@
             "chalk": "^3.0.0",
             "ci-info": "^4.0.0",
             "clipanion": "^4.0.0-rc.2",
-            "cross-spawn": "^7.0.3",
+            "cross-spawn": "7.0.6",
             "diff": "^5.1.0",
             "dotenv": "^16.3.1",
             "fast-glob": "^3.2.2",
@@ -40422,7 +40422,7 @@
             "@yarnpkg/parsers": "^3.0.3",
             "chalk": "^3.0.0",
             "clipanion": "^4.0.0-rc.2",
-            "cross-spawn": "^7.0.3",
+            "cross-spawn": "7.0.6",
             "fast-glob": "^3.2.2",
             "micromatch": "^4.0.2",
             "tslib": "^2.4.0"
@@ -40909,9 +40909,9 @@
       }
     },
     "snyk-mvn-plugin": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-3.8.3.tgz",
-      "integrity": "sha512-6AmAUXXXuRwSm96hXbCZ6A01+R9elzbxPIKnjpawM5s0LGCjgKtWBOa2qE/IvSdbNQy/y1f1/ST68GtCPQSfIQ==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-3.9.0.tgz",
+      "integrity": "sha512-NoSTzlOutMGfIveQdkuYnRklamP9tG4fIwJS4MyBhyTZI07Ze/25hmCrcdQLmQLwq9YhRCp5LfIv6FcSzOKNYQ==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.23.1",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "snyk-go-plugin": "1.23.0",
     "snyk-gradle-plugin": "5.0.1",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "3.8.3",
+    "snyk-mvn-plugin": "3.9.0",
     "snyk-nodejs-lockfile-parser": "1.60.1",
     "snyk-nodejs-plugin": "1.4.4",
     "snyk-nuget-plugin": "2.7.15",

--- a/test/acceptance/workspaces/maven-dverbose-omitted-versions/pom.xml
+++ b/test/acceptance/workspaces/maven-dverbose-omitted-versions/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.snyk.example</groupId>
+  <artifactId>verbose-project</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>Verbose project</name>
+  <description>Test project for the Maven CLI plugin with omit</description>
+
+  <properties>
+    <axis.version>1.4</axis.version>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>axis</groupId>
+      <artifactId>axis</artifactId>
+      <version>${axis.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.10</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+      <version>2.7.15</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+      <version>2.14.2</version>
+    </dependency>
+
+  </dependencies>
+
+
+</project>

--- a/test/jest/acceptance/snyk-sbom/all-projects.spec.ts
+++ b/test/jest/acceptance/snyk-sbom/all-projects.spec.ts
@@ -84,6 +84,6 @@ describe('snyk sbom --all-projects (mocked server only)', () => {
     expect(bom.metadata.component.name).toEqual(
       'mono-repo-project-manifests-only',
     );
-    expect(bom.components).toHaveLength(36);
+    expect(bom.components).toHaveLength(37);
   });
 });

--- a/test/jest/acceptance/snyk-sbom/maven-options.spec.ts
+++ b/test/jest/acceptance/snyk-sbom/maven-options.spec.ts
@@ -58,12 +58,12 @@ describe('snyk sbom: maven options (mocked server only)', () => {
       'io.snyk.example:test-project',
     );
     expect(sbom.dependencies.length).toBeGreaterThanOrEqual(7);
-    expect(sbom.dependencies[6].ref).toEqual(
+    expect(sbom.dependencies[2].ref).toEqual(
       'commons-discovery:commons-discovery@0.2',
     );
-    expect(sbom.dependencies[6].dependsOn.length).toEqual(1);
-    expect(sbom.dependencies[6].dependsOn[0]).toEqual(
-      'commons-logging:commons-logging@1.0.4',
+    expect(sbom.dependencies[2].dependsOn.length).toEqual(1);
+    expect(sbom.dependencies[2].dependsOn[0]).toEqual(
+      'commons-logging:commons-logging@1.0.3',
     );
   });
 

--- a/test/jest/acceptance/snyk-test/maven-dverbose.spec.ts
+++ b/test/jest/acceptance/snyk-test/maven-dverbose.spec.ts
@@ -63,4 +63,17 @@ describe('`snyk test` of basic projects for each language/ecosystem', () => {
 
     expect(code).toEqual(0);
   });
+
+  test('run `snyk test` on a maven project with Dverbose omitted versions', async () => {
+    const project = await createProjectFromWorkspace(
+      'maven-dverbose-omitted-versions',
+    );
+
+    const { code } = await runSnykCLI('test -d - --Dverbose', {
+      cwd: project.path(),
+      env,
+    });
+
+    expect(code).toEqual(0);
+  });
 });


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [x] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?
Bumps snyk-mvn-plugin to include: https://github.com/snyk/snyk-mvn-plugin/pull/189.
Includes:
1. dfs for graph creation - for cycles and dense graphs.
2. package version in the key for the visited/ancestry.

As mentioned on the PR, dependening on the decision to only keep the scope/versions that maven resolves dependencies to, instead of the Dverbose output, a change will come on top of this one.

## Where should the reviewer start?
https://github.com/snyk/snyk-mvn-plugin/pull/189

## How should this be manually tested?
Test with the example [here](https://snyksec.atlassian.net/browse/OSM-2668?focusedCommentId=1183736).

## What's the product update that needs to be communicated to CLI users?
[test, monitor, sbom] Maven Dverbose improvement for long running scans resulting from dense dependency graphs creation.

## What are the relevant tickets?
https://snyksec.atlassian.net/browse/OSM-2668
<!---
## Any background context you want to provide?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
