### PR TITLE
feat(language-server): integrate LS

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/snyk/go-application-framework v0.0.0-20250520093237-2f9180791a51
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20250514053102-44a941375f2b
+	github.com/snyk/snyk-ls v0.0.0-20250521101656-913cdff39dd1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -820,8 +820,8 @@ github.com/snyk/policy-engine v0.33.2 h1:ZxD6/RQ4vqUAXa64V72SsGjZ8vmnBgZNGYQxMIq
 github.com/snyk/policy-engine v0.33.2/go.mod h1:YTZq3GMRbXcHOXQQrFRVEg+MQiIGCGZ1met6KlpruNo=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20250514053102-44a941375f2b h1:WI9bQsCRBPrkWbxNxpmVMv6qYK92l+98P1VYL+AndNM=
-github.com/snyk/snyk-ls v0.0.0-20250514053102-44a941375f2b/go.mod h1:xbvwtDAjQuol2GI45d6awmmRQ3TYcC3jdHFGn+2bTjQ=
+github.com/snyk/snyk-ls v0.0.0-20250521101656-913cdff39dd1 h1:VhQkwPBuhFfKJAUaYKRrOFdkaO3Z6XuUKFf+ESUW0Ks=
+github.com/snyk/snyk-ls v0.0.0-20250521101656-913cdff39dd1/go.mod h1:xbvwtDAjQuol2GI45d6awmmRQ3TYcC3jdHFGn+2bTjQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit 913cdff39dd11355e3f0aa3a2b5182e1c3659c51
Author: Abdelrahman Shawki Hassan <shawki.hassan@snyk.io>
Date:   Wed May 21 12:16:56 2025 +0200

    fix: AIFix load folderPath from cachedIssue instead of computing it [IDE-1045] (#878)
    
    * fix: load folderPath from cachedIssue instead of computing it

:100644 100644 47155ff9 1903c516 M	.goreleaser.yaml
:100644 100644 41a9108c 227a4fba M	domain/ide/command/code_fix_diffs.go
:100644 100644 c7e8598c 7b704ffc M	domain/ide/command/code_fix_diffs_test.go
:100644 100644 02fd71af bfa358f0 M	domain/ide/converter/converter.go
:100644 100644 225906f6 e64948e3 M	internal/types/lsp.go

commit 7783c4e92dd63242ab845b705e770a21b0f7a1fd
Author: Knut Funkel <knut.funkel@snyk.io>
Date:   Mon May 19 17:36:06 2025 +0200

    fix: remove packageManager check [IDE-1174] (#869)
    
    Removes the packageManager check in cli_scanner.go and the packageManagerUnmanaged constant in types.go.

:100644 100644 710d0bf7 ba4075b8 M	infrastructure/oss/cli_scanner.go
:100644 100644 59e362de ac45f465 M	infrastructure/oss/types.go
:100644 100644 a631f3ac 537fbad2 M	internal/uri/uri_util.go
:100644 100644 d0fe5afd 2288b703 M	internal/uri/uri_util_test.go

commit e18a6ed9af606c0b7b3cd9b24e30f312ab9124cd
Author: Knut Funkel <knut.funkel@snyk.io>
Date:   Mon May 19 15:42:59 2025 +0200

    fix: html encode ResourcePath (#872)
    
    * fix: html encode ResourcePath
    
    * fix: added a test that will verify that if a malicious path is used, it will be html encoded and thus not executable
    
    * fix: remove double escaping

:100644 100644 2120323b f6e6732f M	infrastructure/iac/iac_html.go
:100644 100644 ec6da669 a981bee7 M	infrastructure/iac/iac_html_test.go

commit 39179f4d4f3089d5dce7be202e917e4bfb8b97f2
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Fri May 16 17:34:10 2025 +0200

    fix: ensure ignored OSS issues are not propagated to the client [IDE-1165] (#875)
    
    * feat: add type structures for project ignores
    
    * fix: ignore OSS issues marked as ignored [IDE-1165]
    
    Added a fix in convertScanResultToIssues function to actually skip ignored issues rather than just logging them. Also added a comprehensive test case to verify that ignored OSS issues are not propagated to the client.
    
    * chore: change field from time to string
    
    * refactor: export ignore json types
    
    * fix: test

:100644 100644 7ae3f86f 293e89f1 M	infrastructure/oss/cli_scanner_test.go
:100644 100644 b8e1a6d3 b376f353 M	infrastructure/oss/issue.go
:100644 100644 bed1998e 59e362de M	infrastructure/oss/types.go

commit a1e9519129b8d9ce3c3fead69fff5275bb09ede2
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Fri May 16 10:20:27 2025 +0200

    fix: add unit test for prepareScanCommand's --all-projects removal [IDE-1048] (#874)
    
    * test: add unit test for prepareScanCommand's --all-projects removal [IDE-1048]
    
    Added test case to verify the functionality that removes --all-projects parameter from command slice and conditionally adds it back based on parameter conflicts. This ensures the code behaves correctly when handling CLI parameters like --file that are incompatible with --all-projects.
    
    * chore: update copyright note
    
    * refactor: refine all-projects handling

:100644 100644 1d8fe354 bc028f35 M	.windsurfrules
:100644 100644 317cecd4 710d0bf7 M	infrastructure/oss/cli_scanner.go
:100644 100644 559f2623 7ae3f86f M	infrastructure/oss/cli_scanner_test.go

commit dae1084212862b8d2c9d24aa38278cbf6d09807b
Author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
Date:   Thu May 15 14:44:24 2025 +0200

    docs: synchronizing MCP README from snyk/user-docs (#873)
    
    Co-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

:100644 100644 0c67559a adb78cc9 M	mcp_extension/README.md

commit dcbf05a8ccc0dc1835355b1c50cc3cb05a27cb2a
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Thu May 15 10:38:00 2025 +0200

    fix(uri): implement case-insensitive path checking with in-memory cache [IDE-1198] (#871)
    
    * fix(uri): implement case-insensitive path checking with in-memory cache [IDE-1198]
    
    This commit addresses a critical issue where workspace folder trust validation
    fails on case-insensitive filesystems (Windows and macOS) when comparing paths
    with different letter casing.
    
    Key changes:
    - Added robust case sensitivity detection logic for different filesystems:
      - Windows is always treated as case-insensitive
      - macOS is tested by creating temporary files with different case and
        comparing inode numbers
      - Linux and other systems default to case-sensitive behavior
    - Implemented an in-memory cache for filesystem case sensitivity results to
      avoid redundant filesystem operations
    - Used filesystem root/volume as cache key to correctly handle different
      mounted volumes with potentially different case sensitivity settings
    - Fixed several edge cases with proper error handling and fallbacks
    - Added comprehensive test cases to verify behavior across different OSes
    - Ensured compatibility with IDE file scheme handling
    
    This improvement ensures that workspace folder trust validation works
    correctly across all major operating systems, regardless of filesystem
    case sensitivity configuration.
    
    * fix: default handling on macOS
    
    Added a variable osCreate that references os.Create so we can mock it in tests
    Modified checkMacOSCaseSensitivity to use this variable instead of directly calling os.Create
    Created a test that temporarily replaces osCreate with a function that always fails
    Verified that the behavior defaults to case-sensitive when file operations fail on macOS
    
    fix: default handling on macOS
    
    * fix: build on all os
    
    * chore: update internal/uri/fs_case_sensitivity_linux.go
    
    Co-authored-by: gemini-code-assist[bot] <176961590+gemini-code-assist[bot]@users.noreply.github.com>
    
    * chore: update internal/uri/fs_case_sensitivity_windows.go
    
    Co-authored-by: gemini-code-assist[bot] <176961590+gemini-code-assist[bot]@users.noreply.github.com>
    
    ---------
    
    Co-authored-by: gemini-code-assist[bot] <176961590+gemini-code-assist[bot]@users.noreply.github.com>

:000000 100644 00000000 aa901d7a A	internal/uri/fs_case_sensitivity_darwin.go
:000000 100644 00000000 59687dc8 A	internal/uri/fs_case_sensitivity_linux.go
:000000 100644 00000000 d71bf65b A	internal/uri/fs_case_sensitivity_windows.go
:100644 100644 07757a72 a631f3ac M	internal/uri/uri_util.go
:100644 100644 b889174e d0fe5afd M	internal/uri/uri_util_test.go
```

[IDE-1045]: https://snyksec.atlassian.net/browse/IDE-1045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1174]: https://snyksec.atlassian.net/browse/IDE-1174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1165]: https://snyksec.atlassian.net/browse/IDE-1165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ