### PR TITLE
fix: [OSM-2662] maven dverbose show resolved deps versions only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "snyk-go-plugin": "1.23.0",
         "snyk-gradle-plugin": "5.0.1",
         "snyk-module": "3.1.0",
-        "snyk-mvn-plugin": "3.9.0",
+        "snyk-mvn-plugin": "3.9.1",
         "snyk-nodejs-lockfile-parser": "1.60.1",
         "snyk-nodejs-plugin": "1.4.4",
         "snyk-nuget-plugin": "2.7.15",
@@ -21234,9 +21234,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-mvn-plugin": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-3.9.0.tgz",
-      "integrity": "sha512-NoSTzlOutMGfIveQdkuYnRklamP9tG4fIwJS4MyBhyTZI07Ze/25hmCrcdQLmQLwq9YhRCp5LfIv6FcSzOKNYQ==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-3.9.1.tgz",
+      "integrity": "sha512-JF777PlGZ1RFOc0Z9Rxc/Yt0zDtff0WNB6l8Huureu+YjeaJBfMak6x7R15f8ZTM76GmL5GaiozNbwRgziQ6Fg==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.23.1",
@@ -21295,17 +21295,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
-    "node_modules/snyk-mvn-plugin/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/snyk-mvn-plugin/node_modules/object-hash": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
@@ -21315,12 +21304,9 @@
       }
     },
     "node_modules/snyk-mvn-plugin/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -21329,14 +21315,9 @@
       }
     },
     "node_modules/snyk-mvn-plugin/node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
-    },
-    "node_modules/snyk-mvn-plugin/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/snyk-nodejs-lockfile-parser": {
       "version": "1.60.1",
@@ -40909,9 +40890,9 @@
       }
     },
     "snyk-mvn-plugin": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-3.9.0.tgz",
-      "integrity": "sha512-NoSTzlOutMGfIveQdkuYnRklamP9tG4fIwJS4MyBhyTZI07Ze/25hmCrcdQLmQLwq9YhRCp5LfIv6FcSzOKNYQ==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-3.9.1.tgz",
+      "integrity": "sha512-JF777PlGZ1RFOc0Z9Rxc/Yt0zDtff0WNB6l8Huureu+YjeaJBfMak6x7R15f8ZTM76GmL5GaiozNbwRgziQ6Fg==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.23.1",
@@ -40963,36 +40944,20 @@
             }
           }
         },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
         "object-hash": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
           "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="
         },
         "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+          "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="
         },
         "tslib": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "snyk-go-plugin": "1.23.0",
     "snyk-gradle-plugin": "5.0.1",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "3.9.0",
+    "snyk-mvn-plugin": "3.9.1",
     "snyk-nodejs-lockfile-parser": "1.60.1",
     "snyk-nodejs-plugin": "1.4.4",
     "snyk-nuget-plugin": "2.7.15",

--- a/test/jest/acceptance/snyk-sbom/all-projects.spec.ts
+++ b/test/jest/acceptance/snyk-sbom/all-projects.spec.ts
@@ -84,6 +84,6 @@ describe('snyk sbom --all-projects (mocked server only)', () => {
     expect(bom.metadata.component.name).toEqual(
       'mono-repo-project-manifests-only',
     );
-    expect(bom.components).toHaveLength(37);
+    expect(bom.components).toHaveLength(36);
   });
 });

--- a/test/jest/acceptance/snyk-sbom/maven-options.spec.ts
+++ b/test/jest/acceptance/snyk-sbom/maven-options.spec.ts
@@ -63,7 +63,7 @@ describe('snyk sbom: maven options (mocked server only)', () => {
     );
     expect(sbom.dependencies[2].dependsOn.length).toEqual(1);
     expect(sbom.dependencies[2].dependsOn[0]).toEqual(
-      'commons-logging:commons-logging@1.0.3',
+      'commons-logging:commons-logging@1.0.4',
     );
   });
 


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [x] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?
Follow-up from https://github.com/snyk/cli/pull/5891: keep only the versions resolved by maven in the Dverbose algorithm.
Tests are reverted to the values before this PR: the dependency that actually gets resolved by maven (not considered, but omitted) is at version 1.0.3. Same thing for the length of the dependencies array.

## Where should the reviewer start?
This is introduced: https://github.com/snyk/snyk-mvn-plugin/pull/190, see tests.

## How should this be manually tested?
`snyk test/monitor -- -Dverbose` or `snyk sbom` on the fixtures projects.

## What's the product update that needs to be communicated to CLI users?
[test, monitor, sbom] Maven Dverbose algorithm adds only the dependencies resolved by maven in the dependency graph/sbom.

## What are the relevant tickets?
https://snyksec.atlassian.net/browse/OSM-2668
<!---
## Any background context you want to provide?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
