### PR TITLE
chore: version bump to allow ai-bom extension to use depgraphs

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.34.0
-	github.com/snyk/cli-extension-ai-bom v0.0.0-20250521095438-554f620d07db
+	github.com/snyk/cli-extension-ai-bom v0.0.0-20250521172443-60fe93bb8ab6
 	github.com/snyk/cli-extension-dep-graph v0.0.0-20250321153619-9390ab5e348e
 	github.com/snyk/cli-extension-iac v0.0.0-20250521122953-52bf59414647
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20250227121450-6e14346dbd1a
@@ -20,7 +20,7 @@ require (
 	github.com/snyk/go-application-framework v0.0.0-20250520093237-2f9180791a51
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20250521101656-913cdff39dd1
+	github.com/snyk/snyk-ls v0.0.0-20250522155954-c9bd6c939b34
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
@@ -181,7 +181,7 @@ require (
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
-	github.com/snyk/code-client-go v1.21.3 // indirect
+	github.com/snyk/code-client-go v1.22.1 // indirect
 	github.com/snyk/policy-engine v0.33.2 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -796,8 +796,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
-github.com/snyk/cli-extension-ai-bom v0.0.0-20250521095438-554f620d07db h1:OlhaP+aY369qqY1dugNbJorG4BS69QbIIzy5aorcT0Q=
-github.com/snyk/cli-extension-ai-bom v0.0.0-20250521095438-554f620d07db/go.mod h1:uDqoSiY+4y31mCf6pjMa67hLaDsrzBxYP4dOutfkP3c=
+github.com/snyk/cli-extension-ai-bom v0.0.0-20250521172443-60fe93bb8ab6 h1:94afJDk1b4sgTyZ/OdNRRxSiPK/dIYfgMprmCBwFlks=
+github.com/snyk/cli-extension-ai-bom v0.0.0-20250521172443-60fe93bb8ab6/go.mod h1:rQtv2zWRHuGsQ31W00IZWXRnugmRXty5vijjtGIe7ho=
 github.com/snyk/cli-extension-dep-graph v0.0.0-20250321153619-9390ab5e348e h1:lYBeDqyAmb7NPfcLZJb1rcc+BrWhX5Ct9isQO1O4mSc=
 github.com/snyk/cli-extension-dep-graph v0.0.0-20250321153619-9390ab5e348e/go.mod h1:9Zpe+B8SCkWFjpDR3ckFJl1XuMyxysWebKhyAIj7EyI=
 github.com/snyk/cli-extension-iac v0.0.0-20250521122953-52bf59414647 h1:HNuJNUtoJHgaVE514+7gaLTRZj0yl+MBPp0diDgqH34=
@@ -806,8 +806,8 @@ github.com/snyk/cli-extension-iac-rules v0.0.0-20250227121450-6e14346dbd1a h1:SJ
 github.com/snyk/cli-extension-iac-rules v0.0.0-20250227121450-6e14346dbd1a/go.mod h1:IqfQCIkyC26mkwa+aM6d6yxIh5+tCm4fSQG+Ogq3Qbc=
 github.com/snyk/cli-extension-sbom v0.0.0-20250422133603-a5ae6fdf0934 h1:0RCTH9C0zaTrnqpKLaLXTmP7suwWEHBNVwQSaR8Aifo=
 github.com/snyk/cli-extension-sbom v0.0.0-20250422133603-a5ae6fdf0934/go.mod h1:Q8dmRgcpHTk711dkLVtpkTF5RvLkQVcExGuv1cyx/zU=
-github.com/snyk/code-client-go v1.21.3 h1:2+HPXCA9FGn3gaI1Jw1C4Ifn/NRAbSnmohFUvz4GC4I=
-github.com/snyk/code-client-go v1.21.3/go.mod h1:WH6lNkJc785hfXmwhixxWHix3O6z+1zwz40oK8vl/zg=
+github.com/snyk/code-client-go v1.22.1 h1:bgMaShTO+zoCGNp7SRT6tKSngfhVBn0IRK2QEvpj4Vs=
+github.com/snyk/code-client-go v1.22.1/go.mod h1:Jx3Jpo8kHlqHjhGa7a0ROQzPu+X15TBN0zRD+wNcUds=
 github.com/snyk/container-cli v0.0.0-20250321132345-1e2e01681dd7 h1:/2+2piwQtB9fEJCkXEOjboZjY+77lQfnvqBZ/60xNHk=
 github.com/snyk/container-cli v0.0.0-20250321132345-1e2e01681dd7/go.mod h1:38w+dcAQp9eG3P5t2eNS9eG0reut10AeJjLv5lJ5lpM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250520155934-078275889e2c h1:rXUCGepwK38Xn00MKwfJRd5ecQ7ylvkudoMFBycIJUk=
@@ -820,8 +820,8 @@ github.com/snyk/policy-engine v0.33.2 h1:ZxD6/RQ4vqUAXa64V72SsGjZ8vmnBgZNGYQxMIq
 github.com/snyk/policy-engine v0.33.2/go.mod h1:YTZq3GMRbXcHOXQQrFRVEg+MQiIGCGZ1met6KlpruNo=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20250521101656-913cdff39dd1 h1:VhQkwPBuhFfKJAUaYKRrOFdkaO3Z6XuUKFf+ESUW0Ks=
-github.com/snyk/snyk-ls v0.0.0-20250521101656-913cdff39dd1/go.mod h1:xbvwtDAjQuol2GI45d6awmmRQ3TYcC3jdHFGn+2bTjQ=
+github.com/snyk/snyk-ls v0.0.0-20250522155954-c9bd6c939b34 h1:pFUO93B5j41NqWXldISrX98TwqCPGeQMD0ASQbG/Af4=
+github.com/snyk/snyk-ls v0.0.0-20250522155954-c9bd6c939b34/go.mod h1:YNp8kSuOYlAPW70rZwQB2NxaxuyEWsmarv1oChyEylY=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=


### PR DESCRIPTION
## What does this PR do?

We recently introduced changes in cli-extension-aibom (in [this PR](https://github.com/snyk/cli-extension-ai-bom/pull/19)) and in code-client-go (in [this PR](https://github.com/snyk/code-client-go/pull/101)) that allow the aibom cli-extension to use depgraphs as part of the resulting BOM.

This PR aims to bump the corresponding versions in `go.mod` so they can be used by the CLI. Risk level should be minimal as this does not modify any existing behavior, just adds new one.

~**DO NOT MERGE** until [PR#876](https://github.com/snyk/snyk-ls/pull/876) has been merge in snyk-ls and the `go.mod` version has been bumped accordingly.~
[The PR](https://github.com/snyk/snyk-ls/pull/876) has been merged, and snyk-ls version has been bumped as part of this PR (notably, this means that the PR now also includes the previously mentioned change).

## How should this be manually tested?

Run `make build` inside the CLI, then inside a python repo run `/home/buru/work/cli/binary-releases/snyk-linux aibom --experimental`. If there are any AI packages, they should have a version next to them in the output (e.g. `pkg:huggingface-hub@0.30.2`).

## What's the product update that needs to be communicated to CLI users?

None as of yet (we will handle all communication once the aibom extension is released to the public).

## What are the relevant tickets?

See [AIBOM-42](https://snyksec.atlassian.net/browse/AIBOM-42) and [AIBOM-55](https://snyksec.atlassian.net/browse/AIBOM-55).

[AIBOM-42]: https://snyksec.atlassian.net/browse/AIBOM-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ