### PR TITLE
chore: pass `--tmp-path` flag to plugins

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -224,6 +224,7 @@ export function args(rawArgv: string[]): Args {
     'dry-run',
     'sequential',
     'gradle-normalize-deps',
+    'tmp-path',
   ];
   for (const dashedArg of argumentsToTransform) {
     if (argv[dashedArg]) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -264,6 +264,7 @@ export type SupportedUserReachableFacingCliArgs =
   | 'skip-unresolved'
   | 'strict-out-of-sync'
   | 'sub-project'
+  | 'tmp-path'
   | 'trust-policies'
   | 'yarn-workspaces'
   | 'maven-aggregate-project'


### PR DESCRIPTION
# TODO:
- Update `snyk-python-plugin` version once [this PR](https://github.com/snyk/snyk-python-plugin/pull/267) is merged

------

## Pull Request Submission Checklist
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

In [this PR](https://github.com/snyk/snyk-python-plugin/pull/267) we updated the Python plugin to look for a `--tmp-dir` flag, which will be the directory to write temporary files to. This CLI PR ensures that the flag is passed through to the plugin.

## How should this be manually tested?

Build this version of the CLI locally, and then open up a Python project and run the CLI against it:

```bash
<path/to/CLI/repo>/bin/snyk test --tmp-path=<some/directory>
```

If you provide a directory that exists and you have access to, or no directory, there will be no errors. If you e.g. use `--tmp-dir=/usr/bin` (which requires `sudo` to write to), the command will fail:

```
Failed to write temporary files:
Error: EPERM: operation not permitted, mkdir '/usr/bin/tmp-15640-js1sj0BYRdv3'
Try running again with --tmp-path=<some directory>, where <some directory> is a valid directory that you have permissions to write to.
```

## What's the product update that needs to be communicated to CLI users?