### PR TITLE
chore(ci): Check the version earlier during a build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1027,6 +1027,7 @@ jobs:
           name: Set version
           command: |
             make binary-releases/version binary-releases/fips/version
+            make release-validate-version
             make ts-cli-binaries/version BINARY_RELEASES_FOLDER_TS_CLI=ts-cli-binaries
       - run:
           # required for one unit test (ts-binary-wrapper/test/unit/common.spec.ts:15:30)

--- a/Makefile
+++ b/Makefile
@@ -264,15 +264,18 @@ acceptance-test-with-proxy: pre-build
 
 # targets responsible for the CLI release
 .PHONY: release-pre
-release-pre:
-	@echo "-- Validating repository"
-	@./release-scripts/validate-repository.sh
+release-pre: release-validate-version
 	@echo "-- Validating artifacts"
 	@./release-scripts/validate-checksums.sh
 	@echo "-- Validating upload permissions"
 	@./release-scripts/upload-artifacts.sh --dry-run latest github npm
 	@echo "-- Publishing to S3 /version"
 	@./release-scripts/upload-artifacts.sh version
+
+.PHONE: release-validate-version
+release-validate-version:
+	@echo "-- Validating repository"
+	@./release-scripts/validate-repository.sh
 
 .PHONY: release-mgt-prepare
 release-mgt-prepare:


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
This PR adds an additional earlier check of the generated version to the build pipeline.
The reason is, that issues with the version number where only checked and alerted on when the builds were done, which increases the feedback loop unnecessarily. Now the version is additionally checked when the it is generated. Doing it twice doesn't hurt and keeps all the validations in the pre-release step in one place.

Risk: Low, since it is just an additional check that is already part of the pipeline.

## Where should the reviewer start?

## How should this be manually tested?
Execute `make release-validate-version` in the repository root.

## What's the product update that needs to be communicated to CLI users?
N/A

<!---
## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
