### PR TITLE
chore(ci): Print details when failing to trigger snyk-images

### DIFF
--- a/release-scripts/upload-artifacts.sh
+++ b/release-scripts/upload-artifacts.sh
@@ -114,6 +114,7 @@ trigger_build_snyk_images() {
   echo "Triggering build-and-publish workflow at snyk-images..."
   echo "Version: $VERSION_TAG"
   echo "Release Channel: $RELEASE_CHANNEL"
+  response_file=$TMPDIR/trigger_build_snyk_images_response.txt
   RESPONSE=$(curl -L \
     -X POST \
     -H "Accept: application/vnd.github+json" \
@@ -122,11 +123,15 @@ trigger_build_snyk_images() {
     https://api.github.com/repos/snyk/snyk-images/dispatches \
     -d "{\"event_type\":\"build_and_push_images\", \"client_payload\": {\"version\": \"$VERSION_TAG\", \"release_channel\": \"$RELEASE_CHANNEL\"}}" \
     -w "%{http_code}" \
-    -o /dev/null)
+    -s  \
+    -o "$response_file")
   if [ "$RESPONSE" -eq 204 ]; then
     echo "Successfully triggered build-and-publish workflow at snyk-images."
   else
-    echo "Failed to trigger build-and-publish workflow at snyk-images. HTTP response code: $RESPONSE."
+    echo "Failed to trigger build-and-publish workflow at snyk-images."
+    echo "Response status code: $RESPONSE"
+    echo "Details:"
+    cat $response_file
     exit 1
   fi
 }


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
In the previous version of the script that triggers snyk-images to build when a new CLI version is deployed, error cases where only showing the status code of the API request. While the response body was swallowed, it actually contains valuable information to debug or resolve issues. 
With this PR the response body is preserved and displayed in case of an error.

Risk: Low, since it only changes the error handling of a deploy script

## Where should the reviewer start?

## How should this be manually tested?
Run the following steps in a terminal
```
export HAMMERHEAD_GITHUB_PAT=random
./release-scripts/upload-artifacts.sh trigger-snyk-images
```

the output should look like this

```
Triggering build-and-publish workflow at snyk-images...
Version: v1.1298.0-preview.d70f16aba24ba882785a0869bc42dffcc15ff408
Release Channel: dev
Failed to trigger build-and-publish workflow at snyk-images.
Response status code: 401
Details:
{
  "message": "Bad credentials",
  "documentation_url": "https://docs.github.com/rest",
  "status": "401"
}
```


## What's the product update that needs to be communicated to CLI users?
N/A

<!---
## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
