### PR TITLE
feat(aibom): support optional html rendering when using --html

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.34.0
-	github.com/snyk/cli-extension-ai-bom v0.0.0-20250521172443-60fe93bb8ab6
+	github.com/snyk/cli-extension-ai-bom v0.0.0-20250526122118-68d20d659a0e
 	github.com/snyk/cli-extension-dep-graph v0.0.0-20250321153619-9390ab5e348e
 	github.com/snyk/cli-extension-iac v0.0.0-20250521122953-52bf59414647
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20250227121450-6e14346dbd1a
@@ -218,6 +218,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.34.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
+	go.uber.org/mock v0.5.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/exp v0.0.0-20250215185904-eff6e970281f // indirect

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -798,6 +798,8 @@ github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnB
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20250521172443-60fe93bb8ab6 h1:94afJDk1b4sgTyZ/OdNRRxSiPK/dIYfgMprmCBwFlks=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20250521172443-60fe93bb8ab6/go.mod h1:rQtv2zWRHuGsQ31W00IZWXRnugmRXty5vijjtGIe7ho=
+github.com/snyk/cli-extension-ai-bom v0.0.0-20250526122118-68d20d659a0e h1:J5cQM71mn+dGJfyDlC+XKEMgDB3DbqCTxpq828VmtlU=
+github.com/snyk/cli-extension-ai-bom v0.0.0-20250526122118-68d20d659a0e/go.mod h1:t4YJQ7GhCpk4Nt6z0ziFFcQ6Sc921MhUtFtPJov6S6c=
 github.com/snyk/cli-extension-dep-graph v0.0.0-20250321153619-9390ab5e348e h1:lYBeDqyAmb7NPfcLZJb1rcc+BrWhX5Ct9isQO1O4mSc=
 github.com/snyk/cli-extension-dep-graph v0.0.0-20250321153619-9390ab5e348e/go.mod h1:9Zpe+B8SCkWFjpDR3ckFJl1XuMyxysWebKhyAIj7EyI=
 github.com/snyk/cli-extension-iac v0.0.0-20250521122953-52bf59414647 h1:HNuJNUtoJHgaVE514+7gaLTRZj0yl+MBPp0diDgqH34=

--- a/test/jest/acceptance/snyk-aibom/aibom.spec.ts
+++ b/test/jest/acceptance/snyk-aibom/aibom.spec.ts
@@ -107,6 +107,20 @@ describe('snyk aibom (mocked servers only)', () => {
     expect(bom.components.length).toBeGreaterThan(1);
   });
 
+  test('`aibom` generates an AI-BOM CycloneDX in the HTML format', async () => {
+    const { code, stdout } = await runSnykCLI(
+      `aibom ${pythonChatbotProject} --experimental --html`,
+      {
+        env,
+      },
+    );
+    expect(code).toEqual(0);
+    expect(stdout).toContain('<!DOCTYPE html>');
+    expect(stdout).toContain(
+      'https://cyclonedx.org/schema/bom-1.6.schema.json',
+    );
+  });
+
   describe('aibom error handling', () => {
     test('handles a missing experimental flag', async () => {
       const { code, stdout } = await runSnykCLI(


### PR DESCRIPTION
## What does this PR do?

This PR bumps the version of the https://github.com/snyk/cli-extension-ai-bom dependency.

The change there (see https://github.com/snyk/cli-extension-ai-bom/compare/60fe93bb8ab6...68d20d659a0e) consists of the new flag `--html` added to the experimental `aibom` command and a minor dependency bump.

The new flag changes the output that `aibom` produces - instead of CycloneDX JSON it is a pretty-printed HTML.

We deem the risk of merging this PR as small.

## How should this be manually tested?
Run `make build` inside the CLI, then inside a python repo run `$HOME/cli/binary-releases/snyk-linux aibom --experimental --html >aibom.html`. This command will write the AIBOM, visualized as a graph, to `aibom.html` that you can open in the browser.

This PR contains an new automated test for it as well.

## What are the relevant tickets?
[AIBOM-26](https://snyksec.atlassian.net/browse/AIBOM-26)



[AIBOM-26]: https://snyksec.atlassian.net/browse/AIBOM-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ