### PR TITLE
fix(iac): output URL for IaC to contain correct domain [IAC-3367]

### DIFF
--- a/src/lib/config/api-url.ts
+++ b/src/lib/config/api-url.ts
@@ -192,3 +192,13 @@ export function getRootUrl(apiUrlString: string): string {
   const rootUrl = apiUrl.protocol + '//' + apiUrl.host;
   return rootUrl;
 }
+
+export function getAppUrl(url: string): string {
+  const apiUrl = new URL(url);
+
+  if (apiUrl.host.startsWith('api.')) {
+    apiUrl.host = apiUrl.host.replace(/^api\./, 'app.');
+  }
+
+  return apiUrl.protocol + '//' + apiUrl.host;
+}

--- a/src/lib/formatters/iac-output/text/share-results.ts
+++ b/src/lib/formatters/iac-output/text/share-results.ts
@@ -1,6 +1,9 @@
-import config from '../../../config';
 import { EOL } from 'os';
 import { colors, contentPadding } from './utils';
+import { getAppUrl } from '../../../config/api-url';
+import config from '../../../config';
+
+const apiUrl = config.API;
 
 export function formatShareResultsOutput(orgName: string, projectName: string) {
   return (
@@ -9,7 +12,7 @@ export function formatShareResultsOutput(orgName: string, projectName: string) {
     EOL +
     contentPadding +
     'Your test results are available at: ' +
-    colors.title(`${config.ROOT}/org/${orgName}/projects`) +
+    colors.title(`${getAppUrl(apiUrl)}/org/${orgName}/projects`) +
     EOL +
     contentPadding +
     'under the name: ' +
@@ -28,9 +31,7 @@ export function formatShareResultsOutputIacPlus(
     contentPadding +
     'Your test results are available at: ' +
     colors.title(
-      `${
-        config.ROOT
-      }/org/${orgName}/cloud/issues?environment_name=${encodeURIComponent(
+      `${getAppUrl(apiUrl)}/org/${orgName}/cloud/issues?environment_name=${encodeURIComponent(
         projectName,
       )}`,
     )
@@ -43,7 +44,7 @@ export function formatShareResultsOutputIacV2(
 ) {
   let projectLink = ''; // empty link if projectId is undefined, will follow up on this after product decision
   if (projectPublicId) {
-    projectLink = `${config.ROOT}/org/${orgName}/project/${encodeURIComponent(projectPublicId)}`;
+    projectLink = `${getAppUrl(apiUrl)}/org/${orgName}/project/${encodeURIComponent(projectPublicId)}`;
   }
 
   return (

--- a/test/jest/unit/config/api-url.spec.ts
+++ b/test/jest/unit/config/api-url.spec.ts
@@ -3,6 +3,7 @@ import {
   getV1ApiUrl,
   getRestApiUrl,
   getRootUrl,
+  getAppUrl,
 } from '../../../../src/lib/config/api-url';
 
 const urls = [
@@ -12,6 +13,7 @@ const urls = [
     expectedV1: 'https://snyk.io/api/v1',
     expectedRest: 'https://api.snyk.io/rest',
     expectedRoot: 'https://snyk.io',
+    expectedApp: 'https://snyk.io',
   },
   {
     userInput: 'https://snyk.io/api',
@@ -19,6 +21,7 @@ const urls = [
     expectedV1: 'https://snyk.io/api/v1',
     expectedRest: 'https://api.snyk.io/rest',
     expectedRoot: 'https://snyk.io',
+    expectedApp: 'https://snyk.io',
   },
   {
     userInput: 'https://app.snyk.io/api',
@@ -26,6 +29,7 @@ const urls = [
     expectedV1: 'https://app.snyk.io/api/v1',
     expectedRest: 'https://api.snyk.io/rest',
     expectedRoot: 'https://app.snyk.io',
+    expectedApp: 'https://app.snyk.io',
   },
   {
     userInput: 'https://app.snyk.io/api/v1',
@@ -33,6 +37,7 @@ const urls = [
     expectedV1: 'https://app.snyk.io/api/v1',
     expectedRest: 'https://api.snyk.io/rest',
     expectedRoot: 'https://app.snyk.io',
+    expectedApp: 'https://app.snyk.io',
   },
   {
     userInput: 'https://api.snyk.io/v1',
@@ -40,6 +45,7 @@ const urls = [
     expectedV1: 'https://api.snyk.io/v1',
     expectedRest: 'https://api.snyk.io/rest',
     expectedRoot: 'https://snyk.io',
+    expectedApp: 'https://app.snyk.io',
   },
   {
     userInput: 'https://api.snyk.io',
@@ -47,6 +53,7 @@ const urls = [
     expectedV1: 'https://api.snyk.io/v1',
     expectedRest: 'https://api.snyk.io/rest',
     expectedRoot: 'https://snyk.io',
+    expectedApp: 'https://app.snyk.io',
   },
   {
     userInput: 'https://api.snyk.io/',
@@ -54,6 +61,7 @@ const urls = [
     expectedV1: 'https://api.snyk.io/v1',
     expectedRest: 'https://api.snyk.io/rest',
     expectedRoot: 'https://snyk.io',
+    expectedApp: 'https://app.snyk.io',
   },
   {
     userInput: 'https://api.custom.snyk.io',
@@ -61,6 +69,7 @@ const urls = [
     expectedV1: 'https://api.custom.snyk.io/v1',
     expectedRest: 'https://api.custom.snyk.io/rest',
     expectedRoot: 'https://custom.snyk.io',
+    expectedApp: 'https://app.custom.snyk.io',
   },
   {
     userInput: 'http://localhost:9000/',
@@ -68,6 +77,7 @@ const urls = [
     expectedV1: 'http://localhost:9000/v1',
     expectedRest: 'http://localhost:9000/rest',
     expectedRoot: 'http://localhost:9000',
+    expectedApp: 'http://localhost:9000',
   },
   {
     userInput: 'http://localhost:9000/api/v1',
@@ -75,6 +85,7 @@ const urls = [
     expectedV1: 'http://localhost:9000/api/v1',
     expectedRest: 'http://localhost:9000/rest',
     expectedRoot: 'http://localhost:9000',
+    expectedApp: 'http://localhost:9000',
   },
   {
     userInput: 'http://alpha:omega@localhost:9000',
@@ -82,6 +93,7 @@ const urls = [
     expectedV1: 'http://alpha:omega@localhost:9000/v1',
     expectedRest: 'http://alpha:omega@localhost:9000/rest',
     expectedRoot: 'http://localhost:9000',
+    expectedApp: 'http://localhost:9000',
   },
   {
     userInput: 'https://app.dev.snyk.io/api/v1',
@@ -89,6 +101,7 @@ const urls = [
     expectedV1: 'https://app.dev.snyk.io/api/v1',
     expectedRest: 'https://api.dev.snyk.io/rest',
     expectedRoot: 'https://app.dev.snyk.io',
+    expectedApp: 'https://app.dev.snyk.io',
   },
 ];
 
@@ -170,6 +183,14 @@ describe('CLI config - API URL', () => {
     urls.forEach((url) => {
       it(`returns ROOT URL ${url.userInput}`, () => {
         expect(getRootUrl(url.userInput)).toEqual(url.expectedRoot);
+      });
+    });
+  });
+
+  describe('getAppUrl', () => {
+    urls.forEach((url) => {
+      it(`returns ROOT URL ${url.userInput}`, () => {
+        expect(getAppUrl(url.userInput)).toEqual(url.expectedApp);
       });
     });
   });

--- a/test/jest/unit/lib/formatters/iac-output/text/share-results.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output/text/share-results.spec.ts
@@ -1,10 +1,11 @@
 import { EOL } from 'os';
-import config from '../../../../../../../src/lib/config';
 import { formatShareResultsOutput } from '../../../../../../../src/lib/formatters/iac-output/text';
 import {
   colors,
   contentPadding,
 } from '../../../../../../../src/lib/formatters/iac-output/text/utils';
+import { getAppUrl } from '../../../../../../../src/lib/config/api-url';
+import config from '../../../../../../../src/lib/config';
 
 describe('formatShareResultsOutput', () => {
   it('returns the correct output', () => {
@@ -22,7 +23,7 @@ describe('formatShareResultsOutput', () => {
         EOL +
         contentPadding +
         'Your test results are available at: ' +
-        colors.title(`${config.ROOT}/org/${testOrgName}/projects`) +
+        colors.title(`${getAppUrl(config.API)}/org/${testOrgName}/projects`) +
         EOL +
         contentPadding +
         'under the name: ' +


### PR DESCRIPTION
## Pull Request Submission Checklist

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
This change updates the URL generated by `snyk iac test --report` command to consistently use the `app.snyk.io` domain (or its regional equivalent, e.g., `app.eu.snyk.io`) instead of the root `snyk.io` domain. This was previously working because of some redirects between the Snyk domains, that were redirecting the domain `https://eu.snyk.io` to `https://app.eu.snyk.io/`.

A new `getAppUrl` helper function has been introduced in `lib/config/api-url.ts` to reliably derive the correct application base URL, which is now used in the output formatting for shared IaC test results.

## Where should the reviewer start?
`<local build> iac test --report`

## How should this be manually tested?
Run comand: `snyk iac test --report` on an IaC Project. This command should return the results of the IaC scan and the URL should be like `https://app.snyk.io/...`.

## What's the product update that needs to be communicated to CLI users?
This fix addresses a bug preventing users on regional Snyk instances (e.g. eu.snyk.io) from accessing their IaC scan results via the link provided by the output of the `snyk iac test --report` command.

The issue came from the CLI outputting  for Current IaC: `https://eu.snyk.io/org/<ORG>/projects` and for IaC+: `https://eu.snyk.io/org/<ORG>/cloud/issues?environment_name=<ENV_NAME>` which was previously redirecting the user to the correct link that is for Current IaC: `https://app.eu.snyk.io/org/<ORG>/projects` and for IaC+: `https://app.eu.snyk.io/org/<ORG>/cloud/issues?environment_name=<ENV_NAME>`. With these redirects no longer working for regional domains, the links became invalid.

The output now correctly generates the `app.` prefixed URLs directly, ensuring users can access their IaC reports.

## What are the relevant tickets?
[IAC-3367](https://snyksec.atlassian.net/jira/software/c/projects/IAC/boards/301?selectedIssue=IAC-3367)

[IAC-3367]: https://snyksec.atlassian.net/browse/IAC-3367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ