### PR TITLE
fix: [OSM-2902] Better support for comments in Dotnet global.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "snyk-mvn-plugin": "3.9.1",
         "snyk-nodejs-lockfile-parser": "2.1.0",
         "snyk-nodejs-plugin": "1.4.4",
-        "snyk-nuget-plugin": "2.7.15",
+        "snyk-nuget-plugin": "2.9.0",
         "snyk-php-plugin": "1.12.1",
         "snyk-policy": "4.1.5",
         "snyk-python-plugin": "2.7.0",
@@ -9420,24 +9420,24 @@
       }
     },
     "node_modules/dotnet-deps-parser": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/dotnet-deps-parser/-/dotnet-deps-parser-5.5.3.tgz",
-      "integrity": "sha512-wZShT7WkpCX0f1FMC3jhzmTHIhNNwpZ/ZfzPakPTB6cwHaHsodaMvBxPkqIwiAQX9m7jywhV4sclPp6VNqGChg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/dotnet-deps-parser/-/dotnet-deps-parser-5.8.0.tgz",
+      "integrity": "sha512-H+Sq0HCVIBWZJymvmsjBMbwHyczlAim2RADQlIxmOFII76ot9342h/baQBHXf56Rb90PrTakZ5nvX/wR/DtUYA==",
       "dependencies": {
         "@snyk/error-catalog-nodejs-public": "^4.0.1",
+        "jsonc-parser": "^3.3.1",
         "lodash": "^4.17.21",
         "source-map-support": "^0.5.21",
         "xml2js": "0.6.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/dotnet-deps-parser/node_modules/@snyk/error-catalog-nodejs-public": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@snyk/error-catalog-nodejs-public/-/error-catalog-nodejs-public-4.0.4.tgz",
       "integrity": "sha512-M+t/MNfR/qr/Rdxc3Kl2p26mIx0YdcM22CAZfNsCuldl1DIZQma8jc7zmm14AwhwmdoU6TE7mzzO33KINgB8LA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2",
         "uuid": "^9.0.0"
@@ -9446,8 +9446,7 @@
     "node_modules/dotnet-deps-parser/node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/dotnet-deps-parser/node_modules/uuid": {
       "version": "9.0.1",
@@ -9457,7 +9456,6 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -15372,6 +15370,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -21182,14 +21185,14 @@
       }
     },
     "node_modules/snyk-nuget-plugin": {
-      "version": "2.7.15",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.7.15.tgz",
-      "integrity": "sha512-Ou6cIwMq1h8nVZlZe42v+iEP1e+Ldrc5Q33ooUixrQNSBDVIGhF7H9ENQZ+JDofaFYWW4jjHQqU+0IUeN+b0SA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.9.0.tgz",
+      "integrity": "sha512-CMQy0af6zDnFjbKXjsP/oFZh+PVLOww8BUQrBYpANiVBOarz4a4vaJkSNGGNvP7eMroEvygSDvj9zXWODg0zcQ==",
       "dependencies": {
         "@snyk/cli-interface": "^2.14.0",
         "@snyk/dep-graph": "^2.8.1",
         "debug": "^4.3.4",
-        "dotnet-deps-parser": "5.5.3",
+        "dotnet-deps-parser": "5.8.0",
         "jszip": "3.10.1",
         "lodash": "^4.17.21",
         "node-cache": "^5.1.2",
@@ -31722,11 +31725,12 @@
       "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg=="
     },
     "dotnet-deps-parser": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/dotnet-deps-parser/-/dotnet-deps-parser-5.5.3.tgz",
-      "integrity": "sha512-wZShT7WkpCX0f1FMC3jhzmTHIhNNwpZ/ZfzPakPTB6cwHaHsodaMvBxPkqIwiAQX9m7jywhV4sclPp6VNqGChg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/dotnet-deps-parser/-/dotnet-deps-parser-5.8.0.tgz",
+      "integrity": "sha512-H+Sq0HCVIBWZJymvmsjBMbwHyczlAim2RADQlIxmOFII76ot9342h/baQBHXf56Rb90PrTakZ5nvX/wR/DtUYA==",
       "requires": {
         "@snyk/error-catalog-nodejs-public": "^4.0.1",
+        "jsonc-parser": "^3.3.1",
         "lodash": "^4.17.21",
         "source-map-support": "^0.5.21",
         "xml2js": "0.6.2"
@@ -36129,6 +36133,11 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
+    },
+    "jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -40548,14 +40557,14 @@
       }
     },
     "snyk-nuget-plugin": {
-      "version": "2.7.15",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.7.15.tgz",
-      "integrity": "sha512-Ou6cIwMq1h8nVZlZe42v+iEP1e+Ldrc5Q33ooUixrQNSBDVIGhF7H9ENQZ+JDofaFYWW4jjHQqU+0IUeN+b0SA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.9.0.tgz",
+      "integrity": "sha512-CMQy0af6zDnFjbKXjsP/oFZh+PVLOww8BUQrBYpANiVBOarz4a4vaJkSNGGNvP7eMroEvygSDvj9zXWODg0zcQ==",
       "requires": {
         "@snyk/cli-interface": "^2.14.0",
         "@snyk/dep-graph": "^2.8.1",
         "debug": "^4.3.4",
-        "dotnet-deps-parser": "5.5.3",
+        "dotnet-deps-parser": "5.8.0",
         "jszip": "3.10.1",
         "lodash": "^4.17.21",
         "node-cache": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "snyk-mvn-plugin": "3.9.1",
     "snyk-nodejs-lockfile-parser": "2.1.0",
     "snyk-nodejs-plugin": "1.4.4",
-    "snyk-nuget-plugin": "2.7.15",
+    "snyk-nuget-plugin": "2.9.0",
     "snyk-php-plugin": "1.12.1",
     "snyk-policy": "4.1.5",
     "snyk-python-plugin": "2.7.0",

--- a/test/acceptance/workspaces/nuget-app-9-globaljson/dotnet_9.csproj
+++ b/test/acceptance/workspaces/nuget-app-9-globaljson/dotnet_9.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/test/acceptance/workspaces/nuget-app-9-globaljson/global.json
+++ b/test/acceptance/workspaces/nuget-app-9-globaljson/global.json
@@ -1,0 +1,7 @@
+{
+  "comment": "Only update the version manually with major SDK updates, see https://dotnet.microsoft.com/en-us/download/dotnet.",
+  "sdk": {
+    "version": "6.0.100",
+    "rollForward": "latestMajor"
+  }
+}

--- a/test/acceptance/workspaces/nuget-app-9-globaljson/program.cs
+++ b/test/acceptance/workspaces/nuget-app-9-globaljson/program.cs
@@ -1,0 +1,8 @@
+using System;
+class TestFixture {
+    static public void Main(String[] args)
+    {
+      var client = new System.Net.Http.HttpClient();
+      Console.WriteLine("Hello, World!");
+    }
+}

--- a/test/jest/acceptance/snyk-test/basic-test-all-languages.spec.ts
+++ b/test/jest/acceptance/snyk-test/basic-test-all-languages.spec.ts
@@ -243,6 +243,10 @@ describe('`snyk test` of basic projects for each language/ecosystem', () => {
       fixture: 'nuget-app-8-with-multi-project and spaces',
       targetFile: 'dotnet_8_first.csproj',
     },
+    {
+      fixture: 'nuget-app-9-globaljson',
+      targetFile: 'dotnet_9.csproj',
+    },
   ])(
     'run `snyk test` on a nuget project using v2 dotnet runtime resolution logic for $fixture',
     async ({ fixture, targetFile }) => {


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [x] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?
Improved support for comments in Dotnet's `global.json` file using a JSONC parser.

## How should this be manually tested?
Run `snyk test` on a Dotnet project having a `global.json` file which containing a URL, such as:
```json
{
  "comment": "Only update the version manually with major SDK updates, see https://dotnet.microsoft.com/en-us/download/dotnet.",
  "sdk": {
    "version": "9.0.100",
    "rollForward": "latestMajor"
  }
}
```

## What's the product update that needs to be communicated to CLI users?
Improved support for comments in Dotnet's `global.json` file. Imports that failed when that file contained special content such as URLs will no longer fail because of it.

## Risk assessment: Low

## What are the relevant tickets?
[OSM-2902](https://snyksec.atlassian.net/browse/OSM-2902)

[OSM-2902]: https://snyksec.atlassian.net/browse/OSM-2902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ