### PR TITLE
fix(logging): Redact Basic auth from debug logs if it exists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
   go_version:
     type: string
     # https://go.dev/doc/devel/release
-    default: '1.23.8'
+    default: '1.23.10'
   aws_version:
     type: string
     # https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst

--- a/.snyk
+++ b/.snyk
@@ -24,6 +24,11 @@ ignore:
         reason: None Given
         expires: 2025-05-01T10:37:59.602Z
         created: 2025-04-01T10:37:59.609Z
+  SNYK-JS-TARFS-10293725:
+    - '*':
+        reason: None Given
+        expires: 2025-07-03T12:38:39.920Z
+        created: 2025-06-03T12:38:39.927Z
 patch: {}
 exclude:
   code:

--- a/binary-releases/RELEASE_NOTES.md
+++ b/binary-releases/RELEASE_NOTES.md
@@ -1,7 +1,8 @@
-## [1.1297.1](https://github.com/snyk/cli/compare/v1.1297.0...v1.1297.1) (2025-05-16)
+## [1.1297.2](https://github.com/snyk/snyk/compare/v1.1297.1...1.1297.2) (2025-06-16)
 
 The Snyk CLI is being deployed to different deployment channels, users can select the stability level according to their needs. For details please see [this documentation](https://docs.snyk.io/snyk-cli/releases-and-channels-for-the-snyk-cli)
 
 ### Bug Fixes
 
-* **test:** Rollbacked a regression introduced by a change in gradle module resolution in version `1.1297.0` ([7991133](https://github.com/snyk/cli/commit/79911337912082454e4362d9473c40699e059425))
+* **logging:** Redact Basic Authorization credentials from debug logs if they exist ([e054455](https://github.com/snyk/snyk/commit/e054455eab8e686f19c165a8bad86259103a5f5d))
+

--- a/binary-releases/RELEASE_NOTES.md
+++ b/binary-releases/RELEASE_NOTES.md
@@ -4,5 +4,7 @@ The Snyk CLI is being deployed to different deployment channels, users can selec
 
 ### Bug Fixes
 
-* **logging:** Redact Basic Authorization credentials from debug logs if they exist ([e054455](https://github.com/snyk/snyk/commit/e054455eab8e686f19c165a8bad86259103a5f5d))
+* **logging:** Improves the sanitization of credentials in local debug logs. ([e054455](https://github.com/snyk/snyk/commit/e054455eab8e686f19c165a8bad86259103a5f5d))
+* **language-server:** IDE Connectivity for Proxy Users: Fixes an issue where IDE plugins could fail to connect when operating behind an NTLM proxy.
+* **language-server:** Snyk Code Local Engine Fix: Addresses a regression that prevented the Snyk Code Local Engine (SCLE) from functioning correctly within the IDEs.
 

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/snyk/cli-extension-sbom v0.0.0-20250422133603-a5ae6fdf0934
 	github.com/snyk/container-cli v0.0.0-20250321132345-1e2e01681dd7
 	github.com/snyk/error-catalog-golang-public v0.0.0-20250429130542-564b0605020e
-	github.com/snyk/go-application-framework v0.0.0-20250505092137-65a591adf20f
+	github.com/snyk/go-application-framework v0.0.0-20250612130357-31093e6eb8ad
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20250514053102-44a941375f2b

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/cli/cliv2
 
-go 1.23.8
+go 1.23.10
 
 require (
 	github.com/elazarl/goproxy v1.7.2

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -808,8 +808,8 @@ github.com/snyk/container-cli v0.0.0-20250321132345-1e2e01681dd7 h1:/2+2piwQtB9f
 github.com/snyk/container-cli v0.0.0-20250321132345-1e2e01681dd7/go.mod h1:38w+dcAQp9eG3P5t2eNS9eG0reut10AeJjLv5lJ5lpM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250429130542-564b0605020e h1:XFGkHDWA8JTPLr82QzoKVqGytofEYBf68VqoUq8yvXk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250429130542-564b0605020e/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.0.0-20250505092137-65a591adf20f h1:L3B/8mDqRayNAiWf2cx2nhirQQI9x9yMfxDqpA+SwcE=
-github.com/snyk/go-application-framework v0.0.0-20250505092137-65a591adf20f/go.mod h1:Hy8dugDhTPRPe99Bf4mG7zeh7+OobdWfX5dzhbeQQsU=
+github.com/snyk/go-application-framework v0.0.0-20250612130357-31093e6eb8ad h1:RpUp1oayxILiWL6jGnXgAYiz7E44minwFEeDXJU3Xc0=
+github.com/snyk/go-application-framework v0.0.0-20250612130357-31093e6eb8ad/go.mod h1:Hy8dugDhTPRPe99Bf4mG7zeh7+OobdWfX5dzhbeQQsU=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v0.33.2 h1:ZxD6/RQ4vqUAXa64V72SsGjZ8vmnBgZNGYQxMIqctYo=

--- a/test/jest/acceptance/debuglog.spec.ts
+++ b/test/jest/acceptance/debuglog.spec.ts
@@ -46,6 +46,25 @@ describe('debug log', () => {
     expect(stderr).not.toContain(expectedToken);
   });
 
+  it('redacts basic authentication', async () => {
+    const { stderr } = await runSnykCLI(
+      'container test ubuntu:latest --username=us --password=pw -d',
+      {
+        env: {
+          ...process.env,
+          SNYK_DISABLE_ANALYTICS: '1',
+          SNYK_LOG_LEVEL: 'trace',
+        },
+      },
+    );
+
+    // this test only makes sense when Basic auth would be expected, otherwise the checks below
+    if (stderr.includes('Basic ')) {
+      expect(stderr).not.toContain('Basic dXM6cHc=');
+      expect(stderr).toContain('Basic ***');
+    }
+  });
+
   it('redacts externally injected bearer token', async () => {
     const project = await createProject('cocoapods-app');
 


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
With this change debug logs will redact Basic Authorization header if they would accour. While Basic Auth is not a common case in the CLI, there are edge cases where this could happen.

In addition, this PR updates the golang version from 1.23.8 to 1.23.10.

## Where should the reviewer start?
https://github.com/snyk/go-application-framework/pull/363

## How should this be manually tested?
1. Stop docker daemon
2. snyk container test ubuntu:latest --username=us --password=pw -d
3. The debug logs must include `Basic ***`

## What's the product update that needs to be communicated to CLI users?
N/A

## Any background context you want to provide?
CLI-949

<!---
## Risk assessment (Low | Medium | High)?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
