### PR TITLE
feat: support mcp components in aibom html output

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.34.0
-	github.com/snyk/cli-extension-ai-bom v0.0.0-20250528093742-9a4b94382ef7
+	github.com/snyk/cli-extension-ai-bom v0.0.0-20250616112001-3bba91586896
 	github.com/snyk/cli-extension-dep-graph v0.0.0-20250321153619-9390ab5e348e
 	github.com/snyk/cli-extension-iac v0.0.0-20250521122953-52bf59414647
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20250227121450-6e14346dbd1a

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -788,8 +788,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
-github.com/snyk/cli-extension-ai-bom v0.0.0-20250528093742-9a4b94382ef7 h1:0Ej508T7Krfv4ONfckxt8BE9ZbIl+lErTVt/GAJWdDc=
-github.com/snyk/cli-extension-ai-bom v0.0.0-20250528093742-9a4b94382ef7/go.mod h1:t4YJQ7GhCpk4Nt6z0ziFFcQ6Sc921MhUtFtPJov6S6c=
+github.com/snyk/cli-extension-ai-bom v0.0.0-20250616112001-3bba91586896 h1:psBmUQawP1JByIEcA9lpwu2mfZ5BoeTNq879LOWMIYc=
+github.com/snyk/cli-extension-ai-bom v0.0.0-20250616112001-3bba91586896/go.mod h1:t4YJQ7GhCpk4Nt6z0ziFFcQ6Sc921MhUtFtPJov6S6c=
 github.com/snyk/cli-extension-dep-graph v0.0.0-20250321153619-9390ab5e348e h1:lYBeDqyAmb7NPfcLZJb1rcc+BrWhX5Ct9isQO1O4mSc=
 github.com/snyk/cli-extension-dep-graph v0.0.0-20250321153619-9390ab5e348e/go.mod h1:9Zpe+B8SCkWFjpDR3ckFJl1XuMyxysWebKhyAIj7EyI=
 github.com/snyk/cli-extension-iac v0.0.0-20250521122953-52bf59414647 h1:HNuJNUtoJHgaVE514+7gaLTRZj0yl+MBPp0diDgqH34=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable): there are no breaking changes.
- [x] Includes manual testing instructions (if necessary)

## What does this PR do?

Updates the experimental cli extension ai-bom.
The output of `snyk aibom --experimental --html` was improved:

* updates the aibom colors to better distinguish the MCP components
* introduces a fixed order in the legend
* adds the type of the components to the label in the graph, to make the graph more readable

## Where should the reviewer start?
https://github.com/snyk/cli-extension-ai-bom/pull/25 and https://github.com/snyk/cli-extension-ai-bom/pull/26.

## How should this be manually tested?

`snyk aibom --experimental --html`. Users need to be on an allow-listed org to use this command.

## What's the product update that needs to be communicated to CLI users?
None.

## What are the relevant tickets?
https://snyksec.atlassian.net/browse/AIBOM-100

## Risk assessment
Low. `snyk aibom` is an experimental feature, the rollout is tightly controlled, currently by an allow list of orgs. Only very few non-internal users have access. The feature does not interact with any other features of the cli.