### PR TITLE
chore: adding an ignore step to the docs update pipelines to avoid ov…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,9 +399,19 @@ workflows:
           channel: cli-alerts
           trusted-branch: main
 
+      - docs-only-check:
+          filters:
+            branches:
+              only:
+                - '/^docs\/.*/'
+
       - prepare-build:
           requires:
             - secrets-scan
+          filters:
+            branches:
+              ignore:
+                - '/^docs\/.*/'
 
       - code-analysis:
           go_target_os: linux
@@ -1083,6 +1093,30 @@ jobs:
           open-source-additional-arguments: --exclude=test,dist
           iac-scan: disabled
           release-branch: main
+
+  docs-only-check:
+    executor: docker-amd64
+    steps:
+      - checkout
+      - run:
+          name: Check if all changed files are documentation (.md)
+          command: |
+            CHANGED_FILES=$(git diff --name-only main)
+
+            # If this step fails, check if you need to add another extension, 
+            # or indeed if this PR adds more than docs-related changes.
+            ALLOWED_DOCS_EXTENSIONS="(\.md|\.svg|\.jpg)$"
+
+            for file in $CHANGED_FILES; do
+              echo "Checking extension of file: $file"
+              # -q:  quiet
+              # -E: extended regular expressions
+              if ! echo "$file" | grep -q -E "$ALLOWED_DOCS_EXTENSIONS"; then
+                echo "Error: Disallowed file type found: $file"
+                exit 1
+              fi
+            done
+            exit 0
 
   test-node:
     executor: docker-amd64


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Stops the full test pipeline if only docs-related changes are being merged, as these automated docs-update steps waste a lot of resources and time, such as: https://github.com/snyk/cli/pull/5979

A step was also added to block attempts to cheat the pipeline by just naming the branch accordingly 😸 

## Where should the reviewer start?

The CircleCI orb.

## How should this be manually tested?

Create a bash script with the relevant changes and try to commit things to your branch that does not follow the rules, and run the script.

## What's the product update that needs to be communicated to CLI users?

None, internal CI/CD optimization.

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
