### PR TITLE
fix: support using sarif and json output files at the same time

### DIFF
--- a/cliv2/cmd/cliv2/main.go
+++ b/cliv2/cmd/cliv2/main.go
@@ -309,10 +309,22 @@ func defaultCmd(args []string) error {
 func runCodeTestCommand(cmd *cobra.Command, args []string) error {
 	// ensure legacy behavior, where sarif and json can be used interchangeably
 	globalConfiguration.AddAlternativeKeys(output_workflow.OUTPUT_CONFIG_KEY_SARIF, []string{output_workflow.OUTPUT_CONFIG_KEY_JSON})
-	globalConfiguration.AddAlternativeKeys(output_workflow.OUTPUT_CONFIG_KEY_SARIF_FILE, []string{output_workflow.OUTPUT_CONFIG_KEY_JSON_FILE})
 
-	// ensure legacy behavior, where sarif files with no findings are not written
-	globalConfiguration.Set(output_workflow.OUTPUT_CONFIG_WRITE_EMPTY_FILE, false)
+	fileWriters := []output_workflow.FileWriter{
+		{
+			NameConfigKey:     output_workflow.OUTPUT_CONFIG_KEY_SARIF_FILE,
+			MimeType:          output_workflow.SARIF_MIME_TYPE,
+			TemplateFiles:     output_workflow.ApplicationSarifTemplates,
+			WriteEmptyContent: true,
+		},
+		{
+			NameConfigKey:     output_workflow.OUTPUT_CONFIG_KEY_JSON_FILE,
+			MimeType:          output_workflow.SARIF_MIME_TYPE,
+			TemplateFiles:     output_workflow.ApplicationSarifTemplates,
+			WriteEmptyContent: false,
+		},
+	}
+	globalConfiguration.Set(output_workflow.OUTPUT_CONFIG_KEY_FILE_WRITERS, fileWriters)
 
 	return runCommand(cmd, args)
 }

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/snyk/cli-extension-sbom v0.0.0-20250422133603-a5ae6fdf0934
 	github.com/snyk/container-cli v0.0.0-20250321132345-1e2e01681dd7
 	github.com/snyk/error-catalog-golang-public v0.0.0-20250520155934-078275889e2c
-	github.com/snyk/go-application-framework v0.0.0-20250709155813-f556bec6f4f4
+	github.com/snyk/go-application-framework v0.0.0-20250711115946-e64056bc2173
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20250708142519-32d15f8b765a

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -804,8 +804,8 @@ github.com/snyk/container-cli v0.0.0-20250321132345-1e2e01681dd7 h1:/2+2piwQtB9f
 github.com/snyk/container-cli v0.0.0-20250321132345-1e2e01681dd7/go.mod h1:38w+dcAQp9eG3P5t2eNS9eG0reut10AeJjLv5lJ5lpM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250520155934-078275889e2c h1:rXUCGepwK38Xn00MKwfJRd5ecQ7ylvkudoMFBycIJUk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250520155934-078275889e2c/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.0.0-20250709155813-f556bec6f4f4 h1:ImrcCrDMYcIbT3isQC/4irSG52pt/7dpBo9fOSH8WX4=
-github.com/snyk/go-application-framework v0.0.0-20250709155813-f556bec6f4f4/go.mod h1:4DSu9PL2hypUjZhrT+zaMh3H5stAerMVfUs5XP1ST8U=
+github.com/snyk/go-application-framework v0.0.0-20250711115946-e64056bc2173 h1:w8uZgvG3arvDPwWd5V3IF1+lU3gLf1sQtoMCFmW37c8=
+github.com/snyk/go-application-framework v0.0.0-20250711115946-e64056bc2173/go.mod h1:4DSu9PL2hypUjZhrT+zaMh3H5stAerMVfUs5XP1ST8U=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v0.33.2 h1:ZxD6/RQ4vqUAXa64V72SsGjZ8vmnBgZNGYQxMIqctYo=

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "build-cli:prod": "node --max-old-space-size=8192 node_modules/webpack/bin/webpack.js --config webpack.prod.ts",
     "watch": "npm run build-cli:dev -- --watch",
     "test": "npm run test:unit && npm run test:acceptance && npm run test:tap",
-    "test:unit": "jest --runInBand --testPathPattern '/test(/jest)?/unit/' --reporters=jest-junit",
-    "test:acceptance": "jest --maxWorkers=1 --testPathPattern \"/test(/jest)?/acceptance/\" --reporters=jest-junit",
+    "test:unit": "jest --runInBand --testPathPattern '/test(/jest)?/unit/' --reporters=jest-junit --reporters=default",
+    "test:acceptance": "jest --maxWorkers=1 --testPathPattern \"/test(/jest)?/acceptance/\" --reporters=jest-junit --reporters=default",
     "test:tap": "tap -Rspec --timeout=300 test/tap/*.test.* ",
     "test:smoke": "./scripts/run-smoke-tests-locally.sh",
     "dev": "ts-node ./src/cli/index.ts"

--- a/test/jest/acceptance/snyk-code/snyk-code-user-journey.spec.ts
+++ b/test/jest/acceptance/snyk-code/snyk-code-user-journey.spec.ts
@@ -41,6 +41,10 @@ const projectWithCodeIssues = resolve(
   'test/fixtures/sast/with_code_issues',
 );
 const emptyProject = resolve(projectRoot, 'test/fixtures/empty');
+const projectWithoutCodeIssues = resolve(
+  projectRoot,
+  'test/fixtures/sast-empty',
+);
 
 // This method does some basic checks on the given sarif file
 function checkSarif(file: string, expectedIgnoredFindings: number): any {
@@ -369,6 +373,72 @@ describe('snyk code test', () => {
           // cleanup file
           try {
             unlinkSync(filePath);
+          } catch (error) {
+            console.error('failed to remove file.', error);
+          }
+        });
+
+        it('works with both --sarif-file-output and --json-file-output', async () => {
+          const sarifFileName = 'sarifOutput.json';
+          const jsonFileName = 'jsonOutput.json';
+          const sarifFilePath = `${projectRoot}/${sarifFileName}`;
+          const jsonFilePath = `${projectRoot}/${jsonFileName}`;
+          const path = await ensureUniqueBundleIsUsed(projectWithCodeIssues);
+          const { stderr, code } = await runSnykCLI(
+            `code test ${path} --sarif-file-output=${sarifFilePath} --json-file-output=${jsonFilePath}`,
+            {
+              env: {
+                ...process.env,
+                ...integrationEnv,
+              },
+            },
+          );
+
+          expect(stderr).toBe('');
+          expect(code).toBe(EXIT_CODE_ACTION_NEEDED);
+
+          expect(existsSync(sarifFilePath)).toBe(true);
+          expect(require(sarifFilePath)).toMatchSchema(sarifSchema);
+
+          expect(existsSync(jsonFilePath)).toBe(true);
+          expect(require(jsonFilePath)).toMatchSchema(sarifSchema);
+
+          // cleanup file
+          try {
+            unlinkSync(sarifFilePath);
+            unlinkSync(jsonFilePath);
+          } catch (error) {
+            console.error('failed to remove file.', error);
+          }
+        });
+
+        it('zero findings is handled differently with --sarif-file-output and --json-file-output', async () => {
+          const sarifFileName = 'sarifOutput.json';
+          const jsonFileName = 'jsonOutput.json';
+          const sarifFilePath = `${projectRoot}/${sarifFileName}`;
+          const jsonFilePath = `${projectRoot}/${jsonFileName}`;
+          const path = await ensureUniqueBundleIsUsed(projectWithoutCodeIssues);
+          const { stderr, code } = await runSnykCLI(
+            `code test ${path} --sarif-file-output=${sarifFilePath} --json-file-output=${jsonFilePath}`,
+            {
+              env: {
+                ...process.env,
+                ...integrationEnv,
+              },
+            },
+          );
+
+          expect(stderr).toBe('');
+          expect(code).toBe(EXIT_CODE_SUCCESS);
+
+          expect(existsSync(sarifFilePath)).toBe(true);
+          expect(require(sarifFilePath)).toMatchSchema(sarifSchema);
+
+          expect(existsSync(jsonFilePath)).toBe(false);
+
+          // cleanup file
+          try {
+            unlinkSync(sarifFilePath);
           } catch (error) {
             console.error('failed to remove file.', error);
           }


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

This PR changes the behaviour of the golang native `code test` implementation to match the typescript implementation with regards to output file handling.

1. It enables to specify and write two different files when specifying `--sarif-file-output` and `--json-file-output`.
2. It mimics the behaviour where testing a code base without issues creates an empty sarif file for `--sarif-file-output` but doesn't create a file for `--json-file-output`.

## Where should the reviewer start?

The main changes can be found in [this GAF PR](https://github.com/snyk/go-application-framework/pull/375). 
This PR also adds user journey tests for both cases and adapt the output configuration based on the new options.

## How should this be manually tested?

Using `--json-file-output` and `--sarif-file-output` for code scans with CCI enabled should create two files like the parameters would specify. This can be compared to the old behaviour where only one file was being created.

## What's the product update that needs to be communicated to CLI users?

1. It enables to specify and write two different files when specifying `--sarif-file-output` and `--json-file-output`.
2. It mimics the behaviour where testing a code base without issues creates an empty sarif file for `--sarif-file-output` but doesn't create a file for `--json-file-output`.

## Risk assessment (Low | Medium | High)?
The Risk of the change is Low as it affects the rendering engine currently only used for CCI for which we have a good test coverage.

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->


Ref: [CLI-860](https://snyksec.atlassian.net/browse/CLI-860)
Ref: [CLI-980](https://snyksec.atlassian.net/browse/CLI-980)

[CLI-860]: https://snyksec.atlassian.net/browse/CLI-860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ