### PR TITLE
fix: dropping or changing redundant logs

### DIFF
--- a/cliv2/internal/cliv2/cliv2.go
+++ b/cliv2/internal/cliv2/cliv2.go
@@ -427,7 +427,7 @@ func (c *CLI) executeV1Default(proxyInfo *proxy.ProxyInfo, passThroughArgs []str
 		c.DebugLogger.Println("Launching: ")
 		c.DebugLogger.Println("  ", c.v1BinaryLocation)
 		c.DebugLogger.Println(" With Arguments:")
-		c.DebugLogger.Println("  ", strings.Join(passThroughArgs, ", "))
+		c.DebugLogger.Println("  ", strings.Join(passThroughArgs, " "))
 		c.DebugLogger.Println(" With Environment: ")
 
 		variablesMap := utils.ToKeyValueMap(snykCmd.Env, "=")

--- a/cliv2/pkg/basic_workflows/legacycli.go
+++ b/cliv2/pkg/basic_workflows/legacycli.go
@@ -84,7 +84,6 @@ func legacycliWorkflow(
 	proxyAuthenticationMechanism := httpauth.AuthenticationMechanismFromString(proxyAuthenticationMechanismString)
 	analyticsDisabled := config.GetBool(configuration.ANALYTICS_DISABLED)
 
-	debugLogger.Print("Arguments:", args)
 	debugLogger.Print("Use StdIO:", useStdIo)
 	debugLogger.Print("Working directory:", workingDirectory)
 

--- a/ts-binary-wrapper/src/common.ts
+++ b/ts-binary-wrapper/src/common.ts
@@ -181,9 +181,7 @@ export function runWrapper(executable: string, cliArguments: string[]): number {
   const debug = debugEnabled(cliArguments);
 
   if (debug) {
-    logErrorWithTimeStamps(
-      'Executing: ' + executable + ' ' + cliArguments.join(' '),
-    );
+    logErrorWithTimeStamps('Executing: ' + executable);
   }
 
   const res = spawnSync(executable, cliArguments, {


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

We're logging the same arguments at least three places. Removing two of them and changing the format for the third for easier scrubbing.

## Where should the reviewer start?

Just the few changed files.

## How should this be manually tested?

Watch any trace or debug log and notice the removed output.

## What's the product update that needs to be communicated to CLI users?

N/A, debugging logs only.

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
