### PR TITLE
chore: wait for testing go until prepare build is done

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -447,7 +447,7 @@ workflows:
             - nodejs-install
             - team_hammerhead-cli
           requires:
-            - secrets-scan
+            - prepare-build
           filters:
             branches:
               ignore:


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Fixes the build dependency of testing go before build preparations have finished.

<!---

## Where should the reviewer start?

## How should this be manually tested?

## What's the product update that needs to be communicated to CLI users?


## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
