### PR TITLE
fix: bump snyk-docker-plugin to v8.3.1

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -19,16 +19,6 @@ ignore:
         reason: Not directely exploitable
         expires: 2025-01-01T00:12:20.523Z
         created: 2024-11-08T10:22:20.531Z
-  SNYK-JS-TARFS-9535930:
-    - '*':
-        reason: None Given
-        expires: 2025-05-01T10:37:59.602Z
-        created: 2025-04-01T10:37:59.609Z
-  SNYK-JS-TARFS-10293725:
-    - '*':
-        reason: Renew temporary ignore for snyk-docker-plugin to resolve vulnerability
-        expires: 2025-07-14T11:14:01.040Z
-        created: 2025-07-07T11:14:01.047Z
 patch: {}
 exclude:
   code:

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "semver": "^6.0.0",
         "snyk-config": "^5.0.0",
         "snyk-cpp-plugin": "2.24.1",
-        "snyk-docker-plugin": "7.1.0",
+        "snyk-docker-plugin": "^8.3.1",
         "snyk-go-plugin": "1.23.0",
         "snyk-gradle-plugin": "5.0.4",
         "snyk-module": "3.1.0",
@@ -3135,9 +3135,10 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@snyk/docker-registry-v2-client": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.15.0.tgz",
-      "integrity": "sha512-h81cwwoX6rxYHuCSD4+KeTHSIQZz8RSOuszS8QfC+FDoKROmM2H02hnqxsYPY247GZVTK+NN1iK5cHwBQeBP+Q==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.21.1.tgz",
+      "integrity": "sha512-jK6I5NwrkpIup5hE/nIojYGjAgoQ9yWquNZE1E7ULFEw4GbE2Y+cgmQa2HOLqGvFv7MtixkvJ4ouKNShV9EDxg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "needle": "^3.2.0",
         "parse-link-header": "^2.0.0",
@@ -3489,24 +3490,22 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@snyk/snyk-docker-pull": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@snyk/snyk-docker-pull/-/snyk-docker-pull-3.14.0.tgz",
-      "integrity": "sha512-SB/4isKmYwp/2FEjkHl2+5aTH3Q651h799Mr3Jz3IO5Js6t6x7mxO8SPeRw86zcbF5oisr7sR5mGuGHAxkT6Og==",
-      "license": "Apache-2.0",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@snyk/snyk-docker-pull/-/snyk-docker-pull-3.14.2.tgz",
+      "integrity": "sha512-FUyf86Uh9B+1pTTFyRZ3LCaVkxDsqgFQNFtc3RixVWRfLKvQUf3FjYc7TDDZ+yv3Sjbu5STHX8NIwitzMaerQQ==",
       "dependencies": {
-        "@snyk/docker-registry-v2-client": "2.15.0",
+        "@snyk/docker-registry-v2-client": "^2.20.0",
         "child-process": "^1.0.2",
-        "tar-fs": "^3.0.7"
+        "tar-fs": "^3.0.9"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@snyk/snyk-docker-pull/node_modules/tar-fs": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
-      "license": "MIT",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.10.tgz",
+      "integrity": "sha512-C1SwlQGNLe/jPNqapK8epDsXME7CAJR5RL3GcE6KWx1d9OUByzoHVcbu1VPI8tevg9H8Alae0AApHHFGzrD5zA==",
       "dependencies": {
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
@@ -3520,7 +3519,6 @@
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
       "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
-      "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
@@ -6975,8 +6973,7 @@
     "node_modules/b4a": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
-      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
-      "license": "Apache-2.0"
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg=="
     },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
@@ -7042,14 +7039,12 @@
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
       "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
-      "license": "Apache-2.0",
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.2.tgz",
-      "integrity": "sha512-8wSeOia5B7LwD4+h465y73KOdj5QHsbbuoUfPBi+pXgFJIPuG7SsiOdJuijWMyfid49eD+WivpfY7KT8gbAzBA==",
-      "license": "Apache-2.0",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.5.tgz",
+      "integrity": "sha512-1zccWBMypln0jEE05LzZt+V/8y8AQsQQqxtklqaIyg5nu6OAYFhZxPXinJTSG+kU5qyNmeLgcn9AW7eHiCHVLA==",
       "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -7072,7 +7067,6 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
       "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
-      "license": "Apache-2.0",
       "optional": true,
       "engines": {
         "bare": ">=1.14.0"
@@ -7082,7 +7076,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "bare-os": "^3.0.1"
@@ -7092,7 +7085,6 @@
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
       "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "streamx": "^2.21.0"
@@ -7804,8 +7796,7 @@
     "node_modules/child-process": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/child-process/-/child-process-1.0.2.tgz",
-      "integrity": "sha512-e45+JmjvkV2XQsJ9rUJghiYJ7/9Uk8fyYi1UwfP071VmGKBu/oD1OIwuD0+jSwjMtQkV0a0FVpPTEW+XGlbSdw==",
-      "license": "ISC"
+      "integrity": "sha512-e45+JmjvkV2XQsJ9rUJghiYJ7/9Uk8fyYi1UwfP071VmGKBu/oD1OIwuD0+jSwjMtQkV0a0FVpPTEW+XGlbSdw=="
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -10797,8 +10788,7 @@
     "node_modules/fast-fifo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-      "license": "MIT"
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -20235,16 +20225,16 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-7.1.0.tgz",
-      "integrity": "sha512-trzygssWPriUX2KuWIyPFmhhHVsEEhDTIEpe6cco55IqtnD0kRfQb/Bhm7rGIojmGwaHPHbTYtc3BgQJnPKkXA==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-8.3.1.tgz",
+      "integrity": "sha512-Q9leWkd/O1cFfLSFHFORfGM8ay7h/3ysddcEY9IUBBSRD7oikIv2+tdd8wSAs2BfeCnxHMPEozdWV/McdTCJqw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.8.1",
-        "@snyk/docker-registry-v2-client": "^2.15.0",
+        "@snyk/docker-registry-v2-client": "^2.21.1",
         "@snyk/rpm-parser": "^3.3.0",
-        "@snyk/snyk-docker-pull": "^3.14.0",
+        "@snyk/snyk-docker-pull": "^3.14.2",
         "@swimlane/docker-reference": "^2.0.1",
         "adm-zip": "^0.5.16",
         "chalk": "^2.4.2",
@@ -20257,7 +20247,7 @@
         "mkdirp": "^1.0.4",
         "packageurl-js": "1.2.0",
         "semver": "^7.6.3",
-        "shescape": "^1.7.4",
+        "shescape": "2.1.0",
         "snyk-nodejs-lockfile-parser": "^2.0.0",
         "snyk-poetry-lockfile-parser": "^1.4.0",
         "snyk-resolve-deps": "^4.7.1",
@@ -20268,7 +20258,7 @@
         "varint": "^6.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/snyk-docker-plugin/node_modules/debug": {
@@ -20315,14 +20305,14 @@
       }
     },
     "node_modules/snyk-docker-plugin/node_modules/shescape": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/shescape/-/shescape-1.7.4.tgz",
-      "integrity": "sha512-6eaKkGvkiR86VmRfFaT1RYP0DtYnOj3u3WR41ItGqADBZMtr0lI4iTnqakE65gnRwHIF7XNvqA9oaE31EZsB7Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/shescape/-/shescape-2.1.0.tgz",
+      "integrity": "sha512-VFjtoo9Y25/fprhMo+bIb+OAM+mFUP0Veg57Bg973j2RSWEAoNPia5hBY+lYVIra5Nl/6CtlQYmDGWSvA3IWWw==",
       "dependencies": {
-        "which": "^2.0.0"
+        "which": "^3.0.0"
       },
       "engines": {
-        "node": "^10.13.0 || ^12 || ^14 || ^16 || ^18 || ^19 || ^20"
+        "node": "^14.18.0 || ^16.13.0 || ^18 || ^19 || ^20"
       }
     },
     "node_modules/snyk-docker-plugin/node_modules/tmp": {
@@ -20334,17 +20324,17 @@
       }
     },
     "node_modules/snyk-docker-plugin/node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+      "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
       "dependencies": {
         "isexe": "^2.0.0"
       },
       "bin": {
-        "node-which": "bin/node-which"
+        "node-which": "bin/which.js"
       },
       "engines": {
-        "node": ">= 8"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/snyk-go-parser": {
@@ -22050,10 +22040,9 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
-      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
-      "license": "MIT",
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
+      "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
       "dependencies": {
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
@@ -22780,7 +22769,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
       "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
       }
@@ -27071,9 +27059,9 @@
       }
     },
     "@snyk/docker-registry-v2-client": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.15.0.tgz",
-      "integrity": "sha512-h81cwwoX6rxYHuCSD4+KeTHSIQZz8RSOuszS8QfC+FDoKROmM2H02hnqxsYPY247GZVTK+NN1iK5cHwBQeBP+Q==",
+      "version": "2.21.1",
+      "resolved": "https://registry.npmjs.org/@snyk/docker-registry-v2-client/-/docker-registry-v2-client-2.21.1.tgz",
+      "integrity": "sha512-jK6I5NwrkpIup5hE/nIojYGjAgoQ9yWquNZE1E7ULFEw4GbE2Y+cgmQa2HOLqGvFv7MtixkvJ4ouKNShV9EDxg==",
       "requires": {
         "needle": "^3.2.0",
         "parse-link-header": "^2.0.0",
@@ -27455,19 +27443,19 @@
       }
     },
     "@snyk/snyk-docker-pull": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@snyk/snyk-docker-pull/-/snyk-docker-pull-3.14.0.tgz",
-      "integrity": "sha512-SB/4isKmYwp/2FEjkHl2+5aTH3Q651h799Mr3Jz3IO5Js6t6x7mxO8SPeRw86zcbF5oisr7sR5mGuGHAxkT6Og==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@snyk/snyk-docker-pull/-/snyk-docker-pull-3.14.2.tgz",
+      "integrity": "sha512-FUyf86Uh9B+1pTTFyRZ3LCaVkxDsqgFQNFtc3RixVWRfLKvQUf3FjYc7TDDZ+yv3Sjbu5STHX8NIwitzMaerQQ==",
       "requires": {
-        "@snyk/docker-registry-v2-client": "2.15.0",
+        "@snyk/docker-registry-v2-client": "^2.20.0",
         "child-process": "^1.0.2",
-        "tar-fs": "^3.0.7"
+        "tar-fs": "^3.0.9"
       },
       "dependencies": {
         "tar-fs": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-          "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+          "version": "3.0.10",
+          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.10.tgz",
+          "integrity": "sha512-C1SwlQGNLe/jPNqapK8epDsXME7CAJR5RL3GcE6KWx1d9OUByzoHVcbu1VPI8tevg9H8Alae0AApHHFGzrD5zA==",
           "requires": {
             "bare-fs": "^4.0.1",
             "bare-path": "^3.0.0",
@@ -30120,9 +30108,9 @@
       "optional": true
     },
     "bare-fs": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.2.tgz",
-      "integrity": "sha512-8wSeOia5B7LwD4+h465y73KOdj5QHsbbuoUfPBi+pXgFJIPuG7SsiOdJuijWMyfid49eD+WivpfY7KT8gbAzBA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.5.tgz",
+      "integrity": "sha512-1zccWBMypln0jEE05LzZt+V/8y8AQsQQqxtklqaIyg5nu6OAYFhZxPXinJTSG+kU5qyNmeLgcn9AW7eHiCHVLA==",
       "optional": true,
       "requires": {
         "bare-events": "^2.5.4",
@@ -39941,15 +39929,15 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-7.1.0.tgz",
-      "integrity": "sha512-trzygssWPriUX2KuWIyPFmhhHVsEEhDTIEpe6cco55IqtnD0kRfQb/Bhm7rGIojmGwaHPHbTYtc3BgQJnPKkXA==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-8.3.1.tgz",
+      "integrity": "sha512-Q9leWkd/O1cFfLSFHFORfGM8ay7h/3ysddcEY9IUBBSRD7oikIv2+tdd8wSAs2BfeCnxHMPEozdWV/McdTCJqw==",
       "requires": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.8.1",
-        "@snyk/docker-registry-v2-client": "^2.15.0",
+        "@snyk/docker-registry-v2-client": "^2.21.1",
         "@snyk/rpm-parser": "^3.3.0",
-        "@snyk/snyk-docker-pull": "^3.14.0",
+        "@snyk/snyk-docker-pull": "^3.14.2",
         "@swimlane/docker-reference": "^2.0.1",
         "adm-zip": "^0.5.16",
         "chalk": "^2.4.2",
@@ -39962,7 +39950,7 @@
         "mkdirp": "^1.0.4",
         "packageurl-js": "1.2.0",
         "semver": "^7.6.3",
-        "shescape": "^1.7.4",
+        "shescape": "2.1.0",
         "snyk-nodejs-lockfile-parser": "^2.0.0",
         "snyk-poetry-lockfile-parser": "^1.4.0",
         "snyk-resolve-deps": "^4.7.1",
@@ -39997,11 +39985,11 @@
           "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
         },
         "shescape": {
-          "version": "1.7.4",
-          "resolved": "https://registry.npmjs.org/shescape/-/shescape-1.7.4.tgz",
-          "integrity": "sha512-6eaKkGvkiR86VmRfFaT1RYP0DtYnOj3u3WR41ItGqADBZMtr0lI4iTnqakE65gnRwHIF7XNvqA9oaE31EZsB7Q==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/shescape/-/shescape-2.1.0.tgz",
+          "integrity": "sha512-VFjtoo9Y25/fprhMo+bIb+OAM+mFUP0Veg57Bg973j2RSWEAoNPia5hBY+lYVIra5Nl/6CtlQYmDGWSvA3IWWw==",
           "requires": {
-            "which": "^2.0.0"
+            "which": "^3.0.0"
           }
         },
         "tmp": {
@@ -40010,9 +39998,9 @@
           "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w=="
         },
         "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
+          "integrity": "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==",
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -41412,9 +41400,9 @@
       }
     },
     "streamx": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
-      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
+      "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
       "requires": {
         "bare-events": "^2.2.0",
         "fast-fifo": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "semver": "^6.0.0",
     "snyk-config": "^5.0.0",
     "snyk-cpp-plugin": "2.24.1",
-    "snyk-docker-plugin": "7.1.0",
+    "snyk-docker-plugin": "8.3.1",
     "snyk-go-plugin": "1.23.0",
     "snyk-gradle-plugin": "5.0.4",
     "snyk-module": "3.1.0",

--- a/test/jest/acceptance/snyk-container/container.spec.ts
+++ b/test/jest/acceptance/snyk-container/container.spec.ts
@@ -127,6 +127,14 @@ describe('snyk container', () => {
       expect(code).toEqual(1);
     });
 
+    it('finds dependencies in wolfi/chainguard image', async () => {
+      const { stdout } = await runSnykCLI(
+        `container test chainguard/wolfi-base:latest --json`,
+      );
+      const jsonOutput = JSON.parse(stdout);
+      expect(jsonOutput.dependencyCount).toBeGreaterThan(0);
+    });
+
     it('container tests the platform specified in the parameters', async () => {
       const { code, stdout, stderr } = await runSnykCLIWithDebug(
         `container test debian:unstable-slim --platform=linux/arm64/v8`,


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [x] Updates relevant GitBook documentation (PR link: [Link](https://app.gitbook.com/o/-M4tdxG8qotLgGZnLpFR/s/-MdwVZ6HOZriajCf5nXH/~/diff/~/changes/9548/scan-with-snyk/snyk-container/how-snyk-container-works/operating-system-distributions-supported-by-snyk-container?email=neil.lowrie%40snyk.io&no_sso=account_exists))
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Version 8.3.0 of the snyk-docker-plugin adds the following features : 

Support for RHEL10 and CentOS10 and above - [CN-67](https://snyksec.atlassian.net/jira/software/c/projects/CN/boards/1538?selectedIssue=CN-67)
Starting from RHEL 10 Red Hat will be providing vulnerability data in CSAF/VEX format. With this change the security data relates to source packages  instead of binary packages in the previous OVAL format. This PR adds support for extracting the source name and version for RPM packages in RHEL and CentOS 10 and above in order to correctly identify vulnerable packages.

Support for NDB RPM database used in SLE15.2 - [CN-72](https://snyksec.atlassian.net/jira/software/c/projects/CN/boards/1538?selectedIssue=CN-72)
Starting with SLE 15.3, SUSE Linux Enterprise transitioned the RPM database backend from the traditional Berkeley DB BTree format to the newer NDB binary format, stored in /usr/lib/sysimage/rpm/Packages.db. This PR adds support for parsing the new NDB format and thereby being able to identify which RPM packages are installed.
More information regarding this feature can be found [here](https://snyk.slack.com/archives/CER5URNJJ/p1750088790004189?thread_ts=1749564933.782159&cid=CER5URNJJ).

support for new wolfi/chainguard apk database location - [CN-150](https://snyksec.atlassian.net/jira/software/c/projects/CN/boards/1538?selectedIssue=CN-150)
There was a problem with new versions of Chainguard Wolfi images that affected compatibility with the Snyk scanner. The location of /lib/apk has been moved to /usr/lib/apk, and a symlink has been created from /lib/apk to /usr/lib/apk. This change fixes this issue.

## Where should the reviewer start?

## How should this be manually tested?

For the RHEL/CentOS 10 changes a RHEL 10 image can be tested and compared to the current CLI which results in more vulnerabilities being detected with this change. Also an older RHEL 9 image can be tested to verify that the results for anything below 10 have not changed.

For the SLE 15.2+ changes a SUSE 15.3 image can be scanned which will result in packages and vulnerabilities being identified, compared to nothing being identified when scanning with an older version of the CLI.

For the Chainguard changes the latest version of a Chainguard Wolfi image can be scanned and packages and vulnerabilities should be identified.

## What's the product update that needs to be communicated to CLI users?

Only internal communication needed for these features.

## Risk assessement
These changes only target distributions above a certain version and fix issues with missing vulnerabilities.  These changes have been tested locally to verify that other versions are not effected. The chainguard changes are a fix for something that is currently broken. The assessment is that the risk is low. 

## What are the relevant tickets?

[CN-67](https://snyksec.atlassian.net/jira/software/c/projects/CN/boards/1538?selectedIssue=CN-67)
[CN-72](https://snyksec.atlassian.net/jira/software/c/projects/CN/boards/1538?selectedIssue=CN-72)
[CN-150](https://snyksec.atlassian.net/jira/software/c/projects/CN/boards/1538?selectedIssue=CN-150)




[CN-67]: https://snyksec.atlassian.net/browse/CN-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CN-72]: https://snyksec.atlassian.net/browse/CN-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ