### PR TITLE
feat: Better gradle internal project dependencies support and complete module artifact name in dep-graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "snyk-cpp-plugin": "2.24.1",
         "snyk-docker-plugin": "7.1.0",
         "snyk-go-plugin": "1.23.0",
-        "snyk-gradle-plugin": "4.9.2",
+        "snyk-gradle-plugin": "5.0.2",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "4.0.1",
         "snyk-nodejs-lockfile-parser": "2.2.1",
@@ -20466,10 +20466,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-gradle-plugin": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-4.9.2.tgz",
-      "integrity": "sha512-V/2Ys4yCzSuMn2qRkkllO3XZ8fcq8U95oM6otwm3G+zk+jJjaCL7IL1+A41r1t37GQTmBj8eyXLO6hP5jnSXgw==",
-      "license": "Apache-2.0",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-5.0.2.tgz",
+      "integrity": "sha512-nXah5kW/+e5sD1IhC+TUTT4Ay+/vDvGZVCiqcb5RT4lQH17vj2DLWNjvKvr5srngJosxK4Ry2UnRTlXZo46S1g==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",
@@ -40107,9 +40106,9 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-4.9.2.tgz",
-      "integrity": "sha512-V/2Ys4yCzSuMn2qRkkllO3XZ8fcq8U95oM6otwm3G+zk+jJjaCL7IL1+A41r1t37GQTmBj8eyXLO6hP5jnSXgw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-5.0.2.tgz",
+      "integrity": "sha512-nXah5kW/+e5sD1IhC+TUTT4Ay+/vDvGZVCiqcb5RT4lQH17vj2DLWNjvKvr5srngJosxK4Ry2UnRTlXZo46S1g==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "snyk-cpp-plugin": "2.24.1",
     "snyk-docker-plugin": "7.1.0",
     "snyk-go-plugin": "1.23.0",
-    "snyk-gradle-plugin": "4.9.2",
+    "snyk-gradle-plugin": "5.0.2",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "4.0.1",
     "snyk-nodejs-lockfile-parser": "2.2.1",

--- a/test/acceptance/workspaces/gradle-with-classifier/build.gradle
+++ b/test/acceptance/workspaces/gradle-with-classifier/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+    id 'application'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'net.sf.json-lib:json-lib:2.4:jdk13'
+}

--- a/test/jest/acceptance/snyk-test/basic-test-all-languages.spec.ts
+++ b/test/jest/acceptance/snyk-test/basic-test-all-languages.spec.ts
@@ -186,6 +186,37 @@ describe('`snyk test` of basic projects for each language/ecosystem', () => {
     expect(code).toEqual(0);
   });
 
+  test('run `snyk test` on a gradle project and check top-level dependency node id', async () => {
+    const project = await createProjectFromWorkspace('gradle-with-classifier');
+
+    const { code, stderr, stdout } = await runSnykCLI('test --print-graph', {
+      cwd: project.path(),
+      env,
+    });
+
+    if (code != 0) {
+      console.debug(stderr);
+      console.debug('---------------------------');
+      console.debug(stdout);
+    }
+    expect(code).toEqual(0);
+
+    const depGraphJsonStr = stdout
+      .split('DepGraph data:')[1]
+      .split('DepGraph target:')[0];
+    const depGraphJson = JSON.parse(depGraphJsonStr);
+    expect(depGraphJson.pkgManager.name).toEqual('gradle');
+    expect(depGraphJson.pkgs).toContainEqual({
+      id: 'net.sf.json-lib:json-lib@2.4',
+      info: { name: 'net.sf.json-lib:json-lib', version: '2.4' },
+    });
+    expect(depGraphJson.graph.nodes).toContainEqual({
+      nodeId: 'net.sf.json-lib:json-lib:jar:jdk13@2.4',
+      pkgId: 'net.sf.json-lib:json-lib@2.4',
+      deps: expect.any(Array),
+    });
+  });
+
   test('run `snyk test` on a cocoapods project', async () => {
     const project = await createProjectFromWorkspace('cocoapods-app');
 


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment Medium (probably)
- [x] Highlights breaking API changes (if applicable) -- N/A
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## Background

This includes changes that were originally introduced in:
* https://github.com/snyk/cli/pull/5852
* https://github.com/snyk/cli/pull/5858

Then rolled back by https://github.com/snyk/cli/pull/5896

This reintroduces the changes from those PRs as well as including: https://github.com/snyk/snyk-gradle-plugin/pull/307

## What does this PR do?

Include all module artifacts as nodes in the dep-graph: https://github.com/snyk/snyk-gradle-plugin/pull/299

Changes the ID of nodes in the resulting dep-graph resolved by snyk-gradle-plugin.

The new node ID ensures each module artifact is identified as:

`groupId:artifactId:type(:classifier)@version`

where type and (optionally) classifier are new.

Also better support for internal project dependencies: https://github.com/snyk/snyk-gradle-plugin/pull/304

Includes changes to make the above safe for android projects: https://github.com/snyk/snyk-gradle-plugin/pull/307

## Where should the reviewer start?

Reviewing the previous PRs and the issues encountered. Then testing the output on a modern android project

## How should this be manually tested?

`snyk test` on a Gradle project, to see the dep-graph use `snyk test --print-deps --json-output-file=out.json` then `cat out.json | jq .depGraph`

Notably, testing this on the output of complex android projects is wise -- I specifically tested against [nowinandroid](https://github.com/android/nowinandroid) running Gradle versions 8.14.2 and 9.0.0-rc-1.

Compare the output vs `v1.1297.0` of the cli -- which fails.
```
~/code/playground/nowinandroid main
❯ ~/code/cli/bin/snyk test --all-projects
... omitted for brevity
Organization:      randd-enablement-template
Package manager:   gradle
Target file:       build.gradle.kts
Project name:      nowinandroid/sync/work
Open source:       no
Project path:      /Users/calumharrison/code/playground/nowinandroid
Licenses:          enabled


Tested 33 projects, 29 contained vulnerable paths.
```
Versus:
```
~/code/playground/nowinandroid main
❯ snyk --version
1.1297.0

~/code/playground/nowinandroid main
❯ snyk test --all-projects

 ERROR   Unspecified Error (SNYK-CLI-0000)

           Failed to get dependencies for all 1 potential projects.
           Tip: Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>
           If the issue persists contact support@snyk.io

Docs:    https://docs.snyk.io/scan-with-snyk/error-catalog#snyk-cli-0000

ID:      urn:snyk:interaction:6d06dfe0-ab06-451e-a78a-ecf524543707
```

## What's the product update that needs to be communicated to CLI users?

* **test**: Node Ids in the dep-graph produced by `snyk test --print-graph` will now contain `type` and `classifier` i.e. `groupId:artifactId:type(:classifier)@version`. e.g. `org.example:foo:jar@1.2.3`.
* **test**: For gradle projects, internal project dependencies containing multiple artifacts disguised under one artifact should now show all dependencies instead of randomly picking one of the dependencies grouped under the 'disguised' coordinate when scanned using the `snyk test --gradle-normalize-deps`.

## Risk assessement
Given the previous circumstances around these changes. Probably Medium. I've also [solicited feedback](https://github.com/snyk/snyk-gradle-plugin/issues/306) from users who encountered issues with v5.0.0.

## What are the relevant tickets or issues
* https://github.com/snyk/snyk-gradle-plugin/issues/306
* [OSM-2484](https://snyksec.atlassian.net/browse/OSM-2484)



[OSM-2484]: https://snyksec.atlassian.net/browse/OSM-2484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ