### PR TITLE
fix: unmanaged json output to use ignores file

### DIFF
--- a/test/fixtures/unmanaged/test-dep-graph-result-with-ignore.json
+++ b/test/fixtures/unmanaged/test-dep-graph-result-with-ignore.json
@@ -1,0 +1,109 @@
+{
+  "result": {
+    "issues": [
+      {
+        "issueId": "SNYK-UNMANAGED-CPIO-2319543",
+        "pkgName": "https://ftp.gnu.org|cpio",
+        "pkgVersion": "2.12",
+        "fixInfo": {
+          "isPatchable": false,
+          "nearestFixedInVersion": "",
+          "upgradePaths": []
+        }
+      }
+    ],
+    "issuesData": {
+      "SNYK-UNMANAGED-CPIO-2319543": {
+        "id": "SNYK-UNMANAGED-CPIO-2319543",
+        "packageManager": "Unmanaged (C/C++)",
+        "packageName": "https://ftp.gnu.org|cpio",
+        "severity": "medium",
+        "isIgnored": true,
+        "name": "https://ftp.gnu.org|cpio@2.12",
+        "version": "2.12",
+        "from": [
+          "https://ftp.gnu.org|cpio@2.12"
+        ],
+        "upgradePath": [
+          false
+        ],
+        "ignoreReasons": [
+          {
+            "reason": "Test ignore",
+            "created": "2024-01-01T00:00:00.000Z",
+            "expires": "2026-01-01T00:00:00.000Z"
+          }
+        ]
+      }
+    },
+    "depGraphData": {
+      "schemaVersion": "1.2.0",
+      "pkgManager": {
+        "name": "unmanaged",
+        "repositories": []
+      },
+      "pkgs": [
+        {
+          "id": "https://ftp.gnu.org|cpio@2.12",
+          "info": {
+            "name": "https://ftp.gnu.org|cpio",
+            "version": "2.12"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "https://ftp.gnu.org|cpio@2.12",
+            "deps": []
+          }
+        ]
+      }
+    },
+    "depsFilePaths": {
+      "https://ftp.gnu.org|cpio@2.12": [
+        "deps/cpio-2.12/src/cpio.c"
+      ]
+    },
+    "fileSignaturesDetails": {
+      "https://ftp.gnu.org|cpio@2.12": {
+        "filePaths": [
+          "deps/cpio-2.12/src/cpio.c"
+        ],
+        "confidence": 1
+      }
+    },
+    "vulnerabilities": [],
+    "filtered": {
+      "ignore": [
+        {
+          "id": "SNYK-UNMANAGED-CPIO-2319543",
+          "packageManager": "Unmanaged (C/C++)",
+          "name": "https://ftp.gnu.org|cpio@2.12",
+          "version": "2.12",
+          "from": [
+            "https://ftp.gnu.org|cpio@2.12"
+          ],
+          "upgradePath": [
+            false
+          ],
+          "isPatchable": false,
+          "ignoreReasons": [
+            {
+              "reason": "Test ignore",
+              "created": "2024-01-01T00:00:00.000Z",
+              "expires": "2026-01-01T00:00:00.000Z"
+            }
+          ]
+        }
+      ]
+    },
+    "dependencyCount": 1
+  },
+  "meta": {
+    "org": "test-org",
+    "isPrivate": false
+  }
+}

--- a/test/fixtures/unmanaged/test-dep-graph-result.json
+++ b/test/fixtures/unmanaged/test-dep-graph-result.json
@@ -1,0 +1,95 @@
+{
+  "result": {
+    "issues": [
+      {
+        "issueId": "SNYK-UNMANAGED-CPIO-2319543",
+        "pkgName": "https://ftp.gnu.org|cpio",
+        "pkgVersion": "2.12",
+        "fixInfo": {
+          "isPatchable": false,
+          "nearestFixedInVersion": "",
+          "upgradePaths": []
+        }
+      }
+    ],
+    "issuesData": {
+      "SNYK-UNMANAGED-CPIO-2319543": {
+        "id": "SNYK-UNMANAGED-CPIO-2319543",
+        "packageManager": "Unmanaged (C/C++)",
+        "packageName": "https://ftp.gnu.org|cpio",
+        "severity": "medium",
+        "isIgnored": false,
+        "name": "https://ftp.gnu.org|cpio@2.12",
+        "version": "2.12",
+        "from": [
+          "https://ftp.gnu.org|cpio@2.12"
+        ],
+        "upgradePath": [
+          false
+        ]
+      }
+    },
+    "depGraphData": {
+      "schemaVersion": "1.2.0",
+      "pkgManager": {
+        "name": "unmanaged",
+        "repositories": []
+      },
+      "pkgs": [
+        {
+          "id": "https://ftp.gnu.org|cpio@2.12",
+          "info": {
+            "name": "https://ftp.gnu.org|cpio",
+            "version": "2.12"
+          }
+        }
+      ],
+      "graph": {
+        "rootNodeId": "root-node",
+        "nodes": [
+          {
+            "nodeId": "root-node",
+            "pkgId": "https://ftp.gnu.org|cpio@2.12",
+            "deps": []
+          }
+        ]
+      }
+    },
+    "depsFilePaths": {
+      "https://ftp.gnu.org|cpio@2.12": [
+        "deps/cpio-2.12/src/cpio.c"
+      ]
+    },
+    "fileSignaturesDetails": {
+      "https://ftp.gnu.org|cpio@2.12": {
+        "filePaths": [
+          "deps/cpio-2.12/src/cpio.c"
+        ],
+        "confidence": 1
+      }
+    },
+    "vulnerabilities": [
+      {
+        "id": "SNYK-UNMANAGED-CPIO-2319543",
+        "packageManager": "Unmanaged (C/C++)",
+        "name": "https://ftp.gnu.org|cpio@2.12",
+        "version": "2.12",
+        "from": [
+          "https://ftp.gnu.org|cpio@2.12"
+        ],
+        "upgradePath": [
+          false
+        ],
+        "isPatchable": false
+      }
+    ],
+    "filtered": {
+      "ignore": []
+    },
+    "dependencyCount": 1
+  },
+  "meta": {
+    "org": "test-org",
+    "isPrivate": false
+  }
+}

--- a/test/jest/acceptance/snyk-test/basic-test-all-languages.spec.ts
+++ b/test/jest/acceptance/snyk-test/basic-test-all-languages.spec.ts
@@ -1,13 +1,13 @@
+import * as path from 'path';
+import { fakeServer } from '../../../acceptance/fake-server';
 import {
   createProjectFromFixture,
   createProjectFromWorkspace,
 } from '../../util/createProject';
-import { runSnykCLI } from '../../util/runSnykCLI';
-import { fakeServer } from '../../../acceptance/fake-server';
-import { runCommand } from '../../util/runCommand';
-import { isDontSkipTestsEnabled } from '../../util/isDontSkipTestsEnabled';
 import { getServerPort } from '../../util/getServerPort';
-import * as path from 'path';
+import { isDontSkipTestsEnabled } from '../../util/isDontSkipTestsEnabled';
+import { runCommand } from '../../util/runCommand';
+import { runSnykCLI } from '../../util/runSnykCLI';
 
 jest.setTimeout(1000 * 60);
 
@@ -553,7 +553,7 @@ describe('`snyk test` of basic projects for each language/ecosystem', () => {
     },
   );
 
-  test.skip('run `snyk test` on an unmanaged project', async () => {
+  test('run `snyk test` on an unmanaged project', async () => {
     const project = await createProjectFromWorkspace('unmanaged');
 
     const { code } = await runSnykCLI('test --unmanaged -d', {
@@ -563,7 +563,7 @@ describe('`snyk test` of basic projects for each language/ecosystem', () => {
     expect(code).toEqual(1);
   });
 
-  test.skip('run `snyk test` on an unmanaged project with a org-slug', async () => {
+  test('run `snyk test` on an unmanaged project with a org-slug', async () => {
     const project = await createProjectFromWorkspace('unmanaged');
 
     const { code } = await runSnykCLI(

--- a/test/jest/acceptance/snyk-test/unmanaged.spec.ts
+++ b/test/jest/acceptance/snyk-test/unmanaged.spec.ts
@@ -1,0 +1,156 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { fakeServer } from '../../../acceptance/fake-server';
+import { createProjectFromWorkspace } from '../../util/createProject';
+import { getFixturePath } from '../../util/getFixturePath';
+import { getServerPort } from '../../util/getServerPort';
+import { runSnykCLI } from '../../util/runSnykCLI';
+
+jest.setTimeout(1000 * 60);
+
+describe('unmanaged test', () => {
+  let server;
+  let env: Record<string, string>;
+
+  beforeAll((done) => {
+    const port = getServerPort(process);
+    const baseApi = '/api/v1';
+    env = {
+      ...process.env,
+      SNYK_API: 'http://localhost:' + port + baseApi,
+      SNYK_HOST: 'http://localhost:' + port,
+      SNYK_TOKEN: '123456789',
+      SNYK_DISABLE_ANALYTICS: '1',
+    };
+    server = fakeServer(baseApi, env.SNYK_TOKEN);
+    server.listen(port, () => {
+      done();
+    });
+  });
+
+  afterEach(() => {
+    server.restore();
+  });
+
+  afterAll((done) => {
+    server.close(() => {
+      done();
+    });
+  });
+
+  const loadFixture = async (fixtureName: string) => {
+    const fixturePath = path.resolve(getFixturePath('unmanaged'), fixtureName);
+    return JSON.parse(await fs.promises.readFile(fixturePath, 'utf-8'));
+  };
+
+  const createIgnorePolicy = async (
+    projectPath: string,
+    issueId: string,
+    reason: string,
+  ) => {
+    const policyContent = `
+# Snyk (https://snyk.io) policy file
+version: v1.19.0
+ignore:
+  '${issueId}':
+    - '*':
+        reason: ${reason}
+        expires: '2026-01-01T00:00:00.000Z'
+        created: '2024-01-01T00:00:00.000Z'
+`;
+    await fs.promises.writeFile(path.join(projectPath, '.snyk'), policyContent);
+  };
+
+  test('unmanaged issues returned by the backend', async () => {
+    const project = await createProjectFromWorkspace('unmanaged');
+    server.setCustomResponse(await loadFixture('test-dep-graph-result.json'));
+
+    const { code, stdout } = await runSnykCLI('test --unmanaged', {
+      cwd: project.path(),
+      env,
+    });
+
+    expect(code).toEqual(1);
+    expect(stdout).toContain('SNYK-UNMANAGED-CPIO-2319543');
+    expect(stdout).toContain('https://ftp.gnu.org|cpio@2.12');
+  });
+
+  test('unmanaged issues ignored when .snyk exists', async () => {
+    const project = await createProjectFromWorkspace('unmanaged');
+    await createIgnorePolicy(
+      project.path(),
+      'SNYK-UNMANAGED-CPIO-2319543',
+      'Test ignore',
+    );
+
+    server.setCustomResponse(await loadFixture('test-dep-graph-result.json'));
+
+    const { code, stdout } = await runSnykCLI('test --unmanaged', {
+      cwd: project.path(),
+      env,
+    });
+
+    expect(code).toEqual(0);
+    expect(stdout).not.toContain('SNYK-UNMANAGED-CPIO-2319543');
+    expect(stdout).not.toContain('https://ftp.gnu.org|cpio@2.12');
+  });
+
+  test('unmanaged JSON output includes unmanaged issues returned by the backend', async () => {
+    const project = await createProjectFromWorkspace('unmanaged');
+    server.setCustomResponse(await loadFixture('test-dep-graph-result.json'));
+
+    const { stdout } = await runSnykCLI('test --unmanaged --json', {
+      cwd: project.path(),
+      env,
+    });
+
+    const jsonOutput = JSON.parse(stdout);
+    expect(jsonOutput).toBeInstanceOf(Array);
+    expect(jsonOutput).toHaveLength(1);
+
+    const result = jsonOutput[0];
+
+    expect(result.filtered).toBeDefined();
+    expect(result.filtered.ignore).toBeDefined();
+    expect(result.filtered.ignore).toBeInstanceOf(Array);
+    expect(result.filtered.ignore).toHaveLength(0);
+
+    expect(result.vulnerabilities).toBeDefined();
+    expect(result.vulnerabilities.length).toEqual(1);
+  });
+
+  test('unmanaged JSON output includes ignored issues when .snyk exists', async () => {
+    const project = await createProjectFromWorkspace('unmanaged');
+    await createIgnorePolicy(
+      project.path(),
+      'SNYK-UNMANAGED-CPIO-2319543',
+      'Test ignore for JSON output',
+    );
+
+    server.setCustomResponse(await loadFixture('test-dep-graph-result.json'));
+
+    const { code, stdout } = await runSnykCLI('test --unmanaged --json', {
+      cwd: project.path(),
+      env,
+    });
+
+    expect(code).toEqual(0);
+
+    const jsonOutput = JSON.parse(stdout);
+    expect(jsonOutput).toBeInstanceOf(Array);
+    expect(jsonOutput).toHaveLength(1);
+
+    const result = jsonOutput[0];
+
+    expect(result.filtered).toBeDefined();
+    expect(result.filtered.ignore).toBeDefined();
+    expect(result.filtered.ignore).toHaveLength(1);
+    expect(result.filtered.ignore[0]).toMatchObject({
+      id: 'SNYK-UNMANAGED-CPIO-2319543',
+      packageManager: 'Unmanaged (C/C++)',
+      from: ['https://ftp.gnu.org|cpio@2.12'],
+    });
+
+    expect(result.vulnerabilities).toHaveLength(0);
+  });
+});

--- a/test/jest/unit/lib/ecosystems/fixtures/expected-test-result-new-impl.ts
+++ b/test/jest/unit/lib/ecosystems/fixtures/expected-test-result-new-impl.ts
@@ -1,6 +1,3 @@
-import { TestResult } from '../../../../../../src/lib/ecosystems/types';
-import {SEVERITY} from "@snyk/fix/dist/types";
-
 const expectedDescription = `## Overview
 
 Affected versions of this package are vulnerable to Symlink Attack cpio, as used in build 2007.05.10, 2010.07.28, and possibly other versions, allows remote attackers to overwrite arbitrary files via a symlink within an RPM package archive.
@@ -56,42 +53,42 @@ export const expectedTestResult = [
         dependencyCount: 1,
         depsFilePaths: {
             "http://github.com/nmoinvaz/minizip/archive/1.1.tar.gz@1.1": [
-        "deps/zlib-1.2.11.1/contrib/minizip/Makefile.am",
-            "deps/zlib-1.2.11.1/contrib/minizip/MiniZip64_Changes.txt",
-            "deps/zlib-1.2.11.1/contrib/minizip/MiniZip64_info.txt",
-            "deps/zlib-1.2.11.1/contrib/minizip/configure.ac",
-            "deps/zlib-1.2.11.1/contrib/minizip/crypt.h",
-            "deps/zlib-1.2.11.1/contrib/minizip/ioapi.c",
-            "deps/zlib-1.2.11.1/contrib/minizip/ioapi.h",
-            "deps/zlib-1.2.11.1/contrib/minizip/iowin32.c",
-            "deps/zlib-1.2.11.1/contrib/minizip/iowin32.h",
+                "deps/zlib-1.2.11.1/contrib/minizip/Makefile.am",
+                "deps/zlib-1.2.11.1/contrib/minizip/MiniZip64_Changes.txt",
+                "deps/zlib-1.2.11.1/contrib/minizip/MiniZip64_info.txt",
+                "deps/zlib-1.2.11.1/contrib/minizip/configure.ac",
+                "deps/zlib-1.2.11.1/contrib/minizip/crypt.h",
+                "deps/zlib-1.2.11.1/contrib/minizip/ioapi.c",
+                "deps/zlib-1.2.11.1/contrib/minizip/ioapi.h",
+                "deps/zlib-1.2.11.1/contrib/minizip/iowin32.c",
+                "deps/zlib-1.2.11.1/contrib/minizip/iowin32.h",
             ],
-        "https://thekelleys.org.uk|dnsmasq@2.80": [
-        "deps/dnsmasq-2.80/Android.mk",
-            "deps/dnsmasq-2.80/CHANGELOG",
-            "deps/dnsmasq-2.80/CHANGELOG.archive",
-            "deps/dnsmasq-2.80/COPYING",
-            "deps/dnsmasq-2.80/COPYING-v3",
-            "deps/dnsmasq-2.80/FAQ",
-            "deps/dnsmasq-2.80/Makefile",
+            "https://thekelleys.org.uk|dnsmasq@2.80": [
+                "deps/dnsmasq-2.80/Android.mk",
+                "deps/dnsmasq-2.80/CHANGELOG",
+                "deps/dnsmasq-2.80/CHANGELOG.archive",
+                "deps/dnsmasq-2.80/COPYING",
+                "deps/dnsmasq-2.80/COPYING-v3",
+                "deps/dnsmasq-2.80/FAQ",
+                "deps/dnsmasq-2.80/Makefile",
             ],
         },
         "displayTargetFile": "",
         "fileSignaturesDetails": {
             "https://thekelleys.org.uk|dnsmasq@2.80": {
                 "confidence": 1,
-                    "filePaths": [
-                        "deps/dnsmasq-2.80/Android.mk",
-                          "deps/dnsmasq-2.80/CHANGELOG",
-                          "deps/dnsmasq-2.80/CHANGELOG.archive",
-                          "deps/dnsmasq-2.80/COPYING",
-                          "deps/dnsmasq-2.80/COPYING-v3",
-                          "deps/dnsmasq-2.80/FAQ",
-                          "deps/dnsmasq-2.80/Makefile",
-                          "deps/dnsmasq-2.80/VERSION",
-                    ],
-                },
+                "filePaths": [
+                    "deps/dnsmasq-2.80/Android.mk",
+                    "deps/dnsmasq-2.80/CHANGELOG",
+                    "deps/dnsmasq-2.80/CHANGELOG.archive",
+                    "deps/dnsmasq-2.80/COPYING",
+                    "deps/dnsmasq-2.80/COPYING-v3",
+                    "deps/dnsmasq-2.80/FAQ",
+                    "deps/dnsmasq-2.80/Makefile",
+                    "deps/dnsmasq-2.80/VERSION",
+                ],
             },
+        },
         issues: [
             {
                 fixInfo: {
@@ -156,5 +153,8 @@ export const expectedTestResult = [
                 },
             },
         ],
+        filtered: {
+            ignore: [],
+        },
     },
 ];


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
**Problem**:
- When running `snyk test --unmanaged --json`, ignored vulnerabilities were still present in the `vulnerabilities` field of the JSON output
- This caused issues when piping output to `snyk-to-html`, which would display all unfiltered vulnerabilities in HTML reports
- The `issues` field was correctly filtered, but the `vulnerabilities` field contained all issues regardless of policy

**Solution**:
- Move policy loading and filtering to happen before building the vulnerabilities array
- Build vulnerabilities array only from filtered data (`issuesDataFiltered`) instead of all data (`issuesData`)
- Add `filtered.ignore` array to track ignored vulnerabilities, matching behavior of managed projects

## Where should the reviewer start?

1. Review the main change in `src/lib/ecosystems/resolve-test-facts.ts` around lines 211-257
2. Look at the new test case in `test/jest/unit/lib/ecosystems/resolve-test-facts.spec.ts` (lines 239-314)
3. Check the updated test fixtures in `expected-test-result-new-impl.ts`

## How should this be manually tested?

1. Create an unmanaged project with vulnerabilities
2. Create a `.snyk` policy file to ignore specific vulnerabilities
3. Run `snyk test --unmanaged` - should show reduced vulnerability count
4. Run `snyk test --unmanaged --json` - verify:
   - `vulnerabilities` array only contains non-ignored issues
   - `filtered.ignore` array contains ignored issues with proper structure
5. Pipe to snyk-to-html: `snyk test --unmanaged --json | snyk-to-html -o results.html`
6. Verify HTML report only shows non-ignored vulnerabilities

## What's the product update that needs to be communicated to CLI users?

Ignored vulnerabilities in unmanaged (C/C++) projects are now properly excluded from JSON output when using `.snyk` policy files. This ensures that `snyk-to-html` and other tools that consume JSON output will correctly respect vulnerability ignores.

## Risk assessment (Low)?

- Maintains backward compatibility for existing JSON structure
- Only affects filtering logic, doesn't change core scanning functionality
- Changes are isolated to unmanaged ecosystem handling with JSON output

## What are the relevant tickets?

[UNIFY-667](https://snyksec.atlassian.net/browse/UNIFY-667)

[UNIFY-667]: https://snyksec.atlassian.net/browse/UNIFY-667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ