### PR TITLE
chore(iac): added test limit reached error for IaC [IAC-3308]

### DIFF
--- a/src/cli/commands/test/iac/local-execution/types.ts
+++ b/src/cli/commands/test/iac/local-execution/types.ts
@@ -401,6 +401,7 @@ export enum IaCErrorCodes {
   NoLoadableInput = 2114,
   FailedToMakeResourcesResolvers = 2115,
   ResourcesResolverError = 2116,
+  TestLimitReached = 2117,
   FailedToProcessResults = 2200,
   EntitlementNotEnabled = 2201,
   ReadSettings = 2202,

--- a/src/lib/iac/test/v2/errors.ts
+++ b/src/lib/iac/test/v2/errors.ts
@@ -37,6 +37,8 @@ const snykIacTestErrorsUserMessages = {
   MissingRemoteSubmodulesError: `Could not load some remote modules. Run 'terraform init' if you would like to include them in the evaluation`,
   EvaluationError: 'Skipping evaluation',
   MissingTermError: 'Missing term - term has been assigned as the name itself',
+  TestLimitReached:
+    'Test limit reached! You have exceeded your infrastructure as code test allocation for this billing period.',
 };
 
 export function getErrorUserMessage(code: number, error: string): string {


### PR DESCRIPTION
## Pull Request Submission Checklist

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
This PR introduces a new error code, `TestLimitReached`, to support test limit enforcement for `IaCV2`.
When we determine that an organization has exceeded its plan's test allocation, it will now return this specific error code. This change enables the CLI to correctly interpret the error and display a clear, user-friendly message, ensuring a consistent experience with our other products.

This is a prerequisite for the usage tracking functionality being added in `cli-extension-iac`, in this [PR](https://github.com/snyk/cli-extension-iac/pull/28). 

## Where should the reviewer start?
`<local build> iac test --report`

## How should this be manually tested?
Run comand: `snyk iac test --report` on an IaC Project, having the `iacNewEngine` FF enabled and the test limit reached for IaC. This command should return the `TestLimitReached` error and stop the scan.

## What's the product update that needs to be communicated to CLI users?

## What are the relevant tickets?
[IAC-3308](https://snyksec.atlassian.net/jira/software/c/projects/IAC/boards/301?selectedIssue=IAC-3308)

## Screenshots (if appropriate)
<img width="1400" height="422" alt="image" src="https://github.com/user-attachments/assets/bd0809f1-63c3-499a-bba0-a5f9f2e52a3d" />


[IAC-3308]: https://snyksec.atlassian.net/browse/IAC-3308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ