### PR TITLE
chore: maven dverbose returns all versions of deps under ff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,11 +69,11 @@
         "semver": "^6.0.0",
         "snyk-config": "^5.0.0",
         "snyk-cpp-plugin": "2.24.1",
-        "snyk-docker-plugin": "^8.3.1",
+        "snyk-docker-plugin": "8.3.1",
         "snyk-go-plugin": "1.23.0",
         "snyk-gradle-plugin": "5.0.4",
         "snyk-module": "3.1.0",
-        "snyk-mvn-plugin": "4.0.1",
+        "snyk-mvn-plugin": "4.1.0",
         "snyk-nodejs-lockfile-parser": "2.2.2",
         "snyk-nodejs-plugin": "1.4.4",
         "snyk-nuget-plugin": "2.10.1",
@@ -20698,9 +20698,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-mvn-plugin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-4.0.1.tgz",
-      "integrity": "sha512-c+dDb0db+jYyaF3dd47vxvnDcRvifJs4yw9/gkgNmMdqkv9pQ+ukoz0jv+oL3NpqEGHWw3R1y4wOzoYEQyeaGw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-4.1.0.tgz",
+      "integrity": "sha512-qPt1tq1A8UQJX31XUbon9e++i4Etk+FPBdY7JQZiLTbnwF0gTwobYZDuxmpmcjbHgLNJXl6YOg9PkpL6OCiiIA==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.23.1",
@@ -40294,9 +40294,9 @@
       }
     },
     "snyk-mvn-plugin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-4.0.1.tgz",
-      "integrity": "sha512-c+dDb0db+jYyaF3dd47vxvnDcRvifJs4yw9/gkgNmMdqkv9pQ+ukoz0jv+oL3NpqEGHWw3R1y4wOzoYEQyeaGw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-4.1.0.tgz",
+      "integrity": "sha512-qPt1tq1A8UQJX31XUbon9e++i4Etk+FPBdY7JQZiLTbnwF0gTwobYZDuxmpmcjbHgLNJXl6YOg9PkpL6OCiiIA==",
       "requires": {
         "@snyk/cli-interface": "2.11.3",
         "@snyk/dep-graph": "^1.23.1",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "snyk-go-plugin": "1.23.0",
     "snyk-gradle-plugin": "5.0.4",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "4.0.1",
+    "snyk-mvn-plugin": "4.1.0",
     "snyk-nodejs-lockfile-parser": "2.2.2",
     "snyk-nodejs-plugin": "1.4.4",
     "snyk-nuget-plugin": "2.10.1",

--- a/src/lib/package-managers.ts
+++ b/src/lib/package-managers.ts
@@ -1,6 +1,8 @@
 export const PNPM_FEATURE_FLAG = 'enablePnpmCli';
 export const DOTNET_WITHOUT_PUBLISH_FEATURE_FLAG =
   'useImprovedDotnetWithoutPublish';
+export const MAVEN_DVERBOSE_EXHAUSTIVE_DEPS_FF =
+  'enableMavenDverboseExhaustiveDeps';
 
 export type SupportedPackageManagers =
   | 'rubygems'

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -54,6 +54,7 @@ export interface Options {
   'dry-run'?: boolean;
   allSubProjects?: boolean;
   mavenAggregateProject?: boolean;
+  mavenVerboseIncludeAllVersions?: boolean;
   'project-name'?: string;
   'show-vulnerable-paths'?: string;
   packageManager?: SupportedPackageManagers;

--- a/test/jest/acceptance/snyk-sbom/all-projects.spec.ts
+++ b/test/jest/acceptance/snyk-sbom/all-projects.spec.ts
@@ -62,6 +62,7 @@ describe('snyk sbom --all-projects (mocked server only)', () => {
   });
 
   test('`sbom mono-repo-project-manifests-only` generates an SBOM for multiple projects', async () => {
+    server.setFeatureFlag('enableMavenDverboseExhaustiveDeps', false);
     const project = await createProjectFromWorkspace(
       'mono-repo-project-manifests-only',
     );
@@ -85,5 +86,32 @@ describe('snyk sbom --all-projects (mocked server only)', () => {
       'mono-repo-project-manifests-only',
     );
     expect(bom.components).toHaveLength(36);
+  });
+
+  test('`sbom mono-repo-project-manifests-only` generates an SBOM for multiple projects with enableMavenDverboseExhaustiveDeps enabled', async () => {
+    server.setFeatureFlag('enableMavenDverboseExhaustiveDeps', true);
+    const project = await createProjectFromWorkspace(
+      'mono-repo-project-manifests-only',
+    );
+
+    const { code, stdout, stderr } = await runSnykCLI(
+      `sbom --org aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee --format cyclonedx1.4+json --debug --all-projects`,
+      {
+        cwd: project.path(),
+        env,
+      },
+    );
+    let bom;
+
+    console.log(stderr);
+
+    expect(code).toEqual(0);
+    expect(() => {
+      bom = JSON.parse(stdout);
+    }).not.toThrow();
+    expect(bom.metadata.component.name).toEqual(
+      'mono-repo-project-manifests-only',
+    );
+    expect(bom.components).toHaveLength(37);
   });
 });

--- a/test/jest/acceptance/snyk-sbom/maven-options.spec.ts
+++ b/test/jest/acceptance/snyk-sbom/maven-options.spec.ts
@@ -48,6 +48,7 @@ describe('snyk sbom: maven options (mocked server only)', () => {
   });
 
   test('`sbom --file` generates an SBOM without pruning', async () => {
+    server.setFeatureFlag('enableMavenDverboseExhaustiveDeps', false);
     const sbom = await runSnykSbomCliCycloneDxJsonForFixture(
       'maven-print-graph',
       '--file=pom.xml',
@@ -64,6 +65,27 @@ describe('snyk sbom: maven options (mocked server only)', () => {
     expect(sbom.dependencies[2].dependsOn.length).toEqual(1);
     expect(sbom.dependencies[2].dependsOn[0]).toEqual(
       'commons-logging:commons-logging@1.0.4',
+    );
+  });
+
+  test('`sbom --file` generates an SBOM without pruning with enableMavenDverboseExhaustiveDeps enabled', async () => {
+    server.setFeatureFlag('enableMavenDverboseExhaustiveDeps', true);
+    const sbom = await runSnykSbomCliCycloneDxJsonForFixture(
+      'maven-print-graph',
+      '--file=pom.xml',
+      env,
+    );
+
+    expect(sbom.metadata.component.name).toEqual(
+      'io.snyk.example:test-project',
+    );
+    expect(sbom.dependencies.length).toBeGreaterThanOrEqual(7);
+    expect(sbom.dependencies[2].ref).toEqual(
+      'commons-discovery:commons-discovery@0.2',
+    );
+    expect(sbom.dependencies[2].dependsOn.length).toEqual(1);
+    expect(sbom.dependencies[2].dependsOn[0]).toEqual(
+      'commons-logging:commons-logging@1.0.3',
     );
   });
 


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
Sends an option 'mavenVerboseIncludeAllVersions' to the snyk-maven-plugin based on a feature flag. 
This option enables returning a more exhaustive dep graph/sbom for maven (Dverbose) - including all versions of dependencies that maven considers for resolution (not just the versions that get resolved). 

Also bumps snyk-mvn-plugin to include the behaviour with the enabled option: https://github.com/snyk/snyk-mvn-plugin/pull/195.

## Where should the reviewer start?
This change enables the behaviour in this previous PR: https://github.com/snyk/cli/pull/5891 (under a feature flag).
The default behaviour is the one last introduced here: https://github.com/snyk/cli/pull/5894

## How should this be manually tested?
Use any fixture from here: https://github.com/snyk/snyk-mvn-plugin/pull/195/files as a project and run `snyk test -- -Dverbose` or `snyk sbom` with/without FF enabled. Without FF will return only the versions of deps that are finally resolved by maven and with FF will include all versions (even omitted ones).

## What's the product update that needs to be communicated to CLI users?

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
