### PR TITLE
chore(language-server): integrate LS

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/snyk/go-application-framework v0.0.0-20250721152513-f5f856730f1a
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20250721151312-af6f306b820e
+	github.com/snyk/snyk-ls v0.0.0-20250722140207-448e7bbcd22a
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -812,8 +812,8 @@ github.com/snyk/policy-engine v0.33.2 h1:ZxD6/RQ4vqUAXa64V72SsGjZ8vmnBgZNGYQxMIq
 github.com/snyk/policy-engine v0.33.2/go.mod h1:YTZq3GMRbXcHOXQQrFRVEg+MQiIGCGZ1met6KlpruNo=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20250721151312-af6f306b820e h1:1FEXD1IBcNehMGD7yY355nl1FGYFIbT6VHBSzvTW//o=
-github.com/snyk/snyk-ls v0.0.0-20250721151312-af6f306b820e/go.mod h1:KICSlUZ6ueogFjCl1OkBytkUXT+5gMWNXKjl1qn6znU=
+github.com/snyk/snyk-ls v0.0.0-20250722140207-448e7bbcd22a h1:lagJPey8uYEt8WFiJznbKlN72KyvDqJdk5dr2+BCHu4=
+github.com/snyk/snyk-ls v0.0.0-20250722140207-448e7bbcd22a/go.mod h1:KICSlUZ6ueogFjCl1OkBytkUXT+5gMWNXKjl1qn6znU=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit 448e7bbcd22a0ea224ddd1a7a9243c00eb99df71
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Tue Jul 22 16:02:07 2025 +0200

    chore: change location of compatibility-matrix [IDE-1226] (#934)
    
    * feat: add cache implementation for API responses [IDE-1226]
    
    * feat: add GitHub API client for fetching releases [IDE-1226]
    
    * feat: add plugin-specific protocol version extraction [IDE-1226]
    
    * feat: add CLI version mapping from protocol version [IDE-1226]
    
    * feat: complete main compatibility matrix generator implementation [IDE-1226]
    
    * feat: add GitHub Action workflow for daily matrix updates [IDE-1226]
    
    * test: add unit tests for compatibility matrix generator [IDE-1226]
    
    * docs: add README for compatibility matrix generator [IDE-1226]
    
    * fix: resolve linting issues in compatibility matrix scripts [IDE-1226]
    
    * chore: add compatibility matrix cache to gitignore [IDE-1226]
    
    * chore: update copyright year to 2025 in new files [IDE-1226]
    
    * fix: use stable channel for CLI versions instead of preview [IDE-1226]
    
    * perf: optimize cache implementation using json.RawMessage [IDE-1226]
    
    Refactored cache implementation to use json.RawMessage instead of interface{}
    for the Data field in CacheEntry. This eliminates unnecessary marshalling
    and unmarshalling operations, improving performance.
    
    - Changed CacheEntry.Data type from interface{} to json.RawMessage
    - Removed redundant marshal/unmarshal in Get method
    - Updated Set method to marshal value to json.RawMessage
    
    Co-authored-by: Code Reviewer <reviewer@snyk.io>
    
    * fix: handle io.ReadAll error in GitHub API client [IDE-1226]
    
    Previously, the error from io.ReadAll was being ignored when reading
    error response bodies from the GitHub API. This could hide useful
    error information. Now properly handle this error to provide more
    complete error messages.
    
    Co-authored-by: Code Reviewer <reviewer@snyk.io>
    
    * fix: properly propagate errors from concurrent goroutines [IDE-1226]
    
    Previously, fetchAllReleases would silently swallow errors from goroutines,
    always returning nil error even when fetching releases failed. This could
    lead to incomplete matrices without proper failure indication in automated
    environments like GitHub Actions.
    
    Now we:
    - Collect all errors from goroutines in a thread-safe manner
    - Return an error if any plugin fetch fails
    - Exit with non-zero status on failure, properly signaling errors
    
    Also fixed error wrapping in GitHub API client to use %w verb.
    
    Co-authored-by: Code Reviewer <reviewer@snyk.io>
    
    * fix: log cache.Set errors for better diagnostics [IDE-1226]
    
    Previously, cache.Set errors were silently ignored, making it difficult
    to diagnose issues like file system permissions or disk space problems.
    
    Now we log warnings when cache operations fail, providing visibility
    into cache-related issues without interrupting the main workflow.
    
    Co-authored-by: Code Reviewer <reviewer@snyk.io>
    
    * refactor: replace error-based value return with idiomatic approach [IDE-1226]
    
    Previously, we used fmt.Errorf("FOUND:...") as a workaround to return values
    from filepath.Walk, which is brittle and non-idiomatic Go code.
    
    Now we:
    - Use a proper sentinel error (errStopWalk) to signal early termination
    - Store the found value in a variable in the outer scope
    - Use errors.Is() for proper error comparison
    - Add linter exclusions for acceptable code duplication
    
    This makes the code more maintainable and follows Go best practices.
    
    Co-authored-by: Code Reviewer <reviewer@snyk.io>
    
    * fix: prevent path traversal attacks in tar extraction (Zip Slip) [IDE-1226]
    
    Added validation to ensure extracted files remain within the destination
    directory. This prevents malicious tar archives from writing files outside
    the intended directory through path traversal sequences like '../'.
    
    Security fix addresses potential vulnerability where attackers could:
    - Overwrite system files
    - Access sensitive data outside the extraction directory
    - Compromise the host system
    
    The fix validates that all resolved target paths start with the
    destination directory before any file operations.
    
    Co-authored-by: Code Reviewer <reviewer@snyk.io>
    
    * chore: add .cursorrules for project-specific AI guidelines [IDE-1226]
    
    Added repository-specific rules and guidelines for AI assistants to ensure:
    - Consistent code patterns and conventions
    - Proper security scanning with Snyk
    - Correct commit message formatting
    - Adherence to project-specific requirements
    
    * refactor: remove unused cache parameter from generateMatrix [IDE-1226]
    
    The cache parameter was passed to generateMatrix but never used within
    the function. Removed it from the function signature and all call sites
    to improve code clarity.
    
    Co-authored-by: Code Reviewer <reviewer@snyk.io>
    
    * refactor: remove redundant Tag field from Release struct [IDE-1226]
    
    The Tag field was assigned the same value as Version and never used.
    Removed it from:
    - Release struct definition
    - Assignment at line 116 (previously 117)
    - Test data structures
    
    This improves code maintainability by eliminating redundancy.
    
    Co-authored-by: Code Reviewer <reviewer@snyk.io>
    
    * refactor: use defer for file closing in tar extraction [IDE-1226]
    
    Replaced manual file closing with defer f.Close() for more idiomatic
    and robust file handling. This ensures the file is closed on all
    execution paths and reduces the chance of resource leaks if the
    function is modified in the future.
    
    Co-authored-by: Code Reviewer <reviewer@snyk.io>
    
    * fix(compatibility-matrix): close files immediately in tar extraction loop
    
    Previously, using defer f.Close() inside the loop would accumulate all
    deferred calls until the function returned, potentially exhausting file
    descriptors for archives with many files. Now files are closed explicitly
    after each iteration, properly handling both copy and close errors.
    
    [IDE-1226]
    
    * feat(compatibility-matrix): rename column to 'Latest Compatible CLI Version'
    
    Updated the third column name from 'Minimum CLI Version' to 'Latest Compatible
    CLI Version' throughout the codebase to better reflect that the CLI version
    shown is the latest compatible version for each IDE plugin version.
    
    Updated:
    - Matrix generator output format
    - Documentation and README
    - Test expectations
    - GitHub Action description
    - Implementation plan
    
    [IDE-1226]
    
    * fix(compatibility-matrix): add IntelliJ requiredLsProtocolVersion pattern
    
    Added support for extracting 'val requiredLsProtocolVersion = xxx' pattern
    from IntelliJ plugin source code. This fixes the protocol version extraction
    for IntelliJ releases.
    
    [IDE-1226]
    
    * chore(compatibility-matrix): remove unused nolint directives
    
    Removed unused nolint:dupl directives that were flagged by the linter. These
    directives were no longer necessary.
    
    [IDE-1226]
    
    * docs: updated licenses
    
    * fix(test): resolve race condition in Test_loginCommand_StartsAuthentication
    
    The test was accessing notifications[0] without verifying the slice had elements,
    causing an index out of range panic. Fixed by:
    - Waiting specifically for the hasAuthenticated notification in Eventually
    - Adding require.NotEmpty check before accessing the first element
    - This ensures we only proceed when the expected notification is available
    
    [IDE-1226]
    
    * feat(compatibility-matrix): display Eclipse semantic version with release tag
    
    Eclipse plugin versions now show as 'Eclipse v3.3.0 (v20250717.103834)' where:
    - The semantic version (3.3.0) is extracted from MANIFEST.MF Bundle-Version
    - The GitHub release tag is shown in parentheses
    - The .identifier suffix is automatically omitted from Bundle-Version
    
    This provides clearer version information for Eclipse plugins while maintaining
    the original release tag for reference.
    
    [IDE-1226]
    
    * feat(compatibility-matrix): display CLI version ranges instead of single version
    
    Enhanced the compatibility matrix generator to show the range of compatible CLI
    versions for each IDE plugin version. The tool now:
    
    - Clones and analyzes the Snyk CLI repository to extract protocol versions
    - Maps each CLI release to its protocol version via go.mod analysis
    - Displays all compatible CLI versions as a range (e.g., v1.1298.0 - v1.1298.1)
    - Renamed the column from 'Latest Compatible CLI Version' to 'Compatible CLIs'
    
    This provides more comprehensive compatibility information by showing all CLI
    versions that work with each IDE plugin version, not just the latest one.
    
    [IDE-1226]
    
    * docs: updated licenses
    
    * chore: remove implementation plan from repository
    
    Implementation plans should not be committed to the repository as per
    project rules. Moving to local-only reference.
    
    [IDE-1226]
    
    * fix: remove generated matrix and revert hashicorp go.mod changes
    
    - Removed the generated compatibility-matrix.md file (should not be committed)
    - Reverted changes to licenses/github.com/hashicorp/hcl/go.mod (per project rules)
    
    [IDE-1226]
    
    * chore: change schedule to weekly and remove update date
    
    - Changed GitHub Actions schedule from daily to weekly (Sundays at 2 AM UTC)
    - Removed 'Last updated' date from generated matrix to avoid unnecessary PR reviews
    - Updated PR description to reflect weekly schedule
    
    [IDE-1226]
    
    * chore: change schedule back to daily
    
    Since the workflow checks for content changes before creating a PR,
    running daily won't create unnecessary PRs. The workflow will only
    create a PR when there are actual changes to the compatibility matrix.
    
    [IDE-1226]
    
    * chore: change location of generated file
    
    ---------
    
    Co-authored-by: Code Reviewer <reviewer@snyk.io>
    Co-authored-by: bastiandoetsch <bastiandoetsch@users.noreply.github.com>

:100644 100644 da44dc78 5090c3f6 M	.github/workflows/update-compatibility-matrix.yaml

commit 616158f71f381b9ace3e8501d659661510fe8aca
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Tue Jul 22 15:40:10 2025 +0200

    feat: add IDE plugin compatibility matrix generator [IDE-1226] (#932)
    
    * feat: add cache implementation for API responses [IDE-1226]
    
    * feat: add GitHub API client for fetching releases [IDE-1226]
    
    * feat: add plugin-specific protocol version extraction [IDE-1226]
    
    * feat: add CLI version mapping from protocol version [IDE-1226]
    
    * feat: complete main compatibility matrix generator implementation [IDE-1226]
    
    * feat: add GitHub Action workflow for daily matrix updates [IDE-1226]
    
    * test: add unit tests for compatibility matrix generator [IDE-1226]
    
    * docs: add README for compatibility matrix generator [IDE-1226]
    
    * fix: resolve linting issues in compatibility matrix scripts [IDE-1226]
    
    * chore: add compatibility matrix cache to gitignore [IDE-1226]
    
    * chore: update copyright year to 2025 in new files [IDE-1226]
    
    * fix: use stable channel for CLI versions instead of preview [IDE-1226]
    
    * perf: optimize cache implementation using json.RawMessage [IDE-1226]
    
    Refactored cache implementation to use json.RawMessage instead of interface{}
    for the Data field in CacheEntry. This eliminates unnecessary marshalling
    and unmarshalling operations, improving performance.
    
    - Changed CacheEntry.Data type from interface{} to json.RawMessage
    - Removed redundant marshal/unmarshal in Get method
    - Updated Set method to marshal value to json.RawMessage
    
    Co-authored-by: Code Reviewer <reviewer@snyk.io>
    
    * fix: handle io.ReadAll error in GitHub API client [IDE-1226]
    
    Previously, the error from io.ReadAll was being ignored when reading
    error response bodies from the GitHub API. This could hide useful
    error information. Now properly handle this error to provide more
    complete error messages.
    
    Co-authored-by: Code Reviewer <reviewer@snyk.io>
    
    * fix: properly propagate errors from concurrent goroutines [IDE-1226]
    
    Previously, fetchAllReleases would silently swallow errors from goroutines,
    always returning nil error even when fetching releases failed. This could
    lead to incomplete matrices without proper failure indication in automated
    environments like GitHub Actions.
    
    Now we:
    - Collect all errors from goroutines in a thread-safe manner
    - Return an error if any plugin fetch fails
    - Exit with non-zero status on failure, properly signaling errors
    
    Also fixed error wrapping in GitHub API client to use %w verb.
    
    Co-authored-by: Code Reviewer <reviewer@snyk.io>
    
    * fix: log cache.Set errors for better diagnostics [IDE-1226]
    
    Previously, cache.Set errors were silently ignored, making it difficult
    to diagnose issues like file system permissions or disk space problems.
    
    Now we log warnings when cache operations fail, providing visibility
    into cache-related issues without interrupting the main workflow.
    
    Co-authored-by: Code Reviewer <reviewer@snyk.io>
    
    * refactor: replace error-based value return with idiomatic approach [IDE-1226]
    
    Previously, we used fmt.Errorf("FOUND:...") as a workaround to return values
    from filepath.Walk, which is brittle and non-idiomatic Go code.
    
    Now we:
    - Use a proper sentinel error (errStopWalk) to signal early termination
    - Store the found value in a variable in the outer scope
    - Use errors.Is() for proper error comparison
    - Add linter exclusions for acceptable code duplication
    
    This makes the code more maintainable and follows Go best practices.
    
    Co-authored-by: Code Reviewer <reviewer@snyk.io>
    
    * fix: prevent path traversal attacks in tar extraction (Zip Slip) [IDE-1226]
    
    Added validation to ensure extracted files remain within the destination
    directory. This prevents malicious tar archives from writing files outside
    the intended directory through path traversal sequences like '../'.
    
    Security fix addresses potential vulnerability where attackers could:
    - Overwrite system files
    - Access sensitive data outside the extraction directory
    - Compromise the host system
    
    The fix validates that all resolved target paths start with the
    destination directory before any file operations.
    
    Co-authored-by: Code Reviewer <reviewer@snyk.io>
    
    * chore: add .cursorrules for project-specific AI guidelines [IDE-1226]
    
    Added repository-specific rules and guidelines for AI assistants to ensure:
    - Consistent code patterns and conventions
    - Proper security scanning with Snyk
    - Correct commit message formatting
    - Adherence to project-specific requirements
    
    * refactor: remove unused cache parameter from generateMatrix [IDE-1226]
    
    The cache parameter was passed to generateMatrix but never used within
    the function. Removed it from the function signature and all call sites
    to improve code clarity.
    
    Co-authored-by: Code Reviewer <reviewer@snyk.io>
    
    * refactor: remove redundant Tag field from Release struct [IDE-1226]
    
    The Tag field was assigned the same value as Version and never used.
    Removed it from:
    - Release struct definition
    - Assignment at line 116 (previously 117)
    - Test data structures
    
    This improves code maintainability by eliminating redundancy.
    
    Co-authored-by: Code Reviewer <reviewer@snyk.io>
    
    * refactor: use defer for file closing in tar extraction [IDE-1226]
    
    Replaced manual file closing with defer f.Close() for more idiomatic
    and robust file handling. This ensures the file is closed on all
    execution paths and reduces the chance of resource leaks if the
    function is modified in the future.
    
    Co-authored-by: Code Reviewer <reviewer@snyk.io>
    
    * fix(compatibility-matrix): close files immediately in tar extraction loop
    
    Previously, using defer f.Close() inside the loop would accumulate all
    deferred calls until the function returned, potentially exhausting file
    descriptors for archives with many files. Now files are closed explicitly
    after each iteration, properly handling both copy and close errors.
    
    [IDE-1226]
    
    * feat(compatibility-matrix): rename column to 'Latest Compatible CLI Version'
    
    Updated the third column name from 'Minimum CLI Version' to 'Latest Compatible
    CLI Version' throughout the codebase to better reflect that the CLI version
    shown is the latest compatible version for each IDE plugin version.
    
    Updated:
    - Matrix generator output format
    - Documentation and README
    - Test expectations
    - GitHub Action description
    - Implementation plan
    
    [IDE-1226]
    
    * fix(compatibility-matrix): add IntelliJ requiredLsProtocolVersion pattern
    
    Added support for extracting 'val requiredLsProtocolVersion = xxx' pattern
    from IntelliJ plugin source code. This fixes the protocol version extraction
    for IntelliJ releases.
    
    [IDE-1226]
    
    * chore(compatibility-matrix): remove unused nolint directives
    
    Removed unused nolint:dupl directives that were flagged by the linter. These
    directives were no longer necessary.
    
    [IDE-1226]
    
    * docs: updated licenses
    
    * fix(test): resolve race condition in Test_loginCommand_StartsAuthentication
    
    The test was accessing notifications[0] without verifying the slice had elements,
    causing an index out of range panic. Fixed by:
    - Waiting specifically for the hasAuthenticated notification in Eventually
    - Adding require.NotEmpty check before accessing the first element
    - This ensures we only proceed when the expected notification is available
    
    [IDE-1226]
    
    * feat(compatibility-matrix): display Eclipse semantic version with release tag
    
    Eclipse plugin versions now show as 'Eclipse v3.3.0 (v20250717.103834)' where:
    - The semantic version (3.3.0) is extracted from MANIFEST.MF Bundle-Version
    - The GitHub release tag is shown in parentheses
    - The .identifier suffix is automatically omitted from Bundle-Version
    
    This provides clearer version information for Eclipse plugins while maintaining
    the original release tag for reference.
    
    [IDE-1226]
    
    * feat(compatibility-matrix): display CLI version ranges instead of single version
    
    Enhanced the compatibility matrix generator to show the range of compatible CLI
    versions for each IDE plugin version. The tool now:
    
    - Clones and analyzes the Snyk CLI repository to extract protocol versions
    - Maps each CLI release to its protocol version via go.mod analysis
    - Displays all compatible CLI versions as a range (e.g., v1.1298.0 - v1.1298.1)
    - Renamed the column from 'Latest Compatible CLI Version' to 'Compatible CLIs'
    
    This provides more comprehensive compatibility information by showing all CLI
    versions that work with each IDE plugin version, not just the latest one.
    
    [IDE-1226]
    
    * docs: updated licenses
    
    * chore: remove implementation plan from repository
    
    Implementation plans should not be committed to the repository as per
    project rules. Moving to local-only reference.
    
    [IDE-1226]
    
    * fix: remove generated matrix and revert hashicorp go.mod changes
    
    - Removed the generated compatibility-matrix.md file (should not be committed)
    - Reverted changes to licenses/github.com/hashicorp/hcl/go.mod (per project rules)
    
    [IDE-1226]
    
    * chore: change schedule to weekly and remove update date
    
    - Changed GitHub Actions schedule from daily to weekly (Sundays at 2 AM UTC)
    - Removed 'Last updated' date from generated matrix to avoid unnecessary PR reviews
    - Updated PR description to reflect weekly schedule
    
    [IDE-1226]
    
    * chore: change schedule back to daily
    
    Since the workflow checks for content changes before creating a PR,
    running daily won't create unnecessary PRs. The workflow will only
    create a PR when there are actual changes to the compatibility matrix.
    
    [IDE-1226]
    
    ---------
    
    Co-authored-by: Code Reviewer <reviewer@snyk.io>
    Co-authored-by: bastiandoetsch <bastiandoetsch@users.noreply.github.com>

:000000 100644 00000000 f39873b2 A	.cursorrules
:000000 100644 00000000 da44dc78 A	.github/workflows/update-compatibility-matrix.yaml
:100644 100644 77a2ee96 5a3bbf56 M	.gitignore
:100644 100644 37410e6b 6ca5d840 M	application/server/execute_command_test.go
:000000 100644 00000000 d60bae88 A	scripts/compatibility-matrix/README.md
:000000 100644 00000000 d192ea49 A	scripts/compatibility-matrix/cache.go
:000000 100644 00000000 bc228b66 A	scripts/compatibility-matrix/cli_analyzer.go
:000000 100644 00000000 efc45e76 A	scripts/compatibility-matrix/cli_version.go
:000000 100644 00000000 831b490d A	scripts/compatibility-matrix/github.go
:000000 100644 00000000 dbfbe56a A	scripts/compatibility-matrix/main.go
:000000 100644 00000000 10ed4e7e A	scripts/compatibility-matrix/main_test.go
:000000 100644 00000000 a09bcac1 A	scripts/compatibility-matrix/plugins.go

commit e5e713ecefc0b57c63a12e263e932a9829f3d07c
Author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
Date:   Tue Jul 22 14:58:00 2025 +0200

    docs: synchronizing MCP README from snyk/user-docs (#933)
    
    Co-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

:100644 100644 01847f62 e05d41f2 M	mcp_extension/README.md

commit 6a60dea9d1df835335e1f9c87bd0cf2f2515ac1a
Author: Abdelrahman Shawki Hassan <shawki.hassan@snyk.io>
Date:   Mon Jul 21 19:13:26 2025 +0200

    chore: Update mcp-readme-sync.yml and fix pipeline (#930)
    
    docs: synchronizing MCP README from snyk/user-docs (#931)
    chore: Update mcp-readme-sync.yml

:100644 100644 2f9ca82b 5f596af0 M	.github/workflows/mcp-readme-sync.yml
:100644 100644 d6134583 01847f62 M	mcp_extension/README.md

commit 6648b0d781c72ec92369c183ce0a3888a154f375
Author: Abdelrahman Shawki Hassan <shawki.hassan@snyk.io>
Date:   Mon Jul 21 19:06:15 2025 +0200

    chore: added manifest.json file (#929)

:000000 100644 00000000 9ebdb116 A	mcp_extension/manifest.json
```

[IDE-1226]: https://snyksec.atlassian.net/browse/IDE-1226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1226]: https://snyksec.atlassian.net/browse/IDE-1226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1226]: https://snyksec.atlassian.net/browse/IDE-1226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1226]: https://snyksec.atlassian.net/browse/IDE-1226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1226]: https://snyksec.atlassian.net/browse/IDE-1226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1226]: https://snyksec.atlassian.net/browse/IDE-1226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1226]: https://snyksec.atlassian.net/browse/IDE-1226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1226]: https://snyksec.atlassian.net/browse/IDE-1226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1226]: https://snyksec.atlassian.net/browse/IDE-1226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1226]: https://snyksec.atlassian.net/browse/IDE-1226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1226]: https://snyksec.atlassian.net/browse/IDE-1226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ