### PR TITLE
chore(language-server): integrate LS

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/snyk/go-application-framework v0.0.0-20250806121453-f52d07f97ed7
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20250806130213-c7d99d8e362c
+	github.com/snyk/snyk-ls v0.0.0-20250807144637-cf5a04582d11
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
@@ -235,7 +235,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250409194420-de1ac958c67a // indirect
 	google.golang.org/grpc v1.71.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
-	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -810,8 +810,8 @@ github.com/snyk/policy-engine v0.33.2 h1:ZxD6/RQ4vqUAXa64V72SsGjZ8vmnBgZNGYQxMIq
 github.com/snyk/policy-engine v0.33.2/go.mod h1:YTZq3GMRbXcHOXQQrFRVEg+MQiIGCGZ1met6KlpruNo=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20250806130213-c7d99d8e362c h1:KyioF9Imd/8mmTNyNDvoxLNhWrMiwj8kzFqenDbTmWQ=
-github.com/snyk/snyk-ls v0.0.0-20250806130213-c7d99d8e362c/go.mod h1:JrcjatzOFaKAxTCmgiAbwLlm2Hm4ZpnoLsca9sSTW/M=
+github.com/snyk/snyk-ls v0.0.0-20250807144637-cf5a04582d11 h1:OFSZP68fAK/Ix/1DHAJfncf5ObjKZ0kk9k5dbDNJZbg=
+github.com/snyk/snyk-ls v0.0.0-20250807144637-cf5a04582d11/go.mod h1:gPUxKB2Su3BaZvCZYg8wz3/uZDXWFt92wzVl9X/Ni98=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=
@@ -1487,8 +1487,6 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
-gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
-gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit cf5a04582d11c4040e39fda2c39fe0c4ebb7470f
Author: prodsec-github-automation <146025078+prodsec-github-automation@users.noreply.github.com>
Date:   Thu Aug 7 15:46:37 2025 +0100

    chore: update codeowners [IDE-1357] (#950)

:100644 100644 41a2652e 0b8a9090 M	.github/CODEOWNERS

commit 898c53fa553f73a40ef13fa2ebaae089f99d0a37
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Thu Aug 7 15:21:03 2025 +0100

    fix: download client's requested protocol version [IDE-1356] (#949)
    
    * fix: download client's requested protocol version
    
    Previously the "Download manually in browser" button would return a link to the same protocol version as we currently have, not the client's requested one.
    Add additional logging to the code for determining the release channel.
    
    * fix: logging in GetCLIDownloadURLForProtocol
    
    * refactor: use `require.Eventually`

:100644 100644 d62a7c76 4b756c7d M	application/server/server.go
:100644 100644 f62bb850 7a9210a8 M	application/server/server_test.go
:100644 100644 73e9f1fe 79df5b47 M	infrastructure/cli/install/releases.go

commit 3821394d0f1bb79353605e438f28797d33d555e0
Author: Abdelrahman Shawki Hassan <shawki.hassan@snyk.io>
Date:   Thu Aug 7 15:27:29 2025 +0200

    feat: send feedback (#948)

:100644 100644 23633219 05ba2709 M	application/server/configuration.go
:100644 100644 3894efe9 02c08337 M	domain/ide/command/get_active_user_test.go
:100644 100644 f7345ec8 e84bfd50 M	domain/ide/command/ignores_request.go
:100644 100644 8c758370 c7cf4706 M	domain/ide/command/report_analytics.go
:100644 100644 c7661702 7eebf13d M	domain/ide/command/report_analytics_test.go
:100644 100644 cd6833f2 d1485150 M	domain/ide/workspace/folder.go
:100644 100644 6b30160a 904fa614 M	domain/ide/workspace/folder_test.go
:100644 100644 a1ef40f5 20013571 M	infrastructure/analytics/analytics.go
:100644 100644 be4a18be dca31324 M	infrastructure/analytics/pact_test.go
:100644 100644 6cecfb1f ea561e43 M	infrastructure/authentication/auth_service_impl.go
:100644 100644 43281304 fb95eb10 M	infrastructure/authentication/auth_service_impl_test.go
:100644 100644 8e86dabe 6a2b052d M	mcp_extension/llm_binding.go
:100644 100644 c9afbfe1 44c989cc M	mcp_extension/main.go
:100644 100644 9ce35a5c 585f98f3 M	mcp_extension/scan_response_mapper.go
:100644 100644 2012ff85 72245c73 M	mcp_extension/scan_tool.go
:100644 100644 a6ea3642 6fe36ea7 M	mcp_extension/scan_tool_test.go
:100644 100644 3d2e61b0 ae34e20f M	mcp_extension/snyk_tools.json
:100644 100644 86d12d09 4ac0b000 M	mcp_extension/utils.go

commit d09345ea186be1568bf8bfac1ca60fd1a718fb73
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Thu Aug 7 13:47:47 2025 +0100

    fix(test): flaky server test (#954)
    
    Test_textDocumentDidOpenHandler_shouldPublishIfCached had the logical operation precedent wrong and wasn't waiting long enough.

:100644 100644 3e4251ee f62bb850 M	application/server/server_test.go

commit 635465abfc7bc2dcf9acdef8ffe2237d4b1f771a
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Thu Aug 7 09:06:31 2025 +0100

    fix: remove Git-stored folder config migration [IDE-1291] (#942)
    
    * fix: remove Git-stored folder config migration
    
    The stored config migration code (from local Git repo config to the new file) had existed for over 6 months, so could be removed.
    A bug with the migration code meant we were using the Git branches stored in the config file as opposed to getting them freshly from Git each time, this has been fixed.
    
    * docs: updated licenses
    
    * chore: make enrichFromGit return folderConfig
    
    Refactored for clarity.
    
    ---------
    
    Co-authored-by: rrama <rrama@users.noreply.github.com>

:100644 100644 0eb8513d f8871ed2 M	application/config/config.go
:100644 100644 ffc08ec3 faad3e92 M	domain/ide/command/folder_handler.go
:100644 100644 191f50bd a8ea4374 M	go.mod
:100644 100644 6a8097a3 7deb7678 M	go.sum
:100644 100644 1fbf5fcf bf2cedca M	internal/storedconfig/git.go
:100644 100644 44c85000 72fdbc92 M	internal/storedconfig/git_test.go
:100644 100644 6e496905 6d928a7d M	internal/storedconfig/stored_config.go
:100644 100644 34233fb2 475d2816 M	internal/storedconfig/stored_config_test.go
:100644 100644 193b5387 94cf7af4 M	internal/storedconfig/xdg.go
:100644 100644 385eea59 8e39396c M	internal/storedconfig/xdg_test.go
:100644 100644 61c07776 6e47d81a M	internal/vcs/checkout_handler.go
:100644 100644 fcc81dcf 80b6c8e4 M	internal/vcs/git_cloner.go
:100644 100644 b99291a1 d2d8c8c4 M	internal/vcs/git_utils.go
:100644 000000 d361bbcd 00000000 D	licenses/gopkg.in/ini.v1/LICENSE
```

[IDE-1357]: https://snyksec.atlassian.net/browse/IDE-1357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1356]: https://snyksec.atlassian.net/browse/IDE-1356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1291]: https://snyksec.atlassian.net/browse/IDE-1291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ