### PR TITLE
chore(language-server): integrate LS

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/snyk/go-application-framework v0.0.0-20250814144548-195929064715
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20250807144637-cf5a04582d11
+	github.com/snyk/snyk-ls v0.0.0-20250815153058-26a722dfc7be
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -810,8 +810,8 @@ github.com/snyk/policy-engine v0.33.2 h1:ZxD6/RQ4vqUAXa64V72SsGjZ8vmnBgZNGYQxMIq
 github.com/snyk/policy-engine v0.33.2/go.mod h1:YTZq3GMRbXcHOXQQrFRVEg+MQiIGCGZ1met6KlpruNo=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20250807144637-cf5a04582d11 h1:OFSZP68fAK/Ix/1DHAJfncf5ObjKZ0kk9k5dbDNJZbg=
-github.com/snyk/snyk-ls v0.0.0-20250807144637-cf5a04582d11/go.mod h1:gPUxKB2Su3BaZvCZYg8wz3/uZDXWFt92wzVl9X/Ni98=
+github.com/snyk/snyk-ls v0.0.0-20250815153058-26a722dfc7be h1:rFx2KOYKbSxKpZ6vLB/44X5xKCcnlcPu5RR1Z33qTgM=
+github.com/snyk/snyk-ls v0.0.0-20250815153058-26a722dfc7be/go.mod h1:gPUxKB2Su3BaZvCZYg8wz3/uZDXWFt92wzVl9X/Ni98=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit 26a722dfc7be7d0b2b1714c82b2f736a8453e8d8
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Fri Aug 15 16:30:58 2025 +0100

    refactor(test): reduce usage of `CurrentConfig()` [IDE-1314] (#964)
    
    Instead rely on the config reference already in the test.

:100644 100644 ef4b3a96 e9d3477a M	application/codeaction/codeaction_test.go
:100644 100644 af58eec5 338ad005 M	application/server/execute_command_test.go
:100644 100644 c419f80e e2c96088 M	domain/ide/command/code_fix_test.go
:100644 100644 23343c37 94593aca M	infrastructure/authentication/cli_provider_test.go
:100644 100644 baccdf90 e0251f7d M	infrastructure/cli/install/downloader_test.go
:100644 100644 3838e2aa 1b1d3bfa M	infrastructure/cli/install/installer_test.go
:100644 100644 a8cf564d 2073f7af M	infrastructure/code/code_test.go
:100644 100644 ea0071d7 79516b53 M	infrastructure/learn/pact_test.go
:100644 100644 b7ead36e 4cef9163 M	infrastructure/learn/service_test.go
:100644 100644 cf56e8ff 33af376a M	infrastructure/sentry/sentry_error_reporter_test.go
:100644 100644 1cf2c6dc 3be1d409 M	infrastructure/snyk_api/snyk_api_pact_test.go
```