### PR TITLE
fix: display error details for all project scans on failing targets

### DIFF
--- a/src/lib/plugins/get-multi-plugin-result.ts
+++ b/src/lib/plugins/get-multi-plugin-result.ts
@@ -161,11 +161,19 @@ export async function getMultiPluginResult(
   }
 
   if (!allResults.length) {
-    throw new FailedToRunTestError(
-      errorMessageWithRetry(
-        `Failed to get dependencies for all ${targetFiles.length} potential projects.`,
-      ),
-    );
+    // No projects were scanned successfully
+    let message = `Failed to get dependencies for all ${targetFiles.length} potential projects.\n`;
+
+    if (failedResults.length > 0) {
+      const errorDetails = failedResults
+        .map((result) => `${result.targetFile}:\n${result.errMessage}`)
+        .join('\n\n');
+      message += `\n${errorDetails}`;
+    } else {
+      message = errorMessageWithRetry(message);
+    }
+
+    throw new FailedToRunTestError(message);
   }
 
   return {


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Previously, when failing to get dependencies during a single project scan with the `--all-projects` flag, the error message that would surface would be quite generic:
```
Failed to get dependencies for all 1 potential projects.
Tip: Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>
If the issue persists contact support@snyk.io
```

This could also happen when scanning multiple projects where all of them would fail to get the dependencies. If there are any project that successfully scanned, more detailed error messages would be presented to the user, without the need to enable debug logs.

The behaviour is caused by [this check](https://github.com/snyk/cli/blob/dd19ec4f9008028224c30086c1f29a652312820f/src/lib/plugins/get-multi-plugin-result.ts#L163-L169), where if there are no results, the generic error is thowed. The proposed fix just creates a new error messages from the failed results before returning them to the user.

## Where should the reviewer start?

- [src/lib/plugins/get-multi-plugin-result.ts](https://github.com/snyk/cli/blob/df7515c913f0ee3f572acacb7a2dc351491c0053/src/lib/plugins/get-multi-plugin-result.ts#L163-L177) - contains the main changes, just constructing the new error message with the details available.

## How should this be manually tested?

An easy way of testing this is to have an invalid package.json file being scanned with `--all-projects`. Having an invalid JSON object inside this fill will cause the scan to fail. The old CLI behaviour will present the generic error message, while with this change the error message would surface the error message from the JSON parsing failure. 

## What's the product update that needs to be communicated to CLI users?

Surface error messages when failing to get dependencies on multi project scans.

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
