### PR TITLE
fix: resolve project assets file path dynamically

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "snyk-mvn-plugin": "4.1.0",
         "snyk-nodejs-lockfile-parser": "2.2.2",
         "snyk-nodejs-plugin": "1.4.4",
-        "snyk-nuget-plugin": "2.10.1",
+        "snyk-nuget-plugin": "2.10.4",
         "snyk-php-plugin": "1.12.1",
         "snyk-policy": "4.1.5",
         "snyk-python-plugin": "2.7.1",
@@ -21477,9 +21477,9 @@
       }
     },
     "node_modules/snyk-nuget-plugin": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.10.1.tgz",
-      "integrity": "sha512-7J+h61CnKF5REjuCGqSXOv5Dg/4T8iQbaDTRazyBZUEqjXFFpmQIOgRbGA4iQMhVNhvHlqBu3/e28C8vXFEErA==",
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.10.4.tgz",
+      "integrity": "sha512-7YZvorrYzQWMXYSc/NlvpVh/Kad9DuBz4SEkcfO7Mgt2k2Fpu1FiDdPrHbp3OKmhm+KoMaqxzUYdw7ns1mwVgw==",
       "dependencies": {
         "@snyk/cli-interface": "^2.14.0",
         "@snyk/dep-graph": "^2.8.1",
@@ -41216,9 +41216,9 @@
       }
     },
     "snyk-nuget-plugin": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.10.1.tgz",
-      "integrity": "sha512-7J+h61CnKF5REjuCGqSXOv5Dg/4T8iQbaDTRazyBZUEqjXFFpmQIOgRbGA4iQMhVNhvHlqBu3/e28C8vXFEErA==",
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.10.4.tgz",
+      "integrity": "sha512-7YZvorrYzQWMXYSc/NlvpVh/Kad9DuBz4SEkcfO7Mgt2k2Fpu1FiDdPrHbp3OKmhm+KoMaqxzUYdw7ns1mwVgw==",
       "requires": {
         "@snyk/cli-interface": "^2.14.0",
         "@snyk/dep-graph": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "snyk-mvn-plugin": "4.1.0",
     "snyk-nodejs-lockfile-parser": "2.2.2",
     "snyk-nodejs-plugin": "1.4.4",
-    "snyk-nuget-plugin": "2.10.1",
+    "snyk-nuget-plugin": "2.10.4",
     "snyk-php-plugin": "1.12.1",
     "snyk-policy": "4.1.5",
     "snyk-python-plugin": "2.7.1",


### PR DESCRIPTION
## Pull Request Submission Checklist

- [X] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [X] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [X] Includes detailed description of changes
- [X] Contains risk assessment (Low | Medium | High)
- [X] Highlights breaking API changes (if applicable)
- [X] Links to automated tests covering new functionality
- [X] Includes manual testing instructions (if necessary)
- [X] Updates relevant GitBook documentation (PR link: ___)
- [X] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps snyk-nuget-plugin to version 2.10.4. This was done in order to correctly locate the `project.assets.json` files in cases where it's destination path was altered with .Net properties. Related snyk-nuget-plugin [PR here](https://github.com/snyk/snyk-nuget-plugin/pull/258)

## Where should the reviewer start?

Checking the snyk-nuget-plugin [PR here](https://github.com/snyk/snyk-nuget-plugin/pull/258)

## How should this be manually tested?

By testing the CLI versions again [this fixture](https://github.com/snyk/snyk-nuget-plugin/pull/258/files#diff-39a2e085ff3ffb024f8f8acc7aa9a7126548ce926a1176fa0afdc0197d579038R1)

## What's the product update that needs to be communicated to CLI users?

-

## Risk assessment (Low | Medium | High)?

Low, we try to fetch the assets file by it's normal location and only if that fails we're going to scan for different locations

## Any background context you want to provide?

-

## What are the relevant tickets?

https://snyksec.atlassian.net/issues/?jql=textfields~godot&selectedIssue=OSM-3021

## Screenshots (if appropriate)


