### PR TITLE
fix: Use snyk-code-0006 for sast consistently

### DIFF
--- a/src/lib/errors/no-supported-sast-files-found.ts
+++ b/src/lib/errors/no-supported-sast-files-found.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { CustomError } from './custom-error';
-import { CLI } from '@snyk/error-catalog-nodejs-public';
+import { Code } from '@snyk/error-catalog-nodejs-public';
 
 export class NoSupportedSastFiles extends CustomError {
   private static ERROR_MESSAGE =
@@ -14,7 +14,7 @@ export class NoSupportedSastFiles extends CustomError {
     super(NoSupportedSastFiles.ERROR_MESSAGE);
     this.code = 422;
     this.userMessage = NoSupportedSastFiles.ERROR_MESSAGE;
-    this.errorCatalog = new CLI.NoSupportedFilesFoundError(
+    this.errorCatalog = new Code.UnsupportedProjectError(
       NoSupportedSastFiles.ERROR_MESSAGE,
     );
   }

--- a/test/jest/acceptance/snyk-code/snyk-code-user-journey.spec.ts
+++ b/test/jest/acceptance/snyk-code/snyk-code-user-journey.spec.ts
@@ -247,7 +247,7 @@ describe('snyk code test', () => {
         });
 
         it('should fail with correct exit code - when testing empty project', async () => {
-          const { stderr, code } = await runSnykCLI(
+          const { stdout, stderr, code } = await runSnykCLI(
             `code test ${emptyProject}`,
             {
               env: {
@@ -258,6 +258,7 @@ describe('snyk code test', () => {
           );
 
           expect(stderr).toBe('');
+          expect(stdout).toContain('snyk-code-0006');
           expect(code).toBe(EXIT_CODE_NO_SUPPORTED_FILES);
         });
 


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
This PR fixes an inconsistency in error codes used when running `snyk code test` on a code base without any supported file type. The inconsistency is between the legacy and native implementation.

## Where should the reviewer start?

## How should this be manually tested?

## What's the product update that needs to be communicated to CLI users?

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
