### PR TITLE
fix: ignoring windows signing operations on feature branches (non-e2e test)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,11 +241,6 @@ commands:
           paths:
             - ~\smtools-windows-x64.msi
 
-  install-deps-windows-full-signing:
-    steps:
-      - install-deps-windows-signing
-      - install-deps-windows-make
-
   install-deps-windows-make:
     steps:
       - restore_cache:
@@ -559,11 +554,10 @@ workflows:
           go_arch: amd64
           go_download_base_url: << pipeline.parameters.fips_go_download_base_url >>
           make_target: build clean-golang build-fips
-          install_deps_extension: windows-full-signing
+          install_deps_extension: windows-full
           install_path: 'C:\'
           executor: win-server2022-amd64
           context:
-            - snyk-windows-signing
             - iac-cli
           requires:
             - prepare-build


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Stops the digicert signing process on non-feature branches by simply removing the context containing credentials.

## Where should the reviewer start?

The CircleCI pipeline file as well as my comments try to elaborate. A full end-to-end version has been created to prove no regressions: https://github.com/snyk/cli/pull/6132

## How should this be manually tested?

N/A, see e2e runs.

## What's the product update that needs to be communicated to CLI users?

N/A, pipeline optimization.

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
