### PR TITLE
fix(iac): upgrade iac components to address a vulnerability [IAC-3439]

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/snyk/cli-extension-ai-bom v0.0.0-20250806122647-dd6a7986878e
 	github.com/snyk/cli-extension-dep-graph v0.0.0-20250321153619-9390ab5e348e
-	github.com/snyk/cli-extension-iac v0.0.0-20250711122243-0de490b44873
-	github.com/snyk/cli-extension-iac-rules v0.0.0-20250227121450-6e14346dbd1a
+	github.com/snyk/cli-extension-iac v0.0.0-20250829110702-b41ac109dab0
+	github.com/snyk/cli-extension-iac-rules v0.0.0-20250829110455-1260348bc188
 	github.com/snyk/cli-extension-os-flows v0.0.0-20250813112222-a4de039ac630
 	github.com/snyk/cli-extension-sbom v0.0.0-20250801142135-ae472dafa4cd
 	github.com/snyk/container-cli v0.0.0-20250321132345-1e2e01681dd7
@@ -179,7 +179,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/snyk/code-client-go v1.22.3 // indirect
-	github.com/snyk/policy-engine v0.33.2 // indirect
+	github.com/snyk/policy-engine v1.1.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect
 	github.com/speakeasy-api/jsonpath v0.6.2 // indirect

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -1287,10 +1287,10 @@ github.com/snyk/cli-extension-ai-bom v0.0.0-20250806122647-dd6a7986878e h1:Xmjk9
 github.com/snyk/cli-extension-ai-bom v0.0.0-20250806122647-dd6a7986878e/go.mod h1:dySxka2pkVqMV+zL6yNbHBKTf3Cy7yBUsvah4hyQOeE=
 github.com/snyk/cli-extension-dep-graph v0.0.0-20250321153619-9390ab5e348e h1:lYBeDqyAmb7NPfcLZJb1rcc+BrWhX5Ct9isQO1O4mSc=
 github.com/snyk/cli-extension-dep-graph v0.0.0-20250321153619-9390ab5e348e/go.mod h1:9Zpe+B8SCkWFjpDR3ckFJl1XuMyxysWebKhyAIj7EyI=
-github.com/snyk/cli-extension-iac v0.0.0-20250711122243-0de490b44873 h1:D2LsRbi9qFm8NsWXHmS29vC1mzTg7uoXi9ewQ7NC+Ig=
-github.com/snyk/cli-extension-iac v0.0.0-20250711122243-0de490b44873/go.mod h1:HHOvlKnJfypPCYNP+yG7FLu0ii02UwumpkWlSLy5pYc=
-github.com/snyk/cli-extension-iac-rules v0.0.0-20250227121450-6e14346dbd1a h1:SJ+Ts7e1EYcGJXeENR5inTGwPNRlNVgmMN2itO3+yj8=
-github.com/snyk/cli-extension-iac-rules v0.0.0-20250227121450-6e14346dbd1a/go.mod h1:IqfQCIkyC26mkwa+aM6d6yxIh5+tCm4fSQG+Ogq3Qbc=
+github.com/snyk/cli-extension-iac v0.0.0-20250829110702-b41ac109dab0 h1:ecGoMisVTnz5xRnt9yXW2hlRrIyYM123yMt1NeNEo6s=
+github.com/snyk/cli-extension-iac v0.0.0-20250829110702-b41ac109dab0/go.mod h1:tLxyhtrRiEvbSLQ6PbCsl29ZXK6s2aunRuL6cSe/8cE=
+github.com/snyk/cli-extension-iac-rules v0.0.0-20250829110455-1260348bc188 h1:UoyD7cB9XZVHPTRugsmCt6rBvAw5IoiBjI8go2qj1pk=
+github.com/snyk/cli-extension-iac-rules v0.0.0-20250829110455-1260348bc188/go.mod h1:qUc1yjKJe6tt/8/MJasnog3VBXd/b619MSFVfKAlDxE=
 github.com/snyk/cli-extension-os-flows v0.0.0-20250813112222-a4de039ac630 h1:sNa9Z/WAwn5fAMUdyMFPVvoE9WH/fUa6qqmKOC8Xo/s=
 github.com/snyk/cli-extension-os-flows v0.0.0-20250813112222-a4de039ac630/go.mod h1:Epnqr2TQGownRG+pW63Yn0QIKdj50UYBJuJpeLvkPm4=
 github.com/snyk/cli-extension-sbom v0.0.0-20250801142135-ae472dafa4cd h1:bZg7Zkctm2tvaznI8A4/0fFOZMgglNAIFmIIlRz16W0=
@@ -1305,8 +1305,8 @@ github.com/snyk/go-application-framework v0.0.0-20250829091032-bea1827e8723 h1:R
 github.com/snyk/go-application-framework v0.0.0-20250829091032-bea1827e8723/go.mod h1:BcHDVsw0EkwisckVp8qVItO1eqI98fMrb61GCGr7ERM=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
-github.com/snyk/policy-engine v0.33.2 h1:ZxD6/RQ4vqUAXa64V72SsGjZ8vmnBgZNGYQxMIqctYo=
-github.com/snyk/policy-engine v0.33.2/go.mod h1:YTZq3GMRbXcHOXQQrFRVEg+MQiIGCGZ1met6KlpruNo=
+github.com/snyk/policy-engine v1.1.0 h1:vFbFZbs3B0Y3XuGSur5om2meo4JEcCaKfNzshZFGOUs=
+github.com/snyk/policy-engine v1.1.0/go.mod h1:SSZiMz6TiggRAk33duOueWeSG0Xwl0QoZo8hfPcEAh0=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
 github.com/snyk/snyk-ls v0.0.0-20250826112710-2b9103023173 h1:R7PNDiGNuVdunALRilo+yG9GF7S7cOcaF4fQcPmvrFo=

--- a/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
+++ b/src/lib/iac/test/v2/local-cache/policy-engine/constants/utils.ts
@@ -1,11 +1,11 @@
 import * as os from 'os';
 
 const policyEngineChecksums = `
-220f4633530056053ab1805b553b71c71f01a6cef63409afe968227ddbc40dda  snyk-iac-test_0.57.10_Windows_x86_64.exe
-31199556c8a42a50c1b08210acb0463152d56769f3fe77dd7da54db88504ef4e  snyk-iac-test_0.57.10_Darwin_arm64
-81cf580b14d0f2df7d6b731c2bdc23a1a784be5254c036fe0dac5b3e18127ba1  snyk-iac-test_0.57.10_Linux_x86_64
-bea67e70c80508683298ce6e7d1b744c5cef0e83c51b7936ba50251fff73cd79  snyk-iac-test_0.57.10_Linux_arm64
-c5fcba71b9594f60ff1506a770d55a8b3b32aed44657e2609e572c0160463a2e  snyk-iac-test_0.57.10_Darwin_x86_64
+1334e0dd61975f2a90d7f4c7612288b2e3cb6658b23c269bdd2c5a19f960a9c8  snyk-iac-test_0.57.11_Darwin_x86_64
+2c8dbad1190c1794b27772967a908c362c1fdcd0b6fd76a9b9a9b40d9b45eaf7  snyk-iac-test_0.57.11_Darwin_arm64
+47f12ea5072a89d54369a50bdb81384c39db08ec0b4f7f6e2bda120ddcf509f4  snyk-iac-test_0.57.11_Linux_arm64
+996f759a52806988f3c37a3c78de07df8828609b37c4371ad66f4be40303445b  snyk-iac-test_0.57.11_Linux_x86_64
+9dd0042026af42c9b3761f2b2ada9584f8ff7f8b2e5f7b03c56fb3b00652fdb4  snyk-iac-test_0.57.11_Windows_x86_64.exe
 `;
 
 export const policyEngineVersion = getPolicyEngineVersion();


### PR DESCRIPTION
## Pull Request Submission Checklist

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
Upgrades IaC components to the latest version in which a minor fix of a package that had a vulnerability was added.

## Where should the reviewer start?
```
<local build> iac test --help
<local build> iac rules --help
```

^ but no changes were introduced, those should work as until now

## How should this be manually tested?
The commands would work for orgs that have IaC+ enabled.
For IaC command:
```
<local build> iac test <path_for_iac_files>
```

For the rules extension:
```
<local build> iac rules init - try something from this interactive UX
For something already written rules from here: https://github.com/chdorner-snyk/sandbox-custom-rules use <local build> iac rules push --org=<that_has_iac+>
```

## What's the product update that needs to be communicated to CLI users?
None, no changes. 

## Risk assessment (Low | Medium | High)?
Low

## Any background context you want to provide?
Both extensions use policy-engine and the minor upgrade of the package with the vulnerability is contained by policy-engine. The package with the vulnerability is go-getter (which was upgraded from v1.7.5 to v1.7.9).

It might seem like policy-engine got a major upgrade in this PR, but actually the changes added with the major release from v1.0.0 were reverted in v1.1.0 and that contains only the go-getter upgrade.

Vulnerability of go-getter: SNYK-GOLANG-GITHUBCOMHASHICORPGOGETTER-11951454

## What are the relevant tickets?
[IAC-3439](https://snyksec.atlassian.net/browse/IAC-3439)

## Screenshots (if appropriate)
-



[IAC-3439]: https://snyksec.atlassian.net/browse/IAC-3439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ