### PR TITLE
fix: ignore casing fix in the policy lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
         "snyk-nodejs-plugin": "1.4.4",
         "snyk-nuget-plugin": "2.11.0",
         "snyk-php-plugin": "1.12.1",
-        "snyk-policy": "4.1.5",
+        "snyk-policy": "^4.1.6",
         "snyk-python-plugin": "3.1.0",
         "snyk-resolve-deps": "4.8.0",
         "snyk-sbt-plugin": "3.1.0",
@@ -21708,9 +21708,10 @@
       }
     },
     "node_modules/snyk-policy": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-4.1.5.tgz",
-      "integrity": "sha512-sWyn12GlzXLwZxzxUtK27b/s8gMVVmkxfDbjgUH6/IILLHcC574RlxKbCyFx0bsDlOblvOGzfSCDKKRPHRM9fw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-4.1.6.tgz",
+      "integrity": "sha512-KbbhZ7Z/C0WdNWd/uUkxaPMx3wHzKmbBp0p0FQIGnvsJIUC4PefcI58XfaC9GinlOHRQdD5S10uzEjPVe2LXvw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.1.1",
         "email-validator": "^2.0.4",
@@ -41531,9 +41532,9 @@
       }
     },
     "snyk-policy": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-4.1.5.tgz",
-      "integrity": "sha512-sWyn12GlzXLwZxzxUtK27b/s8gMVVmkxfDbjgUH6/IILLHcC574RlxKbCyFx0bsDlOblvOGzfSCDKKRPHRM9fw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/snyk-policy/-/snyk-policy-4.1.6.tgz",
+      "integrity": "sha512-KbbhZ7Z/C0WdNWd/uUkxaPMx3wHzKmbBp0p0FQIGnvsJIUC4PefcI58XfaC9GinlOHRQdD5S10uzEjPVe2LXvw==",
       "requires": {
         "debug": "^4.1.1",
         "email-validator": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "snyk-nodejs-plugin": "1.4.4",
     "snyk-nuget-plugin": "2.11.0",
     "snyk-php-plugin": "1.12.1",
-    "snyk-policy": "4.1.5",
+    "snyk-policy": "^4.1.6",
     "snyk-python-plugin": "3.1.0",
     "snyk-resolve-deps": "4.8.0",
     "snyk-sbt-plugin": "3.1.0",

--- a/test/jest/unit/policy.spec.ts
+++ b/test/jest/unit/policy.spec.ts
@@ -2,7 +2,7 @@ import * as policy from 'snyk-policy';
 import * as fs from 'fs';
 import { getFixturePath } from '../util/getFixturePath';
 
-it('blah', async () => {
+it('does not ignore vulnerabilities with invalid expiry dates', async () => {
   const loadedPolicy = await policy.load(
     getFixturePath('snyk-ignores-invalid-expiry'),
   );
@@ -20,4 +20,45 @@ it('blah', async () => {
   expect(result.ok).toBe(false);
   expect(result.vulnerabilities).toHaveLength(2);
   expect(result.filtered.ignore).toHaveLength(1);
+});
+
+it('applies ignore when a valid (non-expired) rule exists for the issue id', async () => {
+  const issueToIgnore = {
+    id: 'NPM-HAWK:123',
+    name: 'problem',
+    from: [''],
+    isPatchable: false,
+  };
+
+  const issueToNotIgnore = {
+    id: '5678',
+    name: 'five six seven eight!',
+    from: [''],
+    isPatchable: false,
+  };
+
+  const vulnerabilities = [issueToIgnore, issueToNotIgnore];
+
+  const loadedPolicy = await policy.loadFromText(`
+ignore:
+  ${issueToIgnore.id}:
+    - '*':
+        reason: None given
+        expires: '2024-01-01T01:01:01.000Z'
+  ${issueToIgnore.id.toLowerCase()}:
+    - '*':
+        reason: None given
+        expires: '2999-01-01T01:01:01.000Z'
+`);
+
+  const input = { ok: false, vulnerabilities: vulnerabilities as any[] } as any;
+  const root = process.cwd();
+  const result = loadedPolicy.filter(input, root);
+
+  // One vulnerability should be ignored according to policy
+  expect(result.filtered.ignore.length).toBe(1);
+
+  const remainingIds = result.vulnerabilities.map((v: any) => v.id);
+  expect(remainingIds).not.toContain(issueToIgnore.id);
+  expect(remainingIds).toContain(issueToNotIgnore.id);
 });


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

We're fixing an issue where where:

You have ignores with different casing e.g. NPM:HAWK:20160119 vs npm:hawk:20160119 
The first ignore is expired
The other ignores that are active do not have the same casing 
Then no ignores are applied to the vuln
What was happening in the logic is that we were setting the value of the vulnId to the value of whatever matches first when checking the ignore keys. That vulnId is then used to check the ignores, so if you have other ignores that do not have the same casing exactly they are never checked.

This PR introduces logic to have a variable for all matching vuln IDs with all types of casing to then check the ignores against, so every ignore stored against the vuln ID no matter what the casing is will be checked.

## What's the product update that needs to be communicated to CLI users?

We're fixing an issue where where:

You have ignores with different casing e.g. NPM:HAWK:20160119 vs npm:hawk:20160119 
The first ignore is expired
The other ignores that are active do not have the same casing 
Then no ignores are applied to the vuln
What was happening in the logic is that we were setting the value of the vulnId to the value of whatever matches first when checking the ignore keys. That vulnId is then used to check the ignores, so if you have other ignores that do not have the same casing exactly they are never checked.

This PR introduces logic to have a variable for all matching vuln IDs with all types of casing to then check the ignores against, so every ignore stored against the vuln ID no matter what the casing is will be checked.

## Risk assessment (Low | Medium | High)?

Low 

## What are the relevant tickets?

https://snyksec.atlassian.net/browse/IGNR-1530

