### PR TITLE
fix(cicd): "gobject-introspection" error when setting up macos acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,12 +118,12 @@ executors:
   macos-arm64:
     macos:
       # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
-      xcode: '14.3.1'
+      xcode: '16.4.0'
     resource_class: macos.m1.medium.gen1
   macos-arm64-large:
     macos:
       # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
-      xcode: '14.3.1'
+      xcode: '16.4.0'
     resource_class: macos.m1.large.gen1
   win-server2022-amd64:
     machine:


### PR DESCRIPTION
## Pull Request Submission Checklist

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
This PR fixes our CICD pipelines, which broke due to a deprecation in the goobject-introspection homebrew [formula](https://github.com/Homebrew/homebrew-core/pull/240475).

## Where should the reviewer start?
CICD should not fail due to 
```
Error: gobject-introspection: no bottle available!
If you're feeling brave, you can try to install from source with:
  brew install --build-from-source gobject-introspection
```

## How should this be manually tested?

## What's the product update that needs to be communicated to CLI users?
n/a - this is an internal change for our CICD pipelines

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
