### PR TITLE
feat: [CN-249] support scanning system JARs

### DIFF
--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -28,7 +28,7 @@ import { apiOrOAuthTokenExists } from '../../../lib/api-token';
 import { maybePrintDepTree, maybePrintDepGraph } from '../../../lib/print-deps';
 import { monitor as snykMonitor } from '../../../lib/monitor';
 import { processJsonMonitorResponse } from './process-json-monitor';
-import snyk = require('../../../lib'); // TODO(kyegupov): fix import
+const snyk = require('../../../lib');
 import { formatMonitorOutput } from '../../../lib/formatters';
 import { getDepsFromPlugin } from '../../../lib/plugins/get-deps-from-plugin';
 import { getExtraProjectCount } from '../../../lib/plugins/get-extra-project-count';
@@ -125,6 +125,15 @@ export default async function monitor(...args0: MethodArgs): Promise<any> {
       ) {
         console.log(theme.color.status.warn(appVulnsReleaseWarningMsg));
       }
+    }
+
+    // Check scanUsrLibJars feature flag and add --include-system-jars parameter
+    const scanUsrLibJarsEnabled = await hasFeatureFlag(
+      'scanUsrLibJars',
+      options,
+    );
+    if (scanUsrLibJarsEnabled) {
+      options['include-system-jars'] = true;
     }
   }
 

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -127,6 +127,15 @@ export default async function test(
         console.log(theme.color.status.warn(appVulnsReleaseWarningMsg));
       }
     }
+
+    // Check scanUsrLibJars feature flag and add --include-system-jars parameter
+    const scanUsrLibJarsEnabled = await hasFeatureFlag(
+      'scanUsrLibJars',
+      options,
+    );
+    if (scanUsrLibJarsEnabled) {
+      options['include-system-jars'] = true;
+    }
   }
 
   const ecosystem = getEcosystemForTest(options);
@@ -251,7 +260,7 @@ export default async function test(
       // Note: this is done based on the logic done below
       // for non-json/sarif outputs, where we take the code of
       // the first error.
-      err.code = errorResults[0].code;
+      (err as any).code = (errorResults[0] as any).code;
     }
     err.json = stringifiedData;
     err.jsonStringifiedResults = stringifiedJsonData;
@@ -300,10 +309,10 @@ export default async function test(
     // translation
     // HACK as there can be different errors, and we pass only the
     // first one
-    error.code = errorResults[0].code;
-    error.userMessage = errorResults[0].userMessage;
-    error.strCode = errorResults[0].strCode;
-    error.innerError = errorResults[0].innerError;
+    (error as any).code = (errorResults[0] as any).code;
+    (error as any).userMessage = (errorResults[0] as any).userMessage;
+    (error as any).strCode = (errorResults[0] as any).strCode;
+    (error as any).innerError = (errorResults[0] as any).innerError;
     throw error;
   }
 

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -17,6 +17,7 @@ const featureFlagDefaults = (): Map<string, boolean> => {
     ['enablePnpmCli', false],
     ['sbomMonitorBeta', false],
     ['useImprovedDotnetWithoutPublish', false],
+    ['scanUsrLibJars', false],
 
     // Default these to false.
     // TODO: Future acceptance tests targeting these features and their

--- a/test/tap/cli-test/cli-test.docker.spec.ts
+++ b/test/tap/cli-test/cli-test.docker.spec.ts
@@ -65,13 +65,13 @@ export const DockerTests: AcceptanceTests = {
         [
           {
             docker: true,
-            'exclude-app-vulns': false,
             org: 'explicit-org',
-            projectName: null,
-            packageManager: null,
-            path: 'foo:latest',
             showVulnPaths: 'some',
             maxVulnPaths: undefined,
+            'exclude-app-vulns': false,
+            path: 'foo:latest',
+            projectName: undefined,
+            packageManager: undefined,
           },
         ],
         'calls docker plugin with expected arguments',
@@ -142,13 +142,13 @@ export const DockerTests: AcceptanceTests = {
           [
             {
               docker: true,
-              'exclude-app-vulns': false,
               org: 'explicit-org',
-              projectName: null,
-              packageManager: null,
-              path: 'foo:latest',
               showVulnPaths: 'some',
               maxVulnPaths: undefined,
+              'exclude-app-vulns': false,
+              path: 'foo:latest',
+              projectName: undefined,
+              packageManager: undefined,
             },
           ],
           'calls docker plugin with expected arguments',
@@ -177,7 +177,7 @@ export const DockerTests: AcceptanceTests = {
         t,
       );
 
-      const vulns = require(getFixturePath('docker/find-result.json'));
+      const vulns = await import(getFixturePath('docker/find-result.json'));
       params.server.setNextResponse(vulns);
 
       try {
@@ -296,13 +296,13 @@ export const DockerTests: AcceptanceTests = {
           {
             file: 'Dockerfile',
             docker: true,
-            'exclude-app-vulns': false,
             org: 'explicit-org',
-            projectName: null,
-            packageManager: null,
-            path: 'foo:latest',
             showVulnPaths: 'some',
             maxVulnPaths: undefined,
+            'exclude-app-vulns': false,
+            path: 'foo:latest',
+            projectName: undefined,
+            packageManager: undefined,
           },
         ],
         'calls docker plugin with expected arguments',
@@ -331,8 +331,8 @@ export const DockerTests: AcceptanceTests = {
           },
           t,
         );
-        const vulns = require(
-          getFixturePath('docker/find-result-remediation.json'),
+        const vulns = await import(
+          getFixturePath('docker/find-result-remediation.json')
         );
         params.server.setNextResponse(vulns);
 
@@ -409,13 +409,13 @@ export const DockerTests: AcceptanceTests = {
           [
             {
               docker: true,
-              'exclude-app-vulns': false,
               org: 'explicit-org',
-              projectName: null,
-              packageManager: null,
-              path: 'foo:latest',
               showVulnPaths: 'some',
               maxVulnPaths: undefined,
+              'exclude-app-vulns': false,
+              path: 'foo:latest',
+              projectName: undefined,
+              packageManager: undefined,
             },
           ],
           'calls docker plugin with expected arguments',
@@ -484,13 +484,13 @@ export const DockerTests: AcceptanceTests = {
           [
             {
               docker: true,
-              'exclude-app-vulns': false,
               org: 'explicit-org',
-              projectName: null,
-              packageManager: null,
-              path: 'foo:latest',
               showVulnPaths: 'some',
               maxVulnPaths: undefined,
+              'exclude-app-vulns': false,
+              path: 'foo:latest',
+              projectName: undefined,
+              packageManager: undefined,
               'policy-path': 'npm-package-policy/custom-location',
             },
           ],
@@ -567,13 +567,13 @@ export const DockerTests: AcceptanceTests = {
         [
           {
             docker: true,
-            'exclude-app-vulns': false,
             org: 'explicit-org',
-            projectName: null,
-            packageManager: null,
-            path: 'foo:latest',
             showVulnPaths: 'some',
             maxVulnPaths: undefined,
+            'exclude-app-vulns': false,
+            path: 'foo:latest',
+            projectName: undefined,
+            packageManager: undefined,
           },
         ],
         'calls docker plugin with expected arguments',
@@ -609,8 +609,8 @@ export const DockerTests: AcceptanceTests = {
           t,
         );
 
-        const vulns = require(
-          getFixturePath('docker/find-result-binaries.json'),
+        const vulns = await import(
+          getFixturePath('docker/find-result-binaries.json')
         );
         params.server.setNextResponse(vulns);
 
@@ -678,8 +678,8 @@ export const DockerTests: AcceptanceTests = {
           t,
         );
 
-        const vulns = require(
-          getFixturePath('docker/find-result-remediation.json'),
+        const vulns = await import(
+          getFixturePath('docker/find-result-remediation.json')
         );
         params.server.setNextResponse(vulns);
 
@@ -727,8 +727,8 @@ export const DockerTests: AcceptanceTests = {
           t,
         );
 
-        const vulns = require(
-          getFixturePath('docker/find-result-remediation.json'),
+        const vulns = await import(
+          getFixturePath('docker/find-result-remediation.json')
         );
         params.server.setNextResponse(vulns);
 
@@ -749,8 +749,8 @@ export const DockerTests: AcceptanceTests = {
         sarif: true,
       });
       const results = JSON.parse(testableObject.message);
-      const sarifResults = require(
-        getFixturePath('docker/sarif-container-result.json'),
+      const sarifResults = await import(
+        getFixturePath('docker/sarif-container-result.json')
       );
       t.same(results, sarifResults, 'stdout containing sarif results');
       t.end();
@@ -763,8 +763,8 @@ export const DockerTests: AcceptanceTests = {
           file: 'Dockerfile',
         });
         const results = JSON.parse(testableObject.message);
-        const sarifResults = require(
-          getFixturePath('docker/sarif-with-file-container-result.json'),
+        const sarifResults = await import(
+          getFixturePath('docker/sarif-with-file-container-result.json')
         );
         t.same(results, sarifResults, 'stdout containing sarif results');
         t.end();
@@ -810,7 +810,7 @@ export const DockerTests: AcceptanceTests = {
 function stubDockerPluginResponse(plugins, fixture: string | object, t) {
   const plugin = {
     async scan() {
-      return typeof fixture === 'object' ? fixture : require(fixture);
+      return typeof fixture === 'object' ? fixture : await import(fixture);
     },
     async display() {
       return '';
@@ -858,7 +858,7 @@ async function testSarif(t, utils, params, flags) {
 
 async function testPrep(t, utils, params, additionaLpropsForCli) {
   utils.chdirWorkspaces();
-  const vulns = require(getFixturePath('docker/find-result.json'));
+  const vulns = await import(getFixturePath('docker/find-result.json'));
   params.server.setNextResponse(vulns);
 
   try {


### PR DESCRIPTION
use the --include-system-jars option on the Snyk Docker Plugin to scan the usr/lib folder for JAR files

## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Reads the `scanUsrLibJars` feature flag and correspondingly sets the `--include-system-jars` parameter when calling snyk-docker-plugin

## Where should the reviewer start?

Main change is in test (cli/commands/test/index.ts) and monitor (cli/commands/monitor/index.ts) command files.  The rest is updating testing.

## How should this be manually tested?

A default `snyk container test/monitor` should return identical results (since the feature flag is off by default).  You can turn the feature flag on, then us `--print-deps` on a container image with JARs in the usr/lib (example openjdk:8-jdk-alpine), and ensure that they show up.  

## What's the product update that needs to be communicated to CLI users?

No change to CLI users.  We will work with the clients who have requested the feature to get the feature flag & functionality turned on for them.


## Risk assessment (Low | Medium | High)?

Low

## Any background context you want to provide?

This is because we are having issues reading JARs on certian base images.  Specifically Chainguard images ever since they switched to the usrmerge format back in May.

## What are the relevant tickets?

CN-352
CN-340
CN-337
CN-249
