### PR TITLE
feat(test): Adds support for maven metaversions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "snyk-go-plugin": "1.23.0",
         "snyk-gradle-plugin": "5.1.0",
         "snyk-module": "3.1.0",
-        "snyk-mvn-plugin": "4.1.0",
+        "snyk-mvn-plugin": "4.3.0",
         "snyk-nodejs-lockfile-parser": "2.2.2",
         "snyk-nodejs-plugin": "1.4.4",
         "snyk-nuget-plugin": "2.11.0",
@@ -3049,9 +3049,9 @@
       }
     },
     "node_modules/@snyk/dep-graph": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-2.8.1.tgz",
-      "integrity": "sha512-bh/uAQBPboj7rDReEAiEN6ukP7dsj5pTRW3fLXVvOXuLb3PN5SC+wj80iAhCNjuiKRSoelt/GHlsngGzUMOwOg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-2.9.0.tgz",
+      "integrity": "sha512-K+0ehJ1ld91LFz88FJEdYJf00f1UnhAacvxe2sm/h9fIXmvd08Yl6o89RcIb5y2H+vBUS4qTxs9VKP+MIRnmDA==",
       "dependencies": {
         "event-loop-spinner": "^2.1.0",
         "lodash.clone": "^4.5.0",
@@ -20950,15 +20950,16 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-mvn-plugin": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-4.1.0.tgz",
-      "integrity": "sha512-qPt1tq1A8UQJX31XUbon9e++i4Etk+FPBdY7JQZiLTbnwF0gTwobYZDuxmpmcjbHgLNJXl6YOg9PkpL6OCiiIA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-4.3.0.tgz",
+      "integrity": "sha512-JZUKD0GSDi3cZ6O+RdMXp3dtsE6Vn0yFOdkHe2fr1mdvHmK3ZRFDTbRfjLjXg4jG2HiwsTCCUUG1Bod81dxc6g==",
       "dependencies": {
-        "@snyk/cli-interface": "2.11.3",
-        "@snyk/dep-graph": "^1.23.1",
+        "@common.js/yocto-queue": "^1.1.1",
+        "@snyk/cli-interface": "2.14.1",
+        "@snyk/dep-graph": "^2.9.0",
         "debug": "^4.3.4",
         "glob": "^7.1.6",
-        "packageurl-js": "^1.0.0",
+        "packageurl-js": "^2.0.1",
         "shescape": "^2.1.4",
         "tslib": "^2.4.0"
       },
@@ -20967,68 +20968,20 @@
       }
     },
     "node_modules/snyk-mvn-plugin/node_modules/@snyk/cli-interface": {
-      "version": "2.11.3",
-      "resolved": "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-2.11.3.tgz",
-      "integrity": "sha512-VQa8nKGQj+gJnRWXzOd5wzinXEjvA/Yna6I34lV2hiTRKA/quttWyzr6AH9KhSovd/4SflUYbu6EKuattrAEMw==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-2.14.1.tgz",
+      "integrity": "sha512-7ooHTlw9tY96ZeLwd+ICzikkgj8Qc4ZyUuXaDEhQzI5Ap/3GStukRDcGsXpsVZp0e/SDMEb690qgK9PefUWz0Q==",
       "dependencies": {
         "@types/graphlib": "^2"
       },
       "peerDependencies": {
-        "@snyk/dep-graph": "^1"
+        "@snyk/dep-graph": ">=1"
       }
     },
-    "node_modules/snyk-mvn-plugin/node_modules/@snyk/dep-graph": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.31.0.tgz",
-      "integrity": "sha512-nGSua40dcI/ISDDW46EYSjwVZxdWohb4bDlHFYtudL5bxo0PV9wFA1QeZewKQVeHLVaGkrESXdqQubP0pFf4vA==",
-      "dependencies": {
-        "event-loop-spinner": "^2.1.0",
-        "lodash.clone": "^4.5.0",
-        "lodash.constant": "^3.0.0",
-        "lodash.filter": "^4.6.0",
-        "lodash.foreach": "^4.5.0",
-        "lodash.isempty": "^4.4.0",
-        "lodash.isequal": "^4.5.0",
-        "lodash.isfunction": "^3.0.9",
-        "lodash.isundefined": "^3.0.1",
-        "lodash.keys": "^4.2.0",
-        "lodash.map": "^4.6.0",
-        "lodash.reduce": "^4.6.0",
-        "lodash.size": "^4.2.0",
-        "lodash.transform": "^4.6.0",
-        "lodash.union": "^4.6.0",
-        "lodash.values": "^4.3.0",
-        "object-hash": "^2.0.3",
-        "semver": "^7.0.0",
-        "tslib": "^1.13.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/snyk-mvn-plugin/node_modules/@snyk/dep-graph/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/snyk-mvn-plugin/node_modules/object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/snyk-mvn-plugin/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
+    "node_modules/snyk-mvn-plugin/node_modules/packageurl-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-2.0.1.tgz",
+      "integrity": "sha512-N5ixXjzTy4QDQH0Q9YFjqIWd6zH6936Djpl2m9QNFmDv5Fum8q8BjkpAcHNMzOFE0IwQrFhJWex3AN6kS0OSwg=="
     },
     "node_modules/snyk-mvn-plugin/node_modules/shescape": {
       "version": "2.1.4",
@@ -27421,9 +27374,9 @@
       }
     },
     "@snyk/dep-graph": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-2.8.1.tgz",
-      "integrity": "sha512-bh/uAQBPboj7rDReEAiEN6ukP7dsj5pTRW3fLXVvOXuLb3PN5SC+wj80iAhCNjuiKRSoelt/GHlsngGzUMOwOg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-2.9.0.tgz",
+      "integrity": "sha512-K+0ehJ1ld91LFz88FJEdYJf00f1UnhAacvxe2sm/h9fIXmvd08Yl6o89RcIb5y2H+vBUS4qTxs9VKP+MIRnmDA==",
       "requires": {
         "event-loop-spinner": "^2.1.0",
         "lodash.clone": "^4.5.0",
@@ -40935,69 +40888,32 @@
       }
     },
     "snyk-mvn-plugin": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-4.1.0.tgz",
-      "integrity": "sha512-qPt1tq1A8UQJX31XUbon9e++i4Etk+FPBdY7JQZiLTbnwF0gTwobYZDuxmpmcjbHgLNJXl6YOg9PkpL6OCiiIA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-4.3.0.tgz",
+      "integrity": "sha512-JZUKD0GSDi3cZ6O+RdMXp3dtsE6Vn0yFOdkHe2fr1mdvHmK3ZRFDTbRfjLjXg4jG2HiwsTCCUUG1Bod81dxc6g==",
       "requires": {
-        "@snyk/cli-interface": "2.11.3",
-        "@snyk/dep-graph": "^1.23.1",
+        "@common.js/yocto-queue": "^1.1.1",
+        "@snyk/cli-interface": "2.14.1",
+        "@snyk/dep-graph": "^2.9.0",
         "debug": "^4.3.4",
         "glob": "^7.1.6",
-        "packageurl-js": "^1.0.0",
+        "packageurl-js": "^2.0.1",
         "shescape": "^2.1.4",
         "tslib": "^2.4.0"
       },
       "dependencies": {
         "@snyk/cli-interface": {
-          "version": "2.11.3",
-          "resolved": "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-2.11.3.tgz",
-          "integrity": "sha512-VQa8nKGQj+gJnRWXzOd5wzinXEjvA/Yna6I34lV2hiTRKA/quttWyzr6AH9KhSovd/4SflUYbu6EKuattrAEMw==",
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-2.14.1.tgz",
+          "integrity": "sha512-7ooHTlw9tY96ZeLwd+ICzikkgj8Qc4ZyUuXaDEhQzI5Ap/3GStukRDcGsXpsVZp0e/SDMEb690qgK9PefUWz0Q==",
           "requires": {
             "@types/graphlib": "^2"
           }
         },
-        "@snyk/dep-graph": {
-          "version": "1.31.0",
-          "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-1.31.0.tgz",
-          "integrity": "sha512-nGSua40dcI/ISDDW46EYSjwVZxdWohb4bDlHFYtudL5bxo0PV9wFA1QeZewKQVeHLVaGkrESXdqQubP0pFf4vA==",
-          "requires": {
-            "event-loop-spinner": "^2.1.0",
-            "lodash.clone": "^4.5.0",
-            "lodash.constant": "^3.0.0",
-            "lodash.filter": "^4.6.0",
-            "lodash.foreach": "^4.5.0",
-            "lodash.isempty": "^4.4.0",
-            "lodash.isequal": "^4.5.0",
-            "lodash.isfunction": "^3.0.9",
-            "lodash.isundefined": "^3.0.1",
-            "lodash.keys": "^4.2.0",
-            "lodash.map": "^4.6.0",
-            "lodash.reduce": "^4.6.0",
-            "lodash.size": "^4.2.0",
-            "lodash.transform": "^4.6.0",
-            "lodash.union": "^4.6.0",
-            "lodash.values": "^4.3.0",
-            "object-hash": "^2.0.3",
-            "semver": "^7.0.0",
-            "tslib": "^1.13.0"
-          },
-          "dependencies": {
-            "tslib": {
-              "version": "1.14.1",
-              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-            }
-          }
-        },
-        "object-hash": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-          "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="
-        },
-        "semver": {
-          "version": "7.7.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-          "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="
+        "packageurl-js": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-2.0.1.tgz",
+          "integrity": "sha512-N5ixXjzTy4QDQH0Q9YFjqIWd6zH6936Djpl2m9QNFmDv5Fum8q8BjkpAcHNMzOFE0IwQrFhJWex3AN6kS0OSwg=="
         },
         "shescape": {
           "version": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "snyk-go-plugin": "1.23.0",
     "snyk-gradle-plugin": "5.1.0",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "4.1.0",
+    "snyk-mvn-plugin": "4.3.0",
     "snyk-nodejs-lockfile-parser": "2.2.2",
     "snyk-nodejs-plugin": "1.4.4",
     "snyk-nuget-plugin": "2.11.0",

--- a/test/fixtures/maven-metaversion/pom.xml
+++ b/test/fixtures/maven-metaversion/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.snyk.example</groupId>
+  <artifactId>maven-metaversion</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>Maven Metaversion Test Project</name>
+  <description>Fixture to verify Maven metaversion (LATEST/RELEASE) resolution</description>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <!-- Metaversion LATEST (compile scope) -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>LATEST</version>
+    </dependency>
+
+    <!-- Metaversion RELEASE (compile scope) -->
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>RELEASE</version>
+    </dependency>
+  </dependencies>
+
+</project>
+
+


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps `snyk-mvn-plugin` to `v4.3.0` and adds simple fixture exercising metaversion resolution.
`snyk-mvn-plugin` contains two notable PRS:
- https://github.com/snyk/snyk-mvn-plugin/pull/198 -- adds support for fingerprinting of artifacts
- https://github.com/snyk/snyk-mvn-plugin/pull/202 -- adds support for maven metaversions

We are only concerned with the features added by the second PR. The first has its functionality locked behind additional options and will _not_ affect the behaviour of the `snyk-mvn-plugin` without changes to the `cli` as well as various `cliv2` extension repositories. See [here](https://github.com/snyk/snyk-mvn-plugin/pull/198/files#diff-d5a4b3a0309f2337144861084c1014523cced561eb722cb9684c63f5e41e0567R114) and [here](https://github.com/snyk/snyk-mvn-plugin/pull/198/files#diff-ad4616cb0616dcd162c2d00bcfc9ff4c0ff34b9e4c204e26b2911373b2c033d9R26).

This correctly resolves the versions represented by maven metaversions (`RELEASE`/`LATEST`), which while deprecated still see some use. These were correctly resolved on older versions of the `maven-dependency-plugin`, however, more recent versions are not resolving them. This also presents a problem for sbom generation which calls the `snyk-mvn-plugin` with the `print-graph` option, which in turn results in us using a more recent `maven-dependency-plugin` version due to requiring verbose output.

This is also built to degrade gracefully in cases where the `mvn dependency:resolve` command fails, and should still result in mostly complete testing output.

## Where should the reviewer start?

The test fixture and added test. Additionally, the PR updating `snyk-mvn-plugin`: https://github.com/snyk/snyk-mvn-plugin/pull/202

## How should this be manually tested?

### `snyk test`
1. Build the legacy cli via `npm install && npm run build-cli:prod`.
2. Auth the built cli with `/path/to/cli/bin/snyk auth`
3. Use a recent version of maven such as `3.9.11` (`sdk install maven 3.9.11`).
4. Test the metaversion fixture with: `/path/to/cli/bin/snyk test --all-projects` as well as with the `--print-graph` flag. The latter clearly shows the lack of metaversions present.
5. Compare with output from current cli.

### `snyk sbom`
1. Build the legacy cli as above. Then build the v2 cli via `make clean pre-build build`
2. Auth the built cli with `/path/to/cli/binary-releases/snyk-${arch} auth`
3. Test the metaversion fixture with `snyk sbom`

Compare (note the metaversion: `{"id":"org.jboss.resteasy:resteasy-core@RELEASE","info":{"name":"org.jboss.resteasy:resteasy-core","version":"RELEASE"}}`):
```
❯ snyk test --all-projects --print-graph
DepGraph data:
{"schemaVersion":"1.2.0","pkgManager":{"name":"maven"},"pkgs":[{"id":"io.snyk.os-managed:bad-resolution@1.0.0","info":{"name":"io.snyk.os-managed:bad-resolution","version":"1.0.0"}},{"id":"org.jboss.resteasy:resteasy-core@RELEASE","info":{"name":"org.jboss.resteasy:resteasy-core","version":"RELEASE"}},{"id":"com.ibm.async:asyncutil@0.1.0","info":{"name":"com.ibm.async:asyncutil","version":"0.1.0"}},{"id":"jakarta.validation:jakarta.validation-api@3.1.1","info":{"name":"jakarta.validation:jakarta.validation-api","version":"3.1.1"}},{"id":"org.eclipse.angus:angus-activation@2.0.2","info":{"name":"org.eclipse.angus:angus-activation","version":"2.0.2"}},{"id":"jakarta.activation:jakarta.activation-api@2.1.3","info":{"name":"jakarta.activation:jakarta.activation-api","version":"2.1.3"}},{"id":"org.reactivestreams:reactive-streams@1.0.4","info":{"name":"org.reactivestreams:reactive-streams","version":"1.0.4"}},{"id":"org.jboss.resteasy:resteasy-core-spi@7.0.0.Beta1","info":{"name":"org.jboss.resteasy:resteasy-core-spi","version":"7.0.0.Beta1"}},{"id":"jakarta.xml.bind:jakarta.xml.bind-api@3.0.1","info":{"name":"jakarta.xml.bind:jakarta.xml.bind-api","version":"3.0.1"}},{"id":"jakarta.ws.rs:jakarta.ws.rs-api@4.0.0","info":{"name":"jakarta.ws.rs:jakarta.ws.rs-api","version":"4.0.0"}},{"id":"jakarta.annotation:jakarta.annotation-api@2.1.1","info":{"name":"jakarta.annotation:jakarta.annotation-api","version":"2.1.1"}},{"id":"org.jboss.logging:jboss-logging@3.6.1.Final","info":{"name":"org.jboss.logging:jboss-logging","version":"3.6.1.Final"}},{"id":"io.smallrye:jandex@3.2.7","info":{"name":"io.smallrye:jandex","version":"3.2.7"}}],"graph":{"rootNodeId":"root-node","nodes":[{"nodeId":"root-node","pkgId":"io.snyk.os-managed:bad-resolution@1.0.0","deps":[{"nodeId":"org.jboss.resteasy:resteasy-core:jar:RELEASE:compile"}]},{"nodeId":"org.jboss.resteasy:resteasy-core:jar:RELEASE:compile","pkgId":"org.jboss.resteasy:resteasy-core@RELEASE","deps":[{"nodeId":"com.ibm.async:asyncutil:jar:0.1.0:compile"},{"nodeId":"jakarta.validation:jakarta.validation-api:jar:3.1.1:compile"},{"nodeId":"org.eclipse.angus:angus-activation:jar:2.0.2:compile"},{"nodeId":"jakarta.activation:jakarta.activation-api:jar:2.1.3:compile"},{"nodeId":"org.reactivestreams:reactive-streams:jar:1.0.4:compile"},{"nodeId":"org.jboss.resteasy:resteasy-core-spi:jar:7.0.0.Beta1:compile"},{"nodeId":"io.smallrye:jandex:jar:3.2.7:compile"},{"nodeId":"jakarta.xml.bind:jakarta.xml.bind-api:jar:3.0.1:compile"},{"nodeId":"jakarta.ws.rs:jakarta.ws.rs-api:jar:4.0.0:compile"},{"nodeId":"jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile"},{"nodeId":"org.jboss.logging:jboss-logging:jar:3.6.1.Final:compile"}]},{"nodeId":"com.ibm.async:asyncutil:jar:0.1.0:compile","pkgId":"com.ibm.async:asyncutil@0.1.0","deps":[]},{"nodeId":"jakarta.validation:jakarta.validation-api:jar:3.1.1:compile","pkgId":"jakarta.validation:jakarta.validation-api@3.1.1","deps":[]},{"nodeId":"org.eclipse.angus:angus-activation:jar:2.0.2:compile","pkgId":"org.eclipse.angus:angus-activation@2.0.2","deps":[]},{"nodeId":"jakarta.activation:jakarta.activation-api:jar:2.1.3:compile","pkgId":"jakarta.activation:jakarta.activation-api@2.1.3","deps":[]},{"nodeId":"org.reactivestreams:reactive-streams:jar:1.0.4:compile","pkgId":"org.reactivestreams:reactive-streams@1.0.4","deps":[]},{"nodeId":"org.jboss.resteasy:resteasy-core-spi:jar:7.0.0.Beta1:compile","pkgId":"org.jboss.resteasy:resteasy-core-spi@7.0.0.Beta1","deps":[{"nodeId":"jakarta.validation:jakarta.validation-api:jar:3.1.1:compile"},{"nodeId":"org.reactivestreams:reactive-streams:jar:1.0.4:compile"},{"nodeId":"jakarta.xml.bind:jakarta.xml.bind-api:jar:3.0.1:compile"},{"nodeId":"jakarta.ws.rs:jakarta.ws.rs-api:jar:4.0.0:compile"},{"nodeId":"jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile"},{"nodeId":"org.jboss.logging:jboss-logging:jar:3.6.1.Final:compile"}]},{"nodeId":"jakarta.xml.bind:jakarta.xml.bind-api:jar:3.0.1:compile","pkgId":"jakarta.xml.bind:jakarta.xml.bind-api@3.0.1","deps":[]},{"nodeId":"jakarta.ws.rs:jakarta.ws.rs-api:jar:4.0.0:compile","pkgId":"jakarta.ws.rs:jakarta.ws.rs-api@4.0.0","deps":[]},{"nodeId":"jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile","pkgId":"jakarta.annotation:jakarta.annotation-api@2.1.1","deps":[]},{"nodeId":"org.jboss.logging:jboss-logging:jar:3.6.1.Final:compile","pkgId":"org.jboss.logging:jboss-logging@3.6.1.Final","deps":[]},{"nodeId":"io.smallrye:jandex:jar:3.2.7:compile","pkgId":"io.smallrye:jandex@3.2.7","deps":[]}]}}
```
Versus (metaversion is resolved `{"id":"org.jboss.resteasy:resteasy-core@7.0.0.Beta1","info":{"name":"org.jboss.resteasy:resteasy-core","version":"7.0.0.Beta1"}}`):
```
❯ ~/code/cli/bin/snyk test --all-projects --print-graph
DepGraph data:
{"schemaVersion":"1.3.0","pkgManager":{"name":"maven"},"pkgs":[{"id":"io.snyk.os-managed:bad-resolution@1.0.0","info":{"name":"io.snyk.os-managed:bad-resolution","version":"1.0.0"}},{"id":"org.jboss.resteasy:resteasy-core@7.0.0.Beta1","info":{"name":"org.jboss.resteasy:resteasy-core","version":"7.0.0.Beta1"}},{"id":"com.ibm.async:asyncutil@0.1.0","info":{"name":"com.ibm.async:asyncutil","version":"0.1.0"}},{"id":"jakarta.validation:jakarta.validation-api@3.1.1","info":{"name":"jakarta.validation:jakarta.validation-api","version":"3.1.1"}},{"id":"org.eclipse.angus:angus-activation@2.0.2","info":{"name":"org.eclipse.angus:angus-activation","version":"2.0.2"}},{"id":"jakarta.activation:jakarta.activation-api@2.1.3","info":{"name":"jakarta.activation:jakarta.activation-api","version":"2.1.3"}},{"id":"org.reactivestreams:reactive-streams@1.0.4","info":{"name":"org.reactivestreams:reactive-streams","version":"1.0.4"}},{"id":"org.jboss.resteasy:resteasy-core-spi@7.0.0.Beta1","info":{"name":"org.jboss.resteasy:resteasy-core-spi","version":"7.0.0.Beta1"}},{"id":"jakarta.xml.bind:jakarta.xml.bind-api@3.0.1","info":{"name":"jakarta.xml.bind:jakarta.xml.bind-api","version":"3.0.1"}},{"id":"jakarta.ws.rs:jakarta.ws.rs-api@4.0.0","info":{"name":"jakarta.ws.rs:jakarta.ws.rs-api","version":"4.0.0"}},{"id":"jakarta.annotation:jakarta.annotation-api@2.1.1","info":{"name":"jakarta.annotation:jakarta.annotation-api","version":"2.1.1"}},{"id":"org.jboss.logging:jboss-logging@3.6.1.Final","info":{"name":"org.jboss.logging:jboss-logging","version":"3.6.1.Final"}},{"id":"io.smallrye:jandex@3.2.7","info":{"name":"io.smallrye:jandex","version":"3.2.7"}}],"graph":{"rootNodeId":"root-node","nodes":[{"nodeId":"root-node","pkgId":"io.snyk.os-managed:bad-resolution@1.0.0","deps":[{"nodeId":"org.jboss.resteasy:resteasy-core:jar:7.0.0.Beta1:compile"}]},{"nodeId":"org.jboss.resteasy:resteasy-core:jar:7.0.0.Beta1:compile","pkgId":"org.jboss.resteasy:resteasy-core@7.0.0.Beta1","deps":[{"nodeId":"com.ibm.async:asyncutil:jar:0.1.0:compile"},{"nodeId":"jakarta.validation:jakarta.validation-api:jar:3.1.1:compile"},{"nodeId":"org.eclipse.angus:angus-activation:jar:2.0.2:compile"},{"nodeId":"jakarta.activation:jakarta.activation-api:jar:2.1.3:compile"},{"nodeId":"org.reactivestreams:reactive-streams:jar:1.0.4:compile"},{"nodeId":"org.jboss.resteasy:resteasy-core-spi:jar:7.0.0.Beta1:compile"},{"nodeId":"io.smallrye:jandex:jar:3.2.7:compile"},{"nodeId":"jakarta.xml.bind:jakarta.xml.bind-api:jar:3.0.1:compile"},{"nodeId":"jakarta.ws.rs:jakarta.ws.rs-api:jar:4.0.0:compile"},{"nodeId":"jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile"},{"nodeId":"org.jboss.logging:jboss-logging:jar:3.6.1.Final:compile"}]},{"nodeId":"com.ibm.async:asyncutil:jar:0.1.0:compile","pkgId":"com.ibm.async:asyncutil@0.1.0","deps":[]},{"nodeId":"jakarta.validation:jakarta.validation-api:jar:3.1.1:compile","pkgId":"jakarta.validation:jakarta.validation-api@3.1.1","deps":[]},{"nodeId":"org.eclipse.angus:angus-activation:jar:2.0.2:compile","pkgId":"org.eclipse.angus:angus-activation@2.0.2","deps":[]},{"nodeId":"jakarta.activation:jakarta.activation-api:jar:2.1.3:compile","pkgId":"jakarta.activation:jakarta.activation-api@2.1.3","deps":[]},{"nodeId":"org.reactivestreams:reactive-streams:jar:1.0.4:compile","pkgId":"org.reactivestreams:reactive-streams@1.0.4","deps":[]},{"nodeId":"org.jboss.resteasy:resteasy-core-spi:jar:7.0.0.Beta1:compile","pkgId":"org.jboss.resteasy:resteasy-core-spi@7.0.0.Beta1","deps":[{"nodeId":"jakarta.validation:jakarta.validation-api:jar:3.1.1:compile"},{"nodeId":"org.reactivestreams:reactive-streams:jar:1.0.4:compile"},{"nodeId":"jakarta.xml.bind:jakarta.xml.bind-api:jar:3.0.1:compile"},{"nodeId":"jakarta.ws.rs:jakarta.ws.rs-api:jar:4.0.0:compile"},{"nodeId":"jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile"},{"nodeId":"org.jboss.logging:jboss-logging:jar:3.6.1.Final:compile"}]},{"nodeId":"jakarta.xml.bind:jakarta.xml.bind-api:jar:3.0.1:compile","pkgId":"jakarta.xml.bind:jakarta.xml.bind-api@3.0.1","deps":[]},{"nodeId":"jakarta.ws.rs:jakarta.ws.rs-api:jar:4.0.0:compile","pkgId":"jakarta.ws.rs:jakarta.ws.rs-api@4.0.0","deps":[]},{"nodeId":"jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile","pkgId":"jakarta.annotation:jakarta.annotation-api@2.1.1","deps":[]},{"nodeId":"org.jboss.logging:jboss-logging:jar:3.6.1.Final:compile","pkgId":"org.jboss.logging:jboss-logging@3.6.1.Final","deps":[]},{"nodeId":"io.smallrye:jandex:jar:3.2.7:compile","pkgId":"io.smallrye:jandex@3.2.7","deps":[]}]}}
```

## What's the product update that needs to be communicated to CLI users?

- **test**: Maven projects relying on metaversions (`RELEASE`/`LATEST`) using recent versions of the `maven-dependncy-plugin`, will now have those metaversions correctly resolved for `snyk test`
- **sbom**: Maven projects relying on metaversions should now have those dependencies fully resolved in sbom output.

## Risk assessment -- Low

While the update to `snyk-mvn-plugin` contains two significant pieces of work, the first (fingerprinting) is hidden behind optional flags that are not yet accessible.
And the second (metaversion resolution) is designed to gracefully degrade -- providing at worst the current behaviour.

## Any background context you want to provide?

Maven has previously supported metaversions such as RELEASE and LATEST. These are deprecated, but are still supported as recently as 4.0.0-rc-4, inconveniently on old versions of the dependency plugin these metaversions would be fully resolved. However, on more recent versions they are not.
```
[INFO] io.snyk.os-managed:bad-resolution:jar:1.0.0
[INFO] \- org.jboss.resteasy:resteasy-core:jar:7.0.0.Beta1:compile
[INFO]    +- org.jboss.logging:jboss-logging:jar:3.6.1.Final:compile
[INFO]    +- jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile
[INFO]    +- jakarta.ws.rs:jakarta.ws.rs-api:jar:4.0.0:compile
[INFO]    +- jakarta.xml.bind:jakarta.xml.bind-api:jar:3.0.1:compile
[INFO]    +- io.smallrye:jandex:jar:3.2.7:compile
[INFO]    +- org.jboss.resteasy:resteasy-core-spi:jar:7.0.0.Beta1:compile
[INFO]    +- org.reactivestreams:reactive-streams:jar:1.0.4:compile
[INFO]    +- jakarta.activation:jakarta.activation-api:jar:2.1.3:compile
[INFO]    +- org.eclipse.angus:angus-activation:jar:2.0.2:compile
[INFO]    +- jakarta.validation:jakarta.validation-api:jar:3.1.1:compile
[INFO]    \- com.ibm.async:asyncutil:jar:0.1.0:compile
```
```
[INFO] io.snyk.os-managed:bad-resolution:jar:1.0.0
[INFO] \- org.jboss.resteasy:resteasy-core:jar:RELEASE:compile
[INFO]    +- org.jboss.logging:jboss-logging:jar:3.6.1.Final:compile
[INFO]    +- jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile
[INFO]    +- jakarta.ws.rs:jakarta.ws.rs-api:jar:4.0.0:compile
[INFO]    +- jakarta.xml.bind:jakarta.xml.bind-api:jar:3.0.1:compile
[INFO]    +- io.smallrye:jandex:jar:3.2.7:compile
[INFO]    +- org.jboss.resteasy:resteasy-core-spi:jar:7.0.0.Beta1:compile
[INFO]    +- org.reactivestreams:reactive-streams:jar:1.0.4:compile
[INFO]    +- jakarta.activation:jakarta.activation-api:jar:2.1.3:compile
[INFO]    +- org.eclipse.angus:angus-activation:jar:2.0.2:compile
[INFO]    +- jakarta.validation:jakarta.validation-api:jar:3.1.1:compile
[INFO]    \- com.ibm.async:asyncutil:jar:0.1.0:compile
```

## What are the relevant tickets?

- [OSE-37](https://snyksec.atlassian.net/browse/OSE-37)


[OSE-37]: https://snyksec.atlassian.net/browse/OSE-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ