### PR TITLE
chore: add snyk mcp metadata field

### DIFF
--- a/ts-binary-wrapper/package.json
+++ b/ts-binary-wrapper/package.json
@@ -2,6 +2,7 @@
   "name": "snyk",
   "version": "1.0.0-monorepo",
   "description": "snyk library and cli utility",
+  "mcpName": "io.snyk/mcp",
   "files": [
     "*"
   ],


### PR DESCRIPTION
## What does this PR do?
Add `mcpName` metadata field to package.json 
Anthropic requires a verification step, to verify that we are the owners of the npm package
This verification step requires us to add an additional property ("mcpName": "io.snyk/mcp") to the CLI package.json file.
Docs:
https://github.com/modelcontextprotocol/registry/blob/main/docs/guides/publishing/publish-server.md#requirements
