### PR TITLE
feat: [CN-249] support scanning system JARs

### DIFF
--- a/src/cli/commands/constants.ts
+++ b/src/cli/commands/constants.ts
@@ -1,0 +1,9 @@
+// Feature flag names
+export const SCAN_USR_LIB_JARS_FEATURE_FLAG = 'scanUsrLibJars';
+export const CONTAINER_CLI_APP_VULNS_ENABLED_FEATURE_FLAG =
+  'containerCliAppVulnsEnabled';
+
+// CLI option names
+export const INCLUDE_SYSTEM_JARS_OPTION = 'include-system-jars';
+export const EXCLUDE_APP_VULNS_OPTION = 'exclude-app-vulns';
+export const APP_VULNS_OPTION = 'app-vulns';

--- a/src/lib/feature-flags/index.ts
+++ b/src/lib/feature-flags/index.ts
@@ -5,6 +5,9 @@ import { assembleQueryString } from '../snyk-test/common';
 import { OrgFeatureFlagResponse } from './types';
 import { Options } from '../types';
 import { AuthFailedError } from '../errors';
+import * as Debug from 'debug';
+
+const debug = Debug('snyk-feature-flags');
 
 export async function isFeatureFlagSupportedForOrg(
   featureFlag: string,
@@ -37,4 +40,18 @@ export async function hasFeatureFlag(
     throw AuthFailedError(error, code);
   }
   return ok;
+}
+
+export async function hasFeatureFlagOrDefault(
+  featureFlag: string,
+  options: Options,
+  defaultValue = false,
+): Promise<boolean> {
+  try {
+    const result = await hasFeatureFlag(featureFlag, options);
+    return result ?? defaultValue;
+  } catch (err) {
+    debug(`error checking feature flag '${featureFlag}':`, err);
+    return defaultValue;
+  }
 }

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -17,6 +17,7 @@ const featureFlagDefaults = (): Map<string, boolean> => {
     ['enablePnpmCli', false],
     ['sbomMonitorBeta', false],
     ['useImprovedDotnetWithoutPublish', false],
+    ['scanUsrLibJars', false],
 
     // Default these to false.
     // TODO: Future acceptance tests targeting these features and their

--- a/test/jest/unit/cli-commands/test-and-monitor.spec.ts
+++ b/test/jest/unit/cli-commands/test-and-monitor.spec.ts
@@ -1,6 +1,11 @@
 import monitor from '../../../../src/cli/commands/monitor';
 import { DOTNET_WITHOUT_PUBLISH_FEATURE_FLAG } from '../../../../src/lib/package-managers';
 import * as featureFlags from '../../../../src/lib/feature-flags';
+import {
+  SCAN_USR_LIB_JARS_FEATURE_FLAG,
+  INCLUDE_SYSTEM_JARS_OPTION,
+  EXCLUDE_APP_VULNS_OPTION,
+} from '../../../../src/cli/commands/constants';
 import * as ecosystems from '../../../../src/lib/ecosystems';
 import * as analytics from '../../../../src/lib/analytics';
 import * as snykMonitor from '../../../../src/lib/monitor';
@@ -8,6 +13,7 @@ import config from '../../../../src/lib/config';
 import { apiOrOAuthTokenExists } from '../../../../src/lib/api-token';
 import { runTest } from '../../../../src/lib/snyk-test/run-test';
 import * as detect from '../../../../src/lib/detect';
+import test from '../../../../src/cli/commands/test';
 
 jest.mock('../../../../src/lib/api-token');
 jest.mock('../../../../src/lib/check-paths');
@@ -17,6 +23,23 @@ jest.mock('../../../../src/lib/plugins/get-deps-from-plugin');
 jest.mock('../../../../src/lib/spinner');
 jest.mock('../../../../src/lib/snyk-test/run-test');
 jest.mock('../../../../src/lib/feature-flags');
+jest.mock('../../../../src/lib/protect-update-notification', () => ({
+  getPackageJsonPathsContainingSnykDependency: jest.fn(() => []),
+  getProtectUpgradeWarningForPaths: jest.fn(() => ''),
+}));
+jest.mock('../../../../src/cli/commands/test/validate-credentials', () => ({
+  validateCredentials: jest.fn(),
+}));
+jest.mock('../../../../src/cli/commands/test/validate-test-options', () => ({
+  validateTestOptions: jest.fn(),
+}));
+jest.mock('../../../../src/lib/ecosystems', () => ({
+  getEcosystem: jest.fn(() => undefined),
+  getEcosystemForTest: jest.fn(() => undefined),
+}));
+jest.mock('../../../../src/lib/snyk-test/legacy', () => ({
+  test: jest.fn(() => Promise.resolve({})),
+}));
 
 const snykTest = require('../../../../src/lib/snyk-test');
 
@@ -42,6 +65,7 @@ describe('monitor & test', () => {
     getEcosystemSpy.mockRestore();
     analyticsSpy.mockRestore();
     snykMonitorSpy.mockRestore();
+    (featureFlags.hasFeatureFlag as jest.Mock).mockResolvedValue(false);
   });
 
   describe('monitor', () => {
@@ -152,6 +176,231 @@ describe('monitor & test', () => {
         options,
       );
       expect(options.useImprovedDotnetWithoutPublish).toBeUndefined();
+    });
+  });
+
+  describe('docker scanUsrLibJars feature flag', () => {
+    beforeEach(() => {
+      getEcosystemSpy.mockReturnValue(undefined); // Don't use ecosystem for these tests
+      analyticsSpy.mockReturnValue(false);
+    });
+
+    describe('test command', () => {
+      let capturedOptions: any = null;
+
+      beforeEach(() => {
+        // Mock the ecosystem detection to return null so it uses the legacy path
+        jest.spyOn(ecosystems, 'getEcosystemForTest').mockReturnValue(null);
+        // Mock runTest to return empty array and capture the options
+        capturedOptions = null;
+        (runTest as jest.Mock).mockImplementation(
+          (projectType, root, options) => {
+            capturedOptions = options;
+            return Promise.resolve([]);
+          },
+        );
+        // Mock detectPackageManager
+        jest.spyOn(detect, 'detectPackageManager').mockReturnValue('docker');
+      });
+
+      it('should set include-system-jars when scanUsrLibJars feature flag is enabled', async () => {
+        const options: any = {
+          docker: true,
+          [EXCLUDE_APP_VULNS_OPTION]: true, // Skip containerCliAppVulnsEnabled check
+        };
+
+        // Mock feature flag responses - need to handle multiple calls
+        (featureFlags.hasFeatureFlag as jest.Mock).mockImplementation(
+          (flag: string) => {
+            if (flag === SCAN_USR_LIB_JARS_FEATURE_FLAG) {
+              return Promise.resolve(true);
+            }
+            return Promise.resolve(false); // Default for other flags
+          },
+        );
+        (featureFlags.hasFeatureFlagOrDefault as jest.Mock).mockImplementation(
+          (flag: string) => {
+            if (flag === SCAN_USR_LIB_JARS_FEATURE_FLAG) {
+              return Promise.resolve(true);
+            }
+            return Promise.resolve(false); // Default for other flags
+          },
+        );
+
+        try {
+          await test('docker-image:latest', options);
+        } catch (error) {
+          // We expect this to fail since we are not mocking all dependencies.
+          // We only care about the feature flag being called correctly.
+        }
+
+        expect(featureFlags.hasFeatureFlagOrDefault).toHaveBeenCalledWith(
+          SCAN_USR_LIB_JARS_FEATURE_FLAG,
+          expect.objectContaining({
+            docker: true,
+          }),
+          false,
+        );
+
+        // Verify that include-system-jars was set on the internal options object passed to runTest
+        expect(capturedOptions).toBeTruthy();
+        expect(capturedOptions[INCLUDE_SYSTEM_JARS_OPTION]).toBe(true);
+      });
+
+      it('should not set include-system-jars when scanUsrLibJars feature flag is disabled', async () => {
+        const options: any = {
+          docker: true,
+          [EXCLUDE_APP_VULNS_OPTION]: true, // Skip containerCliAppVulnsEnabled check
+        };
+
+        // Mock feature flag responses - need to handle multiple calls
+        (featureFlags.hasFeatureFlag as jest.Mock).mockImplementation(() => {
+          return Promise.resolve(false); // All flags disabled
+        });
+        (featureFlags.hasFeatureFlagOrDefault as jest.Mock).mockImplementation(
+          () => {
+            return Promise.resolve(false); // All flags disabled
+          },
+        );
+
+        try {
+          await test('docker-image:latest', options);
+        } catch (error) {
+          // We expect this to fail since we are not mocking all dependencies.
+          // We only care about the feature flag being called correctly.
+        }
+
+        expect(featureFlags.hasFeatureFlagOrDefault).toHaveBeenCalledWith(
+          SCAN_USR_LIB_JARS_FEATURE_FLAG,
+          expect.objectContaining({
+            docker: true,
+          }),
+          false,
+        );
+
+        // Verify that include-system-jars was NOT set when the feature flag is disabled
+        expect(options[INCLUDE_SYSTEM_JARS_OPTION]).toBeUndefined();
+      });
+
+      it('should not check scanUsrLibJars feature flag for non-docker scans', async () => {
+        const options: any = {
+          docker: false,
+        };
+
+        try {
+          await test('path/to/project', options);
+        } catch (error) {
+          // We expect this to fail since we are not mocking all dependencies.
+          // We only care about the options being set correctly.
+        }
+
+        expect(featureFlags.hasFeatureFlagOrDefault).not.toHaveBeenCalledWith(
+          SCAN_USR_LIB_JARS_FEATURE_FLAG,
+          options,
+          false,
+        );
+        expect(options[INCLUDE_SYSTEM_JARS_OPTION]).toBeUndefined();
+      });
+    });
+
+    describe('monitor command', () => {
+      it('should set include-system-jars when scanUsrLibJars feature flag is enabled', async () => {
+        const options: any = {
+          docker: true,
+          [EXCLUDE_APP_VULNS_OPTION]: true, // Skip containerCliAppVulnsEnabled check
+        };
+
+        // Mock feature flag responses - need to handle multiple calls
+        (featureFlags.hasFeatureFlag as jest.Mock).mockImplementation(
+          (flag: string) => {
+            if (flag === SCAN_USR_LIB_JARS_FEATURE_FLAG) {
+              return Promise.resolve(true);
+            }
+            return Promise.resolve(false); // Default for other flags
+          },
+        );
+        (featureFlags.hasFeatureFlagOrDefault as jest.Mock).mockImplementation(
+          (flag: string) => {
+            if (flag === SCAN_USR_LIB_JARS_FEATURE_FLAG) {
+              return Promise.resolve(true);
+            }
+            return Promise.resolve(false); // Default for other flags
+          },
+        );
+
+        try {
+          await monitor('docker-image:latest', options);
+        } catch (error) {
+          // We expect this to fail since we are not mocking all dependencies.
+          // We only care about the feature flag being called correctly.
+        }
+
+        expect(featureFlags.hasFeatureFlagOrDefault).toHaveBeenCalledWith(
+          SCAN_USR_LIB_JARS_FEATURE_FLAG,
+          expect.objectContaining({
+            docker: true,
+          }),
+          false,
+        );
+
+        // Verify that include-system-jars was set on the options object
+        expect(options[INCLUDE_SYSTEM_JARS_OPTION]).toBe(true);
+      });
+
+      it('should not set include-system-jars when scanUsrLibJars feature flag is disabled', async () => {
+        const options: any = {
+          docker: true,
+          [EXCLUDE_APP_VULNS_OPTION]: true, // Skip containerCliAppVulnsEnabled check
+        };
+
+        // Mock feature flag responses - need to handle multiple calls
+        (featureFlags.hasFeatureFlag as jest.Mock).mockImplementation(() => {
+          return Promise.resolve(false); // All flags disabled
+        });
+        (featureFlags.hasFeatureFlagOrDefault as jest.Mock).mockImplementation(
+          () => {
+            return Promise.resolve(false); // All flags disabled
+          },
+        );
+
+        try {
+          await monitor('docker-image:latest', options);
+        } catch (error) {
+          // We expect this to fail since we are not mocking all dependencies.
+          // We only care about the feature flag being called correctly.
+        }
+
+        expect(featureFlags.hasFeatureFlagOrDefault).toHaveBeenCalledWith(
+          SCAN_USR_LIB_JARS_FEATURE_FLAG,
+          expect.objectContaining({
+            docker: true,
+          }),
+          false,
+        );
+
+        // Verify that include-system-jars was NOT set when the feature flag is disabled
+        expect(options[INCLUDE_SYSTEM_JARS_OPTION]).toBeUndefined();
+      });
+
+      it('should not check scanUsrLibJars feature flag for non-docker scans', async () => {
+        const options: any = {
+          docker: false,
+        };
+
+        try {
+          await monitor('path/to/project', options);
+        } catch (error) {
+          // We expect this to fail since we are not mocking all dependencies.
+          // We only care about the options being set correctly.
+        }
+
+        expect(featureFlags.hasFeatureFlagOrDefault).not.toHaveBeenCalledWith(
+          SCAN_USR_LIB_JARS_FEATURE_FLAG,
+          options,
+          false,
+        );
+        expect(options[INCLUDE_SYSTEM_JARS_OPTION]).toBeUndefined();
+      });
     });
   });
 });

--- a/test/tap/cli-test/cli-test.docker.spec.ts
+++ b/test/tap/cli-test/cli-test.docker.spec.ts
@@ -65,13 +65,13 @@ export const DockerTests: AcceptanceTests = {
         [
           {
             docker: true,
-            'exclude-app-vulns': false,
             org: 'explicit-org',
-            projectName: null,
-            packageManager: null,
-            path: 'foo:latest',
             showVulnPaths: 'some',
             maxVulnPaths: undefined,
+            'exclude-app-vulns': false,
+            path: 'foo:latest',
+            projectName: undefined,
+            packageManager: undefined,
           },
         ],
         'calls docker plugin with expected arguments',
@@ -142,13 +142,13 @@ export const DockerTests: AcceptanceTests = {
           [
             {
               docker: true,
-              'exclude-app-vulns': false,
               org: 'explicit-org',
-              projectName: null,
-              packageManager: null,
-              path: 'foo:latest',
               showVulnPaths: 'some',
               maxVulnPaths: undefined,
+              'exclude-app-vulns': false,
+              path: 'foo:latest',
+              projectName: undefined,
+              packageManager: undefined,
             },
           ],
           'calls docker plugin with expected arguments',
@@ -177,7 +177,7 @@ export const DockerTests: AcceptanceTests = {
         t,
       );
 
-      const vulns = require(getFixturePath('docker/find-result.json'));
+      const vulns = await import(getFixturePath('docker/find-result.json'));
       params.server.setNextResponse(vulns);
 
       try {
@@ -296,13 +296,13 @@ export const DockerTests: AcceptanceTests = {
           {
             file: 'Dockerfile',
             docker: true,
-            'exclude-app-vulns': false,
             org: 'explicit-org',
-            projectName: null,
-            packageManager: null,
-            path: 'foo:latest',
             showVulnPaths: 'some',
             maxVulnPaths: undefined,
+            'exclude-app-vulns': false,
+            path: 'foo:latest',
+            projectName: undefined,
+            packageManager: undefined,
           },
         ],
         'calls docker plugin with expected arguments',
@@ -331,8 +331,8 @@ export const DockerTests: AcceptanceTests = {
           },
           t,
         );
-        const vulns = require(
-          getFixturePath('docker/find-result-remediation.json'),
+        const vulns = await import(
+          getFixturePath('docker/find-result-remediation.json')
         );
         params.server.setNextResponse(vulns);
 
@@ -409,13 +409,13 @@ export const DockerTests: AcceptanceTests = {
           [
             {
               docker: true,
-              'exclude-app-vulns': false,
               org: 'explicit-org',
-              projectName: null,
-              packageManager: null,
-              path: 'foo:latest',
               showVulnPaths: 'some',
               maxVulnPaths: undefined,
+              'exclude-app-vulns': false,
+              path: 'foo:latest',
+              projectName: undefined,
+              packageManager: undefined,
             },
           ],
           'calls docker plugin with expected arguments',
@@ -484,13 +484,13 @@ export const DockerTests: AcceptanceTests = {
           [
             {
               docker: true,
-              'exclude-app-vulns': false,
               org: 'explicit-org',
-              projectName: null,
-              packageManager: null,
-              path: 'foo:latest',
               showVulnPaths: 'some',
               maxVulnPaths: undefined,
+              'exclude-app-vulns': false,
+              path: 'foo:latest',
+              projectName: undefined,
+              packageManager: undefined,
               'policy-path': 'npm-package-policy/custom-location',
             },
           ],
@@ -567,13 +567,13 @@ export const DockerTests: AcceptanceTests = {
         [
           {
             docker: true,
-            'exclude-app-vulns': false,
             org: 'explicit-org',
-            projectName: null,
-            packageManager: null,
-            path: 'foo:latest',
             showVulnPaths: 'some',
             maxVulnPaths: undefined,
+            'exclude-app-vulns': false,
+            path: 'foo:latest',
+            projectName: undefined,
+            packageManager: undefined,
           },
         ],
         'calls docker plugin with expected arguments',
@@ -609,8 +609,8 @@ export const DockerTests: AcceptanceTests = {
           t,
         );
 
-        const vulns = require(
-          getFixturePath('docker/find-result-binaries.json'),
+        const vulns = await import(
+          getFixturePath('docker/find-result-binaries.json')
         );
         params.server.setNextResponse(vulns);
 
@@ -678,8 +678,8 @@ export const DockerTests: AcceptanceTests = {
           t,
         );
 
-        const vulns = require(
-          getFixturePath('docker/find-result-remediation.json'),
+        const vulns = await import(
+          getFixturePath('docker/find-result-remediation.json')
         );
         params.server.setNextResponse(vulns);
 
@@ -727,8 +727,8 @@ export const DockerTests: AcceptanceTests = {
           t,
         );
 
-        const vulns = require(
-          getFixturePath('docker/find-result-remediation.json'),
+        const vulns = await import(
+          getFixturePath('docker/find-result-remediation.json')
         );
         params.server.setNextResponse(vulns);
 
@@ -749,8 +749,8 @@ export const DockerTests: AcceptanceTests = {
         sarif: true,
       });
       const results = JSON.parse(testableObject.message);
-      const sarifResults = require(
-        getFixturePath('docker/sarif-container-result.json'),
+      const sarifResults = await import(
+        getFixturePath('docker/sarif-container-result.json')
       );
       t.same(results, sarifResults, 'stdout containing sarif results');
       t.end();
@@ -763,8 +763,8 @@ export const DockerTests: AcceptanceTests = {
           file: 'Dockerfile',
         });
         const results = JSON.parse(testableObject.message);
-        const sarifResults = require(
-          getFixturePath('docker/sarif-with-file-container-result.json'),
+        const sarifResults = await import(
+          getFixturePath('docker/sarif-with-file-container-result.json')
         );
         t.same(results, sarifResults, 'stdout containing sarif results');
         t.end();
@@ -810,7 +810,7 @@ export const DockerTests: AcceptanceTests = {
 function stubDockerPluginResponse(plugins, fixture: string | object, t) {
   const plugin = {
     async scan() {
-      return typeof fixture === 'object' ? fixture : require(fixture);
+      return typeof fixture === 'object' ? fixture : await import(fixture);
     },
     async display() {
       return '';
@@ -858,7 +858,7 @@ async function testSarif(t, utils, params, flags) {
 
 async function testPrep(t, utils, params, additionaLpropsForCli) {
   utils.chdirWorkspaces();
-  const vulns = require(getFixturePath('docker/find-result.json'));
+  const vulns = await import(getFixturePath('docker/find-result.json'));
   params.server.setNextResponse(vulns);
 
   try {


### PR DESCRIPTION
use the --include-system-jars option on the Snyk Docker Plugin to scan the usr/lib folder for JAR files

## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Reads the `scanUsrLibJars` feature flag and correspondingly sets the `--include-system-jars` parameter when calling snyk-docker-plugin

## Where should the reviewer start?

Main change is in test (cli/commands/test/index.ts) and monitor (cli/commands/monitor/index.ts) command files.  The rest is updating testing.

## How should this be manually tested?

A default `snyk container test/monitor` should return identical results (since the feature flag is off by default).  You can turn the feature flag on, then us `--print-deps` on a container image with JARs in the usr/lib (example openjdk:8-jdk-alpine), and ensure that they show up.  

## What's the product update that needs to be communicated to CLI users?

No change to CLI users.  We will work with the clients who have requested the feature to get the feature flag & functionality turned on for them.


## Risk assessment (Low | Medium | High)?

Low

## Any background context you want to provide?

This is because we are having issues reading JARs on certian base images.  Specifically Chainguard images ever since they switched to the usrmerge format back in May.

## What are the relevant tickets?

CN-352
CN-340
CN-337
CN-249
