### PR TITLE
chore(logging): introduce a static allow list dictionary

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/snyk/cli-extension-sbom v0.0.0-20250801142135-ae472dafa4cd
 	github.com/snyk/container-cli v0.0.0-20250321132345-1e2e01681dd7
 	github.com/snyk/error-catalog-golang-public v0.0.0-20250912144134-a308b7983895
-	github.com/snyk/go-application-framework v0.0.0-20250922111038-7c7521b077e1
+	github.com/snyk/go-application-framework v0.0.0-20250926055342-a877d3c44b23
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20250923135355-3f907ea89fcc

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -1268,8 +1268,8 @@ github.com/snyk/container-cli v0.0.0-20250321132345-1e2e01681dd7 h1:/2+2piwQtB9f
 github.com/snyk/container-cli v0.0.0-20250321132345-1e2e01681dd7/go.mod h1:38w+dcAQp9eG3P5t2eNS9eG0reut10AeJjLv5lJ5lpM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250912144134-a308b7983895 h1:JrN/uGEMVprlres/CVMJybSKvaLuW59SfCHoT4TfvUk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20250912144134-a308b7983895/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.0.0-20250922111038-7c7521b077e1 h1:gIs6Nh7MlBgpbV/O5E6/1RTW4OG+zY+LdvaNO7RqwOw=
-github.com/snyk/go-application-framework v0.0.0-20250922111038-7c7521b077e1/go.mod h1:nHVL2jzsJao6vvlJAmre0NJlK2aafOn269w3wLMoU+g=
+github.com/snyk/go-application-framework v0.0.0-20250926055342-a877d3c44b23 h1:oe77va3/+YIgmuoMPc0pVEV4kn7GaR/nOaigoFwHuSE=
+github.com/snyk/go-application-framework v0.0.0-20250926055342-a877d3c44b23/go.mod h1:nHVL2jzsJao6vvlJAmre0NJlK2aafOn269w3wLMoU+g=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.0 h1:vFbFZbs3B0Y3XuGSur5om2meo4JEcCaKfNzshZFGOUs=

--- a/cliv2/internal/utils/args.go
+++ b/cliv2/internal/utils/args.go
@@ -10,6 +10,112 @@ const (
 	FLAG_PREFIX    = "-"
 )
 
+// Static allow list of common words that should not be redacted
+// Only includes words >= MIN_ARG_LENGTH (5 characters) since shorter words are never considered sensitive
+var allowedWords = map[string]bool{
+	"false":   true,
+	"trace":   true,
+	"debug":   true,
+	"error":   true,
+	"fatal":   true,
+	"panic":   true,
+	"version": true,
+	"verbose": true,
+	"quiet":   true,
+	"force":   true,
+
+	// Severity levels (for severity-threshold parameter)
+	"critical": true,
+	"high":     true,
+	"medium":   true,
+	"low":      true,
+
+	// Common enum values for various parameters
+	"production":  true,
+	"staging":     true,
+	"development": true,
+
+	"https": true,
+
+	// Common architectures/platforms
+	"linux":   true,
+	"windows": true,
+	"darwin":  true,
+	"amd64":   true,
+	"arm64":   true,
+	"x86_64":  true,
+
+	// Action words (not commands, but action descriptions)
+	"scanning":   true,
+	"monitoring": true,
+	"testing":    true,
+
+	// Status and result words
+	"success":    true,
+	"successful": true,
+	"failed":     true,
+	"failure":    true,
+	"complete":   true,
+	"completed":  true,
+	"running":    true,
+	"started":    true,
+	"stopped":    true,
+	"paused":     true,
+
+	// State words
+	"enabled":     true,
+	"disabled":    true,
+	"active":      true,
+	"inactive":    true,
+	"available":   true,
+	"unavailable": true,
+	"supported":   true,
+	"unsupported": true,
+
+	// Common CLI terms
+	"vulnerability":   true,
+	"vulnerabilities": true,
+	"license":         true,
+	"licenses":        true,
+	"dependencies":    true,
+	"dependency":      true,
+	"package":         true,
+	"packages":        true,
+	"container":       true,
+	"docker":          true,
+	"kubernetes":      true,
+	"terraform":       true,
+	"infrastructure":  true,
+
+	// Time and size units
+	"seconds": true,
+	"minutes": true,
+	"hours":   true,
+	"weeks":   true,
+	"months":  true,
+	"years":   true,
+	"bytes":   true,
+
+	// Scope and location words
+	"local":    true,
+	"remote":   true,
+	"global":   true,
+	"public":   true,
+	"private":  true,
+	"internal": true,
+	"external": true,
+
+	// Additional common environment variable values
+	"secure":   true,
+	"insecure": true,
+	"strict":   true,
+	"loose":    true,
+	"timeout":  true,
+	"retry":    true,
+	"cache":    true,
+	"proxy":    true,
+}
+
 func GetUnknownParameters(osArgs []string, envVars []string, knownCommands []string) []string {
 	argsOneString := strings.Join(osArgs, " ")
 	if len(envVars) > 0 {
@@ -23,8 +129,9 @@ func GetUnknownParameters(osArgs []string, envVars []string, knownCommands []str
 	for _, arg := range argsSplitAgain {
 		isFlag := strings.HasPrefix(arg, FLAG_PREFIX)
 		isKnownCommand := slices.Contains(knownCommands, arg)
+		isAllowedWord := allowedWords[strings.ToLower(arg)]
 		isPotentiallySensitive := len(arg) >= MIN_ARG_LENGTH
-		if !isFlag && !isKnownCommand && isPotentiallySensitive {
+		if !isFlag && !isKnownCommand && !isAllowedWord && isPotentiallySensitive {
 			argValues = append(argValues, arg)
 		}
 	}

--- a/cliv2/internal/utils/args_test.go
+++ b/cliv2/internal/utils/args_test.go
@@ -36,7 +36,6 @@ func Test_CaptureAllArgs(t *testing.T) {
 				"secret\"password",
 				"sensitive",
 				"super.secret",
-				"trace",
 			},
 		},
 		{
@@ -56,7 +55,6 @@ func Test_CaptureAllArgs(t *testing.T) {
 				"secret\"password",
 				"sensitive",
 				"super.secret",
-				"trace",
 			},
 		},
 		{
@@ -101,7 +99,6 @@ func Test_CaptureAllArgs(t *testing.T) {
 				"mySuperSecretToken",
 				"primary/path/to/file",
 				"super.secret",
-				"trace",
 			},
 		},
 	}


### PR DESCRIPTION
## Pull Request Submission Checklist

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
1. The PR adds a static allow list of words not to redact.
2. The PR updates GAF to use configuration values as static terms rather then as regular expressions.

## Where should the reviewer start?
https://github.com/snyk/go-application-framework/pull/432 

## How should this be manually tested?
Run `snyk code test --severity-threshold=critical -d` and observe that the word critical is not redacted.

## What's the product update that needs to be communicated to CLI users?
N/A

## Risk assessment (Low | Medium | High)?
Low

<!---

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
