### PR TITLE
fix: OSM-2364 discover pinned dependencies in nuget v3 scanner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "snyk-mvn-plugin": "4.3.0",
         "snyk-nodejs-lockfile-parser": "2.2.2",
         "snyk-nodejs-plugin": "1.4.4",
-        "snyk-nuget-plugin": "2.11.0",
+        "snyk-nuget-plugin": "2.11.1",
         "snyk-php-plugin": "1.12.1",
         "snyk-policy": "^4.1.6",
         "snyk-python-plugin": "3.1.0",
@@ -21496,9 +21496,9 @@
       }
     },
     "node_modules/snyk-nuget-plugin": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.11.0.tgz",
-      "integrity": "sha512-IxKOfEE4oHiZfdO2UVUkAsanln8L9hvA8Bvy2Az6KXJzXZYVT2Y/nADodlfRVwjhS2MKkXnL9clUc3fa90xeiw==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.11.1.tgz",
+      "integrity": "sha512-7UDLe5cYVYTkO/HA3+ocX0/+3Bj8dW0oG11hkOFXQPh9sIWxXMOOs4/WP0CyU1BNCpJiJ73NLdTE4U3ayW0yVw==",
       "dependencies": {
         "@snyk/cli-interface": "^2.14.0",
         "@snyk/dep-graph": "^2.8.1",
@@ -41312,9 +41312,9 @@
       }
     },
     "snyk-nuget-plugin": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.11.0.tgz",
-      "integrity": "sha512-IxKOfEE4oHiZfdO2UVUkAsanln8L9hvA8Bvy2Az6KXJzXZYVT2Y/nADodlfRVwjhS2MKkXnL9clUc3fa90xeiw==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.11.1.tgz",
+      "integrity": "sha512-7UDLe5cYVYTkO/HA3+ocX0/+3Bj8dW0oG11hkOFXQPh9sIWxXMOOs4/WP0CyU1BNCpJiJ73NLdTE4U3ayW0yVw==",
       "requires": {
         "@snyk/cli-interface": "^2.14.0",
         "@snyk/dep-graph": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "snyk-mvn-plugin": "4.3.0",
     "snyk-nodejs-lockfile-parser": "2.2.2",
     "snyk-nodejs-plugin": "1.4.4",
-    "snyk-nuget-plugin": "2.11.0",
+    "snyk-nuget-plugin": "2.11.1",
     "snyk-php-plugin": "1.12.1",
     "snyk-policy": "^4.1.6",
     "snyk-python-plugin": "3.1.0",

--- a/test/acceptance/workspaces/nuget-app-pinned-deps/pinned-deps.csproj
+++ b/test/acceptance/workspaces/nuget-app-pinned-deps/pinned-deps.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Dynamicweb.Security" Version="12.5.21" />
+        <PackageReference Include="Aspire.RabbitMQ.Client" Version="8.2.2" />
+        <PackageReference Include="System.ServiceModel.Duplex" Version="[4.10.3]" />
+        <PackageReference
+            Include="Kentico.Xperience.Libraries"
+            Version="13.0.193"
+        />
+    </ItemGroup>
+</Project>

--- a/test/jest/acceptance/snyk-test/basic-test-all-languages.spec.ts
+++ b/test/jest/acceptance/snyk-test/basic-test-all-languages.spec.ts
@@ -331,7 +331,20 @@ describe('`snyk test` of basic projects for each language/ecosystem', () => {
     },
   );
 
-  it('run `snyk test` on a .net framework project using v3 dotnet runtime resolution logic', async () => {
+  it.each([
+    {
+      fixture: 'nuget-app-net48',
+      projectFile: 'net48.csproj',
+      description:
+        '.net framework project using v3 dotnet runtime resolution logic',
+    },
+    {
+      fixture: 'nuget-app-pinned-deps',
+      projectFile: 'pinned-deps.csproj',
+      description:
+        '.net 8 project with pinned dependencies using v3 dotnet runtime resolution logic',
+    },
+  ])('run `snyk test` on a $description', async ({ fixture, projectFile }) => {
     server.setFeatureFlag('useImprovedDotnetWithoutPublish', true);
 
     let prerequisite = await runCommand('dotnet', ['--version']).catch(
@@ -344,11 +357,11 @@ describe('`snyk test` of basic projects for each language/ecosystem', () => {
       return;
     }
 
-    const project = await createProjectFromWorkspace('nuget-app-net48');
+    const project = await createProjectFromWorkspace(fixture);
 
     prerequisite = await runCommand('dotnet', [
       'restore',
-      `"${path.resolve(project.path(), 'net48.csproj')}"`,
+      `"${path.resolve(project.path(), projectFile)}"`,
     ]);
 
     if (prerequisite.code !== 0) {


### PR DESCRIPTION
## Pull Request Submission Checklist

- [X] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [X] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [X] Includes detailed description of changes
- [X] Contains risk assessment (Low | Medium | High)
- [X] Highlights breaking API changes (if applicable)
- [X] Links to automated tests covering new functionality
- [X] Includes manual testing instructions (if necessary)
- [X] Updates relevant GitBook documentation (PR link: ___)
- [X] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps the snyk-nuget-plugin in order to fix an issue with NuGet v3 scanner where the pinned dependencies were not discovered.

## Where should the reviewer start?

By reviewing [this PR](https://github.com/snyk/snyk-nuget-plugin/pull/262)

## How should this be manually tested?

Using this [fixture](https://github.com/snyk/snyk-nuget-plugin/pull/262/files#diff-9dbf354d0d14054b62ef9d797a89aea62f9ca8fb549245047391d470e511d95cR1) or by running this [test](https://github.com/snyk/snyk-nuget-plugin/pull/262/files).

## What's the product update that needs to be communicated to CLI users?

This is a small fix, no product update apart from the one going to a support ticket. Also, NuGet v3 scanner is not GA yet, it is currently beta tested by customers.

<!---
## Risk assessment (Low | Medium | High)?

Low

## Any background context you want to provide?

## What are the relevant tickets?

https://snyksec.atlassian.net/browse/OSM-2364

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
