### PR TITLE
fix: exclude assemblies for netstandard and netcoreapp for nuget v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "snyk-mvn-plugin": "4.3.0",
         "snyk-nodejs-lockfile-parser": "2.2.2",
         "snyk-nodejs-plugin": "1.4.4",
-        "snyk-nuget-plugin": "2.11.1",
+        "snyk-nuget-plugin": "2.11.3",
         "snyk-php-plugin": "1.12.1",
         "snyk-policy": "^4.1.6",
         "snyk-python-plugin": "3.1.2",
@@ -21496,9 +21496,9 @@
       }
     },
     "node_modules/snyk-nuget-plugin": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.11.1.tgz",
-      "integrity": "sha512-7UDLe5cYVYTkO/HA3+ocX0/+3Bj8dW0oG11hkOFXQPh9sIWxXMOOs4/WP0CyU1BNCpJiJ73NLdTE4U3ayW0yVw==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.11.3.tgz",
+      "integrity": "sha512-o/WY62LVch0g8K5liirIbS98qjTFsbiEj3voArUkWt1co+wl3dvEIxbukye3+4jB+PPDhbKyNQxkLQuE3IugLw==",
       "dependencies": {
         "@snyk/cli-interface": "^2.14.0",
         "@snyk/dep-graph": "^2.8.1",
@@ -41312,9 +41312,9 @@
       }
     },
     "snyk-nuget-plugin": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.11.1.tgz",
-      "integrity": "sha512-7UDLe5cYVYTkO/HA3+ocX0/+3Bj8dW0oG11hkOFXQPh9sIWxXMOOs4/WP0CyU1BNCpJiJ73NLdTE4U3ayW0yVw==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-2.11.3.tgz",
+      "integrity": "sha512-o/WY62LVch0g8K5liirIbS98qjTFsbiEj3voArUkWt1co+wl3dvEIxbukye3+4jB+PPDhbKyNQxkLQuE3IugLw==",
       "requires": {
         "@snyk/cli-interface": "^2.14.0",
         "@snyk/dep-graph": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "snyk-mvn-plugin": "4.3.0",
     "snyk-nodejs-lockfile-parser": "2.2.2",
     "snyk-nodejs-plugin": "1.4.4",
-    "snyk-nuget-plugin": "2.11.1",
+    "snyk-nuget-plugin": "2.11.3",
     "snyk-php-plugin": "1.12.1",
     "snyk-policy": "^4.1.6",
     "snyk-python-plugin": "3.1.2",

--- a/test/acceptance/workspaces/nuget-app-netcore31/netcore31.csproj
+++ b/test/acceptance/workspaces/nuget-app-netcore31/netcore31.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference
+      Include="Microsoft.ApplicationInsights.AspNetCore"
+      Version="2.1.1"
+    />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.0.0" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.108" />
+  </ItemGroup>
+</Project>

--- a/test/jest/acceptance/snyk-test/basic-test-all-languages.spec.ts
+++ b/test/jest/acceptance/snyk-test/basic-test-all-languages.spec.ts
@@ -344,6 +344,12 @@ describe('`snyk test` of basic projects for each language/ecosystem', () => {
       description:
         '.net 8 project with pinned dependencies using v3 dotnet runtime resolution logic',
     },
+    {
+      fixture: 'nuget-app-netcore31',
+      projectFile: 'netcore31.csproj',
+      description:
+        '.net core 3.1 web project using v3 dotnet runtime resolution logic',
+    },
   ])('run `snyk test` on a $description', async ({ fixture, projectFile }) => {
     server.setFeatureFlag('useImprovedDotnetWithoutPublish', true);
 


### PR DESCRIPTION
## Pull Request Submission Checklist

- [X] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [X] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [X] Includes detailed description of changes
- [X] Contains risk assessment (Low | Medium | High)
- [X] Highlights breaking API changes (if applicable)
- [X] Links to automated tests covering new functionality
- [X] Includes manual testing instructions (if necessary)
- [X] Updates relevant GitBook documentation (PR link: ___)
- [X] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps the snyk-nuget-plugin in order to fix an issue with NuGet v3 scanner where the netstandard and netcoreapp TargetFrameworks were treated as .netx.x

## Where should the reviewer start?

By reviewing [this PR](https://github.com/snyk/snyk-nuget-plugin/pull/264)

## How should this be manually tested?

Using this [fixture](https://github.com/snyk/snyk-nuget-plugin/pull/264/files#diff-2ad7e47f491557dbeb622ceee0b69d716386163c5f6cc63e23283789efbdfc0dR1) or by running this [test](https://github.com/snyk/snyk-nuget-plugin/pull/264/files#diff-df7909f937abc25b7051556819b8a8347adfa7d5133bd1e15be6e9161005b1ecR302).

## What's the product update that needs to be communicated to CLI users?

This is a small fix, no product update apart from the one going to a support ticket. Also, NuGet v3 scanner is not GA yet, it is currently beta tested by customers.

<!---
## Risk assessment (Low | Medium | High)?

Low

## Any background context you want to provide?

## What are the relevant tickets?

https://snyksec.atlassian.net/browse/OSM-3322

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
