### PR TITLE
fix: bump nodejs-lockfile-parser version to 2.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "snyk-gradle-plugin": "5.1.0",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "4.3.0",
-        "snyk-nodejs-lockfile-parser": "2.2.2",
+        "snyk-nodejs-lockfile-parser": "2.2.3",
         "snyk-nodejs-plugin": "1.4.4",
         "snyk-nuget-plugin": "2.11.3",
         "snyk-php-plugin": "1.12.1",
@@ -21014,9 +21014,10 @@
       }
     },
     "node_modules/snyk-nodejs-lockfile-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-2.2.2.tgz",
-      "integrity": "sha512-+pJnbEK/yvBimpTEv0xrvhaEpRgz/KwZZGJEV+NfPJ4ytoL0TdIpKYSIpw28VMaaWSLna75SoWEKWujw0vYDLQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-2.2.3.tgz",
+      "integrity": "sha512-e6ibsU7/wNvPJNfisd+daTkLpCqiIQ9mg3Olv6L6Y4kRXnxH57yZ78YtowswHElCHs31wium/mL6ZQY4f7Uilw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/error-catalog-nodejs-public": "^5.16.0",
@@ -40939,9 +40940,9 @@
       }
     },
     "snyk-nodejs-lockfile-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-2.2.2.tgz",
-      "integrity": "sha512-+pJnbEK/yvBimpTEv0xrvhaEpRgz/KwZZGJEV+NfPJ4ytoL0TdIpKYSIpw28VMaaWSLna75SoWEKWujw0vYDLQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-2.2.3.tgz",
+      "integrity": "sha512-e6ibsU7/wNvPJNfisd+daTkLpCqiIQ9mg3Olv6L6Y4kRXnxH57yZ78YtowswHElCHs31wium/mL6ZQY4f7Uilw==",
       "requires": {
         "@snyk/dep-graph": "^2.3.0",
         "@snyk/error-catalog-nodejs-public": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "snyk-gradle-plugin": "5.1.0",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "4.3.0",
-    "snyk-nodejs-lockfile-parser": "2.2.2",
+    "snyk-nodejs-lockfile-parser": "2.2.3",
     "snyk-nodejs-plugin": "1.4.4",
     "snyk-nuget-plugin": "2.11.3",
     "snyk-php-plugin": "1.12.1",


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
Bumps the nodejs lockfile parser to improve npm alias support.

## Where should the reviewer start?

## How should this be manually tested?


## What's the product update that needs to be communicated to CLI users?
