### PR TITLE
fix: Fix incorrect error mapping for varying status codes

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -86,3 +86,4 @@ ccd03cce97470452766ab397f2ba770dbb2e002e:test/jest/unit/lib/iac/drift/fixtures/a
 test/jest/acceptance/instrumentation.spec.ts:snyk-api-token:19
 1b65935bc7c69b1029d7c63808af211ae6030c98:test/fixtures/sast/shallow_sast_webgoat/JWTFinalEndpointTest.java:jwt:31
 test/jest/acceptance/snyk-code/snyk-code-integration.spec.ts:snyk-api-token:181
+test/jest/acceptance/error-catalog.spec.ts:snyk-api-token:32

--- a/src/lib/errors/error-catalog-factory.ts
+++ b/src/lib/errors/error-catalog-factory.ts
@@ -1,0 +1,28 @@
+import { CLI, Snyk, ProblemError } from '@snyk/error-catalog-nodejs-public';
+
+/**
+ * Simple factory that creates error catalog instances based on status code
+ * @param statusCode - HTTP status code
+ * @param message - Error message (optional)
+ * @returns ProblemError instance
+ */
+export function createErrorCatalogFromStatusCode(
+  statusCode: number,
+): ProblemError {
+  // For 500 status codes, use Snyk.ServerError
+  if (statusCode === 500) {
+    return new Snyk.ServerError('');
+  }
+
+  // For all other status codes, create a GeneralCLIFailureError and update its status
+  const error = new CLI.GeneralCLIFailureError('');
+
+  // Update error metadata
+  error.metadata.status = statusCode;
+
+  if (statusCode < 400) {
+    error.metadata.level = 'warn';
+  }
+
+  return error;
+}

--- a/src/lib/errors/failed-to-get-vulnerabilities-error.ts
+++ b/src/lib/errors/failed-to-get-vulnerabilities-error.ts
@@ -1,4 +1,4 @@
-import { Snyk } from '@snyk/error-catalog-nodejs-public';
+import { createErrorCatalogFromStatusCode } from './error-catalog-factory';
 import { CustomError } from './custom-error';
 
 export class FailedToGetVulnerabilitiesError extends CustomError {
@@ -8,10 +8,11 @@ export class FailedToGetVulnerabilitiesError extends CustomError {
 
   constructor(userMessage, statusCode) {
     super(FailedToGetVulnerabilitiesError.ERROR_MESSAGE);
-    this.code = statusCode || FailedToGetVulnerabilitiesError.ERROR_CODE;
+    const code = statusCode || FailedToGetVulnerabilitiesError.ERROR_CODE;
+    this.code = code;
     this.strCode = FailedToGetVulnerabilitiesError.ERROR_STRING_CODE;
     this.userMessage =
       userMessage || FailedToGetVulnerabilitiesError.ERROR_MESSAGE;
-    this.errorCatalog = new Snyk.ServerError('');
+    this.errorCatalog = createErrorCatalogFromStatusCode(code);
   }
 }

--- a/src/lib/errors/failed-to-run-test-error.ts
+++ b/src/lib/errors/failed-to-run-test-error.ts
@@ -1,6 +1,6 @@
 import { ProblemError } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
-import { CLI } from '@snyk/error-catalog-nodejs-public';
+import { createErrorCatalogFromStatusCode } from './error-catalog-factory';
 
 export class FailedToRunTestError extends CustomError {
   private static ERROR_MESSAGE = 'Failed to run a test';
@@ -14,9 +14,9 @@ export class FailedToRunTestError extends CustomError {
   ) {
     const code = errorCode || 500;
     super(userMessage || FailedToRunTestError.ERROR_MESSAGE);
-    this.code = errorCode || code;
+    this.code = code;
     this.userMessage = userMessage || FailedToRunTestError.ERROR_MESSAGE;
     this.innerError = innerError;
-    this.errorCatalog = errorCatalog ?? new CLI.GeneralCLIFailureError('');
+    this.errorCatalog = errorCatalog ?? createErrorCatalogFromStatusCode(code);
   }
 }

--- a/src/lib/errors/monitor-error.ts
+++ b/src/lib/errors/monitor-error.ts
@@ -1,5 +1,5 @@
-import { Snyk } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from './custom-error';
+import { createErrorCatalogFromStatusCode } from './error-catalog-factory';
 
 export class MonitorError extends CustomError {
   private static ERROR_MESSAGE =
@@ -9,8 +9,8 @@ export class MonitorError extends CustomError {
     const errorMessage = message ? `, response: ${message}` : '';
     const code = errorCode || 500;
     super(MonitorError.ERROR_MESSAGE + `Status code: ${code}${errorMessage}`);
-    this.code = errorCode;
+    this.code = code;
     this.userMessage = message;
-    this.errorCatalog = new Snyk.ServerError('');
+    this.errorCatalog = createErrorCatalogFromStatusCode(code);
   }
 }

--- a/src/lib/request/promise.ts
+++ b/src/lib/request/promise.ts
@@ -7,7 +7,7 @@ import * as request from './index';
 export async function makeRequest<T>(payload: any): Promise<T> {
   return new Promise((resolve, reject) => {
     request.makeRequest(payload, (error, res, body) => {
-      if (res.headers[headerSnykTsCliTerminate] == 'true') {
+      if (res?.headers?.[headerSnykTsCliTerminate] == 'true') {
         process.exit(EXIT_CODES.EX_TERMINATE);
       }
 


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
This PR mainly fixes multiple issues in the Typescript Error Handling for Errors with dynamic status code. 
It implements a simple factory to create error catalog errors based on status codes and uses it for the 3 dynamic Errors that require it. A forth Auth Error, doesn't require this dynamic handling.

The PR adds an integration test for `snyk container monitor`, which previously incorrectly mapped all errors to SNYK-9999 (which represents a 500 status). No SNYK-9999 is only mapped if the status is 500 otherwise the Generic Error is being raised.

To enable the tests this PR also fixes a small bug that was causing a crash when a network response didn't contain any headers.

## Where should the reviewer start?
`src/lib/errors/error-catalog-factory.ts` from there look at the usages and the added test.

## How should this be manually tested?
Run `npx jest ./test/jest/acceptance/error-catalog.spec.ts`

## What's the product update that needs to be communicated to CLI users?
Not really applicable as the change mainly fixes the reported Error IDs the messages remain the same.

## Risk assessment (Low | Medium | High)?
LOW

<!---

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
