### PR TITLE
fix(dependencies): Upgrade xcode to avoid flaky signing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,14 +117,14 @@ executors:
     resource_class: arm.medium
   macos-arm64:
     macos:
-      # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
-      xcode: '16.4.0'
-    resource_class: macos.m1.medium.gen1
+      # https://circleci.com/developer/machine/image/xcode#image-tags
+      xcode: '26.1.0'
+    resource_class: m4pro.medium
   macos-arm64-large:
     macos:
-      # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
-      xcode: '16.4.0'
-    resource_class: macos.m1.large.gen1
+      # https://circleci.com/developer/machine/image/xcode#image-tags
+      xcode: '26.1.0'
+    resource_class: m4pro.large
   win-server2022-amd64:
     machine:
       image: windows-server-2022-gui:2024.01.1


### PR DESCRIPTION
## Pull Request Submission Checklist

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
This PR upgrades xcode to 26.1.0 and updates the runner to make it available. The previous version of xcode and its tools introduced increased flakiness when signing.

Excerpt from `otool -l snyk-macos-arm64`
```
      minos 13.0
      sdk 26.1
```

## Where should the reviewer start?

## How should this be manually tested?

## What's the product update that needs to be communicated to CLI users?

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
