### PR TITLE
fix: Prevent Node subprocess from hanging during snyk test

### DIFF
--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -188,7 +188,10 @@ export async function makeRequest(
             redirectsLeft > 0
           ) {
             redirectsLeft--;
-            const redirectUrl = new URL(res.headers.location, reqUrl).toString();
+            const redirectUrl = new URL(
+              res.headers.location,
+              reqUrl,
+            ).toString();
             debug('following redirect to %s', redirectUrl);
             const parsedRedirect = parse(redirectUrl);
             const newAgent =

--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -141,6 +141,8 @@ function setupRequest(payload: Payload) {
 }
 
 const REDIRECT_CODES = [301, 302, 303, 307, 308];
+// 307/308 require preserving the original method and body per RFC 9110.
+const METHOD_PRESERVING_REDIRECTS = [307, 308];
 const MAX_REDIRECTS = 5;
 
 export async function makeRequest(
@@ -198,10 +200,15 @@ export async function makeRequest(
               parsedRedirect.protocol === 'http:'
                 ? new http.Agent({ keepAlive: false })
                 : new https.Agent({ keepAlive: false });
-            return sendRequest('get', redirectUrl, null, {
-              ...reqOptions,
-              agent: newAgent,
-            });
+            const preserveMethod =
+              res.statusCode !== undefined &&
+              METHOD_PRESERVING_REDIRECTS.includes(res.statusCode);
+            return sendRequest(
+              preserveMethod ? reqMethod : 'get',
+              redirectUrl,
+              preserveMethod ? reqData : null,
+              { ...reqOptions, agent: newAgent },
+            );
           }
 
           resolve({ res, body: respBody });

--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -140,25 +140,73 @@ function setupRequest(payload: Payload) {
   return { method, url, data, options };
 }
 
+const REDIRECT_CODES = [301, 302, 303, 307, 308];
+const MAX_REDIRECTS = 5;
+
 export async function makeRequest(
   payload: Payload,
 ): Promise<{ res: needle.NeedleResponse; body: any }> {
   const { method, url, data, options } = setupRequest(payload);
+  // Disable needle's internal redirect following. When needle follows a
+  // redirect through a CONNECT proxy, the intermediate socket is never
+  // exposed to the callback and lingers, keeping the process alive.
+  // We follow redirects manually below so each hop gets its own agent
+  // and socket cleanup.
+  options.follow_max = 0;
 
   return new Promise((resolve, reject) => {
-    needle.request(method, url, data, options, (err, res, respBody) => {
-      if (res?.headers?.[headerSnykAuthFailed] === 'true') {
-        return reject(new MissingApiTokenError());
-      }
-      // respBody potentially very large, do not output it in debug
-      debug('response (%s)', (res || {}).statusCode);
-      if (err) {
-        debug('response err: %s', err);
-        return reject(err);
-      }
+    let redirectsLeft = MAX_REDIRECTS;
 
-      resolve({ res, body: respBody });
-    });
+    const sendRequest = (
+      reqMethod: string,
+      reqUrl: string,
+      reqData: any,
+      reqOptions: needle.NeedleOptions,
+    ) => {
+      needle.request(
+        reqMethod as needle.NeedleHttpVerbs,
+        reqUrl,
+        reqData,
+        reqOptions,
+        (err, res, respBody) => {
+          // Destroy the socket so the CONNECT tunnel doesn't keep the process alive.
+          res?.socket?.destroy();
+
+          if (res?.headers?.[headerSnykAuthFailed] === 'true') {
+            return reject(new MissingApiTokenError());
+          }
+          debug('response (%s)', (res || {}).statusCode);
+          if (err) {
+            debug('response err: %s', err);
+            return reject(err);
+          }
+
+          if (
+            res.statusCode &&
+            REDIRECT_CODES.includes(res.statusCode) &&
+            res.headers?.location &&
+            redirectsLeft > 0
+          ) {
+            redirectsLeft--;
+            const redirectUrl = new URL(res.headers.location, reqUrl).toString();
+            debug('following redirect to %s', redirectUrl);
+            const parsedRedirect = parse(redirectUrl);
+            const newAgent =
+              parsedRedirect.protocol === 'http:'
+                ? new http.Agent({ keepAlive: false })
+                : new https.Agent({ keepAlive: false });
+            return sendRequest('get', redirectUrl, null, {
+              ...reqOptions,
+              agent: newAgent,
+            });
+          }
+
+          resolve({ res, body: respBody });
+        },
+      );
+    };
+
+    sendRequest(method, url, data, options);
   });
 }
 

--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -203,11 +203,16 @@ export async function makeRequest(
             const preserveMethod =
               res.statusCode !== undefined &&
               METHOD_PRESERVING_REDIRECTS.includes(res.statusCode);
+            const redirectOptions = { ...reqOptions, agent: newAgent };
+            if (!preserveMethod) {
+              delete redirectOptions.headers!['content-length'];
+              delete redirectOptions.headers!['content-encoding'];
+            }
             return sendRequest(
               preserveMethod ? reqMethod : 'get',
               redirectUrl,
               preserveMethod ? reqData : null,
-              { ...reqOptions, agent: newAgent },
+              redirectOptions,
             );
           }
 

--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -190,12 +190,22 @@ export async function makeRequest(
             redirectsLeft > 0
           ) {
             redirectsLeft--;
-            const redirectUrl = new URL(
-              res.headers.location,
-              reqUrl,
-            ).toString();
+
+            let redirectUrl: string;
+            try {
+              redirectUrl = new URL(
+                res.headers.location,
+                reqUrl,
+              ).toString();
+            } catch (e) {
+              return reject(
+                new Error(`Invalid redirect Location: ${res.headers.location}`),
+              );
+            }
+
             debug('following redirect to %s', redirectUrl);
             const parsedRedirect = parse(redirectUrl);
+            const parsedOriginal = parse(reqUrl);
             const newAgent =
               parsedRedirect.protocol === 'http:'
                 ? new http.Agent({ keepAlive: false })
@@ -207,6 +217,11 @@ export async function makeRequest(
             if (!preserveMethod) {
               delete redirectOptions.headers!['content-length'];
               delete redirectOptions.headers!['content-encoding'];
+            }
+            // Strip auth headers on cross-origin redirects to avoid leaking credentials.
+            if (parsedRedirect.host !== parsedOriginal.host) {
+              delete redirectOptions.headers!['authorization'];
+              delete redirectOptions.headers!['session-token'];
             }
             return sendRequest(
               preserveMethod ? reqMethod : 'get',

--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -213,16 +213,28 @@ export async function makeRequest(
             const preserveMethod =
               res.statusCode !== undefined &&
               METHOD_PRESERVING_REDIRECTS.includes(res.statusCode);
-            const redirectOptions = { ...reqOptions, agent: newAgent };
+            const redirectHeaders = { ...reqOptions.headers };
             if (!preserveMethod) {
-              delete redirectOptions.headers!['content-length'];
-              delete redirectOptions.headers!['content-encoding'];
+              delete redirectHeaders['content-length'];
+              delete redirectHeaders['content-encoding'];
             }
-            // Strip auth headers on cross-origin redirects to avoid leaking credentials.
             if (parsedRedirect.host !== parsedOriginal.host) {
-              delete redirectOptions.headers!['authorization'];
-              delete redirectOptions.headers!['session-token'];
+              const sensitiveHeaders = [
+                'authorization',
+                'session-token',
+                'cookie',
+                'x-api-key',
+                'x-snyk-token',
+              ];
+              for (const h of sensitiveHeaders) {
+                delete redirectHeaders[h];
+              }
             }
+            const redirectOptions = {
+              ...reqOptions,
+              agent: newAgent,
+              headers: redirectHeaders,
+            };
             return sendRequest(
               preserveMethod ? reqMethod : 'get',
               redirectUrl,

--- a/test/tap/request.test.ts
+++ b/test/tap/request.test.ts
@@ -47,7 +47,7 @@ test('request calls needle as expected and returns status code and body', (t) =>
               'content-encoding': undefined, // should not set when no data
               'content-length': undefined, // should not be set when no data
             }),
-            follow_max: 5, // default
+            follow_max: 0, // needle's redirect following is disabled; we handle redirects manually
             timeout: 300000, // default
             json: undefined, // default
             agent: sinon.match.instanceOf(http.Agent),
@@ -85,7 +85,7 @@ test('request to localhost calls needle as expected', (t) => {
               'content-encoding': undefined, // should not set when no data
               'content-length': undefined, // should not be set when no data
             }),
-            follow_max: 5, // default
+            follow_max: 0, // needle's redirect following is disabled; we handle redirects manually
             timeout: 300000, // default
             json: undefined, // default
             agent: sinon.match.instanceOf(http.Agent),
@@ -124,7 +124,7 @@ test('request with timeout calls needle as expected', (t) => {
               'content-encoding': undefined, // should not set when no data
               'content-length': undefined, // should not be set when no data
             }),
-            follow_max: 5, // default
+            follow_max: 0, // needle's redirect following is disabled; we handle redirects manually
             timeout: 100000, // provided
             json: undefined, // default
             agent: sinon.match.instanceOf(http.Agent),
@@ -166,7 +166,7 @@ test('request with query string calls needle as expected', (t) => {
               'content-encoding': undefined, // should not set when no data
               'content-length': undefined, // should not be set when no data
             }),
-            follow_max: 5, // default
+            follow_max: 0, // needle's redirect following is disabled; we handle redirects manually
             timeout: 300000, // default
             json: undefined, // default
             agent: sinon.match.instanceOf(http.Agent),
@@ -205,7 +205,7 @@ test('request with json calls needle as expected', (t) => {
               'content-encoding': undefined, // should not set when no data
               'content-length': undefined, // should not be set when no data
             }),
-            follow_max: 5, // default
+            follow_max: 0, // needle's redirect following is disabled; we handle redirects manually
             timeout: 300000, // default
             json: false, // provided
             agent: sinon.match.instanceOf(http.Agent),
@@ -247,7 +247,7 @@ test('request with custom header calls needle as expected', (t) => {
               'content-encoding': undefined, // should not set when no data
               'content-length': undefined, // should not be set when no data
             }),
-            follow_max: 5, // default
+            follow_max: 0, // needle's redirect following is disabled; we handle redirects manually
             timeout: 300000, // default
             json: undefined, // default
             agent: sinon.match.instanceOf(http.Agent),
@@ -286,7 +286,7 @@ test('request with https proxy calls needle as expected', (t) => {
               'content-encoding': undefined, // should not set when no data
               'content-length': undefined, // should not be set when no data
             }),
-            follow_max: 5, // default
+            follow_max: 0, // needle's redirect following is disabled; we handle redirects manually
             timeout: 300000, // default
             json: undefined, // default
             agent: sinon.match.truthy,
@@ -335,7 +335,7 @@ test('request with http proxy calls needle as expected', (t) => {
               'content-encoding': undefined, // should not set when no data
               'content-length': undefined, // should not be set when no data
             }),
-            follow_max: 5, // default
+            follow_max: 0, // needle's redirect following is disabled; we handle redirects manually
             timeout: 300000, // default
             json: undefined, // default
             agent: sinon.match.truthy,
@@ -375,7 +375,7 @@ test('request with no proxy calls needle as expected', (t) => {
               'content-encoding': undefined, // should not set when no data
               'content-length': undefined, // should not be set when no data
             }),
-            follow_max: 5, // default
+            follow_max: 0, // needle's redirect following is disabled; we handle redirects manually
             timeout: 300000, // default
             json: undefined, // default
             agent: sinon.match.instanceOf(http.Agent),
@@ -414,7 +414,7 @@ test('request with insecure calls needle as expected', (t) => {
               'content-encoding': undefined, // should not set when no data
               'content-length': undefined, // should not be set when no data
             }),
-            follow_max: 5, // default
+            follow_max: 0, // needle's redirect following is disabled; we handle redirects manually
             timeout: 300000, // default
             json: undefined, // default
             agent: sinon.match.instanceOf(http.Agent),
@@ -471,7 +471,7 @@ test('request calls needle as expected and will not update HTTP to HTTPS if envv
               'content-encoding': undefined, // should not set when no data
               'content-length': undefined, // should not be set when no data
             }),
-            follow_max: 5, // default
+            follow_max: 0, // needle's redirect following is disabled; we handle redirects manually
             timeout: 300000, // default
             json: undefined, // default
             agent: sinon.match.instanceOf(http.Agent),


### PR DESCRIPTION
## Pull Request Submission Checklist

- [X Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [X] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [X] Includes detailed description of changes
- [X] Contains risk assessment (Low | Medium | High)
- [X] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [X] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Fixes snyk test hanging indefinitely when the Snyk API responds with a 302 redirect (e.g. for remote package scans like snyk test xlsx).

The root cause: needle (the HTTP client) follows redirects internally, creating an intermediate CONNECT tunnel socket that is never exposed to the callback. This socket keeps the Node.js event loop alive, preventing the subprocess from exiting, which blocks the Go CLI's snykCmd.Run() indefinitely.

The fix disables needle's built-in redirect following in makeRequest and implements manual redirect handling with explicit socket cleanup (res.socket.destroy()) after each hop. Each redirect creates a fresh agent so sockets are properly isolated and destroyed.

## Where should the reviewer start?

src/lib/request/request.ts — the only file changed. The makeRequest function now:

Sets options.follow_max = 0 to disable needle's redirect following
Uses an internal sendRequest loop that handles redirects manually
Calls res?.socket?.destroy() after every response to close the CONNECT tunnel

## How should this be manually tested?

1. snyk test xlsx — previously hangs indefinitely, should now complete and exit
2. snyk test <local-repo-with-package.json> — should continue to work as before (no redirect involved)
3. Any snyk test that triggers a 302 from the API (version-range vuln lookups)

## What's the product update that needs to be communicated to CLI users?

## Risk assessment (Low | Medium | High)?

Low. The change only affects makeRequest in the request module. Redirect behavior is preserved (same codes, same max of 5 hops), just handled manually instead of by needle. streamRequest is unaffected.

## What are the relevant tickets?

[CLI-1166](https://snyksec.atlassian.net/browse/CLI-1166)

<!---

## Any background context you want to provide?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->


[CLI-1166]: https://snyksec.atlassian.net/browse/CLI-1166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ