### PR TITLE
fix: allow CLI extensions to opt in to self-documented help

### DIFF
--- a/cliv2/cmd/cliv2/main.go
+++ b/cliv2/cmd/cliv2/main.go
@@ -432,6 +432,8 @@ func createCommandsForWorkflows(rootCommand *cobra.Command, engine workflow.Engi
 			// to preserve backwards compatibility we will need to relax flag validation
 			parentCommand.FParseErrWhitelist.UnknownFlags = true
 			parentCommand.Aliases = []string{"mcp-scan"}
+		case "redteam":
+			parentCommand.Annotations = map[string]string{"self-documented": "true"}
 		}
 	}
 }
@@ -444,8 +446,6 @@ func prepareRootCommand() *cobra.Command {
 		},
 	}
 
-	// help for all commands is handled by the legacy cli
-	// TODO: discuss how to move help to extensions
 	helpCommand := cobra.Command{
 		Use:  "help",
 		RunE: help,
@@ -457,8 +457,17 @@ func prepareRootCommand() *cobra.Command {
 	rootCommand.SilenceUsage = true
 	rootCommand.FParseErrWhitelist.UnknownFlags = true
 
-	// ensure that help and usage information comes from the legacy cli instead of cobra's default help
-	rootCommand.SetHelpFunc(func(c *cobra.Command, args []string) { _ = help(c, args) })
+	// Extensions can opt in to handle their own help by setting the "self-documented" annotation.
+	// When set, Cobra renders help from the command's flagset and Short/Long fields.
+	// Commands without the annotation fall back to the legacy CLI help.
+	rootCommand.SetHelpFunc(func(c *cobra.Command, args []string) {
+		if c.Annotations["self-documented"] == "true" {
+			c.InitDefaultHelpFlag()
+			_ = c.Usage()
+		} else {
+			_ = help(c, args)
+		}
+	})
 	rootCommand.SetHelpCommand(&helpCommand)
 	rootCommand.PersistentFlags().AddFlagSet(getGlobalFLags())
 


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Allows CLI extensions to opt in to handling `--help` via Cobra's flagset instead of TypeScript CLI's markdown-based help renderer. 

This is **opt-in** for now and each command would need to have the annotation added if they want to use the Cobra native help. 

### Context

Currently, all help is routed through the legacy CLI which reads markdown files from `help/cli-commands/` and renders them with a custom TypeScript pipeline. This couples extension help to external docs and means extensions cannot keep their documentation close to and true to the source code. This also adds the overhead of having to coordinate simple things like flag releases with the docs team. 

This is a minimal, backwards-compatible change. Extensions opt in by adding a single annotation in the switch case in `createCommandsForWorkflows()`. No changes to `go-application-framework` or individual extension repos are required.

### Extra considerations
- PROS: quicker help release cycle, smaller drift, especially when it comes to flags. This is important especially if agents are using our CLIs.
- CONS: 
     - this would need a little extra plumbing to allow extensions defining Short/Long descriptions for richer help output.
     -  not clear what would be the goal of the current help docs if extension switches

### TODO

- [ ] if accepted by the team, this needs to be documented 



## Where should the reviewer start?

`cliv2/cmd/cliv2/main.go` — the `prepareRootCommand()` and `createCommandsForWorkflows()` functions.

## How should this be manually tested?

1. Build the CLI: `cd cliv2 && go build ./cmd/cliv2/`
2. Run `snyk redteam --help` — should render Cobra-generated help from the flagset
3. Run `snyk test --help` — should still render the legacy markdown-based help (unchanged)

### Example

<img width="857" height="408" alt="image" src="https://github.com/user-attachments/assets/e92c318c-06ae-4a44-9d66-fb6fbce4b586" />

## What's the product update that needs to be communicated to CLI users?

N/A

## Risk assessment: Low

- Only affects commands that explicitly opt in via the `"self-documented"` annotation
- All existing commands continue to use the legacy help pipeline
- No changes to external dependencies