### PR TITLE
chore: fix UFM transitive upgrades being marked as directly upgradable

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.26.2
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260316131845-f02d7f42046b
-	github.com/snyk/go-application-framework v0.0.0-20260409121620-3a9c4e9c4dcd
+	github.com/snyk/go-application-framework v0.0.0-20260417133707-00def3e4b86d
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260414093345-2a6d7434eb91

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -561,8 +561,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260316131845-f02d7f42046b h1:DM2SPu7rhsD/TNS7zhv4ZoqLLi2cFOqg1VTBCP6RfSg=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260316131845-f02d7f42046b/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.0.0-20260409121620-3a9c4e9c4dcd h1:6dhKp2MiV5Xf+7vehQYIWV3z63AurlKT1X1NfPq46Es=
-github.com/snyk/go-application-framework v0.0.0-20260409121620-3a9c4e9c4dcd/go.mod h1:7IOOtKxiQhtTbkrX7rax20QNJ/rwGill6n2Rejtld2I=
+github.com/snyk/go-application-framework v0.0.0-20260417133707-00def3e4b86d h1:FRZzc/FkD19AfgRU3Y0kwIpZMZAlQ4bGicQt6VFViqU=
+github.com/snyk/go-application-framework v0.0.0-20260417133707-00def3e4b86d/go.mod h1:7IOOtKxiQhtTbkrX7rax20QNJ/rwGill6n2Rejtld2I=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.3 h1:MU+K8pxbN6VZ9P5wALUt8BwTjrPDpoEtmTtQqj7sKfY=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
In certain cases the Remediation Summary from the UFM Presenter would treat transitive dependency upgrades as directly upgradable. This would results in incorrect upgrade advice (e.g. Upgrade from x@1.2.3 to x@1.2.3 - since the actual upgrade would be inside for a nested dependency).


## Where should the reviewer start?

- [GAF PR](https://github.com/snyk/go-application-framework/pull/582)

## How should this be manually tested?

- Running an OSS against the CLI repository with `--reachability` enabled should show some different results in terms of issues reported as directly upgradable. The changes should also align more the UFM remediation output to the legacy CLI output (can be teste with OSS scans with/without reachability enabled).

## What's the product update that needs to be communicated to CLI users?

None.

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
