### PR TITLE
refactor: use uv plugin behind new interface

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260312152423-bc36193ecaa8
 	github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603
 	github.com/snyk/cli-extension-ai-redteam v0.0.0-20260331152502-ce341aeaff9e
-	github.com/snyk/cli-extension-dep-graph v0.32.0
+	github.com/snyk/cli-extension-dep-graph v0.32.3
 	github.com/snyk/cli-extension-iac v0.0.0-20260206082514-00c443ccee80
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260206080712-9cbb5f95465d
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260330131038-f7539faafecf

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -541,8 +541,8 @@ github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603 h1:uZyw9
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603/go.mod h1:RnMP+tFTeKygfXSx7z+heyMZoOps67u5HFytjptHjuk=
 github.com/snyk/cli-extension-ai-redteam v0.0.0-20260331152502-ce341aeaff9e h1:WZ4Ph3iX+fAu3/HgblVnA+AXfKiEvrgHsZq8GHjnzzo=
 github.com/snyk/cli-extension-ai-redteam v0.0.0-20260331152502-ce341aeaff9e/go.mod h1:445d735F53IuegetHs/S4GyWyng4Crd9TPj4vosmFmM=
-github.com/snyk/cli-extension-dep-graph v0.32.0 h1:6otM3SIqYIRFonKXeIGg0tZVcNxZevAySg3sOOT+64Q=
-github.com/snyk/cli-extension-dep-graph v0.32.0/go.mod h1:66H2oCkziptQrUDibPe3m8rx+S6XcpnUL5udT+wfrmY=
+github.com/snyk/cli-extension-dep-graph v0.32.3 h1:XpPqBPQg3gwVUM2oM3Li2w1y8JTMIN8+M/egVsdBDI8=
+github.com/snyk/cli-extension-dep-graph v0.32.3/go.mod h1:66H2oCkziptQrUDibPe3m8rx+S6XcpnUL5udT+wfrmY=
 github.com/snyk/cli-extension-iac v0.0.0-20260206082514-00c443ccee80 h1:JHbnSkgGc2oUejjzdWdeTghl0BZV7QamcRuyh7ornVo=
 github.com/snyk/cli-extension-iac v0.0.0-20260206082514-00c443ccee80/go.mod h1:Ht5k+sWdi//fM2MjcmBMWjcJmr35iMvQpYlBWnUHL4I=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260206080712-9cbb5f95465d h1:xkxHgZ+DT4hRiIEeAEv1JWLJRYV4MbAFvtEUpUkndPA=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High) - Low
- [ ] Highlights breaking API changes (if applicable) - n/a
- [ ] Links to automated tests covering new functionality - n/a
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___) - n/a
- [ ] Includes product update to be announced in the next stable release notes - n/a

## What does this PR do?

In [this PR](https://github.com/snyk/cli-extension-dep-graph/pull/134/) we updated the uv plugin in the dep-graph extension to use a new interface. This PR pulls in that change. Given that this was purely a refactor there should be no changes due to this change, but I wanted to bump the extension version nonetheless to ensure that this change was separated out from future changes.

## How should this be manually tested?

Build the CLI and run `test`, `monitor` and `sbom` against a uv project.

## What's the product update that needs to be communicated to CLI users?

None