### PR TITLE
fix: map uv to correct semver definition

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/snyk/cli-extension-dep-graph v0.32.3
 	github.com/snyk/cli-extension-iac v0.0.0-20260206082514-00c443ccee80
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260206080712-9cbb5f95465d
-	github.com/snyk/cli-extension-os-flows v0.0.0-20260330131038-f7539faafecf
+	github.com/snyk/cli-extension-os-flows v0.0.0-20260407123134-f9617cb05038
 	github.com/snyk/cli-extension-sbom v0.0.0-20260327120356-9befea04c9b0
 	github.com/snyk/cli-extension-secrets v0.0.0-20260407113038-69d8fdb95266
 	github.com/snyk/code-client-go v1.26.2

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -547,8 +547,8 @@ github.com/snyk/cli-extension-iac v0.0.0-20260206082514-00c443ccee80 h1:JHbnSkgG
 github.com/snyk/cli-extension-iac v0.0.0-20260206082514-00c443ccee80/go.mod h1:Ht5k+sWdi//fM2MjcmBMWjcJmr35iMvQpYlBWnUHL4I=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260206080712-9cbb5f95465d h1:xkxHgZ+DT4hRiIEeAEv1JWLJRYV4MbAFvtEUpUkndPA=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260206080712-9cbb5f95465d/go.mod h1:ztpTmC4n8MEO0B48M2nL/Q9tb6CkLZ61ZKZbjwhOKRo=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260330131038-f7539faafecf h1:CGZ3hKD5O0g6Zfg51WqKxVUZWuIi/g+CiAekxQVqqbg=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260330131038-f7539faafecf/go.mod h1:guMfnOGktk4XXZ5fXulGPn55IlH3/8J8pMDcSXBWm54=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260407123134-f9617cb05038 h1:6Myzjw4cYOBVVwsJfdqwks4Wf6zVFdOGynIylky7wc4=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260407123134-f9617cb05038/go.mod h1:9Vz1sr4air/Oj/shth646UHSyChTRAZ1Ulx9BFbUCf0=
 github.com/snyk/cli-extension-sbom v0.0.0-20260327120356-9befea04c9b0 h1:QK9cPBpPYzm1jxT2VAUUjtdXZfJllRRjRwuslTERuco=
 github.com/snyk/cli-extension-sbom v0.0.0-20260327120356-9befea04c9b0/go.mod h1:SJ624HENWG4yjM6jNuLebTeNsMriozf1LcKhMYVm1aY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260407113038-69d8fdb95266 h1:nZzwbMUTm3vXwT7jvNF7T1JxjHHNQIVu7Rzf3hCeMIQ=

--- a/package-lock.json
+++ b/package-lock.json
@@ -22771,68 +22771,6 @@
         "npm": ">= 8.6.0"
       }
     },
-    "packages/cli-alert/node_modules/@slack/webhook/node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "packages/cli-alert/node_modules/@slack/webhook/node_modules/axios/node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "packages/cli-alert/node_modules/@slack/webhook/node_modules/axios/node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "packages/cli-alert/node_modules/@slack/webhook/node_modules/axios/node_modules/form-data/node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "packages/cli-alert/node_modules/@types/node": {
       "version": "20.11.30",
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -195,7 +195,8 @@
     },
     "@types/jest-json-schema@^6.1.5": {
       "ajv@6.10.2": "8.18.0"
-    }
+    },
+    "axios": "^1.15.0"
   },
   "repository": {
     "type": "git",

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -684,45 +684,20 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
     });
   });
 
-  app.post(`/api/hidden/orgs/:orgId/upload_revisions`, (req, res) => {
-    res.status(201).send({
-      data: {
-        attributes: {
-          revision_type: 'snapshot',
-          sealed: false,
-        },
-        id: 'bc0729a7-109f-4fe9-a048-aac410e28c9a',
-        type: 'upload_revision',
-      },
-      jsonapi: {
-        version: '1.0',
-      },
-      links: {
-        self: {
-          href: '/orgs/bb262a15-d798-458b-81fa-30a92cb3475c/upload_revisions/bc0729a7-109f-4fe9-a048-aac410e28c9a',
-        },
-      },
-    });
-  });
-
+  // Both prefixes are required due to API URL canonicalisation, performed in some extensions.
   app.post(
-    `/api/hidden/orgs/:orgId/upload_revisions/:uploadRevisionId/files`,
-    (_, res) => {
-      res.status(204);
-      res.send();
-    },
-  );
-
-  app.patch(
-    `/api/hidden/orgs/:orgId/upload_revisions/:uploadRevisionId`,
+    [
+      `/hidden/orgs/:orgId/upload_revisions`,
+      `/api/hidden/orgs/:orgId/upload_revisions`,
+    ],
     (req, res) => {
-      res.status(200).send({
+      res.status(201).send({
         data: {
           attributes: {
             revision_type: 'snapshot',
-            sealed: true,
+            sealed: false,
           },
-          id: 'fbdb5cc0-6e34-4191-b088-0dff740faf38',
+          id: 'bc0729a7-109f-4fe9-a048-aac410e28c9a',
           type: 'upload_revision',
         },
         jsonapi: {
@@ -730,7 +705,45 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
         },
         links: {
           self: {
-            href: '/orgs/bb262a15-d798-458b-81fa-30a92cb3475c/upload_revisions/fbdb5cc0-6e34-4191-b088-0dff740faf38',
+            href: `/orgs/${req.params.orgId}/upload_revisions/bc0729a7-109f-4fe9-a048-aac410e28c9a`,
+          },
+        },
+      });
+    },
+  );
+
+  app.post(
+    [
+      `/hidden/orgs/:orgId/upload_revisions/:uploadRevisionId/files`,
+      `/api/hidden/orgs/:orgId/upload_revisions/:uploadRevisionId/files`,
+    ],
+    (_, res) => {
+      res.status(204);
+      res.send();
+    },
+  );
+
+  app.patch(
+    [
+      `/hidden/orgs/:orgId/upload_revisions/:uploadRevisionId`,
+      `/api/hidden/orgs/:orgId/upload_revisions/:uploadRevisionId`,
+    ],
+    (req, res) => {
+      res.status(200).send({
+        data: {
+          attributes: {
+            revision_type: 'snapshot',
+            sealed: true,
+          },
+          id: req.params.uploadRevisionId,
+          type: 'upload_revision',
+        },
+        jsonapi: {
+          version: '1.0',
+        },
+        links: {
+          self: {
+            href: `/orgs/${req.params.orgId}/upload_revisions/${req.params.uploadRevisionId}`,
           },
         },
       });

--- a/test/fixtures/sbom/uv-findings-response.json
+++ b/test/fixtures/sbom/uv-findings-response.json
@@ -1,0 +1,404 @@
+{
+  "data": [
+    {
+      "attributes": {
+        "cause_of_failure": false,
+        "description": "## Overview\n[Jinja2](https://pypi.org/project/Jinja2/) is a template engine written in pure Python. It provides a Django inspired non-XML syntax but supports inline expressions and an optional sandboxed environment.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). The ReDoS vulnerability is mainly due to the `_punctuation_re regex` operator and its use of multiple wildcards. The last wildcard is the most exploitable as it searches for trailing punctuation.\r\n\r\nThis issue can be mitigated by using Markdown to format user content instead of the urlize filter, or by implementing request timeouts or limiting process memory.\r\n\r\n### PoC by Yeting Li\r\n```\r\nfrom jinja2.utils import urlize\r\nfrom time import perf_counter\r\n\r\nfor i in range(3):\r\n    text = \"abc@\" + \".\" * (i+1)*5000 + \"!\"\r\n    LEN = len(text)\r\n    BEGIN = perf_counter()\r\n    urlize(text)\r\n    DURATION = perf_counter() - BEGIN\r\n    print(f\"{LEN}: took {DURATION} seconds!\")\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet\u2019s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn\u2019t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `Jinja2` to version 2.11.3 or higher.\n## References\n- [GitHub Additional Information](https://github.com/pallets/jinja/blob/ab81fd9c277900c85da0c322a2ff9d68a235b2e6/src/jinja2/utils.py#L20)\n- [GitHub PR](https://github.com/pallets/jinja/pull/1343)\n",
+        "evidence": [
+          {
+            "path": [
+              {
+                "name": "simple-project",
+                "version": "0.1.0"
+              },
+              {
+                "name": "jinja2",
+                "version": "2.11.2"
+              }
+            ],
+            "source": "dependency_path"
+          },
+          {
+            "reachability": "not_applicable",
+            "source": "reachability"
+          }
+        ],
+        "finding_type": "sca",
+        "key": "1713892d-d0ce-41d4-8623-e179e3c33128",
+        "locations": [
+          {
+            "package": {
+              "name": "jinja2",
+              "version": "2.11.2"
+            },
+            "type": "package"
+          }
+        ],
+        "policy_modifications": [],
+        "problems": [
+          {
+            "id": "CVE-2020-28493",
+            "source": "cve"
+          },
+          {
+            "id": "GHSA-g3rq-g295-4j3m",
+            "source": "ghsa"
+          },
+          {
+            "affected_hash_ranges": [],
+            "affected_hashes": [],
+            "affected_versions": [
+              "[,2.11.3)"
+            ],
+            "alternative_ids": [],
+            "created_at": "2020-09-25T17:30:26Z",
+            "credits": [
+              "Yeting Li"
+            ],
+            "cvss_base_score": 5.3,
+            "cvss_sources": [
+              {
+                "assigner": "Snyk",
+                "base_score": 5.3,
+                "cvss_version": "CVSSv31",
+                "modified_at": "0001-01-01T00:00:00Z",
+                "severity": "medium",
+                "type": "primary",
+                "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P"
+              },
+              {
+                "assigner": "SUSE",
+                "base_score": 7.5,
+                "cvss_version": "CVSSv31",
+                "modified_at": "0001-01-01T00:00:00Z",
+                "severity": "high",
+                "type": "secondary",
+                "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+              },
+              {
+                "assigner": "NVD",
+                "base_score": 5.3,
+                "cvss_version": "CVSSv31",
+                "modified_at": "0001-01-01T00:00:00Z",
+                "severity": "medium",
+                "type": "secondary",
+                "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+              },
+              {
+                "assigner": "Red Hat",
+                "base_score": 7.5,
+                "cvss_version": "CVSSv31",
+                "modified_at": "0001-01-01T00:00:00Z",
+                "severity": "high",
+                "type": "secondary",
+                "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+              }
+            ],
+            "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:P",
+            "disclosed_at": "2020-09-25T17:29:19Z",
+            "ecosystem": {
+              "language": "python",
+              "package_manager": "uv",
+              "type": "build"
+            },
+            "epss_details": {
+              "model_version": "v2025.03.14",
+              "percentile": "0.42975",
+              "probability": "0.00207"
+            },
+            "exploit_details": {
+              "maturity_levels": [
+                {
+                  "format": "CVSSv3",
+                  "level": "proof of concept",
+                  "type": "secondary"
+                },
+                {
+                  "format": "CVSSv4",
+                  "level": "proof of concept",
+                  "type": "primary"
+                }
+              ],
+              "sources": [
+                "Snyk"
+              ]
+            },
+            "id": "SNYK-PYTHON-JINJA2-1012994",
+            "initially_fixed_in_versions": [
+              "2.11.3"
+            ],
+            "is_fixable": true,
+            "is_malicious": false,
+            "is_social_media_trending": false,
+            "modified_at": "2024-03-11T09:53:50Z",
+            "package_name": "jinja2",
+            "package_version": "2.11.2",
+            "published_at": "2021-02-01T19:52:17Z",
+            "references": [
+              {
+                "title": "GitHub Additional Information",
+                "url": "https://github.com/pallets/jinja/blob/ab81fd9c277900c85da0c322a2ff9d68a235b2e6/src/jinja2/utils.py%23L20"
+              },
+              {
+                "title": "GitHub PR",
+                "url": "https://github.com/pallets/jinja/pull/1343"
+              }
+            ],
+            "severity": "medium",
+            "source": "snyk_vuln"
+          },
+          {
+            "id": "CWE-400",
+            "source": "cwe"
+          }
+        ],
+        "rating": {
+          "severity": "medium"
+        },
+        "risk": {},
+        "title": "Regular Expression Denial of Service (ReDoS)"
+      },
+      "id": "1713892d-d0ce-41d4-8623-e179e3c33128",
+      "links": {},
+      "relationships": {
+        "fix": {
+          "data": {
+            "attributes": {
+              "action": {
+                "format": "upgrade_package_advice",
+                "package_name": "jinja2",
+                "upgrade_paths": [
+                  {
+                    "dependency_path": [
+                      {
+                        "name": "simple-project",
+                        "version": "0.1.0"
+                      },
+                      {
+                        "name": "jinja2",
+                        "version": "2.11.3"
+                      }
+                    ],
+                    "is_drop": false
+                  }
+                ]
+              },
+              "outcome": "fully_resolved"
+            },
+            "id": "1713892d-d0ce-41d4-8623-e179e3c33128",
+            "type": "fixes"
+          }
+        }
+      },
+      "type": "findings"
+    },
+    {
+      "attributes": {
+        "cause_of_failure": false,
+        "description": "## Overview\n[urllib3](https://pypi.org/project/urllib3/) is a HTTP library with thread-safe connection pooling, file post, and more.\n\nAffected versions of this package are vulnerable to Improper Handling of Highly Compressed Data (Data Amplification) in the Streaming API. The `ContentDecoder` class can be forced to allocate disproportionate resources when processing a single chunk with very high compression, such as via the `stream()`, `read(amt=256)`, `read1(amt=256)`, `read_chunked(amt=256)`, and `readinto(b)` functions.\r\n\r\n**Note:** It is recommended to patch Brotli dependencies (upgrade to at least 1.2.0) if they are installed outside of `urllib3` as well, to avoid other instances of the same vulnerability.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\n\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\n\nTwo common types of DoS vulnerabilities:\n\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](https://security.snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-30082).\n\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](https://snyk.io/vuln/npm:ws:20171108)\n\n## Remediation\nUpgrade `urllib3` to version 2.6.0 or higher.\n## References\n- [GitHub Commit](https://github.com/urllib3/urllib3/commit/c19571de34c47de3a766541b041637ba5f716ed7)\n",
+        "evidence": [
+          {
+            "path": [
+              {
+                "name": "simple-project",
+                "version": "0.1.0"
+              },
+              {
+                "name": "urllib3",
+                "version": "1.24.3"
+              }
+            ],
+            "source": "dependency_path"
+          },
+          {
+            "reachability": "not_applicable",
+            "source": "reachability"
+          }
+        ],
+        "finding_type": "sca",
+        "key": "192e81de-cce6-4b8d-b18a-064041a22fdc",
+        "locations": [
+          {
+            "package": {
+              "name": "urllib3",
+              "version": "1.24.3"
+            },
+            "type": "package"
+          }
+        ],
+        "policy_modifications": [],
+        "problems": [
+          {
+            "id": "CWE-409",
+            "source": "cwe"
+          },
+          {
+            "id": "CVE-2025-66471",
+            "source": "cve"
+          },
+          {
+            "id": "GHSA-2xpw-w6gg-jr37",
+            "source": "ghsa"
+          },
+          {
+            "affected_hash_ranges": [],
+            "affected_hashes": [],
+            "affected_versions": [
+              "[1.0,2.6.0)"
+            ],
+            "alternative_ids": [],
+            "created_at": "2025-12-05T17:34:10Z",
+            "credits": [
+              "Rui Xi",
+              "Miroslav Stampar"
+            ],
+            "cvss_base_score": 8.9,
+            "cvss_sources": [
+              {
+                "assigner": "Snyk",
+                "base_score": 8.9,
+                "cvss_version": "CVSSv4",
+                "modified_at": "0001-01-01T00:00:00Z",
+                "severity": "high",
+                "type": "primary",
+                "vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:H"
+              },
+              {
+                "assigner": "Snyk",
+                "base_score": 6.8,
+                "cvss_version": "CVSSv31",
+                "modified_at": "0001-01-01T00:00:00Z",
+                "severity": "medium",
+                "type": "secondary",
+                "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:N/I:N/A:H"
+              },
+              {
+                "assigner": "NVD",
+                "base_score": 7.5,
+                "cvss_version": "CVSSv31",
+                "modified_at": "0001-01-01T00:00:00Z",
+                "severity": "high",
+                "type": "secondary",
+                "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+              },
+              {
+                "assigner": "SUSE",
+                "base_score": 5.3,
+                "cvss_version": "CVSSv31",
+                "modified_at": "0001-01-01T00:00:00Z",
+                "severity": "medium",
+                "type": "secondary",
+                "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+              },
+              {
+                "assigner": "Red Hat",
+                "base_score": 7.5,
+                "cvss_version": "CVSSv31",
+                "modified_at": "0001-01-01T00:00:00Z",
+                "severity": "high",
+                "type": "secondary",
+                "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+              }
+            ],
+            "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:H",
+            "disclosed_at": "2025-12-05T16:40:41Z",
+            "ecosystem": {
+              "language": "python",
+              "package_manager": "uv",
+              "type": "build"
+            },
+            "epss_details": {
+              "model_version": "v2025.03.14",
+              "percentile": "0.08913",
+              "probability": "0.00031"
+            },
+            "exploit_details": {
+              "maturity_levels": [
+                {
+                  "format": "CVSSv3",
+                  "level": "unproven",
+                  "type": "secondary"
+                },
+                {
+                  "format": "CVSSv4",
+                  "level": "unreported",
+                  "type": "primary"
+                }
+              ],
+              "sources": []
+            },
+            "id": "SNYK-PYTHON-URLLIB3-14192442",
+            "initially_fixed_in_versions": [
+              "2.6.0"
+            ],
+            "is_fixable": true,
+            "is_malicious": false,
+            "is_social_media_trending": false,
+            "modified_at": "2026-02-07T05:35:23Z",
+            "package_name": "urllib3",
+            "package_version": "1.24.3",
+            "published_at": "2025-12-07T11:04:17Z",
+            "references": [
+              {
+                "title": "GitHub Commit",
+                "url": "https://github.com/urllib3/urllib3/commit/c19571de34c47de3a766541b041637ba5f716ed7"
+              }
+            ],
+            "severity": "high",
+            "source": "snyk_vuln"
+          }
+        ],
+        "rating": {
+          "severity": "high"
+        },
+        "risk": {},
+        "title": "Improper Handling of Highly Compressed Data (Data Amplification)"
+      },
+      "id": "192e81de-cce6-4b8d-b18a-064041a22fdc",
+      "links": {},
+      "relationships": {
+        "fix": {
+          "data": {
+            "attributes": {
+              "action": {
+                "format": "upgrade_package_advice",
+                "package_name": "urllib3",
+                "upgrade_paths": [
+                  {
+                    "dependency_path": [
+                      {
+                        "name": "simple-project",
+                        "version": "0.1.0"
+                      },
+                      {
+                        "name": "urllib3",
+                        "version": "2.6.0"
+                      }
+                    ],
+                    "is_drop": false
+                  }
+                ]
+              },
+              "outcome": "fully_resolved"
+            },
+            "id": "192e81de-cce6-4b8d-b18a-064041a22fdc",
+            "type": "fixes"
+          }
+        }
+      },
+      "type": "findings"
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+    "first": "/orgs/6d66a729-298d-4055-a3e2-94e9b44e6c26/tests/916196fb-c6ad-4958-93d2-0e6cefe777bb/findings?version=2024-10-15&limit=100",
+    "self": "/orgs/6d66a729-298d-4055-a3e2-94e9b44e6c26/tests/916196fb-c6ad-4958-93d2-0e6cefe777bb/findings?version=2024-10-15&limit=100"
+  },
+  "meta": {
+    "count": 2,
+    "order": "asc",
+    "sorted-by": "id"
+  }
+}

--- a/test/fixtures/sbom/uv-sbom-cdx15.json
+++ b/test/fixtures/sbom/uv-sbom-cdx15.json
@@ -1,0 +1,74 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "serialNumber": "urn:uuid:360d9923-6729-4332-9370-ee0dc4758e04",
+  "metadata": {
+    "timestamp": "2026-04-10T10:40:16.133339000Z",
+    "tools": [
+      {
+        "vendor": "Astral Software Inc.",
+        "name": "uv",
+        "version": "0.11.3"
+      }
+    ],
+    "component": {
+      "type": "library",
+      "bom-ref": "simple-project-1@0.1.0",
+      "name": "simple-project",
+      "version": "0.1.0",
+      "properties": [
+        {
+          "name": "uv:package:is_project_root",
+          "value": "true"
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "jinja2-2@2.11.2",
+      "name": "jinja2",
+      "version": "2.11.2",
+      "purl": "pkg:pypi/jinja2@2.11.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "markupsafe-3@3.0.3",
+      "name": "markupsafe",
+      "version": "3.0.3",
+      "purl": "pkg:pypi/markupsafe@3.0.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "urllib3-4@1.24.3",
+      "name": "urllib3",
+      "version": "1.24.3",
+      "purl": "pkg:pypi/urllib3@1.24.3"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "jinja2-2@2.11.2",
+      "dependsOn": [
+        "markupsafe-3@3.0.3"
+      ]
+    },
+    {
+      "ref": "markupsafe-3@3.0.3",
+      "dependsOn": []
+    },
+    {
+      "ref": "simple-project-1@0.1.0",
+      "dependsOn": [
+        "jinja2-2@2.11.2",
+        "urllib3-4@1.24.3"
+      ]
+    },
+    {
+      "ref": "urllib3-4@1.24.3",
+      "dependsOn": []
+    }
+  ]
+}

--- a/test/jest/acceptance/snyk-sbom-test/snyk-sbom-test.spec.ts
+++ b/test/jest/acceptance/snyk-sbom-test/snyk-sbom-test.spec.ts
@@ -1,0 +1,78 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { fakeServer } from '../../../acceptance/fake-server';
+import { getAvailableServerPort } from '../../util/getServerPort';
+import { getFixturePath } from '../../util/getFixturePath';
+import { runSnykCLI } from '../../util/runSnykCLI';
+import { EXIT_CODES } from '../../../../src/cli/exit-codes';
+import { testIf } from '../../../utils';
+
+jest.setTimeout(1000 * 60 * 5);
+
+const hasBinary = !!process.env.TEST_SNYK_COMMAND;
+
+// Org ID returned by the fake server's /rest/self endpoint.
+const FAKE_SERVER_ORG_ID = '55555555-5555-5555-5555-555555555555';
+// Test ID the fake server assigns via the test_jobs 303 redirect.
+const FAKE_SERVER_TEST_ID = 'aaaaaaaa-bbbb-cccc-dddd-000000000002';
+
+describe('snyk sbom test (mocked server only)', () => {
+  let server;
+  let env: Record<string, string>;
+
+  beforeAll(async () => {
+    const port = await getAvailableServerPort(process);
+    const baseApi = '/v1';
+    env = {
+      ...process.env,
+      SNYK_API: 'http://localhost:' + port + baseApi,
+      SNYK_HOST: 'http://localhost:' + port,
+      SNYK_TOKEN: '123456789',
+      SNYK_HTTP_PROTOCOL_UPGRADE: '0',
+    };
+    server = fakeServer(baseApi, env.SNYK_TOKEN);
+    await server.listenPromise(port);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    server.restore();
+  });
+
+  afterAll((done) => {
+    server.close(() => {
+      done();
+    });
+  });
+
+  testIf(hasBinary)(
+    '`sbom test` succeeds for a uv CycloneDX SBOM',
+    async () => {
+      server.setFeatureFlag('enableUvCLI', true);
+
+      const findingsResponse = JSON.parse(
+        fs.readFileSync(
+          path.resolve(getFixturePath('sbom'), 'uv-findings-response.json'),
+          'utf8',
+        ),
+      );
+      server.setEndpointResponse(
+        `/rest/orgs/${FAKE_SERVER_ORG_ID}/tests/${FAKE_SERVER_TEST_ID}/findings`,
+        findingsResponse,
+      );
+
+      const sbomFilePath = getFixturePath('sbom/uv-sbom-cdx15.json');
+      const { code, stdout, stderr } = await runSnykCLI(
+        `sbom test --file=${sbomFilePath}`,
+        { env },
+      );
+
+      expect(stderr).toBe('');
+      expect(stdout).not.toContain('no semver library defined for ecosystem');
+      expect(stdout).toContain('Test Summary');
+      expect(stdout).toContain('Issues to fix by upgrading');
+      expect(code).toBe(EXIT_CODES.VULNS_FOUND);
+    },
+  );
+});


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High) - Low
- [ ] Highlights breaking API changes (if applicable) - n/a
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___) - n/a
- [ ] Includes product update to be announced in the next stable release notes - n/a

## What does this PR do?

This PR makes use of the fix [here](https://github.com/snyk/cli-extension-os-flows/pull/221) to map to the correct semver definition for uv. This resolves an issue with testing SBOMs generated directly by uv (it does not affect SBOMs of uv projects generated by `snyk sbom`).

I also had to update `fake-server.ts`. Extensions using a localhost API URL (e.g. os-flows/sbom) have it canonicalised by go-application-framework, stripping the `/api` prefix, so they call `/hidden/orgs/...`. Extensions using a non-localhost IP (e.g. aibom) skip canonicalisation and call `/api/hidden/orgs/...`. The fix registers the `upload_revisions` handlers for both prefixes, and updates response bodies to use dynamic path params rather than hardcoded UUIDs.

Finally, I also added an override for `axios` to address https://security.snyk.io/vuln/SNYK-JS-AXIOS-15965856.

## How should this be manually tested?

Generate an SBOM for a uv project using

```sh
uv export --format=cyclonedx1.5 --preview --frozen --no-dev > sbom.json
```

then test it using

```sh
snyk sbom test --file=sbom.json
```

On main you should see an error like the following:

```
 ERROR   Unspecified Error (SNYK-CLI-0000)
         The encountered error only provides basic information, please take a look at
         the given details. If they do not help to resolve the issue, consider
         debugging or consulting support.

           failed to compute remediation summary: failed to resolve semver library: no
           semver library defined for ecosystem: uv
```

but on this branch you should see a successful run.

## What's the product update that needs to be communicated to CLI users?

None