### PR TITLE
chore(language-server): integrate LS

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/snyk/go-application-framework v0.0.0-20260409121620-3a9c4e9c4dcd
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20260401163317-c1fe9ee766fd
+	github.com/snyk/snyk-ls v0.0.0-20260414093345-2a6d7434eb91
 	github.com/snyk/studio-mcp v1.9.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -569,8 +569,8 @@ github.com/snyk/policy-engine v1.1.3 h1:MU+K8pxbN6VZ9P5wALUt8BwTjrPDpoEtmTtQqj7s
 github.com/snyk/policy-engine v1.1.3/go.mod h1:yOc6YZLWhVGUZjzskDTen8zxrNTUHL4FyZXM0Ezlb8M=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260401163317-c1fe9ee766fd h1:U1LAtMHLmLK1lxfvFX4errx7cA1l5jKKSLFoZFdPsmw=
-github.com/snyk/snyk-ls v0.0.0-20260401163317-c1fe9ee766fd/go.mod h1:3lXmUS3pmxjyIQEfnuf8yFjfSmaOP7XuhTVusJkllhU=
+github.com/snyk/snyk-ls v0.0.0-20260414093345-2a6d7434eb91 h1:1x8/ejhKYyKZ1ifBxODikWwDRHWhDU/8OXkWLd5KTX8=
+github.com/snyk/snyk-ls v0.0.0-20260414093345-2a6d7434eb91/go.mod h1:rcQO2g/KAvJACzKN2ME7xwUb97HpLl+9TM3SyTg+EAA=
 github.com/snyk/studio-mcp v1.9.1 h1:QR8DKICAK51GOf8zhHbGA0y5xK5vv6GiTp1lCXg5BDw=
 github.com/snyk/studio-mcp v1.9.1/go.mod h1:CiMKFs/PJrAMjG8Zjkvx+XwuM0XlxGJ7jP5yCr5hm5w=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit 2a6d7434eb914ebe1d2c4629f1e7d72dc4190432
Author: Andrew Robinson Hodges <andrew.robinsonhodges@snyk.io>
Date:   Tue Apr 14 10:33:45 2026 +0100

    chore: update go to 1.26.2 [IDE-1935] (#1206)
    
    * chore: update go to 1.26.2
    
    * chore: update golangci-lint to 2.9.0
    
    * chore: update contributing.md with new go version

M	.circleci/config.yml
M	CONTRIBUTING.md
M	Makefile
M	go.mod

commit d8c345b66ba62d9f375e63b9df8c9a8a9d35321e
Author: Andrew Robinson Hodges <andrew.robinsonhodges@snyk.io>
Date:   Fri Apr 10 10:17:50 2026 +0100

    fix: if the cli download field is empty, use the falback url (#1198)

M	shared_ide_resources/ui/html/settings-fallback.html
```

[IDE-1935]: https://snyksec.atlassian.net/browse/IDE-1935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ