### PR TITLE
feat: include targetRuntime in output of --print-effective-graph

### DIFF
--- a/src/lib/snyk-test/common.ts
+++ b/src/lib/snyk-test/common.ts
@@ -115,6 +115,7 @@ export async function printEffectiveDepGraph(
   normalisedTargetFile: string,
   targetFileFromPlugin: string | undefined,
   target: GitTarget | ContainerTarget | null | undefined,
+  targetRuntime: string | undefined,
   destination: Writable,
 ): Promise<void> {
   return new Promise((res, rej) => {
@@ -123,6 +124,7 @@ export async function printEffectiveDepGraph(
       normalisedTargetFile,
       targetFileFromPlugin,
       target,
+      targetRuntime,
     };
 
     new ConcatStream(

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -880,6 +880,7 @@ async function assembleLocalPayloads(
           targetFile,
           project.plugin.targetFile,
           target,
+          scannedProject.meta?.targetRuntime ?? project.plugin?.targetRuntime,
           process.stdout,
         );
       }

--- a/test/jest/acceptance/print-effective-dep-graph-with-errors.spec.ts
+++ b/test/jest/acceptance/print-effective-dep-graph-with-errors.spec.ts
@@ -1,7 +1,11 @@
 import { fakeServer } from '../../acceptance/fake-server';
-import { createProjectFromFixture } from '../util/createProject';
-import { runSnykCLI } from '../util/runSnykCLI';
+import {
+  createProjectFromFixture,
+  createProjectFromWorkspace,
+} from '../util/createProject';
 import { getServerPort } from '../util/getServerPort';
+import { parseJSONL } from '../util/parseJSONL';
+import { runSnykCLI } from '../util/runSnykCLI';
 import { ProblemError } from '@snyk/error-catalog-nodejs-public';
 
 jest.setTimeout(1000 * 30);
@@ -163,20 +167,7 @@ describe('`test` command with `--print-effective-graph-with-errors` option', () 
 
     expect(code).toBe(0);
 
-    // Parse JSONL output
-    const lines = stdout
-      .trim()
-      .split('\n')
-      .filter((line) => line.trim());
-
-    const jsonObjects: any[] = [];
-    for (const line of lines) {
-      try {
-        jsonObjects.push(JSON.parse(line));
-      } catch {
-        // Skip non-JSON lines
-      }
-    }
+    const jsonObjects = parseJSONL(stdout) as any[];
 
     // Should have at least one output (either success or error)
     expect(jsonObjects.length).toBeGreaterThan(0);
@@ -224,5 +215,26 @@ describe('`test` command with `--print-effective-graph-with-errors` option', () 
 
     // stderr should contain the failure warning
     expect(stderr).toMatch(/failed to get dependencies/i);
+  });
+
+  it('outputs the target framework for nuget/dotnet projects', async () => {
+    const project = await createProjectFromWorkspace('nuget-app-6-7-8');
+    const { code, stdout } = await runSnykCLI(
+      'test --print-effective-graph-with-errors',
+      {
+        cwd: project.path(),
+        env,
+      },
+    );
+
+    expect(code).toBe(0);
+
+    const outputs = parseJSONL(stdout) as any[];
+
+    expect(outputs[0]).toMatchObject({
+      targetRuntime: 'net6.0',
+      normalisedTargetFile: 'obj/project.assets.json',
+    });
+    expect(outputs[0].depGraph).toBeDefined();
   });
 });

--- a/test/jest/util/parseJSONL.ts
+++ b/test/jest/util/parseJSONL.ts
@@ -1,0 +1,16 @@
+/**
+ * Parses JSON Lines: one JSON value per line. Lines that are not valid JSON are skipped.
+ */
+export function parseJSONL(jsonl: string): unknown[] {
+  const lines: string[] = jsonl.trim().split('\n').filter(Boolean);
+
+  const result: unknown[] = [];
+  for (const line of lines) {
+    try {
+      result.push(JSON.parse(line.trim()));
+    } catch {
+      // Skip non-JSON lines
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [x] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

This PR adds `targetRuntime` as an optional output property to the JSONL payloads of `snyk test --print-effective-graph|--print-effective-graph-with-errors`. This is so we can produce dep-graphs plus exhaustive plugin metadata in cli-extension-dep-graph, to then use it for test and monitor migration to the Unified Test API.