### PR TITLE
chore: update snyk-docker-plugin to v9.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "semver": "^6.0.0",
         "snyk-config": "^5.0.0",
         "snyk-cpp-plugin": "^2.24.3",
-        "snyk-docker-plugin": "^9.6.0",
+        "snyk-docker-plugin": "9.6.5",
         "snyk-go-plugin": "2.1.1",
         "snyk-gradle-plugin": "5.1.1",
         "snyk-module": "3.1.0",
@@ -2229,6 +2229,7 @@
     },
     "node_modules/@octokit/auth-token": {
       "version": "2.4.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^6.0.3"
@@ -2236,6 +2237,7 @@
     },
     "node_modules/@octokit/core": {
       "version": "3.5.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/auth-token": "^2.4.4",
@@ -2249,6 +2251,7 @@
     },
     "node_modules/@octokit/core/node_modules/@octokit/request-error": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^6.0.3",
@@ -2258,10 +2261,12 @@
     },
     "node_modules/@octokit/core/node_modules/universal-user-agent": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@octokit/endpoint": {
       "version": "6.0.12",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^6.0.3",
@@ -2271,10 +2276,12 @@
     },
     "node_modules/@octokit/endpoint/node_modules/universal-user-agent": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@octokit/graphql": {
       "version": "4.6.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/request": "^5.6.0",
@@ -2284,14 +2291,17 @@
     },
     "node_modules/@octokit/graphql/node_modules/universal-user-agent": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@octokit/openapi-types": {
       "version": "12.11.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "2.21.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^6.40.0"
@@ -2302,6 +2312,7 @@
     },
     "node_modules/@octokit/plugin-request-log": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@octokit/core": ">=3"
@@ -2309,6 +2320,7 @@
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
       "version": "5.16.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^6.39.0",
@@ -2320,6 +2332,7 @@
     },
     "node_modules/@octokit/request": {
       "version": "5.6.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/endpoint": "^6.0.1",
@@ -2350,6 +2363,7 @@
     },
     "node_modules/@octokit/request/node_modules/@octokit/request-error": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^6.0.3",
@@ -2359,10 +2373,12 @@
     },
     "node_modules/@octokit/request/node_modules/universal-user-agent": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@octokit/rest": {
       "version": "18.12.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/core": "^3.5.1",
@@ -2373,6 +2389,7 @@
     },
     "node_modules/@octokit/types": {
       "version": "6.41.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^12.11.0"
@@ -2384,17 +2401,6 @@
       "dependencies": {
         "sprintf-js": "^1.1.2",
         "yaml": "^1.10.2"
-      }
-    },
-    "node_modules/@pagerduty/pdjs": {
-      "version": "2.2.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "browser-or-node": "^2.0.0",
-        "cross-fetch": "^3.0.6"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2633,14 +2639,6 @@
       "dev": true,
       "license": "(Unlicense OR Apache-2.0)"
     },
-    "node_modules/@slack/types": {
-      "version": "2.11.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.13.0",
-        "npm": ">= 6.12.0"
-      }
-    },
     "node_modules/@snyk/child-process": {
       "version": "0.4.1",
       "license": "Apache-2.0",
@@ -2656,10 +2654,6 @@
     "node_modules/@snyk/child-process/node_modules/tslib": {
       "version": "2.6.0",
       "license": "0BSD"
-    },
-    "node_modules/@snyk/cli-alert": {
-      "resolved": "packages/cli-alert",
-      "link": true
     },
     "node_modules/@snyk/cli-interface": {
       "version": "2.15.0",
@@ -6514,6 +6508,7 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -6717,6 +6712,7 @@
     },
     "node_modules/before-after-hook": {
       "version": "2.2.2",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/big.js": {
@@ -6849,10 +6845,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/browser-or-node": {
-      "version": "2.1.1",
-      "license": "MIT"
     },
     "node_modules/browserify-zlib": {
       "version": "0.1.4",
@@ -7338,6 +7330,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7780,6 +7773,7 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -8390,13 +8384,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cross-fetch": {
-      "version": "3.1.8",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "6.0.5",
       "dev": true,
@@ -8699,6 +8686,7 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -8834,6 +8822,7 @@
     },
     "node_modules/deprecation": {
       "version": "2.3.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/deps-regex": {
@@ -8982,6 +8971,7 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -9212,6 +9202,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9219,6 +9210,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9231,6 +9223,7 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -10658,6 +10651,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10705,6 +10699,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -10746,6 +10741,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -10988,6 +10984,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11100,6 +11097,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11110,6 +11108,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -11128,6 +11127,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -12070,6 +12070,7 @@
     },
     "node_modules/is-plain-object": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15237,6 +15238,7 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15342,6 +15344,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.49.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -15349,6 +15352,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.32",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.49.0"
@@ -15725,6 +15729,7 @@
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -15743,14 +15748,17 @@
     },
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -19008,9 +19016,10 @@
       "license": "ISC"
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-9.6.0.tgz",
-      "integrity": "sha512-3MWKqxHQJSLa1MPuqaewVQWiQzfRfPPxfrrFcH8HIEPS/PcMKFFGOaSNCreU5sfeGzQOi471S/+GCCUkAoGkaQ==",
+      "version": "9.6.5",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-9.6.5.tgz",
+      "integrity": "sha512-Kmej2LMNvWiUrpZniXbsJENfbiakt2krcKwfXDNDSqp3SsGsm0Lqa4M2aD/e2xqFAK2NYM+7E9KKRBmhwJPMng==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",
         "@snyk/dep-graph": "^2.12.1",
@@ -19028,22 +19037,25 @@
         "fzstd": "^0.1.1",
         "gunzip-maybe": "^1.4.2",
         "minimatch": "^9.0.0",
-        "mkdirp": "^1.0.4",
         "packageurl-js": "1.2.0",
         "semver": "^7.7.3",
         "shescape": "^2.1.7",
-        "snyk-nodejs-lockfile-parser": "^2.2.2",
+        "snyk-nodejs-lockfile-parser": "^2.7.0",
         "snyk-poetry-lockfile-parser": "1.9.1",
         "snyk-resolve-deps": "^4.9.1",
         "tar-stream": "^2.2.0",
-        "tmp": "^0.2.5",
         "tslib": "^1",
-        "uuid": "^8.2.0",
         "varint": "^6.0.0"
       },
       "engines": {
         "node": ">=20.19"
       }
+    },
+    "node_modules/snyk-docker-plugin/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/snyk-docker-plugin/node_modules/brace-expansion": {
       "version": "2.0.3",
@@ -19079,6 +19091,18 @@
         "node": ">=20"
       }
     },
+    "node_modules/snyk-docker-plugin/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/snyk-docker-plugin/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -19091,18 +19115,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/snyk-docker-plugin/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/snyk-docker-plugin/node_modules/ms": {
@@ -19136,13 +19148,36 @@
         "node": "^14.18.0 || ^16.13.0 || ^18 || ^19 || ^20 || ^22 || ^24 || ^25"
       }
     },
-    "node_modules/snyk-docker-plugin/node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
-      "license": "MIT",
+    "node_modules/snyk-docker-plugin/node_modules/snyk-nodejs-lockfile-parser": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-2.7.0.tgz",
+      "integrity": "sha512-0M4paLnhKSDtj2akT6qztFC2MPfLO7vHxIeXYI1+rMv8fBC5RfzqHcfCraFbEDe961oPWOMXhSryLANtC5OcVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@snyk/dep-graph": "^2.12.0",
+        "@snyk/error-catalog-nodejs-public": "^5.16.0",
+        "@snyk/graphlib": "2.1.9-patch.3",
+        "@yarnpkg/core": "^4.4.1",
+        "@yarnpkg/lockfile": "^1.1.0",
+        "dependency-path": "^9.2.8",
+        "event-loop-spinner": "^2.0.0",
+        "js-yaml": "^4.1.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.flatmap": "^4.5.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.topairs": "^4.3.0",
+        "micromatch": "^4.0.8",
+        "p-map": "^4.0.0",
+        "semver": "^7.6.0",
+        "snyk-config": "^5.2.0",
+        "tslib": "^1.9.3",
+        "uuid": "^8.3.0"
+      },
+      "bin": {
+        "parse-nodejs-lockfile": "bin/index.js"
+      },
       "engines": {
-        "node": ">=14.14"
+        "node": ">=18"
       }
     },
     "node_modules/snyk-docker-plugin/node_modules/which": {
@@ -21702,6 +21737,7 @@
     },
     "node_modules/typescript": {
       "version": "4.9.5",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -21736,10 +21772,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "license": "MIT"
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",
@@ -22745,6 +22777,7 @@
     "packages/cli-alert": {
       "name": "@snyk/cli-alert",
       "version": "1.0.0",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@octokit/rest": "^18.0.5",
@@ -22754,28 +22787,6 @@
       },
       "devDependencies": {
         "@types/node": "^20.11.30"
-      }
-    },
-    "packages/cli-alert/node_modules/@slack/webhook": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@slack/webhook/-/webhook-7.0.6.tgz",
-      "integrity": "sha512-RvNCcOjNbzl5uQ2TZsbTJ+A+5ptoWMwnyd/W4lKzeXFToIwebeaZiuntcP0usmhZHj1LH9H1T9WN6Bt1B/DLyg==",
-      "license": "MIT",
-      "dependencies": {
-        "@slack/types": "^2.9.0",
-        "@types/node": ">=18.0.0",
-        "axios": "^1.11.0"
-      },
-      "engines": {
-        "node": ">= 18",
-        "npm": ">= 8.6.0"
-      }
-    },
-    "packages/cli-alert/node_modules/@types/node": {
-      "version": "20.11.30",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "packages/snyk-fix": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "semver": "^6.0.0",
     "snyk-config": "^5.0.0",
     "snyk-cpp-plugin": "^2.24.3",
-    "snyk-docker-plugin": "9.6.0",
+    "snyk-docker-plugin": "9.6.5",
     "snyk-go-plugin": "2.1.1",
     "snyk-gradle-plugin": "5.1.1",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [X] Updates relevant GitBook documentation (PR link: https://app.gitbook.com/o/-M4tdxG8qotLgGZnLpFR/s/-MdwVZ6HOZriajCf5nXH/~/changes/10393/)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

This PR updates `snyk-docker-plugin` from 9.6.0 to 9.6.5. This brings in [these changes](https://github.com/snyk/snyk-docker-plugin/compare/v9.6.0...v9.6.5):

Features:
- improve Dockerfile attribution and base image exclusion
- enable Kaniko archive

Bug Fixes:
- prevent temp directory leak in node-modules-utils

Sub-dependency updates:
- update snyk-nodejs-lockfile-parser

## Where should the reviewer start?

Review the package.json and package-lock.json files.

## How should this be manually tested?

## What's the product update that needs to be communicated to CLI users?

- Support for Kaniko Archives: A bug has been resolved enabling scanning container images built with Kaniko and saved as archives. This was previously advertised as supported (e.g. [docs](https://docs.snyk.io/developer-tools/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-container/advanced-use-of-snyk-container-cli#scan-archives)) but the bug prevented this in practice.
- Improved Dockerfile Attribution: A fix in snyk-docker-plugin improves how vulnerabilities are attributed to Dockerfile instructions. By addressing a bug in how package names and their transitive dependencies are mapped, the CLI will more accurately differentiate between vulnerabilities introduced by the Dockerfile (e.g., via RUN apt-get install) versus those inherited from the base image. This fix also enables the `--exclude-base-image-vulns` flag in `snyk container monitor`. A change will be submitted to the CLI docs to reflect this.

## Risk assessment

Low

## What are the relevant tickets?

https://snyksec.atlassian.net/browse/CN-568
https://snyksec.atlassian.net/browse/CN-942

