### PR TITLE
apps: fix 'occured' -> 'occurred' in rest-utils error message

### DIFF
--- a/src/lib/apps/rest-utils.ts
+++ b/src/lib/apps/rest-utils.ts
@@ -87,7 +87,7 @@ Please run the command with '--debug' or '-d' to get more information`;
     const meta = metaString || '-';
     const source = sourceString || '-';
 
-    return `Uh oh! an error occured while trying to create the Snyk App.
+    return `Uh oh! an error occurred while trying to create the Snyk App.
 
 Error Description:\t${e.detail}
 Request Status:\t${e.status}


### PR DESCRIPTION
Error message in `src/lib/apps/rest-utils.ts` line 90 reads `an error occured while trying to create the Snyk App`. User-visible in CLI output. Fixed to `occurred`. String-literal-only change.