### PR TITLE
chore: update cli-extension-secrets to exclude ignore-files from scans [PS-571]

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260206080712-9cbb5f95465d
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260407123134-f9617cb05038
 	github.com/snyk/cli-extension-sbom v0.0.0-20260327120356-9befea04c9b0
-	github.com/snyk/cli-extension-secrets v0.0.0-20260407113038-69d8fdb95266
+	github.com/snyk/cli-extension-secrets v0.0.0-20260421112643-c8c29ed060b9
 	github.com/snyk/code-client-go v1.26.2
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260316131845-f02d7f42046b

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -551,8 +551,8 @@ github.com/snyk/cli-extension-os-flows v0.0.0-20260407123134-f9617cb05038 h1:6My
 github.com/snyk/cli-extension-os-flows v0.0.0-20260407123134-f9617cb05038/go.mod h1:9Vz1sr4air/Oj/shth646UHSyChTRAZ1Ulx9BFbUCf0=
 github.com/snyk/cli-extension-sbom v0.0.0-20260327120356-9befea04c9b0 h1:QK9cPBpPYzm1jxT2VAUUjtdXZfJllRRjRwuslTERuco=
 github.com/snyk/cli-extension-sbom v0.0.0-20260327120356-9befea04c9b0/go.mod h1:SJ624HENWG4yjM6jNuLebTeNsMriozf1LcKhMYVm1aY=
-github.com/snyk/cli-extension-secrets v0.0.0-20260407113038-69d8fdb95266 h1:nZzwbMUTm3vXwT7jvNF7T1JxjHHNQIVu7Rzf3hCeMIQ=
-github.com/snyk/cli-extension-secrets v0.0.0-20260407113038-69d8fdb95266/go.mod h1:vGlGtPhCnO7VYRuVjUa6TSZkIsQ4c99Bafu4xQYGQTM=
+github.com/snyk/cli-extension-secrets v0.0.0-20260421112643-c8c29ed060b9 h1:jUC2++pNczGu1QK3K7E0Hx/hXk0niNy6ND38U+gkF/A=
+github.com/snyk/cli-extension-secrets v0.0.0-20260421112643-c8c29ed060b9/go.mod h1:vGlGtPhCnO7VYRuVjUa6TSZkIsQ4c99Bafu4xQYGQTM=
 github.com/snyk/code-client-go v1.26.2 h1:vto7ZKj9OoU1rnmKeoZ+i68qXrT0I94CEMhvwK03O24=
 github.com/snyk/code-client-go v1.26.2/go.mod h1:0NcZZHB48Sr4UAucEH2H10HwV7gjI2Ue0c+FxPWaTNo=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea h1:/v48hCMPiZVjplylgE2FX1ib8Qd8LN/vf8ZIKfA+wkI=


### PR DESCRIPTION
…
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
Bump `cli-extension-secrets` version to not scan `.gitleaksignore` and `.gitignore` files in order to reduce noise. It also improves `remote-repo-url` validation to support diverse formats including SSH, SCP-style, and credentials.

## Where should the reviewer start?
- [fix: ensure .gitleaksignore is excluded from scanning #66](https://github.com/snyk/cli-extension-secrets/pull/66)
- [fix: ensure .gitignore is excluded from scanning #64](https://github.com/snyk/cli-extension-secrets/pull/64)
- [fix: remote repo url validation PS-470 #63](https://github.com/snyk/cli-extension-secrets/pull/63)
- [feat: add validation for remote-repo-url, string length limits and file output paths #61](https://github.com/snyk/cli-extension-secrets/pull/61)

## How should this be manually tested?
Scan a directory containing only these two files. The CLI should return a `No supported files found error`.

## What's the product update that needs to be communicated to CLI users?
N/A

## Risk assessment (Low | Medium | High)?
- Low - it reduces noise caused by these files.

## Any background context you want to provide?
N/A

## What are the relevant tickets?
- [PS-571](https://snyksec.atlassian.net/browse/PS-571)

## Screenshots (if appropriate)



[PS-571]: https://snyksec.atlassian.net/browse/PS-571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ