### PR TITLE
chore: bump go-application-framework and cli-extension-secrets

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -18,11 +18,11 @@ require (
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260206080712-9cbb5f95465d
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260423112219-b7ba9dd68e57
 	github.com/snyk/cli-extension-sbom v0.0.0-20260423112228-5d124dd8c9b0
-	github.com/snyk/cli-extension-secrets v0.0.0-20260427110003-0648d310ddd7
+	github.com/snyk/cli-extension-secrets v0.0.0-20260428134403-4abf8c4744ce
 	github.com/snyk/code-client-go v1.26.2
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90
-	github.com/snyk/go-application-framework v0.0.0-20260422120642-828033ca5788
+	github.com/snyk/go-application-framework v0.0.0-20260428085257-c8a2764ca048
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260414093345-2a6d7434eb91

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -551,8 +551,8 @@ github.com/snyk/cli-extension-os-flows v0.0.0-20260423112219-b7ba9dd68e57 h1:8dp
 github.com/snyk/cli-extension-os-flows v0.0.0-20260423112219-b7ba9dd68e57/go.mod h1:f16TyLAOBiU485lN/odNfmiyWyMu1iVrDoSEieiiblQ=
 github.com/snyk/cli-extension-sbom v0.0.0-20260423112228-5d124dd8c9b0 h1:bwtq5pAQCpD1wFErD6dzpGevYwjVyREgS9H96ctHhII=
 github.com/snyk/cli-extension-sbom v0.0.0-20260423112228-5d124dd8c9b0/go.mod h1:SJ624HENWG4yjM6jNuLebTeNsMriozf1LcKhMYVm1aY=
-github.com/snyk/cli-extension-secrets v0.0.0-20260427110003-0648d310ddd7 h1:xr4jMKWVUOyyrw9VkUbbBf0EiS/uBOWrf7MzhuyTSI4=
-github.com/snyk/cli-extension-secrets v0.0.0-20260427110003-0648d310ddd7/go.mod h1:tupr4CQ/eOFuuahxlBGJnyLY5LOKIw8znX+Vc7RL6Ik=
+github.com/snyk/cli-extension-secrets v0.0.0-20260428134403-4abf8c4744ce h1:zSY/JOCMhERLpW9kvzChae1MGh6OF3FzSdi4kAYsuKk=
+github.com/snyk/cli-extension-secrets v0.0.0-20260428134403-4abf8c4744ce/go.mod h1:tupr4CQ/eOFuuahxlBGJnyLY5LOKIw8znX+Vc7RL6Ik=
 github.com/snyk/code-client-go v1.26.2 h1:vto7ZKj9OoU1rnmKeoZ+i68qXrT0I94CEMhvwK03O24=
 github.com/snyk/code-client-go v1.26.2/go.mod h1:0NcZZHB48Sr4UAucEH2H10HwV7gjI2Ue0c+FxPWaTNo=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea h1:/v48hCMPiZVjplylgE2FX1ib8Qd8LN/vf8ZIKfA+wkI=
@@ -561,8 +561,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90 h1:MumWzLKiIFhZEk/wP71S/zv2cceygDb3+KNXGBb1hC0=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.0.0-20260422120642-828033ca5788 h1:q55BNWTHeNBuFq2fmryxIrnHYC53LXDEnPlu+d+JT3o=
-github.com/snyk/go-application-framework v0.0.0-20260422120642-828033ca5788/go.mod h1:7IOOtKxiQhtTbkrX7rax20QNJ/rwGill6n2Rejtld2I=
+github.com/snyk/go-application-framework v0.0.0-20260428085257-c8a2764ca048 h1:HBeZVqAXFYCkbnZLx7E4gdUQ+T8r6hzSvuMjP2KkAlk=
+github.com/snyk/go-application-framework v0.0.0-20260428085257-c8a2764ca048/go.mod h1:7IOOtKxiQhtTbkrX7rax20QNJ/rwGill6n2Rejtld2I=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.3 h1:MU+K8pxbN6VZ9P5wALUt8BwTjrPDpoEtmTtQqj7sKfY=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps `go-application-framework` to pick up the UFM presenter changes that render the WebUI project page link when running `snyk secrets test --report`.

The updated GAF commit adds:
- A conditional `properties.uploadResult` block in the SARIF template with `reportUrl`, emitted when `metadata["project-page-link"]` is present.
- A "Report" footer in the human-readable template showing the project page URL.

## Where should the reviewer start?

`cliv2/go.mod` — the GAF version bump is the only change.

## How should this be manually tested?

Run: `snyk secrets test . --report --sarif-file-output=results.sarif.json`
However sarif output won't work at the current version as cli-extension-secrets is currently not allowing sarif flag: https://github.com/snyk/cli-extension-secrets/blob/2f8f499d3e73f870d6f11a0208f2dd5aae23162a/internal/commands/secretstest/validate.go#L85
Comment those lines and build a custom CLI, you'll see the generated SARIF contains the reportUrl field.

## What are the relevant tickets?

[CLI-1429](https://snyksec.atlassian.net/browse/CLI-1429)


[CLI-1429]: https://snyksec.atlassian.net/browse/CLI-1429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ