### PR TITLE
feat: parallelize container monitor dependency requests

### DIFF
--- a/src/lib/ecosystems/monitor.ts
+++ b/src/lib/ecosystems/monitor.ts
@@ -144,50 +144,95 @@ async function monitorDependencies(
   const errors: EcosystemMonitorError[] = [];
   for (const [path, scanResults] of Object.entries(scans)) {
     await spinner(`Monitoring dependencies in ${path}`);
-    for (const scanResult of scanResults) {
-      const monitorDependenciesRequest =
-        await generateMonitorDependenciesRequest(scanResult, options);
+    const [firstScanResult, ...remainingScanResults] = scanResults;
+    if (!firstScanResult) {
+      spinner.clearAll();
+      continue;
+    }
 
-      const configOrg = config.org ? decodeURIComponent(config.org) : undefined;
+    const firstResult = await monitorDependenciesForScanResult(
+      firstScanResult,
+      options,
+      path,
+    );
+    if (firstResult.monitorResult) {
+      results.push(firstResult.monitorResult);
+    }
+    if (firstResult.monitorError) {
+      errors.push(firstResult.monitorError);
+    }
 
-      const payload = {
-        method: 'PUT',
-        url: `${config.API}/monitor-dependencies`,
-        json: true,
-        headers: {
-          'x-is-ci': isCI(),
-          authorization: getAuthHeader(),
-        },
-        body: monitorDependenciesRequest,
-        qs: {
-          org: options.org || configOrg,
-        },
-      };
-      try {
-        const response =
-          await makeRequest<MonitorDependenciesResponse>(payload);
-        results.push({
-          ...response,
-          path,
-          scanResult,
-        });
-      } catch (error) {
-        if (error.code === 401) {
-          throw AuthFailedError();
-        }
-        if (error.code >= 400 && error.code < 500) {
-          throw new MonitorError(error.code, error.message);
-        }
-        errors.push({
-          error: 'Could not monitor dependencies in ' + path,
-          path,
-          scanResult,
-        });
+    const remainingResults = await Promise.all(
+      remainingScanResults.map((scanResult) =>
+        monitorDependenciesForScanResult(scanResult, options, path),
+      ),
+    );
+
+    for (const remainingResult of remainingResults) {
+      if (remainingResult.monitorResult) {
+        results.push(remainingResult.monitorResult);
+      }
+      if (remainingResult.monitorError) {
+        errors.push(remainingResult.monitorError);
       }
     }
     spinner.clearAll();
   }
   return [results, errors];
+}
+
+async function monitorDependenciesForScanResult(
+  scanResult: ScanResult,
+  options: Options & MonitorOptions,
+  path: string,
+): Promise<{
+  monitorResult?: EcosystemMonitorResult;
+  monitorError?: EcosystemMonitorError;
+}> {
+  const monitorDependenciesRequest = await generateMonitorDependenciesRequest(
+    scanResult,
+    options,
+  );
+
+  const configOrg = config.org ? decodeURIComponent(config.org) : undefined;
+  const payload = {
+    method: 'PUT',
+    url: `${config.API}/monitor-dependencies`,
+    json: true,
+    headers: {
+      'x-is-ci': isCI(),
+      authorization: getAuthHeader(),
+    },
+    body: monitorDependenciesRequest,
+    qs: {
+      org: options.org || configOrg,
+    },
+  };
+
+  try {
+    const response = await makeRequest<MonitorDependenciesResponse>(payload);
+    return {
+      monitorResult: {
+        ...response,
+        path,
+        scanResult,
+      },
+    };
+  } catch (error) {
+    if (error.code === 401) {
+      throw AuthFailedError();
+    }
+    if (error.code >= 400 && error.code < 500) {
+      throw new MonitorError(error.code, error.message);
+    }
+    return {
+      monitorError: {
+        error: 'Could not monitor dependencies in ' + path,
+        path,
+        scanResult,
+      },
+    };
+  }
 }
 
 export async function getFormattedMonitorOutput(

--- a/test/jest/unit/ecosystems-monitor-docker.spec.ts
+++ b/test/jest/unit/ecosystems-monitor-docker.spec.ts
@@ -285,4 +285,89 @@ describe('monitorEcosystem docker/container', () => {
     );
     expect(parsedOutput.projectName).not.toBe('my-custom-project-name');
   });
+
+  it('should monitor base scan result first and then parallelize remaining requests', async () => {
+    const baseScanResult = {
+      ...readJsonFixture('container-deb-scan-result.json'),
+      identity: {
+        type: 'deb',
+        targetFile: 'base-os',
+      },
+    } as ScanResult;
+    const appScanResultOne = {
+      ...readJsonFixture('maven-project-0-dependencies-scan-result.json'),
+      identity: {
+        type: 'maven',
+        targetFile: 'app-1',
+      },
+    } as ScanResult;
+    const appScanResultTwo = {
+      ...readJsonFixture('maven-project-0-dependencies-scan-result.json'),
+      identity: {
+        type: 'maven',
+        targetFile: 'app-2',
+      },
+    } as ScanResult;
+
+    jest.spyOn(dockerPlugin, 'scan').mockResolvedValue({
+      scanResults: [baseScanResult, appScanResultOne, appScanResultTwo],
+    });
+
+    const requestsByIdentity: string[] = [];
+    let baseRequestResolved = false;
+    let appOneStartedBeforeBaseResolved = false;
+    let appTwoStartedBeforeBaseResolved = false;
+
+    jest.spyOn(request, 'makeRequest').mockImplementation((payload: any) => {
+      const identity = payload.body.scanResult.identity.targetFile as string;
+      requestsByIdentity.push(identity);
+      const baseResponse = readJsonFixture(
+        'monitor-dependencies-response-with-project-name.json',
+      ) as ecosystemsTypes.MonitorDependenciesResponse;
+      const responseForIdentity = {
+        ...baseResponse,
+        id: `${identity}-id`,
+        projectName: identity,
+      };
+
+      return new Promise((resolve) => {
+        if (identity === 'base-os') {
+          setTimeout(() => {
+            baseRequestResolved = true;
+            resolve(responseForIdentity);
+          }, 25);
+          return;
+        }
+
+        if (identity === 'app-1' && !baseRequestResolved) {
+          appOneStartedBeforeBaseResolved = true;
+        }
+        if (identity === 'app-2' && !baseRequestResolved) {
+          appTwoStartedBeforeBaseResolved = true;
+        }
+
+        resolve(responseForIdentity);
+      });
+    });
+
+    const [monitorResults, monitorErrors] = await ecosystems.monitorEcosystem(
+      'docker',
+      ['/srv'],
+      {
+        path: '/srv',
+        docker: true,
+        org: 'my-org',
+      },
+    );
+
+    expect(monitorErrors).toEqual([]);
+    expect(requestsByIdentity).toEqual(['base-os', 'app-1', 'app-2']);
+    expect(appOneStartedBeforeBaseResolved).toBe(false);
+    expect(appTwoStartedBeforeBaseResolved).toBe(false);
+    expect(monitorResults.map((result) => result.projectName)).toEqual([
+      'base-os',
+      'app-1',
+      'app-2',
+    ]);
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

This PR improves performance for ecosystem/container monitoring by changing the `/monitor-dependencies` request flow from fully sequential to hybrid execution:

- For each path, it always executes the first `ScanResult` request first (base OS project ordering retained)
- It then executes the remaining `ScanResult` requests in parallel
- It preserves output ordering by collecting parallel responses and appending them in scan order
- It preserves existing error semantics:
  - 401 still throws `AuthFailedError`
  - other 4xx errors still throw `MonitorError`
  - non-4xx failures are collected as monitor errors and execution continues

## Where should the reviewer start?

- `src/lib/ecosystems/monitor.ts`
- `test/jest/unit/ecosystems-monitor-docker.spec.ts`

## How should this be manually tested?

1. Run monitor unit tests:
   - `npm run test:unit -- --runTestsByPath test/jest/unit/ecosystems-monitor-docker.spec.ts`
2. Optionally run a representative multi-project container monitor command and compare runtime:
   - `snyk container monitor <image>`

## What's the product update that needs to be communicated to CLI users?

Container monitor execution is now faster for images that produce multiple scan results. The CLI now keeps base OS processing first and parallelizes the remaining dependency API requests.

## Risk assessment (Low | Medium | High)?

Low. This is a scoped orchestration change with focused tests that verify ordering and existing error semantics.

## Any background context you want to provide?

Large images that produce many scan results can experience long monitor durations due to sequential API calls; this change addresses that bottleneck.

## What are the relevant tickets?

N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e66e8549-eaa9-4d18-9c41-345f8fed61fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e66e8549-eaa9-4d18-9c41-345f8fed61fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

