### PR TITLE
feat: parallelize container monitor dependency requests

### DIFF
--- a/src/lib/ecosystems/monitor.ts
+++ b/src/lib/ecosystems/monitor.ts
@@ -1,8 +1,10 @@
 import { InspectResult } from '@snyk/cli-interface/legacy/plugin';
 import chalk from 'chalk';
+import * as pMap from 'p-map';
 import config from '../config';
 import { isCI } from '../is-ci';
 import { makeRequest } from '../request/promise';
+import { getRequestConcurrency } from '../snyk-test/common';
 import {
   Contributor,
   MonitorOptions,
@@ -148,52 +150,81 @@ async function monitorDependencies(
 ): Promise<[EcosystemMonitorResult[], EcosystemMonitorError[]]> {
   const results: EcosystemMonitorResult[] = [];
   const errors: EcosystemMonitorError[] = [];
+  const concurrency = getRequestConcurrency();
+
   for (const [path, scanResults] of Object.entries(scans)) {
     await spinner(`Monitoring dependencies in ${path}`);
-    for (const scanResult of scanResults) {
-      const monitorDependenciesRequest =
-        await generateMonitorDependenciesRequest(scanResult, options);
-
-      const configOrg = config.org ? decodeURIComponent(config.org) : undefined;
-
-      const payload = {
-        method: 'PUT',
-        url: `${config.API}/monitor-dependencies`,
-        json: true,
-        headers: {
-          'x-is-ci': isCI(),
-          authorization: getAuthHeader(),
-        },
-        body: monitorDependenciesRequest,
-        qs: {
-          org: options.org || configOrg,
-        },
-      };
-      try {
-        const response =
-          await makeRequest<MonitorDependenciesResponse>(payload);
-        results.push({
-          ...response,
-          path,
-          scanResult,
-        });
-      } catch (error) {
-        if (error.code === 401) {
-          throw AuthFailedError();
-        }
-        if (error.code >= 400 && error.code < 500) {
-          throw new MonitorError(error.code, error.message);
-        }
-        errors.push({
-          error: 'Could not monitor dependencies in ' + path,
-          path,
-          scanResult,
-        });
+    const perScanResults = await pMap(
+      scanResults,
+      (scanResult) => monitorOneScanResult(scanResult, options, path),
+      { concurrency },
+    );
+    for (const r of perScanResults) {
+      if (r.result) {
+        results.push(r.result);
+      }
+      if (r.error) {
+        errors.push(r.error);
       }
     }
     spinner.clearAll();
   }
   return [results, errors];
+}
+
+async function monitorOneScanResult(
+  scanResult: ScanResult,
+  options: Options & MonitorOptions,
+  path: string,
+): Promise<{
+  result?: EcosystemMonitorResult;
+  error?: EcosystemMonitorError;
+}> {
+  const monitorDependenciesRequest = await generateMonitorDependenciesRequest(
+    scanResult,
+    options,
+  );
+
+  const configOrg = config.org ? decodeURIComponent(config.org) : undefined;
+
+  const payload = {
+    method: 'PUT',
+    url: `${config.API}/monitor-dependencies`,
+    json: true,
+    headers: {
+      'x-is-ci': isCI(),
+      authorization: getAuthHeader(),
+    },
+    body: monitorDependenciesRequest,
+    qs: {
+      org: options.org || configOrg,
+    },
+  };
+
+  try {
+    const response = await makeRequest<MonitorDependenciesResponse>(payload);
+    return {
+      result: {
+        ...response,
+        path,
+        scanResult,
+      },
+    };
+  } catch (error) {
+    if (error.code === 401) {
+      throw AuthFailedError();
+    }
+    if (error.code >= 400 && error.code < 500) {
+      throw new MonitorError(error.code, error.message);
+    }
+    return {
+      error: {
+        error: 'Could not monitor dependencies in ' + path,
+        path,
+        scanResult,
+      },
+    };
+  }
 }
 
 export async function getFormattedMonitorOutput(

--- a/test/jest/unit/ecosystems-monitor-docker.spec.ts
+++ b/test/jest/unit/ecosystems-monitor-docker.spec.ts
@@ -285,4 +285,160 @@ describe('monitorEcosystem docker/container', () => {
     );
     expect(parsedOutput.projectName).not.toBe('my-custom-project-name');
   });
+
+  describe('parallelization of monitor-dependencies requests', () => {
+    const ORIGINAL_CONCURRENCY = process.env.SNYK_INTERNAL_REQUEST_CONCURRENCY;
+
+    afterEach(() => {
+      if (ORIGINAL_CONCURRENCY === undefined) {
+        delete process.env.SNYK_INTERNAL_REQUEST_CONCURRENCY;
+      } else {
+        process.env.SNYK_INTERNAL_REQUEST_CONCURRENCY = ORIGINAL_CONCURRENCY;
+      }
+    });
+
+    function makeMavenScanResult(targetFile: string): ScanResult {
+      const base = readJsonFixture(
+        'maven-project-0-dependencies-scan-result.json',
+      ) as ScanResult;
+      return {
+        ...base,
+        identity: { ...base.identity, targetFile },
+      };
+    }
+
+    function makeMonitorResponse(identity: string) {
+      const base = readJsonFixture(
+        'monitor-dependencies-response-with-project-name.json',
+      ) as ecosystemsTypes.MonitorDependenciesResponse;
+      return {
+        ...base,
+        id: `${identity}-id`,
+        projectName: identity,
+      };
+    }
+
+    async function runMonitor(scanResults: ScanResult[]) {
+      jest.spyOn(dockerPlugin, 'scan').mockResolvedValue({ scanResults });
+      return ecosystems.monitorEcosystem('docker', ['/srv'], {
+        path: '/srv',
+        docker: true,
+        org: 'my-org',
+      });
+    }
+
+    it('caps in-flight requests at the default concurrency (5)', async () => {
+      delete process.env.SNYK_INTERNAL_REQUEST_CONCURRENCY;
+      const scanResults = Array.from({ length: 25 }, (_, i) =>
+        makeMavenScanResult(`app-${i}`),
+      );
+
+      let inFlight = 0;
+      let peakInFlight = 0;
+      jest.spyOn(request, 'makeRequest').mockImplementation((payload: any) => {
+        inFlight++;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+        const identity = payload.body.scanResult.identity.targetFile;
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            inFlight--;
+            resolve(makeMonitorResponse(identity));
+          }, 10);
+        });
+      });
+
+      await runMonitor(scanResults);
+
+      expect(peakInFlight).toBeLessThanOrEqual(5);
+      expect(peakInFlight).toBeGreaterThan(1);
+    });
+
+    it('respects SNYK_INTERNAL_REQUEST_CONCURRENCY override', async () => {
+      process.env.SNYK_INTERNAL_REQUEST_CONCURRENCY = '3';
+      const scanResults = Array.from({ length: 15 }, (_, i) =>
+        makeMavenScanResult(`app-${i}`),
+      );
+
+      let inFlight = 0;
+      let peakInFlight = 0;
+      jest.spyOn(request, 'makeRequest').mockImplementation((payload: any) => {
+        inFlight++;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+        const identity = payload.body.scanResult.identity.targetFile;
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            inFlight--;
+            resolve(makeMonitorResponse(identity));
+          }, 10);
+        });
+      });
+
+      await runMonitor(scanResults);
+
+      expect(peakInFlight).toBeLessThanOrEqual(3);
+    });
+
+    it('preserves result order matching input order', async () => {
+      delete process.env.SNYK_INTERNAL_REQUEST_CONCURRENCY;
+      const scanResults = ['os', 'app-1', 'app-2', 'app-3', 'app-4'].map(
+        makeMavenScanResult,
+      );
+
+      // Stagger response times in reverse so completion order != input order.
+      jest.spyOn(request, 'makeRequest').mockImplementation((payload: any) => {
+        const identity = payload.body.scanResult.identity.targetFile;
+        const delay =
+          { os: 30, 'app-1': 20, 'app-2': 5, 'app-3': 25, 'app-4': 10 }[
+            identity
+          ] ?? 0;
+        return new Promise((resolve) =>
+          setTimeout(() => resolve(makeMonitorResponse(identity)), delay),
+        );
+      });
+
+      const [results] = await runMonitor(scanResults);
+
+      expect(results.map((r) => r.projectName)).toEqual([
+        'os',
+        'app-1',
+        'app-2',
+        'app-3',
+        'app-4',
+      ]);
+    });
+
+    it('throws MonitorError when any request returns 4xx (fail-fast)', async () => {
+      delete process.env.SNYK_INTERNAL_REQUEST_CONCURRENCY;
+      const scanResults = ['app-1', 'app-2', 'app-3'].map(makeMavenScanResult);
+
+      jest.spyOn(request, 'makeRequest').mockImplementation((payload: any) => {
+        const identity = payload.body.scanResult.identity.targetFile;
+        if (identity === 'app-2') {
+          return Promise.reject({ code: 403, message: 'forbidden' });
+        }
+        return Promise.resolve(makeMonitorResponse(identity));
+      });
+
+      await expect(runMonitor(scanResults)).rejects.toThrow('forbidden');
+    });
+
+    it('accumulates 5xx errors per scan-result without aborting', async () => {
+      delete process.env.SNYK_INTERNAL_REQUEST_CONCURRENCY;
+      const scanResults = ['app-1', 'app-2', 'app-3'].map(makeMavenScanResult);
+
+      jest.spyOn(request, 'makeRequest').mockImplementation((payload: any) => {
+        const identity = payload.body.scanResult.identity.targetFile;
+        if (identity === 'app-2') {
+          return Promise.reject({ code: 503, message: 'unavailable' });
+        }
+        return Promise.resolve(makeMonitorResponse(identity));
+      });
+
+      const [results, errors] = await runMonitor(scanResults);
+
+      expect(results.map((r) => r.projectName)).toEqual(['app-1', 'app-3']);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].error).toContain('Could not monitor dependencies');
+    });
+  });
 });


### PR DESCRIPTION
## What does this PR do?

Rewrites `monitorDependencies` in `src/lib/ecosystems/monitor.ts` to fan out per-`ScanResult` `PUT /monitor-dependencies` calls in parallel via `pMap`, bounded by the `getRequestConcurrency()` helper introduced in #6756 (default **5**, user-overridable via `SNYK_REQUEST_CONCURRENCY`).

Effective change for users: container monitor goes from sequential (1 in-flight request) to **5 in-flight by default**, with the same env-var override surface as `snyk container test`.

- Per-ScanResult work is extracted into a small `monitorOneScanResult` helper for testability.
- Outer loop over paths still runs sequentially (one path per `monitor` invocation is the common case anyway).
- Inner loop is now `pMap(scanResults, ..., { concurrency })`.

This PR is **based on `feat/snyk-request-concurrency` (#6756)** so its diff shows only the monitor-flow changes.

## Why?

`snyk container monitor` previously ran fully sequentially — one full RTT per ScanResult — because of a nested `for...of await` loop. For large images with many ScanResults (e.g. fat-JAR-heavy images that produce one ScanResult per directory of JARs in `snyk-docker-plugin`'s `groupJarFingerprintsByPath`), this is the dominant wall-clock cost.

### Benchmark — `quay.io/wildfly/wildfly:34.0.1.Final-jdk21` (512 ScanResults)

Sequential baseline measured against the released CLI (`snyk` v1.1303.2, prior code path). PR configurations measured against the locally-built PR binary, varying only `SNYK_REQUEST_CONCURRENCY`. Re-monitoring updates existing project snapshots rather than creating duplicates.

| Configuration | Wall-clock | vs sequential |
|---|---|---|
| sequential (`snyk` v1.1303.2, prior code) | **481 s (8m 1s)** | 1.00× |
| **default (`c=5`, this PR)** | **104 s** | **4.6× faster** |
| override (`c=10`) | 54 s | 8.9× faster |
| override (`c=20`) | 29 s | 16.6× faster |

Each PR run successfully updated all 512 snapshots. The sequential run produced 510 snapshots; possibly minor version drift between v1.1303.2 and the PR binary's bundled `snyk-docker-plugin`. No errors logged; doesn't affect the timing comparison.

The default-of-5 row is the new behavior users will see without any opt-in.

## Error semantics preserved

- **401** → still throws `AuthFailedError` (terminates the run).
- **Other 4xx** → still throws `MonitorError` (terminates the run via `pMap`'s default fail-fast on rejection).
- **5xx and other non-4xx** errors are accumulated per-ScanResult into the `errors` array, matching prior continue-on-error behavior.

## Result ordering preserved

`pMap` returns results in input order regardless of completion order, so the formatted output remains deterministic.

## Where should the reviewer start?

- `src/lib/ecosystems/monitor.ts` — `monitorDependencies` rewrite + new `monitorOneScanResult`.
- `test/jest/unit/ecosystems-monitor-docker.spec.ts` — 5 new tests in a `parallelization of monitor-dependencies requests` describe:
  - Concurrency cap honored at default 5.
  - `SNYK_INTERNAL_REQUEST_CONCURRENCY=3` override respected (the internal env var the TS code reads; the user-facing `SNYK_REQUEST_CONCURRENCY` is plumbed through Go in #6756).
  - Result ordering preserved when responses arrive out of order.
  - 4xx fail-fast (throws `MonitorError`).
  - 5xx accumulation (continues, returns errors).

## How should this be manually tested?

1. Run unit tests:
   ```sh
   npx jest --selectProjects coreCli --testPathPattern 'test/jest/unit/ecosystems-monitor-docker'
   ```
2. Optional smoke test against a throwaway org with a multi-project image — use the Go-wrapped binary so `SNYK_REQUEST_CONCURRENCY` is plumbed through:
   ```sh
   ./binary-releases/snyk-... container monitor <image> --org=<throwaway-org>
   SNYK_REQUEST_CONCURRENCY=20 ./binary-releases/snyk-... container monitor <image> --org=<throwaway-org>
   ```

## Risk assessment

**Low.** The change is scoped to a single function. Error semantics are preserved (verified by tests). Concurrency is bounded and configurable. `pMap` is already used by `runTest` so it's a familiar dependency in this codebase.

## Background

**Depends on / based on #6756**, which:
- introduces the `getRequestConcurrency` helper and clamps,
- pipes the user-facing `SNYK_REQUEST_CONCURRENCY` env var through the Go-side GAF configuration so the legacy CLI receives the resolved value via the internal `SNYK_INTERNAL_REQUEST_CONCURRENCY` env var.

Supersedes #6748:
- That PR used unbounded `Promise.all`, which on a 500-ScanResult image would fire 500+ concurrent PUTs — a real risk of 429s, socket exhaustion, or thundering-herd backend load.
- That PR added a "base scan first, then `Promise.all` the rest" hybrid pattern; once results are kept in input order via `pMap`, the special case isn't load-bearing.