### PR TITLE
chore: Windows CI Node install and snyk-env.sh BOM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,7 +276,7 @@ commands:
       - restore_cache:
           name: Restoring Windows tools cache
           keys:
-            - windows-tools-cache-v2-{{ arch }}
+            - windows-tools-cache-v4-{{ arch }}-{{ checksum ".nvmrc" }}
       - run:
           name: Install Node.js (native)
           shell: powershell
@@ -315,9 +315,10 @@ commands:
             .\scripts\windows\ensure-python-uv.ps1
       - save_cache:
           name: Saving Windows tools cache
-          key: windows-tools-cache-v2-{{ arch }}
+          key: windows-tools-cache-v4-{{ arch }}-{{ checksum ".nvmrc" }}
           paths:
             - << pipeline.parameters.windows_cache_dir >>
+            - C:\ProgramData\nvm
 
   install-deps-windows-native-full-signing:
     steps:

--- a/scripts/windows/install-node.ps1
+++ b/scripts/windows/install-node.ps1
@@ -13,10 +13,7 @@ if (Test-Path $envScript) {
 }
 
 try {
-  $expectedNodeVersion = '20.11.1'
-  $expectedSha256 = 'c54f5f7e2416e826fd84e878f28e3b53363ae9c3f60a140af4434b2453b5ae89'
-
-  # Resolve repo root from script location (script is in .circleci/windows)
+  # Resolve repo root from script location (script is in scripts/windows)
   $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..')
   $nvmrcPath = Join-Path $repoRoot '.nvmrc'
 
@@ -24,42 +21,33 @@ try {
     throw ".nvmrc not found at $nvmrcPath"
   }
 
-  $nvmVersion = (Get-Content $nvmrcPath -Raw).Trim()
-  if ([string]::IsNullOrWhiteSpace($nvmVersion)) {
+  $nodeVersion = (Get-Content $nvmrcPath -Raw).Trim().TrimStart('v')
+  if ([string]::IsNullOrWhiteSpace($nodeVersion)) {
     throw ".nvmrc is empty at $nvmrcPath"
   }
 
-  if ($nvmVersion -ne $expectedNodeVersion) {
-    throw ".nvmrc version '$nvmVersion' does not match expected Node.js version '$expectedNodeVersion' used by Windows CI."
+  # nvm-windows is the only supported installer here. It manages
+  # C:\Program Files\nodejs as a junction; using a parallel MSI install on the
+  # same machine leaves stale npm internals.
+  $nvmExe = Get-Command nvm -ErrorAction SilentlyContinue
+  if (-not $nvmExe) {
+    throw "nvm-windows is required but was not found on PATH. Ensure the runner image provides nvm-windows."
   }
 
-  $nodeVersion = $expectedNodeVersion
+  Write-Host "nvm-windows: $($nvmExe.Source)"
+  Write-Host "NVM_HOME: $env:NVM_HOME"
+  Write-Host "NVM_SYMLINK: $env:NVM_SYMLINK"
 
-  $msiPath = Join-Path $cacheDir "node-v$nodeVersion-x64.msi"
-
-  if (-not (Test-Path $cacheDir)) {
-    New-Item -ItemType Directory -Path $cacheDir | Out-Null
+  $nvmList = & nvm list 2>&1 | Out-String
+  if ($nvmList -notmatch ('\b' + [regex]::Escape($nodeVersion) + '\b')) {
+    Write-Host "[nvm-cache] MISS: Node.js v$nodeVersion not present; installing via nvm..."
+    & nvm install $nodeVersion
+  } else {
+    Write-Host "[nvm-cache] HIT: Node.js v$nodeVersion already installed in nvm; skipping download."
   }
 
-  if (-not (Test-Path $msiPath)) {
-    Write-Host "Downloading Node.js v$nodeVersion (x64 MSI)..."
-    $url = "https://nodejs.org/dist/v$nodeVersion/node-v$nodeVersion-x64.msi"
-    curl.exe -L $url -o $msiPath
-  }
-
-  Write-Host 'Verifying Node.js installer checksum...'
-  $hash = Get-FileHash -Path $msiPath -Algorithm SHA256
-  if ($hash.Hash.ToLower() -ne $expectedSha256.ToLower()) {
-    throw "Checksum verification failed for $msiPath. Expected $expectedSha256 but got $($hash.Hash.ToLower())."
-  }
-
-  Write-Host "Installing Node.js v$nodeVersion..."
-  $msiArgs = "/i `"$msiPath`" /qn /norestart"
-  $process = Start-Process -FilePath msiexec.exe -ArgumentList $msiArgs -PassThru
-  $process.WaitForExit()
-  if ($process.ExitCode -ne 0) {
-    throw "Node.js MSI installer exited with code $($process.ExitCode)."
-  }
+  Write-Host "Activating Node.js v$nodeVersion via nvm..."
+  & nvm use $nodeVersion
 
   # Verify installation using the known default installation path
   $nodeExe = "C:\Program Files\nodejs\node.exe"
@@ -72,44 +60,10 @@ try {
     throw "Installed Node.js version '$reportedVersion' does not match expected 'v$nodeVersion'."
   }
 
-  Write-Host "Node.js $reportedVersion installed successfully at $nodeExe"
+  Write-Host "Node.js $reportedVersion installed and active at $nodeExe"
 
-  try {
-    $nodeDir = Split-Path $nodeExe -Parent
-    $envScript = Join-Path $cacheDir $cacheFileName
-    if (-not (Test-Path $envScript)) {
-      New-Item -Path $envScript -ItemType File -Force | Out-Null
-    }
-
-    $pathUpdateLine = '$Env:Path = "' + $nodeDir + ';" + $Env:Path'
-    $existing = Get-Content -Path $envScript -ErrorAction SilentlyContinue
-    if (-not $existing -or -not ($existing -contains $pathUpdateLine)) {
-      $pathUpdateLine | Out-File -FilePath $envScript -Append -Encoding UTF8
-    }
-  }
-  catch {
-    Write-Host "Warning: failed to persist Node.js PATH update to env script: $($_.Exception.Message)"
-  }
-
-  # Also create a bash-compatible version for non-PowerShell envs
-  try {
-    $bashEnvScript = Join-Path $cacheDir $bashCacheFileName
-    if (-not (Test-Path $bashEnvScript)) {
-      New-Item -Path $bashEnvScript -ItemType File -Force | Out-Null
-    }
-    $bashPath = $nodeDir.Replace('\', '/').Replace('C:', '/c')
-    $bashUpdateLine = 'export PATH="' + $bashPath + ':$PATH"'
-    $bashExisting = Get-Content -Path $bashEnvScript -ErrorAction SilentlyContinue
-    if (-not $bashExisting -or -not ($bashExisting -contains $bashUpdateLine)) {
-      $bashUpdateLine | Out-File -FilePath $bashEnvScript -Append -Encoding UTF8
-    }
-  }
-  catch {
-    Write-Host "Warning: failed to persist Node.js PATH update to bash env script: $($_.Exception.Message)"
-  }
 }
 catch {
   Write-Error "Failed to install Node.js: $($_.Exception.Message)"
   exit 1
 }
-


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Hardens **Windows CI** for the Node toolchain used when building the CLI:

- **Node is installed only via nvm-windows** (`nvm install` / `nvm use`) using the version pinned in **`.nvmrc`**. There is **no MSI** path or SHA256 check. If **`nvm`** is not on `PATH`, the script **fails fast** with a clear error.
- **Diagnostic logging:** `nvm` binary path, **`NVM_HOME`**, **`NVM_SYMLINK`**, and **`[nvm-cache] HIT`** / **`[nvm-cache] MISS`** so logs show whether Node was downloaded this run or reused from the nvm store.
- **CircleCI cache:** Windows tools cache bumped to **`windows-tools-cache-v4-{{ arch }}-{{ checksum ".nvmrc" }}`** so caches invalidate when Node changes; **`save_cache`** includes **`<< windows_cache_dir >>`** and **`C:\ProgramData\nvm`** so the nvm install tree persists between jobs.

This addresses the class of failures where **`node.exe`** and **npm’s own files** came from **different** layouts (e.g. MSI vs NVM), by standardizing on **one** manager (nvm) on CI.

**Note:** `scripts/windows/install-node.ps1` in this PR **does not** append Node to `snyk-env.ps1` / `snyk-env.sh`; it only runs nvm and verifies **`C:\Program Files\nodejs\node.exe`**. Downstream steps rely on **`nvm use`** having switched the **junction** and on the image / default **`PATH`** including **`Program Files\nodejs`** as usual. If anything regresses, we can restore explicit PATH lines or document the assumption.

## Changes

- **`scripts/windows/install-node.ps1`** — nvm-only install from `.nvmrc`; verification; logging; **no MSI**.
- **`.circleci/config.yml`** — `install-deps-windows-native-build`: cache key **`v4`** + **`{{ checksum ".nvmrc" }}`**; **`save_cache.paths`** adds **`C:\ProgramData\nvm`**.

## Where should the reviewer start?

1. `scripts/windows/install-node.ps1`
2. `.circleci/config.yml` — `install-deps-windows-native-build` (restore/save cache)

## How should this be manually tested?

1. Run a **Windows** job that uses **`install-deps-windows-native-build`** (e.g. full Windows build).
2. In **Install Node.js (native)**, confirm **`nvm-windows:`**, **`NVM_HOME:`**, and **`[nvm-cache]`** HIT/MISS.
3. Confirm **legacy TS / npm** steps still succeed (no **`Class extends value undefined`** from npm).
4. On first green run, confirm **`NVM_HOME`** in logs matches **`C:\ProgramData\nvm`**; if not, adjust the **`save_cache`** path in `.circleci/config.yml`.

## What's the product update that needs to be communicated to CLI users?

None. CI/build plumbing only.

## Risk assessment (Low | Medium | High)?

**Low** — CI scripts and config only; no change to shipped CLI behaviour.

## Any background context you want to provide?

CircleCI Windows images ship **nvm-windows**; a second **MSI** installer was redundant and risked inconsistent installs. **`{{ checksum ".nvmrc" }}`** ties the cache to the pinned Node version.

Related: [CLI-1469](https://snyksec.atlassian.net/browse/CLI-1469). Prior discussion: https://github.com/snyk/cli/pull/6758

## What are the relevant tickets?

[CLI-1469](https://snyksec.atlassian.net/browse/CLI-1469)

## Screenshots (if appropriate)

N/A

[CLI-1469]: https://snyksec.atlassian.net/browse/CLI-1469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ