### PR TITLE
fix(ci): Hanging e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1760,7 +1760,10 @@ jobs:
               pattern: '^linux.*'
               value: << parameters.executor >>
           steps:
-            - run: echo UTC > /etc/timezone && apt update && apt install -y sudo curl python3 python3-pip python3-requests
+            - run: |
+                export DEBIAN_FRONTEND=noninteractive   
+                ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+                apt update && apt install -y sudo curl python3 python3-pip python3-requests
 
       - run:
           name: Checking Snyk CLI


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
This PR changes the way how the timezone is configured when install e2e test dependencies.

## Where should the reviewer start?

## How should this be manually tested?

## What's the product update that needs to be communicated to CLI users?
N/A

## Risk assessment (Low | Medium | High)?
Low, as it affects the e2e tests only

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
