### PR TITLE
fix: bump secrets extension [PS-489]

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260206080712-9cbb5f95465d
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260423112219-b7ba9dd68e57
 	github.com/snyk/cli-extension-sbom v0.0.0-20260423112228-5d124dd8c9b0
-	github.com/snyk/cli-extension-secrets v0.0.0-20260430092921-e70fbeb9dbea
+	github.com/snyk/cli-extension-secrets v0.0.0-20260505103358-cc205308a93e
 	github.com/snyk/code-client-go v1.26.2
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260410094451-50af33399e90

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -551,8 +551,8 @@ github.com/snyk/cli-extension-os-flows v0.0.0-20260423112219-b7ba9dd68e57 h1:8dp
 github.com/snyk/cli-extension-os-flows v0.0.0-20260423112219-b7ba9dd68e57/go.mod h1:f16TyLAOBiU485lN/odNfmiyWyMu1iVrDoSEieiiblQ=
 github.com/snyk/cli-extension-sbom v0.0.0-20260423112228-5d124dd8c9b0 h1:bwtq5pAQCpD1wFErD6dzpGevYwjVyREgS9H96ctHhII=
 github.com/snyk/cli-extension-sbom v0.0.0-20260423112228-5d124dd8c9b0/go.mod h1:SJ624HENWG4yjM6jNuLebTeNsMriozf1LcKhMYVm1aY=
-github.com/snyk/cli-extension-secrets v0.0.0-20260430092921-e70fbeb9dbea h1:rBm7mbxO2pE2fA1k96ltgVtqKl3nK6L7cY3rgNcwEDY=
-github.com/snyk/cli-extension-secrets v0.0.0-20260430092921-e70fbeb9dbea/go.mod h1:+Ey86Xjvw2HhDM8OisCVNzlatzO9wEfSQRPapaNfwIk=
+github.com/snyk/cli-extension-secrets v0.0.0-20260505103358-cc205308a93e h1:LLdPjkz6zRxYwos2iIyKvlaCL7x8bZAAxeUF+4nG+So=
+github.com/snyk/cli-extension-secrets v0.0.0-20260505103358-cc205308a93e/go.mod h1:+Ey86Xjvw2HhDM8OisCVNzlatzO9wEfSQRPapaNfwIk=
 github.com/snyk/code-client-go v1.26.2 h1:vto7ZKj9OoU1rnmKeoZ+i68qXrT0I94CEMhvwK03O24=
 github.com/snyk/code-client-go v1.26.2/go.mod h1:0NcZZHB48Sr4UAucEH2H10HwV7gjI2Ue0c+FxPWaTNo=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea h1:/v48hCMPiZVjplylgE2FX1ib8Qd8LN/vf8ZIKfA+wkI=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps the cli-secrets-extension to the latest version that fixes a bug related to persisting target reference info consistently for secrets projects.

## Where should the reviewer start?

https://github.com/snyk/cli-extension-secrets/pull/71

## How should this be manually tested?

Build the cli locally and run `snyk secrets test --report` with an without the `--target-reference` flag. Check that the secrets projects are grouped per branch in the UI.

## What's the product update that needs to be communicated to CLI users?

None, this only affects `snyk secrets test` which is not yet released to customers.

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
