### PR TITLE
fix: bump cli-ext-agent-scan version [MCP-947]

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.34.0
-	github.com/snyk/cli-extension-agent-scan v0.0.0-20260423170155-f094d5d5a2f1
+	github.com/snyk/cli-extension-agent-scan v0.0.0-20260505093105-90d9442ea939
 	github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603
 	github.com/snyk/cli-extension-ai-redteam v0.0.0-20260331152502-ce341aeaff9e
 	github.com/snyk/cli-extension-dep-graph v1.4.0

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -535,8 +535,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.3.2 h1:EDL9mgf4NzwMXCTfaxSD/o/a5fxDw/xL9nkU28JjdBg=
 github.com/skeema/knownhosts v1.3.2/go.mod h1:bEg3iQAuw+jyiw+484wwFJoKSLwcfd7fqRy+N0QTiow=
-github.com/snyk/cli-extension-agent-scan v0.0.0-20260423170155-f094d5d5a2f1 h1:fUyibEStlF5gY4H4TdtQ0WW6MsnWjDhew6v1CGMdnfY=
-github.com/snyk/cli-extension-agent-scan v0.0.0-20260423170155-f094d5d5a2f1/go.mod h1:+Znlgu2v7sOTNAVjsoldFjDZUIo8tpdKnFlMptZHzz0=
+github.com/snyk/cli-extension-agent-scan v0.0.0-20260505093105-90d9442ea939 h1:GvW35inJZTr2AD1c/sIRkVOajom0kEY8nN30cqes+u0=
+github.com/snyk/cli-extension-agent-scan v0.0.0-20260505093105-90d9442ea939/go.mod h1:+Znlgu2v7sOTNAVjsoldFjDZUIo8tpdKnFlMptZHzz0=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603 h1:uZyw9OvOGCMFloZy8Fyu6l4K5y77o4k0KdxHuUKAp8M=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603/go.mod h1:RnMP+tFTeKygfXSx7z+heyMZoOps67u5HFytjptHjuk=
 github.com/snyk/cli-extension-ai-redteam v0.0.0-20260331152502-ce341aeaff9e h1:WZ4Ph3iX+fAu3/HgblVnA+AXfKiEvrgHsZq8GHjnzzo=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
- Bump cli extension for agent-scan to use latest version.

## Where should the reviewer start?

## How should this be manually tested?
snyk agent-scan --experimental

## What's the product update that needs to be communicated to CLI users?
Experimental module agent-scan version bump, so no formal communication required.

## Risk assessment (Low | Medium | High)?
Low

## Any background context you want to provide?
Maintenance bump
- JIRA [ticket](https://snyksec.atlassian.net/browse/MCP-947)