### PR TITLE
chore: respect snyk-ls replace for LS protocol metadata [IDE-2001]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,11 @@ test-binary-wrapper: build-binary-wrapper
 	@echo "-- Testing binary wrapper"
 	@cd $(BINARY_WRAPPER_DIR); npm run test
 
+.PHONY: test-release-scripts
+test-release-scripts:
+	@echo "-- Testing release scripts"
+	@cd release-scripts; go test ./...
+
 
 # targets responsible for the complete CLI build
 .PHONY: pre-build

--- a/cliv2/Makefile
+++ b/cliv2/Makefile
@@ -5,7 +5,6 @@ GOOS = $(shell go env GOOS)
 GOARCH = $(shell go env GOARCH)
 GOHOSTOS = $(shell go env GOHOSTOS)
 GOHOSTARCH = $(shell go env GOHOSTARCH)
-LS_COMMIT_HASH = $(shell cat go.mod | grep snyk-ls | cut -d "-" -f 4 | head -1)
 FIPS_CRYPTO_BACKEND_DEFAULT = systemcrypto
 FIPS_CRYPTO_BACKEND =
 MS_GO_NOSYSTEMCRYPTO ?= 1
@@ -34,6 +33,9 @@ bindir = $(exec_prefix)/bin
 WORKING_DIR = $(CURDIR)
 BUILD_DIR = $(WORKING_DIR)/_bin
 CACHE_DIR = $(WORKING_DIR)/_cache
+LS_PROTOCOL_VERSION_FILE = $(CACHE_DIR)/ls-protocol-version
+LS_COMMIT_HASH_FILE = $(CACHE_DIR)/ls-commit-hash
+LS_COMMIT_HASH = $(if $(wildcard $(LS_COMMIT_HASH_FILE)),$(shell cat $(LS_COMMIT_HASH_FILE)),determined during LS metadata generation)
 SRCS = $(shell find $(WORKING_DIR) -type f -name '*.go')
 
 # load cached variables if available
@@ -155,6 +157,8 @@ summary:
 configure: summary $(CACHE_DIR) $(CACHE_DIR)/variables.mk $(V1_DIRECTORY)/$(V1_EMBEDDED_FILE_OUTPUT) dependencies $(CACHE_DIR)/prepare-3rd-party-licenses
 
 $(BUILD_DIR)/$(V2_EXECUTABLE_NAME): $(BUILD_DIR) $(SRCS) generate-ls-protocol-metadata
+	$(eval LS_PROTOCOL_VERSION := $(shell cat $(LS_PROTOCOL_VERSION_FILE)))
+	$(eval LS_COMMIT_HASH := $(shell cat $(LS_COMMIT_HASH_FILE)))
 	$(eval EXTRA_FLAGS := -X github.com/snyk/snyk-ls/application/config.Version=$(LS_COMMIT_HASH) -X github.com/snyk/snyk-ls/application/config.LsProtocolVersion=$(LS_PROTOCOL_VERSION)  -X main.internalOS=$(GOOS) -X github.com/snyk/cli/cliv2/internal/embedded/cliv1.snykCLIVersion=$(CLI_V1_VERSION_TAG) -X github.com/snyk/cli-extension-iac/internal/commands/iactest.internalRulesClientURL=$(IAC_RULES_URL) -X github.com/snyk/cli/cliv2/internal/constants.StaticNodeJsBinary=$(STATIC_NODE_BINARY))
 	@echo "$(LOG_PREFIX) Building ( $(BUILD_DIR)/$(V2_EXECUTABLE_NAME) )"
 	@echo "$(LOG_PREFIX)  CGO_ENABLED: $(CGO_ENABLED)"
@@ -252,12 +256,13 @@ build-ts-cli: $(V1_WORKING_DIR)/$(V1_BINARY_FOLDER)/$(V1_BINARY_SUBFOLDER)$(V1_E
 	$(eval CLI_V1_LOCATION := $(V1_WORKING_DIR)/$(V1_BINARY_FOLDER)/$(V1_BINARY_SUBFOLDER))
 
 .PHONY: generate-ls-protocol-metadata
-generate-ls-protocol-metadata:
+generate-ls-protocol-metadata: $(CACHE_DIR)
 	$(eval CLI_V1_VERSION_TAG := $(shell cat $(DESTDIR)$(bindir)/version))
 	@echo "$(LOG_PREFIX) Determining LS protocol version"
 	@echo "$(LOG_PREFIX) Writing protocol version file to $(DESTDIR)$(bindir)"
-	$(eval LS_PROTOCOL_VERSION := $(shell $(GOCMD) run $(WORKING_DIR)/../release-scripts/write-ls-protocol-version.go $(LS_COMMIT_HASH) $(CLI_V1_VERSION_TAG) $(DESTDIR)$(bindir)))
-	@echo "$(LOG_PREFIX) LS protocol version: $(LS_PROTOCOL_VERSION)"
+	@GOOS=$(GOHOSTOS) GOARCH=$(GOHOSTARCH) $(GOCMD) run $(WORKING_DIR)/../release-scripts/write-ls-protocol-version.go $(CLI_V1_VERSION_TAG) $(DESTDIR)$(bindir) $(LS_COMMIT_HASH_FILE) > $(LS_PROTOCOL_VERSION_FILE)
+	@echo "$(LOG_PREFIX) LS protocol version: $$(cat $(LS_PROTOCOL_VERSION_FILE))"
+	@echo "$(LOG_PREFIX) LS commit hash: $$(cat $(LS_COMMIT_HASH_FILE))"
 
 .PHONY: clean-ts-cli
 clean-ts-cli:

--- a/release-scripts/go.mod
+++ b/release-scripts/go.mod
@@ -1,0 +1,3 @@
+module github.com/snyk/cli/release-scripts
+
+go 1.26.2

--- a/release-scripts/write-ls-protocol-version.go
+++ b/release-scripts/write-ls-protocol-version.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,23 +12,121 @@ import (
 	"strings"
 )
 
+const snykLSModulePath = "github.com/snyk/snyk-ls"
+
+type lsProtocolVersion struct {
+	version    int
+	commitHash string
+	source     string
+}
+
+var resolveLSProtocolVersionFromCommit = getLSProtocolVersionFromCommit
+var resolveCommitHashFromDir = gitCommitHashFromDir
+
 func getGoreleaserYAML(commit string) (int, error) {
-	installOutput, err := exec.Command("go", "install", "github.com/snyk/snyk-ls@"+commit).CombinedOutput()
+	resolved, err := getLSProtocolVersion()
 	if err != nil {
-		return -3, fmt.Errorf("go install failed: %w: %q", err, string(installOutput))
+		return -3, err
+	}
+	return resolved.version, nil
+}
+
+func getLSProtocolVersion() (lsProtocolVersion, error) {
+	goModPath, err := currentGoModPath()
+	if err != nil {
+		return lsProtocolVersion{version: -3}, fmt.Errorf("failed to locate go.mod: %w", err)
+	}
+	if goModPath == "" {
+		return lsProtocolVersion{version: -3}, fmt.Errorf("failed to locate go.mod")
+	}
+
+	return getLSProtocolVersionWithGoMod(goModPath)
+}
+
+func getGoreleaserYAMLWithGoMod(commit string, goModPath string) (int, error) {
+	resolved, err := getLSProtocolVersionWithGoMod(goModPath)
+	if err != nil {
+		return -3, err
+	}
+	return resolved.version, nil
+}
+
+func getLSProtocolVersionWithGoMod(goModPath string) (lsProtocolVersion, error) {
+	dependency, err := snykLSDependency(goModPath)
+	if err != nil {
+		return lsProtocolVersion{version: -3}, err
+	}
+	if dependency.replacementDir != "" {
+		goreleaserPath := filepath.Join(dependency.replacementDir, ".goreleaser.yaml")
+		protocolVersion, err := readLSProtocolVersion(goreleaserPath)
+		if err != nil {
+			return lsProtocolVersion{version: -3}, fmt.Errorf("failed to read LS_PROTOCOL_VERSION from .goreleaser.yaml in replaced snyk-ls path %q: %w", goreleaserPath, err)
+		}
+
+		commitHash, err := resolveCommitHashFromDir(dependency.replacementDir)
+		if err != nil {
+			return lsProtocolVersion{version: -3}, fmt.Errorf("failed to determine commit hash from replaced snyk-ls path %q: %w", dependency.replacementDir, err)
+		}
+		return lsProtocolVersion{
+			version:    protocolVersion,
+			commitHash: commitHash,
+			source:     fmt.Sprintf(".goreleaser.yaml from replaced snyk-ls path %q", goreleaserPath),
+		}, nil
+	}
+
+	commitHash, err := commitHashFromModuleVersion(dependency.version)
+	if err != nil {
+		return lsProtocolVersion{version: -3}, err
+	}
+
+	resolved, err := resolveLSProtocolVersionFromCommit(commitHash)
+	if err != nil {
+		return lsProtocolVersion{version: -3}, err
+	}
+	if resolved.commitHash == "" {
+		resolved.commitHash = commitHash
+	}
+	return resolved, nil
+}
+
+func getGoreleaserYAMLFromCommit(commit string) (int, error) {
+	resolved, err := getLSProtocolVersionFromCommit(commit)
+	if err != nil {
+		return -3, err
+	}
+	return resolved.version, nil
+}
+
+func getLSProtocolVersionFromCommit(commit string) (lsProtocolVersion, error) {
+	installOutput, err := exec.Command("go", "install", snykLSModulePath+"@"+commit).CombinedOutput()
+	if err != nil {
+		return lsProtocolVersion{version: -3}, fmt.Errorf("go install failed: %w: %q", err, string(installOutput))
 	}
 	modCacheDir, err := goModCache()
 	if err != nil {
-		return -3, fmt.Errorf("failed to locate go module cache: %w", err)
+		return lsProtocolVersion{version: -3}, fmt.Errorf("failed to locate go module cache: %w", err)
 	}
 	snykLsPkgPaths, err := filepath.Glob(filepath.Join(modCacheDir, "github.com", "snyk", "snyk-ls@v*-"+commit[:12]))
 	if err != nil {
-		return -3, fmt.Errorf("failed to match snyk-ls: %w", err)
+		return lsProtocolVersion{version: -3}, fmt.Errorf("failed to match snyk-ls: %w", err)
 	}
 	if len(snykLsPkgPaths) == 0 {
-		return -3, fmt.Errorf("snyk-ls @ %s not found in module cache; try `go get`?", commit)
+		return lsProtocolVersion{version: -3}, fmt.Errorf("snyk-ls @ %s not found in module cache; try `go get`?", commit)
 	}
-	goReleaserContents, err := os.ReadFile(filepath.Join(snykLsPkgPaths[0], ".goreleaser.yaml"))
+	goreleaserPath := filepath.Join(snykLsPkgPaths[0], ".goreleaser.yaml")
+	protocolVersion, err := readLSProtocolVersion(goreleaserPath)
+	if err != nil {
+		return lsProtocolVersion{version: -3}, err
+	}
+	return lsProtocolVersion{
+		version:    protocolVersion,
+		commitHash: commit,
+		source:     fmt.Sprintf("commit-hash-based resolution from %s@%s", snykLSModulePath, commit),
+	}, nil
+}
+
+func readLSProtocolVersion(goreleaserPath string) (int, error) {
+	goReleaserContents, err := os.ReadFile(goreleaserPath)
 	if err != nil {
 		return -3, fmt.Errorf("failed to read goreleaser file: %w", err)
 	}
@@ -42,6 +142,128 @@ func getGoreleaserYAML(commit string) (int, error) {
 	}
 
 	return protocolVersion, nil
+}
+
+func currentGoModPath() (string, error) {
+	goModPath, ok, err := findGoModFromWorkingDir()
+	if err != nil {
+		return "", err
+	}
+	if ok {
+		return goModPath, nil
+	}
+
+	stdout, err := exec.Command("go", "env", "GOMOD").Output()
+	if err != nil {
+		return "", err
+	}
+
+	goModPath = strings.TrimSpace(string(stdout))
+	if goModPath == "" || goModPath == os.DevNull {
+		return "", nil
+	}
+	return goModPath, nil
+}
+
+func findGoModFromWorkingDir() (string, bool, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", false, err
+	}
+
+	for {
+		goModPath := filepath.Join(dir, "go.mod")
+		if _, err := os.Stat(goModPath); err == nil {
+			return goModPath, true, nil
+		} else if !os.IsNotExist(err) {
+			return "", false, err
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false, nil
+		}
+		dir = parent
+	}
+}
+
+type moduleVersion struct {
+	Path    string
+	Version string
+}
+
+type replaceDirective struct {
+	Old moduleVersion
+	New moduleVersion
+}
+
+type goMod struct {
+	Require []moduleVersion
+	Replace []replaceDirective
+}
+
+type snykLSModule struct {
+	version        string
+	replacementDir string
+}
+
+func parseGoMod(goModPath string) (goMod, error) {
+	output, err := exec.Command("go", "mod", "edit", "-json", goModPath).CombinedOutput()
+	if err != nil {
+		return goMod{}, fmt.Errorf("failed to inspect go.mod: %w: %q", err, string(output))
+	}
+
+	var parsed goMod
+	if err := json.Unmarshal(output, &parsed); err != nil {
+		return goMod{}, fmt.Errorf("failed to parse go.mod: %w", err)
+	}
+
+	return parsed, nil
+}
+
+func snykLSDependency(goModPath string) (snykLSModule, error) {
+	parsed, err := parseGoMod(goModPath)
+	if err != nil {
+		return snykLSModule{}, err
+	}
+
+	var dependency snykLSModule
+	for _, required := range parsed.Require {
+		if required.Path == snykLSModulePath {
+			dependency.version = required.Version
+			break
+		}
+	}
+	if dependency.version == "" {
+		return snykLSModule{}, fmt.Errorf("%s dependency not found in %s", snykLSModulePath, goModPath)
+	}
+
+	for _, replacement := range parsed.Replace {
+		if replacement.Old.Path != snykLSModulePath || replacement.New.Version != "" {
+			continue
+		}
+
+		replacementPath := replacement.New.Path
+		if filepath.IsAbs(replacementPath) {
+			dependency.replacementDir = filepath.Clean(replacementPath)
+			return dependency, nil
+		}
+		dependency.replacementDir = filepath.Clean(filepath.Join(filepath.Dir(goModPath), replacementPath))
+		return dependency, nil
+	}
+
+	return dependency, nil
+}
+
+func snykLSReplacementDir(goModPath string) (string, bool, error) {
+	dependency, err := snykLSDependency(goModPath)
+	if err != nil {
+		return "", false, err
+	}
+	if dependency.replacementDir == "" {
+		return "", false, nil
+	}
+	return dependency.replacementDir, true, nil
 }
 
 func goModCache() (string, error) {
@@ -62,25 +284,60 @@ func extractLSProtocolVersion(yamlContent []byte) string {
 	return ""
 }
 
+func commitHashFromModuleVersion(version string) (string, error) {
+	parts := strings.Split(version, "-")
+	if len(parts) >= 3 {
+		return parts[len(parts)-1], nil
+	}
+	if version != "" {
+		return version, nil
+	}
+	return "", fmt.Errorf("failed to determine snyk-ls commit hash from empty module version")
+}
+
+func gitCommitHashFromDir(dir string) (string, error) {
+	output, err := exec.Command("git", "-C", dir, "rev-parse", "--short=12", "HEAD").CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse failed: %w: %q", err, string(output))
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func writeLSProtocolVersionMetadata(version string, outputDir string, commitHashFile string, logWriter io.Writer) (int, error) {
+	resolved, err := getLSProtocolVersion()
+	if err != nil || resolved.version < 0 {
+		return -1, err
+	}
+
+	if logWriter != nil {
+		fmt.Fprintf(logWriter, "-- Resolved LS protocol version %d using %s\n", resolved.version, resolved.source)
+		fmt.Fprintf(logWriter, "-- Resolved LS commit hash %s\n", resolved.commitHash)
+	}
+
+	filePath := filepath.Join(outputDir, fmt.Sprintf("ls-protocol-version-%d", resolved.version))
+	if err := os.WriteFile(filePath, []byte(version), 0644); err != nil {
+		return -1, fmt.Errorf("failed to write to file: %w", err)
+	}
+	if err := os.WriteFile(commitHashFile, []byte(resolved.commitHash), 0644); err != nil {
+		return -1, fmt.Errorf("failed to write commit hash file: %w", err)
+	}
+
+	return resolved.version, nil
+}
+
 func main() {
 	if len(os.Args) != 4 {
-		fmt.Println("Usage: go run script.go <commit_hash> <version> <output-directory>")
+		fmt.Println("Usage: go run script.go <version> <output-directory> <commit-hash-output-file>")
 		os.Exit(1)
 	}
 
-	commitHash := os.Args[1]
-	version := os.Args[2]
-	outputDir := os.Args[3]
+	version := os.Args[1]
+	outputDir := os.Args[2]
+	commitHashFile := os.Args[3]
 
-	lsProtocolVersion, err := getGoreleaserYAML(commitHash)
-	if err != nil || lsProtocolVersion < 0 {
-		fmt.Printf("Failed to retrieve LS_PROTOCOL_VERSION: %v\n", err)
-		os.Exit(1)
-	}
-
-	filePath := filepath.Join(outputDir, fmt.Sprintf("ls-protocol-version-%d", lsProtocolVersion))
-	if err := os.WriteFile(filePath, []byte(version), 0644); err != nil {
-		fmt.Printf("Failed to write to file: %v\n", err)
+	lsProtocolVersion, err := writeLSProtocolVersionMetadata(version, outputDir, commitHashFile, os.Stderr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to retrieve LS_PROTOCOL_VERSION: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/release-scripts/write-ls-protocol-version_test.go
+++ b/release-scripts/write-ls-protocol-version_test.go
@@ -1,0 +1,652 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestGetGoreleaserYAMLUsesLocalSnykLSReplace(t *testing.T) {
+	tempDir := t.TempDir()
+	moduleDir := filepath.Join(tempDir, "cliv2")
+	replacedDir := filepath.Join(tempDir, "snyk-ls")
+
+	if err := os.MkdirAll(moduleDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(replacedDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	goMod := []byte(`module github.com/snyk/cli/cliv2
+
+go 1.26
+
+require github.com/snyk/snyk-ls v0.0.0-20260414093345-2a6d7434eb91
+
+replace github.com/snyk/snyk-ls => ../snyk-ls
+`)
+	goModPath := filepath.Join(moduleDir, "go.mod")
+	if err := os.WriteFile(goModPath, goMod, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	goreleaserYAML := []byte(`env:
+  - LS_PROTOCOL_VERSION=123
+`)
+	if err := os.WriteFile(filepath.Join(replacedDir, ".goreleaser.yaml"), goreleaserYAML, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalReplacementResolver := resolveCommitHashFromDir
+	t.Cleanup(func() {
+		resolveCommitHashFromDir = originalReplacementResolver
+	})
+	resolveCommitHashFromDir = func(dir string) (string, error) {
+		return "replacement123", nil
+	}
+
+	protocolVersion, err := getGoreleaserYAMLWithGoMod("commit-is-ignored", goModPath)
+	if err != nil {
+		t.Fatalf("expected protocol version from replacement: %v", err)
+	}
+	if protocolVersion != 123 {
+		t.Fatalf("expected protocol version 123, got %d", protocolVersion)
+	}
+}
+
+func TestWriteLSProtocolVersionMetadataUsesReplacementAndLogsSource(t *testing.T) {
+	tempDir := t.TempDir()
+	moduleDir := filepath.Join(tempDir, "cliv2")
+	replacedDir := filepath.Join(tempDir, "snyk-ls")
+	outputDir := filepath.Join(tempDir, "output")
+
+	if err := os.MkdirAll(moduleDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(replacedDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	goMod := []byte(`module github.com/snyk/cli/cliv2
+
+go 1.26
+
+require github.com/snyk/snyk-ls v0.0.0-20260414093345-2a6d7434eb91
+
+replace github.com/snyk/snyk-ls => ../snyk-ls
+`)
+	if err := os.WriteFile(filepath.Join(moduleDir, "go.mod"), goMod, 0644); err != nil {
+		t.Fatal(err)
+	}
+	goreleaserYAML := []byte(`env:
+  - LS_PROTOCOL_VERSION=456
+`)
+	if err := os.WriteFile(filepath.Join(replacedDir, ".goreleaser.yaml"), goreleaserYAML, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(moduleDir)
+	var log bytes.Buffer
+	commitHashFile := filepath.Join(tempDir, "ls-commit-hash")
+
+	originalReplacementResolver := resolveCommitHashFromDir
+	t.Cleanup(func() {
+		resolveCommitHashFromDir = originalReplacementResolver
+	})
+	resolveCommitHashFromDir = func(dir string) (string, error) {
+		if dir != replacedDir {
+			t.Fatalf("expected replacement commit hash to be resolved from %q, got %q", replacedDir, dir)
+		}
+		return "replacement123", nil
+	}
+
+	protocolVersion, err := writeLSProtocolVersionMetadata("9.9.9", outputDir, commitHashFile, &log)
+	if err != nil {
+		t.Fatalf("expected metadata to be written from replacement: %v", err)
+	}
+	if protocolVersion != 456 {
+		t.Fatalf("expected protocol version 456, got %d", protocolVersion)
+	}
+
+	outputFile := filepath.Join(outputDir, "ls-protocol-version-456")
+	contents, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatalf("expected output file to be written: %v", err)
+	}
+	if string(contents) != "9.9.9" {
+		t.Fatalf("expected output file to contain CLI version, got %q", string(contents))
+	}
+	commitHash, err := os.ReadFile(commitHashFile)
+	if err != nil {
+		t.Fatalf("expected commit hash file to be written: %v", err)
+	}
+	if string(commitHash) != "replacement123" {
+		t.Fatalf("expected replacement commit hash, got %q", commitHash)
+	}
+
+	logOutput := log.String()
+	if !strings.Contains(logOutput, "replaced snyk-ls path") || !strings.Contains(logOutput, filepath.Join(replacedDir, ".goreleaser.yaml")) {
+		t.Fatalf("expected log to identify replacement source, got %q", logOutput)
+	}
+}
+
+func TestReplacementGoreleaserFailureDoesNotFallBackToCommitResolution(t *testing.T) {
+	tempDir := t.TempDir()
+	moduleDir := filepath.Join(tempDir, "cliv2")
+	replacedDir := filepath.Join(tempDir, "snyk-ls")
+
+	if err := os.MkdirAll(moduleDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(replacedDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	goMod := []byte(`module github.com/snyk/cli/cliv2
+
+go 1.26
+
+require github.com/snyk/snyk-ls v0.0.0-20260414093345-2a6d7434eb91
+
+replace github.com/snyk/snyk-ls => ../snyk-ls
+`)
+	goModPath := filepath.Join(moduleDir, "go.mod")
+	if err := os.WriteFile(goModPath, goMod, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := getGoreleaserYAMLWithGoMod("commit-should-not-be-used", goModPath)
+	if err == nil {
+		t.Fatal("expected missing replacement .goreleaser.yaml to fail")
+	}
+
+	errorMessage := err.Error()
+	if !strings.Contains(errorMessage, "replaced snyk-ls path") || !strings.Contains(errorMessage, ".goreleaser.yaml") {
+		t.Fatalf("expected replacement-specific goreleaser error, got %q", errorMessage)
+	}
+	if strings.Contains(errorMessage, "go install") || strings.Contains(errorMessage, "commit-should-not-be-used") {
+		t.Fatalf("expected no commit-hash fallback, got %q", errorMessage)
+	}
+}
+
+func TestWriteLSProtocolVersionMetadataFallsBackToCommitResolutionWhenNoReplaceExists(t *testing.T) {
+	tempDir := t.TempDir()
+	moduleDir := filepath.Join(tempDir, "cliv2")
+	outputDir := filepath.Join(tempDir, "output")
+
+	if err := os.MkdirAll(moduleDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	goMod := []byte(`module github.com/snyk/cli/cliv2
+
+go 1.26
+
+require github.com/snyk/snyk-ls v0.0.0-20260414093345-abcdef123456
+`)
+	if err := os.WriteFile(filepath.Join(moduleDir, "go.mod"), goMod, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalResolver := resolveLSProtocolVersionFromCommit
+	t.Cleanup(func() {
+		resolveLSProtocolVersionFromCommit = originalResolver
+	})
+
+	var resolvedCommit string
+	resolveLSProtocolVersionFromCommit = func(commit string) (lsProtocolVersion, error) {
+		resolvedCommit = commit
+		return lsProtocolVersion{
+			version: 789,
+			source:  "commit-hash-based resolution from test",
+		}, nil
+	}
+
+	t.Chdir(moduleDir)
+	var log bytes.Buffer
+
+	commitHashFile := filepath.Join(tempDir, "ls-commit-hash")
+	protocolVersion, err := writeLSProtocolVersionMetadata("8.8.8", outputDir, commitHashFile, &log)
+	if err != nil {
+		t.Fatalf("expected metadata to be written from commit fallback: %v", err)
+	}
+	if protocolVersion != 789 {
+		t.Fatalf("expected protocol version 789, got %d", protocolVersion)
+	}
+	if resolvedCommit != "abcdef123456" {
+		t.Fatalf("expected commit resolver to use commit hash, got %q", resolvedCommit)
+	}
+	commitHash, err := os.ReadFile(commitHashFile)
+	if err != nil {
+		t.Fatalf("expected commit hash file to be written: %v", err)
+	}
+	if string(commitHash) != "abcdef123456" {
+		t.Fatalf("expected commit hash file to contain dependency commit, got %q", commitHash)
+	}
+
+	outputFile := filepath.Join(outputDir, "ls-protocol-version-789")
+	contents, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatalf("expected output file to be written: %v", err)
+	}
+	if string(contents) != "8.8.8" {
+		t.Fatalf("expected output file to contain CLI version, got %q", string(contents))
+	}
+
+	if !strings.Contains(log.String(), "commit-hash-based resolution") {
+		t.Fatalf("expected log to identify commit source, got %q", log.String())
+	}
+}
+
+func TestSnykLSReplacementDirReturnsFalseWhenNoReplaceExists(t *testing.T) {
+	tempDir := t.TempDir()
+	goModPath := filepath.Join(tempDir, "go.mod")
+	goMod := []byte(`module github.com/snyk/cli/cliv2
+
+go 1.26
+
+require github.com/snyk/snyk-ls v0.0.0-20260414093345-2a6d7434eb91
+`)
+	if err := os.WriteFile(goModPath, goMod, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, ok, err := snykLSReplacementDir(goModPath)
+	if err != nil {
+		t.Fatalf("expected no error when replace is absent: %v", err)
+	}
+	if ok {
+		t.Fatal("expected no replacement to be found")
+	}
+}
+
+func TestCurrentGoModPathFindsGoModFromWorkingDirectory(t *testing.T) {
+	tempDir := t.TempDir()
+	moduleDir := filepath.Join(tempDir, "cliv2")
+	nestedDir := filepath.Join(moduleDir, "nested")
+	if err := os.MkdirAll(nestedDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	goModPath := filepath.Join(moduleDir, "go.mod")
+	goMod := []byte(`module github.com/snyk/cli/cliv2
+
+go 1.26
+`)
+	if err := os.WriteFile(goModPath, goMod, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(nestedDir)
+
+	actual, err := currentGoModPath()
+	if err != nil {
+		t.Fatalf("expected go.mod path from working directory: %v", err)
+	}
+	if actual != goModPath {
+		t.Fatalf("expected %q, got %q", goModPath, actual)
+	}
+}
+
+func TestGenerateLSProtocolMetadataFailsWhenReplacementGoreleaserIsMissing(t *testing.T) {
+	tempDir := t.TempDir()
+	rootDir := filepath.Join(tempDir, "cli")
+	moduleDir := filepath.Join(rootDir, "cliv2")
+	releaseScriptsDir := filepath.Join(rootDir, "release-scripts")
+	binDir := filepath.Join(tempDir, "bin")
+	replacedDir := filepath.Join(rootDir, "snyk-ls")
+
+	if err := os.MkdirAll(moduleDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(releaseScriptsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(replacedDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "version"), []byte("9.9.9"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	goMod := []byte(`module github.com/snyk/cli/cliv2
+
+go 1.26
+
+require github.com/snyk/snyk-ls v0.0.0-20260414093345-2a6d7434eb91
+
+replace github.com/snyk/snyk-ls => ../snyk-ls
+`)
+	if err := os.WriteFile(filepath.Join(moduleDir, "go.mod"), goMod, 0644); err != nil {
+		t.Fatal(err)
+	}
+	copyReleaseScriptForMakefileTest(t, releaseScriptsDir)
+
+	cmd := exec.Command("make", "-f", repoPath(t, "cliv2", "Makefile"), "-C", moduleDir, "generate-ls-protocol-metadata", "bindir="+binDir)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected make target to fail when replacement .goreleaser.yaml is missing; output:\n%s", output)
+	}
+
+	outputString := string(output)
+	if !strings.Contains(outputString, "replaced snyk-ls path") || !strings.Contains(outputString, ".goreleaser.yaml") {
+		t.Fatalf("expected replacement-specific goreleaser error, got:\n%s", outputString)
+	}
+	if strings.Contains(outputString, "LS protocol version: Failed") {
+		t.Fatalf("expected failure before printing an invalid protocol version, got:\n%s", outputString)
+	}
+}
+
+func TestGenerateLSProtocolMetadataPrintsNumericProtocolVersion(t *testing.T) {
+	tempDir := t.TempDir()
+	rootDir := filepath.Join(tempDir, "cli")
+	moduleDir := filepath.Join(rootDir, "cliv2")
+	releaseScriptsDir := filepath.Join(rootDir, "release-scripts")
+	binDir := filepath.Join(tempDir, "bin")
+	replacedDir := filepath.Join(rootDir, "snyk-ls")
+
+	if err := os.MkdirAll(moduleDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(releaseScriptsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(replacedDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "version"), []byte("9.9.9"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	goMod := []byte(`module github.com/snyk/cli/cliv2
+
+go 1.26
+
+require github.com/snyk/snyk-ls v0.0.0-20260414093345-2a6d7434eb91
+
+replace github.com/snyk/snyk-ls => ../snyk-ls
+`)
+	if err := os.WriteFile(filepath.Join(moduleDir, "go.mod"), goMod, 0644); err != nil {
+		t.Fatal(err)
+	}
+	goreleaserYAML := []byte(`env:
+  - LS_PROTOCOL_VERSION=321
+`)
+	if err := os.WriteFile(filepath.Join(replacedDir, ".goreleaser.yaml"), goreleaserYAML, 0644); err != nil {
+		t.Fatal(err)
+	}
+	expectedCommitHash := initGitRepo(t, replacedDir)
+	copyReleaseScriptForMakefileTest(t, releaseScriptsDir)
+
+	cmd := exec.Command("make", "-f", repoPath(t, "cliv2", "Makefile"), "-C", moduleDir, "generate-ls-protocol-metadata", "bindir="+binDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected make target to succeed: %v\n%s", err, output)
+	}
+
+	outputString := string(output)
+	if !strings.Contains(outputString, "LS protocol version: 321") {
+		t.Fatalf("expected numeric LS protocol version in output, got:\n%s", outputString)
+	}
+
+	metadata, err := os.ReadFile(filepath.Join(binDir, "ls-protocol-version-321"))
+	if err != nil {
+		t.Fatalf("expected protocol metadata file to be written: %v", err)
+	}
+	if string(metadata) != "9.9.9" {
+		t.Fatalf("expected metadata file to contain CLI version, got %q", metadata)
+	}
+	commitHash, err := os.ReadFile(filepath.Join(moduleDir, "_cache", "ls-commit-hash"))
+	if err != nil {
+		t.Fatalf("expected LS commit hash cache file to be written: %v", err)
+	}
+	if string(commitHash) != expectedCommitHash {
+		t.Fatalf("expected LS commit hash %q, got %q", expectedCommitHash, commitHash)
+	}
+}
+
+func TestGenerateLSProtocolMetadataUsesHostGoPlatformForAlpineTarget(t *testing.T) {
+	tempDir := t.TempDir()
+	rootDir := filepath.Join(tempDir, "cli")
+	moduleDir := filepath.Join(rootDir, "cliv2")
+	releaseScriptsDir := filepath.Join(rootDir, "release-scripts")
+	binDir := filepath.Join(tempDir, "bin")
+	replacedDir := filepath.Join(rootDir, "snyk-ls")
+
+	if err := os.MkdirAll(moduleDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(releaseScriptsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(replacedDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "version"), []byte("9.9.9"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	goMod := []byte(`module github.com/snyk/cli/cliv2
+
+go 1.26
+
+require github.com/snyk/snyk-ls v0.0.0-20260414093345-2a6d7434eb91
+
+replace github.com/snyk/snyk-ls => ../snyk-ls
+`)
+	if err := os.WriteFile(filepath.Join(moduleDir, "go.mod"), goMod, 0644); err != nil {
+		t.Fatal(err)
+	}
+	goreleaserYAML := []byte(`env:
+  - LS_PROTOCOL_VERSION=432
+`)
+	if err := os.WriteFile(filepath.Join(replacedDir, ".goreleaser.yaml"), goreleaserYAML, 0644); err != nil {
+		t.Fatal(err)
+	}
+	expectedCommitHash := initGitRepo(t, replacedDir)
+	copyReleaseScriptForMakefileTest(t, releaseScriptsDir)
+
+	cmd := exec.Command(
+		"make",
+		"-f", repoPath(t, "cliv2", "Makefile"),
+		"-C", moduleDir,
+		"generate-ls-protocol-metadata",
+		"bindir="+binDir,
+		"GOOS=alpine",
+		"GOARCH=arm64",
+		"GOHOSTOS="+runtime.GOOS,
+		"GOHOSTARCH="+runtime.GOARCH,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected metadata generation to use host GOOS/GOARCH for alpine target: %v\n%s", err, output)
+	}
+
+	outputString := string(output)
+	if strings.Contains(outputString, "unsupported GOOS/GOARCH pair alpine/arm64") {
+		t.Fatalf("expected host platform go run, got target platform failure:\n%s", outputString)
+	}
+	if !strings.Contains(outputString, "LS protocol version: 432") {
+		t.Fatalf("expected LS protocol version in output, got:\n%s", outputString)
+	}
+	if !strings.Contains(outputString, "LS commit hash: "+expectedCommitHash) {
+		t.Fatalf("expected LS commit hash in output, got:\n%s", outputString)
+	}
+}
+
+func TestBuildRecipeUsesGeneratedLSMetadataInLdflags(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX fake go wrapper; script behavior remains covered by unit tests")
+	}
+
+	tempDir := t.TempDir()
+	rootDir := filepath.Join(tempDir, "cli")
+	moduleDir := filepath.Join(rootDir, "cliv2")
+	releaseScriptsDir := filepath.Join(rootDir, "release-scripts")
+	binDir := filepath.Join(tempDir, "bin")
+	replacedDir := filepath.Join(rootDir, "snyk-ls")
+	fakeGoPath := filepath.Join(tempDir, "fake-go")
+	fakeGoBuildLog := filepath.Join(tempDir, "fake-go-build.log")
+
+	if err := os.MkdirAll(moduleDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(releaseScriptsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(replacedDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "version"), []byte("9.9.9"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	goMod := []byte(`module github.com/snyk/cli/cliv2
+
+go 1.26
+
+require github.com/snyk/snyk-ls v0.0.0-20260414093345-2a6d7434eb91
+
+replace github.com/snyk/snyk-ls => ../snyk-ls
+`)
+	if err := os.WriteFile(filepath.Join(moduleDir, "go.mod"), goMod, 0644); err != nil {
+		t.Fatal(err)
+	}
+	goreleaserYAML := []byte(`env:
+  - LS_PROTOCOL_VERSION=654
+`)
+	if err := os.WriteFile(filepath.Join(replacedDir, ".goreleaser.yaml"), goreleaserYAML, 0644); err != nil {
+		t.Fatal(err)
+	}
+	expectedCommitHash := initGitRepo(t, replacedDir)
+	copyReleaseScriptForMakefileTest(t, releaseScriptsDir)
+	writeFakeGo(t, fakeGoPath, fakeGoBuildLog)
+	makeModuleDir, err := filepath.EvalSymlinks(moduleDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(
+		"make",
+		"-f", repoPath(t, "cliv2", "Makefile"),
+		"-C", makeModuleDir,
+		filepath.Join(makeModuleDir, "_bin", "snyk_darwin_arm64"),
+		"GOOS=darwin",
+		"GOARCH=arm64",
+		"GOCMD="+fakeGoPath,
+		"bindir="+binDir,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected build recipe to succeed with fake go: %v\n%s", err, output)
+	}
+
+	outputString := string(output)
+	if !strings.Contains(outputString, "Version="+expectedCommitHash) {
+		t.Fatalf("expected LS commit hash in EXTRA_FLAGS, got:\n%s", outputString)
+	}
+	if !strings.Contains(outputString, "LsProtocolVersion=654") {
+		t.Fatalf("expected LS protocol version in EXTRA_FLAGS, got:\n%s", outputString)
+	}
+
+	buildArgs, err := os.ReadFile(fakeGoBuildLog)
+	if err != nil {
+		t.Fatalf("expected fake go build to be called: %v", err)
+	}
+	if !strings.Contains(string(buildArgs), "Version="+expectedCommitHash) || !strings.Contains(string(buildArgs), "LsProtocolVersion=654") {
+		t.Fatalf("expected generated LS metadata in go build args, got:\n%s", buildArgs)
+	}
+}
+
+func copyReleaseScriptForMakefileTest(t *testing.T, releaseScriptsDir string) {
+	t.Helper()
+
+	contents, err := os.ReadFile(repoPath(t, "release-scripts", "write-ls-protocol-version.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(releaseScriptsDir, "write-ls-protocol-version.go"), contents, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeFakeGo(t *testing.T, fakeGoPath string, fakeGoBuildLog string) {
+	t.Helper()
+
+	realGo, err := exec.LookPath("go")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"run\" ]; then exec " + realGo + " \"$@\"; fi\n" +
+		"if [ \"$1\" = \"build\" ]; then printf '%s\\n' \"$*\" > \"" + fakeGoBuildLog + "\"; exit 0; fi\n" +
+		"exec " + realGo + " \"$@\"\n"
+	if err := os.WriteFile(fakeGoPath, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func initGitRepo(t *testing.T, dir string) string {
+	t.Helper()
+
+	runGit(t, dir, "init")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("snyk-ls test repo"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "-c", "user.email=test@example.com", "-c", "user.name=Test User", "commit", "-m", "initial")
+
+	cmd := exec.Command("git", "-C", dir, "rev-parse", "--short=12", "HEAD")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to read git commit hash: %v\n%s", err, output)
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	cmdArgs := append([]string{"-C", dir}, args...)
+	cmd := exec.Command("git", cmdArgs...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
+}
+
+func repoPath(t *testing.T, elements ...string) string {
+	t.Helper()
+
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to locate current test file")
+	}
+	repoRoot := filepath.Dir(filepath.Dir(currentFile))
+	pathElements := append([]string{repoRoot}, elements...)
+	return filepath.Join(pathElements...)
+}


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Fixes LS protocol metadata generation so `release-scripts/write-ls-protocol-version.go` owns Snyk LS source resolution instead of relying on `cliv2/Makefile` to parse or pass a commit hash.

When `cliv2/go.mod` contains an active local `replace github.com/snyk/snyk-ls => ...`, the script reads `LS_PROTOCOL_VERSION` from the replaced path's `.goreleaser.yaml` and resolves the LS commit hash from that replacement checkout. When no local replace exists, it preserves the existing commit-hash-based behavior by deriving the hash from the `snyk-ls` module version.

The script now writes both metadata values for the Makefile:
- `ls-protocol-version-<protocol>` in the release output directory
- `_cache/ls-commit-hash` for the `snyk-ls/application/config.Version` build ldflag

This also adds a `make test-release-scripts` target and regression coverage for replacement handling, commit fallback, failure behavior, Makefile integration, and populated build ldflags.

Risk assessment: Low. The change is scoped to release metadata generation and cliv2 build metadata wiring. It preserves the non-replace path and adds tests around both source modes.

Breaking API changes: None.

Relevant ticket: [IDE-2001](https://snyksec.atlassian.net/browse/IDE-2001)

## Where should the reviewer start?

Start with `release-scripts/write-ls-protocol-version.go` to review the source-resolution flow, then check `cliv2/Makefile` for how the generated protocol version and LS commit hash are consumed by the build.

Tests are in `release-scripts/write-ls-protocol-version_test.go`.

## How should this be manually tested?

Automated tests:

```sh
make test-release-scripts
```

Manual build check:

```sh
make build
```

Confirm the build output includes non-empty LS metadata in `EXTRA_FLAGS`, for example:

```text
-Xgithub.com/snyk/snyk-ls/application/config.Version=<commit>
-Xgithub.com/snyk/snyk-ls/application/config.LsProtocolVersion=<protocol-version>
```

For local replacement testing, enable a local `replace github.com/snyk/snyk-ls => <path>` in `cliv2/go.mod`, ensure the replacement has `.goreleaser.yaml`, and run:

```sh
cd cliv2
make generate-ls-protocol-metadata bindir=../binary-releases
```

The output should state that `.goreleaser.yaml` from the replaced `snyk-ls` path was used and should print both the LS protocol version and LS commit hash.

## What's the product update that needs to be communicated to CLI users?

No user-facing product update is needed. This is a release/build metadata correctness fix.

[IDE-2001]: https://snyksec.atlassian.net/browse/IDE-2001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ