### PR TITLE
fix: Switch Secrets User Journey tests to prod

### DIFF
--- a/test/jest/acceptance/snyk-secrets/snyk-secrets-test-user-journey.spec.ts
+++ b/test/jest/acceptance/snyk-secrets/snyk-secrets-test-user-journey.spec.ts
@@ -31,8 +31,6 @@ let TEMP_LOCAL_PATH: string;
 const env = {
   ...process.env,
   INTERNAL_SNYK_FEATURE_FLAG_IS_SECRETS_ENABLED: 'true',
-  SNYK_API: process.env.TEST_SNYK_API_DEV,
-  SNYK_TOKEN: process.env.TEST_SNYK_TOKEN_DEV,
 };
 
 beforeAll(async () => {


### PR DESCRIPTION
### **User description**
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
This PR switches Secrets User Journey tests from dev to prod.

## Where should the reviewer start?

## How should this be manually tested?

## What's the product update that needs to be communicated to CLI users?

## Risk assessment (Low | Medium | High)?
Low

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->


