### PR TITLE
chore: separate signed and unsigned builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -707,8 +707,69 @@ workflows:
           requires:
             - prepare-build
 
+      # Unsigned builds for contributor branches (no signing context required)
       - build-artifact:
           name: build macOS amd64
+          go_target_os: darwin
+          go_os: darwin
+          go_arch: amd64
+          go_download_base_url: << pipeline.parameters.go_download_base_url >>
+          executor: macos-arm64-large
+          install_deps_extension: macos-build
+          context:
+            - iac-cli
+          requires:
+            - prepare-build
+          filters:
+            branches:
+              ignore:
+                - main
+                - '/release.*/'
+                - '/.*e2e.*/'
+
+      - build-artifact:
+          name: build macOS arm64
+          go_target_os: darwin
+          go_os: darwin
+          go_arch: arm64
+          go_download_base_url: << pipeline.parameters.go_download_base_url >>
+          executor: macos-arm64-large
+          install_deps_extension: macos-build
+          context:
+            - iac-cli
+          requires:
+            - prepare-build
+          filters:
+            branches:
+              ignore:
+                - main
+                - '/release.*/'
+                - '/.*e2e.*/'
+
+      - build-artifact:
+          name: build windows amd64
+          go_target_os: windows
+          go_os: windows
+          go_arch: amd64
+          go_download_base_url: << pipeline.parameters.fips_go_download_base_url >>
+          make_target: build clean-golang build-fips
+          install_deps_extension: windows-native-build
+          install_path: 'C:\'
+          executor: win-server2022-amd64
+          context:
+            - iac-cli
+          requires:
+            - prepare-build
+          filters:
+            branches:
+              ignore:
+                - main
+                - '/release.*/'
+                - '/.*e2e.*/'
+
+      # Signed builds for release branches (signing context required)
+      - build-artifact:
+          name: build macOS amd64 (signed)
           go_target_os: darwin
           go_os: darwin
           go_arch: amd64
@@ -720,9 +781,15 @@ workflows:
             - iac-cli
           requires:
             - prepare-build
+          filters:
+            branches:
+              only:
+                - main
+                - '/release.*/'
+                - '/.*e2e.*/'
 
       - build-artifact:
-          name: build macOS arm64
+          name: build macOS arm64 (signed)
           go_target_os: darwin
           go_os: darwin
           go_arch: arm64
@@ -734,9 +801,15 @@ workflows:
             - iac-cli
           requires:
             - prepare-build
+          filters:
+            branches:
+              only:
+                - main
+                - '/release.*/'
+                - '/.*e2e.*/'
 
       - build-artifact:
-          name: build windows amd64
+          name: build windows amd64 (signed)
           go_target_os: windows
           go_os: windows
           go_arch: amd64
@@ -750,6 +823,12 @@ workflows:
             - iac-cli
           requires:
             - prepare-build
+          filters:
+            branches:
+              only:
+                - main
+                - '/release.*/'
+                - '/.*e2e.*/'
 
       - acceptance-tests:
           name: acceptance-tests linux static arm64
@@ -900,6 +979,7 @@ workflows:
               ignore:
                 - main
                 - '/release.*/'
+                - '/.*e2e.*/'
           requires:
             - build macOS arm64
           executor: macos-arm64
@@ -920,6 +1000,7 @@ workflows:
               ignore:
                 - main
                 - '/release.*/'
+                - '/.*e2e.*/'
           requires:
             - build windows amd64
           executor: win-server2022-amd64
@@ -935,7 +1016,7 @@ workflows:
           name: sign windows amd64
           context: snyk-windows-signing
           requires:
-            - build windows amd64
+            - build windows amd64 (signed)
           go_os: windows
           go_arch: amd64
           make_target: sign sign-fips
@@ -952,7 +1033,7 @@ workflows:
           name: sign macos amd64
           context: snyk-macos-signing
           requires:
-            - build macOS amd64
+            - build macOS amd64 (signed)
           go_os: darwin
           go_arch: amd64
           executor: macos-arm64
@@ -968,7 +1049,7 @@ workflows:
           name: sign macos arm64
           context: snyk-macos-signing
           requires:
-            - build macOS arm64
+            - build macOS arm64 (signed)
           go_os: darwin
           go_arch: arm64
           executor: macos-arm64


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Refactors the CircleCI pipeline so that contributor branches no longer require access to signing contexts (`snyk-macos-signing`, `snyk-windows-signing`), which contain secrets.

Previously, macOS and Windows build jobs included signing contexts on all branches, even though signing is optional during build and only required for releases. This meant external contributors couldn't run the pipeline without access to those secrets.

**Changes:**
- Split the macOS (amd64, arm64) and Windows (amd64) build jobs into two variants each:
  - **Contributor branches** — no signing context, uses `windows-native-build` deps (no DigiCert tooling)
  - **Release branches** (`main`, `release/*`, `*e2e*`) — includes signing context and full signing deps, named with `(signed)` suffix
- Updated downstream job dependencies (`sign` jobs) to reference the `(signed)` build variants
- Acceptance tests reference the unsigned build variants (they only run on contributor branches anyway)

**Side benefit:** Reduces unnecessary calls to signing infrastructure (DigiCert, Apple notarization) on contributor branches.

## Where should the reviewer start?

The workflow section of .circleci/config.yml, starting around the macOS/Windows `build-artifact` job definitions.

## How should this be manually tested?

1. Push a feature branch — verify macOS and Windows builds run **without** signing contexts
2. Push to `main` or a `release/*` branch — verify the `(signed)` build variants and sign jobs run with signing contexts
3. Verify the full release flow still works end-to-end on `main`

## What's the product update that needs to be communicated to CLI users?

N/A — this is an internal CI change with no user-facing impact.

## Risk assessment (Low | Medium | High)?

**Low** — No changes to build logic, Makefile, or produced artifacts. Only CI workflow job definitions and context assignments are modified. The release flow on `main`/`release/*` is unchanged.

## Any background context you want to provide?

Signing contexts contain secrets that should not be required for contributor builds. The builds work without the signing contexts; signing is handled by separate `sign` jobs that already existed and are filtered to release branches.
