### PR TITLE
docs: fix typo "teh" → "the" in cli/main.ts TODO comment

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -291,7 +291,7 @@ export async function main(): Promise<void> {
   let exitCode = EXIT_CODES.ERROR;
   try {
     modeValidation(globalArgs);
-    // TODO: fix this, we do transformation to options and teh type doesn't reflect it
+    // TODO: fix this, we do transformation to options and the type doesn't reflect it
     validateUnsupportedOptionCombinations(
       globalArgs.options as unknown as AllSupportedCliOptions,
     );


### PR DESCRIPTION
Comment-only typo fix in `src/cli/main.ts:294` on the existing TODO. No behavior change.