### PR TITLE
feat: Linux ARM64 and Linux AMD64 binaries are now statically linked

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -602,7 +602,7 @@ workflows:
           go_target_os: linux
           go_os: linux
           go_arch: amd64
-          static_binary: false # TODO: set to true when we have confidence for v1.1304.0 release
+          static_binary: true
           go_download_base_url: << pipeline.parameters.go_download_base_url >>
           executor: docker-amd64-xl
           requires:
@@ -645,7 +645,7 @@ workflows:
           go_target_os: linux
           go_os: linux
           go_arch: arm64
-          static_binary: false # TODO: set to true when we have confidence for v1.1304.0 release
+          static_binary: true
           go_download_base_url: << pipeline.parameters.go_download_base_url >>
           executor: docker-arm64-xl
           requires:
@@ -1144,6 +1144,20 @@ workflows:
                 - '/release.*/'
                 - '/.*e2e.*/'
 
+      - test-release-static:
+          name: e2e snyk-linux tests (scratch-container-amd64)
+          context:
+            - team_hammerhead-cli
+          requires:
+            - upload version
+          cli_download_base_url: << pipeline.parameters.cli_download_base_url >>
+          filters:
+            branches:
+              only:
+                - main
+                - '/release.*/'
+                - '/.*e2e.*/'
+
       - noop:
           name: Start Deployments
           requires:
@@ -1166,6 +1180,7 @@ workflows:
             - e2e fips tests (win-server2022-amd64)
             - e2e experimental tests (linux-static-amd64)
             - e2e experimental tests (scratch-container-amd64)
+            - e2e snyk-linux tests (scratch-container-amd64)
           filters:
             branches:
               only:

--- a/cliv2/Makefile
+++ b/cliv2/Makefile
@@ -92,6 +92,11 @@ V1_BUILD_TYPE = build:prod
 V1_BINARY_FOLDER = ts-cli-binaries
 # default to empty string, which means no subfolder
 V1_BINARY_SUBFOLDER =
+# ensures we set the correct ts-cli-binaries subfolder for static node binaries
+# when STATIC_NODE_BINARY=true is passed to the make command
+ifeq ($(STATIC_NODE_BINARY), true)
+	V1_BINARY_SUBFOLDER = experimental/
+endif
 HASH_STRING = $(HASH)$(HASH_ALGORITHM)
 SIGN_SCRIPT = $(WORKING_DIR)/scripts/sign_$(_GO_OS).sh
 ISSIGNED_SCRIPT = $(WORKING_DIR)/scripts/issigned_$(_GO_OS).sh


### PR DESCRIPTION
## Pull Request Submission Checklist

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
`snyk-linux` and `snyk-linux-arm64` binaries are now statically linked instead of dynamically linked.

This PR promotes the statically linked binaries for Linux amd64/arm64 that were previously available on the `experimental` distribution channel.

## Where should the reviewer start?
See related linuxstatic epic

## How should this be manually tested?
### Validating the binary is statically linked
- Download the `snyk-linux` and `snyk-linux-arm64` binaries from the `feat/linuxstatic-e2e` branch
- Rename them `snyk-linuxstatic` and `snyk-linuxstatic-arm64` respectively
- Download the latest `snyk-linux` and `snyk-linux-arm64` binaries from `downloads.snyk.io`
- Make the binaries executable via `chmod +x`
- Move the binaries into a folder `snyk`
- `docker pull ubuntu:18.04` to get a Linux image with an unsupported `glibc` library
- Run your docker image and mount the binaries: `docker run --rm -it -v ./snyk/.:/mnt/. -w /mnt ubuntu:18.04 bash`
- For each binary in the container, run `snyk-[OS]-[ARCH] -v`

### Additional testing
- mount the CLI project into the docker container
- Run the acceptance testing: `TEST_SNYK_COMMAND=./snyk-linuxstatic npx jest test/jest/acceptance`

Expected output:
<img width="620" height="430" alt="Screenshot 2026-05-12 at 13 20 17" src="https://github.com/user-attachments/assets/05059150-6886-4ae1-936e-cd2a3d735154" />


## What's the product update that needs to be communicated to CLI users?
Linux binaries are now statically linked

## Risk assessment - Medium?
To reduce risk, a slow rollout has been ongoing, and currently ~30-35% of Linux users are already using the statically linked binaries. This PR rolls it out to 100% of users.

<!---

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
