### PR TITLE
chore: update codeowners [PRODSEC-10215]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # CLI
-* @snyk/cli @snyk/productinfra_cli @snyk/developer-experience_cli
+* @snyk/developer-experience_cli
 
 # Unify
-src/lib/plugins/uv/ @snyk/codesec_unify @snyk/open-source_unify @snyk/productinfra_cli @snyk/developer-experience_cli
+src/lib/plugins/uv/ @snyk/open-source_unify @snyk/developer-experience_cli


### PR DESCRIPTION
Updates codeowners to append the new github governance managed teams.
For more information, please check https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/4613570586/H1+2026+Team+rename+Updates+to+CODEOWNERS+and+repository+collaborators+to+match+organisation+change

[IMPORTANT]: 
   If your service uses vervet, you probably to run a commane like `make generate` to update the vervet files.
   This is specific to your repository as there is not standardisation on the command to run.
   