### PR TITLE
chore: show secrets project link when no findings [PS-625]

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -16,13 +16,13 @@ require (
 	github.com/snyk/cli-extension-dep-graph v1.7.0
 	github.com/snyk/cli-extension-iac v0.0.0-20260206082514-00c443ccee80
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260206080712-9cbb5f95465d
-	github.com/snyk/cli-extension-os-flows v0.0.0-20260423112219-b7ba9dd68e57
+	github.com/snyk/cli-extension-os-flows v0.0.0-20260515090326-f505ef5d1ead
 	github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa
-	github.com/snyk/cli-extension-secrets v0.0.0-20260505103358-cc205308a93e
+	github.com/snyk/cli-extension-secrets v0.0.0-20260514133614-5661d04f7352
 	github.com/snyk/code-client-go v1.27.0
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663
-	github.com/snyk/go-application-framework v0.0.0-20260506111235-cca3157b9435
+	github.com/snyk/go-application-framework v0.0.0-20260511100036-100e7116aec5
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260414093345-2a6d7434eb91
@@ -274,7 +274,7 @@ require (
 // version 2491eb6c1c75 contains a valid license
 replace github.com/mattn/go-localereader v0.0.1 => github.com/mattn/go-localereader v0.0.2-0.20220822084749-2491eb6c1c75
 
-// replace github.com/snyk/go-application-framework => ../../go-application-framework
+//replace github.com/snyk/go-application-framework => ../../go-application-framework
 
 //replace github.com/snyk/snyk-ls => ../../snyk-ls
 //replace github.com/snyk/code-client-go => ../../code-client-go
@@ -293,4 +293,4 @@ replace github.com/mattn/go-localereader v0.0.1 => github.com/mattn/go-localerea
 
 // replace github.com/snyk/cli-extension-sbom => ../../cli-extension-sbom
 
-// replace github.com/snyk/cli-extension-secrets => ../../cli-extension-secrets
+//replace github.com/snyk/cli-extension-secrets => ../../cli-extension-secrets

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -547,12 +547,12 @@ github.com/snyk/cli-extension-iac v0.0.0-20260206082514-00c443ccee80 h1:JHbnSkgG
 github.com/snyk/cli-extension-iac v0.0.0-20260206082514-00c443ccee80/go.mod h1:Ht5k+sWdi//fM2MjcmBMWjcJmr35iMvQpYlBWnUHL4I=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260206080712-9cbb5f95465d h1:xkxHgZ+DT4hRiIEeAEv1JWLJRYV4MbAFvtEUpUkndPA=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260206080712-9cbb5f95465d/go.mod h1:ztpTmC4n8MEO0B48M2nL/Q9tb6CkLZ61ZKZbjwhOKRo=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260423112219-b7ba9dd68e57 h1:8dpjcHif/0D738R4HlMFo7mi2GKNsb20oJawqae62k4=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260423112219-b7ba9dd68e57/go.mod h1:f16TyLAOBiU485lN/odNfmiyWyMu1iVrDoSEieiiblQ=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260515090326-f505ef5d1ead h1:fZkM8/vs5cW5zcrBa8DR/HnuahY3SV4ujd9rtbRHMVo=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260515090326-f505ef5d1ead/go.mod h1:Kcp6erjNclWvjR3v4UAQocXYn1kXDii1Eq9c0ozle4A=
 github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa h1:9GSKXrRCaRkBAj+jglUBuhO09I1xs2G5GxwrPxlj34M=
 github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa/go.mod h1:SJ624HENWG4yjM6jNuLebTeNsMriozf1LcKhMYVm1aY=
-github.com/snyk/cli-extension-secrets v0.0.0-20260505103358-cc205308a93e h1:LLdPjkz6zRxYwos2iIyKvlaCL7x8bZAAxeUF+4nG+So=
-github.com/snyk/cli-extension-secrets v0.0.0-20260505103358-cc205308a93e/go.mod h1:+Ey86Xjvw2HhDM8OisCVNzlatzO9wEfSQRPapaNfwIk=
+github.com/snyk/cli-extension-secrets v0.0.0-20260514133614-5661d04f7352 h1:kpV/yGAusE9SYXxvTOxapXzrTbk4BAC5ltge5J7ILBk=
+github.com/snyk/cli-extension-secrets v0.0.0-20260514133614-5661d04f7352/go.mod h1:Mwmky023WmKXxI2QasxPFbrmivbZV+aTs6kf5q8SlSU=
 github.com/snyk/code-client-go v1.27.0 h1:FOX4JzgHssm5fei4ALyrBAIL9eJGnG52yTkqWcM1Qew=
 github.com/snyk/code-client-go v1.27.0/go.mod h1:DQHr0nRchfrc54aciYyrveKWEpBhJwUoc1XoDhWt6W4=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea h1:/v48hCMPiZVjplylgE2FX1ib8Qd8LN/vf8ZIKfA+wkI=
@@ -561,8 +561,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 h1:j2ZPhi78wKIHTiL9EFTNVXMIbsk56FVF2d5Sy1ZwSYk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.0.0-20260506111235-cca3157b9435 h1:R6tOMqc6GyC8ncoTT+eO6I38qs9/SxgPi9AEYoIEubQ=
-github.com/snyk/go-application-framework v0.0.0-20260506111235-cca3157b9435/go.mod h1:yTGCJKf6RmqdwrNs5B9zmukL9x1D8EhfSK8mzaPB1Rk=
+github.com/snyk/go-application-framework v0.0.0-20260511100036-100e7116aec5 h1:IxTmr+zaWVkjShWQLLy5rx69S+Em4X32MH+Chj1WdFk=
+github.com/snyk/go-application-framework v0.0.0-20260511100036-100e7116aec5/go.mod h1:yTGCJKf6RmqdwrNs5B9zmukL9x1D8EhfSK8mzaPB1Rk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.3 h1:MU+K8pxbN6VZ9P5wALUt8BwTjrPDpoEtmTtQqj7sKfY=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
Upgrades GAF and the secrets/os-flows extension to a new version which allows setting the project link when no secrets findings are found.

## Where should the reviewer start?

## How should this be manually tested?

run `snyk secrets test --report` on a folder that has no findings 

## What's the product update that needs to be communicated to CLI users?

## Risk assessment (Low | Medium | High)?
Low

## Any background context you want to provide?
[GAF upgrade to a version of the test-api-shim that returns components](https://github.com/snyk/go-application-framework/pull/602)
[Secrets extension upgrade ](https://github.com/snyk/cli-extension-secrets)
[OS flows upgrade](https://github.com/snyk/cli-extension-os-flows/pull/237)

## What are the relevant tickets?

[Show test results link to project for cli report](https://snyksec.atlassian.net/browse/PS-625)

## Screenshots (if appropriate)
<img width="657" height="335" alt="Screenshot 2026-05-15 at 12 39 37" src="https://github.com/user-attachments/assets/e15abf03-d2d2-4b28-a019-32d31ea640e4" />


