### PR TITLE
chore: bump snyk-swiftpm-plugin to 1.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "snyk-python-plugin": "^3.2.1",
         "snyk-resolve-deps": "4.10.0",
         "snyk-sbt-plugin": "3.1.0",
-        "snyk-swiftpm-plugin": "1.4.1",
+        "snyk-swiftpm-plugin": "1.5.1",
         "strip-ansi": "^6.0.1",
         "tar": "^7.5.8",
         "uuid": "^8.3.2",
@@ -20684,19 +20684,23 @@
       }
     },
     "node_modules/snyk-swiftpm-plugin": {
-      "version": "1.4.1",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/snyk-swiftpm-plugin/-/snyk-swiftpm-plugin-1.5.1.tgz",
+      "integrity": "sha512-ZsVDQVRpmUl506kjTQ0U7s3fcAaYT+s8Oq1294H4cDsULjotZ0d/UE0ZyltE4F5EVDV8++YQUD/yDhAeIrTOpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@snyk/dep-graph": "^2.3.0",
+        "@snyk/dep-graph": "^2.7.1",
         "lookpath": "^1.2.2",
-        "tslib": "^2.2.0"
+        "tslib": "^2.6.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       }
     },
     "node_modules/snyk-swiftpm-plugin/node_modules/tslib": {
-      "version": "2.4.1",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/snyk-tree": {

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "snyk-python-plugin": "^3.2.1",
     "snyk-resolve-deps": "4.10.0",
     "snyk-sbt-plugin": "3.1.0",
-    "snyk-swiftpm-plugin": "1.4.1",
+    "snyk-swiftpm-plugin": "1.5.1",
     "strip-ansi": "^6.0.1",
     "tar": "^7.5.8",
     "uuid": "^8.3.2",


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [x] Updates relevant GitBook documentation (PR link: N/A — dependency bump only)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps `snyk-swiftpm-plugin` from `1.4.1` to `1.5.1` so the CLI picks up the latest SwiftPM dependency resolution fixes, including resolving registry identity URLs to `github.com` package paths ([snyk/snyk-swiftpm-plugin#43](https://github.com/snyk/snyk-swiftpm-plugin/pull/43), OSM-3567).

## Where should the reviewer start?

- `package.json` / `package-lock.json` — version bump only; no CLI source changes.

## How should this be manually tested?

On a machine with Swift/SwiftPM installed, run `snyk test` (or `snyk monitor`) against a Swift project that uses `Package.swift` with registry-based package identities, and confirm dependency resolution completes without errors.

## What's the product update that needs to be communicated to CLI users?

SwiftPM scans now use an updated SwiftPM plugin that correctly resolves registry identity URLs to GitHub package paths, improving dependency graph accuracy for Swift projects using the Swift package registry.

## Risk assessment (Low | Medium | High)?

**Low** — dependency-only bump; SwiftPM plugin interface unchanged from the CLI’s perspective.

## Any background context you want to provide?

- [snyk-swiftpm-plugin 1.5.1 release](https://github.com/snyk/snyk-swiftpm-plugin/releases/tag/v1.5.1)
- [snyk-swiftpm-plugin 1.5.0 release](https://github.com/snyk/snyk-swiftpm-plugin/releases/tag/v1.5.0)

## What are the relevant tickets?

OSM-3567 (fix included in plugin 1.5.1)

## Screenshots (if appropriate)

N/A

## Test plan

- [x] `npm run lint:formatting` — passed locally
- [x] `npm run lint:js` — passed locally
- [ ] CI green on this PR

Automated coverage: existing Swift CLI tests in `test/tap/cli-test/cli-test.swift.spec.ts`.


Made with [Cursor](https://cursor.com)