### PR TITLE
revert: correct commit used for snyk-ls

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/snyk/go-application-framework v0.0.0-20260506111235-cca3157b9435
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20260507075428-365bccd7be16
+	github.com/snyk/snyk-ls v0.0.0-20260414093345-2a6d7434eb91
 	github.com/snyk/studio-mcp v1.11.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -569,8 +569,8 @@ github.com/snyk/policy-engine v1.1.3 h1:MU+K8pxbN6VZ9P5wALUt8BwTjrPDpoEtmTtQqj7s
 github.com/snyk/policy-engine v1.1.3/go.mod h1:yOc6YZLWhVGUZjzskDTen8zxrNTUHL4FyZXM0Ezlb8M=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260507075428-365bccd7be16 h1:CtZ8OWjWy6X0ErVvywCONoWpeQvSE5Ca3NGuP8OcDJQ=
-github.com/snyk/snyk-ls v0.0.0-20260507075428-365bccd7be16/go.mod h1:N8TjmSBn40TyZMR2g5El+WOIVyCxMT2fIW56Kdh6Ca4=
+github.com/snyk/snyk-ls v0.0.0-20260414093345-2a6d7434eb91 h1:1x8/ejhKYyKZ1ifBxODikWwDRHWhDU/8OXkWLd5KTX8=
+github.com/snyk/snyk-ls v0.0.0-20260414093345-2a6d7434eb91/go.mod h1:rcQO2g/KAvJACzKN2ME7xwUb97HpLl+9TM3SyTg+EAA=
 github.com/snyk/studio-mcp v1.11.0 h1:WfvWqqHu5+Stb/y+LTVdWWiazc0i4BapxqMCJyGRArA=
 github.com/snyk/studio-mcp v1.11.0/go.mod h1:CiMKFs/PJrAMjG8Zjkvx+XwuM0XlxGJ7jP5yCr5hm5w=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/test/jest/acceptance/language-server-extension.spec.ts
+++ b/test/jest/acceptance/language-server-extension.spec.ts
@@ -1,21 +1,11 @@
 import { runSnykCLI } from '../util/runSnykCLI';
-import * as path from 'path';
 import { pathToFileURL } from 'url';
 import { sleep } from '../../../src/lib/common';
 import * as cp from 'child_process';
 import * as rpc from 'vscode-jsonrpc/node';
 import { withFipsEnvIfNeeded } from '../util/fipsTestHelper';
-import { requireSnykToken } from '../util/requireSnykToken';
 
 jest.setTimeout(1000 * 120);
-
-/** snyk-ls v25+ wire type: only entries with `changed: true` are applied (see ConfigSetting in snyk-ls). */
-function lspConfigSetting(value: unknown): {
-  value: unknown;
-  changed: boolean;
-} {
-  return { value, changed: true };
-}
 
 describe('Language Server Extension', () => {
   it('get ls licenses', async () => {
@@ -40,15 +30,9 @@ describe('Language Server Extension', () => {
   });
 
   it('run and wait for diagnostics', async () => {
-    const token = requireSnykToken();
     let cmd = '';
     if (process.env.TEST_SNYK_COMMAND !== undefined) {
       cmd = process.env.TEST_SNYK_COMMAND;
-    }
-    if (!cmd) {
-      throw new Error(
-        'Set TEST_SNYK_COMMAND to the built CLI binary (e.g. ./binary-releases/snyk-macos-arm64).',
-      );
     }
 
     const cli = cp.spawn(cmd, ['language-server'], {
@@ -67,33 +51,6 @@ describe('Language Server Extension', () => {
       new rpc.StreamMessageWriter(cli.stdin),
     );
 
-    const workspaceFixture = path.resolve(
-      path.join(__dirname, '../../fixtures/npm/with-vulnerable-lodash-dep'),
-    );
-    const cliPathResolved = cmd !== '' ? path.resolve(cmd) : '';
-
-    // Keys are internal/pflag names (e.g. internal/types/ldx_sync_config.go in snyk-ls).
-    const initOptions = {
-      settings: {
-        api_endpoint: lspConfigSetting(process.env.TEST_SNYK_API),
-        token: lspConfigSetting(token),
-        authentication_method: lspConfigSetting('token'),
-        automatic_authentication: lspConfigSetting(false),
-        trust_enabled: lspConfigSetting(true),
-        trusted_folders: lspConfigSetting([workspaceFixture]),
-        snyk_oss_enabled: lspConfigSetting(true),
-        snyk_code_enabled: lspConfigSetting(false),
-        snyk_iac_enabled: lspConfigSetting(false),
-        snyk_secrets_enabled: lspConfigSetting(false),
-        automatic_download: lspConfigSetting(false),
-        cli_path: lspConfigSetting(cliPathResolved),
-        scan_automatic: lspConfigSetting(true),
-        send_error_reports: lspConfigSetting(false),
-      },
-      integrationName: 'MyFakePlugin',
-      integrationVersion: '1.2.3',
-    };
-
     // create an RPC endpoint for the process
     connection.listen();
 
@@ -111,11 +68,25 @@ describe('Language Server Extension', () => {
       workspaceFolders: [
         {
           name: 'workspace',
-          uri: pathToFileURL(workspaceFixture).href,
+          uri: pathToFileURL('./test/fixtures/npm/with-vulnerable-lodash-dep')
+            .href,
         },
       ],
       rootUri: null,
-      initializationOptions: initOptions,
+      initializationOptions: {
+        activateSnykCodeSecurity: 'false',
+        activateSnykCodeQuality: 'false',
+        activateSnykOpenSource: 'true',
+        activateSnykIac: 'false',
+        endpoint: process.env.TEST_SNYK_API,
+        token: process.env.TEST_SNYK_TOKEN,
+        manageBinariesAutomatically: 'false',
+        enableTrustedFoldersFeature: 'false',
+        integrationName: 'MyFakePlugin',
+        integrationVersion: '1.2.3',
+        enableTelemetry: 'false',
+        cliPath: cmd,
+      },
     });
 
     let diagnosticCount = 0;


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

The snyk-ls commit was pointing to a commit on a feature branch, not main.
This happened in #6766.
This commit reverts back to the previous snyk-ls commit CLI was using.

Refs: 36ff328

## Where should the reviewer start?

## How should this be manually tested?

## What's the product update that needs to be communicated to CLI users?

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
