### PR TITLE
fix(ci): check-dependecies gh action now uses npm token to access private packages

### DIFF
--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -13,5 +13,10 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
+          # registry-url triggers setup-node to create an .npmrc with auth token interpolation,
+          # required to install private @snyk packages
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.HAMMERHEAD_NPM_TOKEN }}
       - run: npx ts-node ./scripts/check-dependencies.ts

--- a/.github/workflows/danger-zone.yml
+++ b/.github/workflows/danger-zone.yml
@@ -14,7 +14,12 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
+          # registry-url triggers setup-node to create an .npmrc with auth token interpolation,
+          # required to install private @snyk packages
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.HAMMERHEAD_NPM_TOKEN }}
       - run: npx danger ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Pull Request Submission Checklist

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
Fixes the GitHub Action workflow `check-dependencies.yml` and `danger-zone.yml` so that it can access private packages.

## Where should the reviewer start?

## How should this be manually tested?

## What's the product update that needs to be communicated to CLI users?
None - internal fix

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
