### PR TITLE
fix: relative file path

### DIFF
--- a/src/lib/snyk-test/common.ts
+++ b/src/lib/snyk-test/common.ts
@@ -204,7 +204,10 @@ export async function printDepGraphError(
   return new Promise((res, rej) => {
     // Normalize the target file path to be relative to root, consistent with printDepGraphJsonl
     const normalisedTargetFile = failedProjectScanError.targetFile
-      ? path.relative(root, failedProjectScanError.targetFile)
+      ? path.relative(
+          root,
+          path.resolve(root, failedProjectScanError.targetFile),
+        )
       : failedProjectScanError.targetFile;
 
     const problemError = getOrCreateErrorCatalogError(failedProjectScanError);

--- a/test/jest/unit/lib/snyk-test/common.spec.ts
+++ b/test/jest/unit/lib/snyk-test/common.spec.ts
@@ -1,9 +1,11 @@
+import { PassThrough } from 'stream';
 import { CLI, ProblemError } from '@snyk/error-catalog-nodejs-public';
 import { CustomError } from '../../../../../src/lib/errors';
 import { FailedProjectScanError } from '../../../../../src/lib/plugins/get-multi-plugin-result';
 import {
   getOrCreateErrorCatalogError,
   getRequestConcurrency,
+  printDepGraphError,
 } from '../../../../../src/lib/snyk-test/common';
 
 describe('getOrCreateErrorCatalogError', () => {
@@ -117,6 +119,66 @@ describe('getOrCreateErrorCatalogError', () => {
 
     expect(result).toBeInstanceOf(ProblemError);
     expect(result.detail).toBe(defaultErrMessage);
+  });
+});
+
+describe('printDepGraphError', () => {
+  function collectStream(stream: PassThrough): Promise<string> {
+    return new Promise((resolve) => {
+      const chunks: Buffer[] = [];
+      stream.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+      stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    });
+  }
+
+  it('normalises a relative targetFile to stay relative to root', async () => {
+    const root = '/project';
+    const failedProjectScanError: FailedProjectScanError = {
+      errMessage: 'scan failed',
+      error: undefined,
+      targetFile: 'subdir/package.json',
+    };
+    const output = new PassThrough();
+    const collected = collectStream(output);
+
+    await printDepGraphError(root, failedProjectScanError, output);
+    output.end();
+
+    const result = JSON.parse(await collected);
+    expect(result.normalisedTargetFile).toBe('subdir/package.json');
+  });
+
+  it('normalises an absolute targetFile to be relative to root', async () => {
+    const root = '/project';
+    const failedProjectScanError: FailedProjectScanError = {
+      errMessage: 'scan failed',
+      error: undefined,
+      targetFile: '/project/subdir/package.json',
+    };
+    const output = new PassThrough();
+    const collected = collectStream(output);
+
+    await printDepGraphError(root, failedProjectScanError, output);
+    output.end();
+
+    const result = JSON.parse(await collected);
+    expect(result.normalisedTargetFile).toBe('subdir/package.json');
+  });
+
+  it('keeps targetFile undefined when it is not provided', async () => {
+    const root = '/project';
+    const failedProjectScanError: FailedProjectScanError = {
+      errMessage: 'scan failed',
+      error: undefined,
+    };
+    const output = new PassThrough();
+    const collected = collectStream(output);
+
+    await printDepGraphError(root, failedProjectScanError, output);
+    output.end();
+
+    const result = JSON.parse(await collected);
+    expect(result.normalisedTargetFile).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Pull Request Submission Checklist
- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Fixes incorrect file path normalisation in `printDepGraphError`. Previously, `path.relative(root, targetFile)` was called with a relative `targetFile`, which resolves against the current working directory instead of the project `root`. This produced incorrect paths in error output (e.g. `../../subdir/package.json` instead of `subdir/package.json`).

The fix anchors the target file to `root` first using `path.resolve(root, targetFile)` before computing the relative path, ensuring correct behaviour for both relative and absolute `targetFile` values.

## Where should the reviewer start?

`src/lib/snyk-test/common.ts` — the two-line change in `printDepGraphError`.

## How should this be manually tested?

Run `snyk test --all-projects --print-effective-graph-with-errors` on a project with nested subdirectories that contain failing scans. Verify that the `normalisedTargetFile` in the JSONL error output shows a correct relative path from the project root (e.g. `subdir/package.json`), not an incorrectly resolved path.

## What's the product update that needs to be communicated to CLI users?

Fixed a bug where error output from `--print-effective-graph-with-errors` could display incorrect file paths for failed project scans in multi-project workspaces.

## Risk assessment (Low | Medium | High)?

Low — the change is a two-line fix scoped to error output path normalisation, with no impact on scan logic or results.

## What are the relevant tickets?

CSENG-200
