### PR TITLE
feat: add acceptance tests for secrets ignore output [PS-669]

### DIFF
--- a/test/jest/acceptance/snyk-secrets/snyk-secrets-test-user-journey.spec.ts
+++ b/test/jest/acceptance/snyk-secrets/snyk-secrets-test-user-journey.spec.ts
@@ -72,6 +72,25 @@ const copyFolderSync = (from: string, to: string) => {
   });
 };
 
+// Guards against an empty/malformed SARIF
+// so failures surface as readable assertion messages
+function assertSarifShape(sarifOutput: any): void {
+  expect(Array.isArray(sarifOutput?.runs)).toBe(true);
+  expect(sarifOutput.runs.length).toBeGreaterThan(0);
+  expect(Array.isArray(sarifOutput.runs[0]?.results)).toBe(true);
+}
+
+function checkSarif(sarifOutput: any, expectedIgnoredFindings: number): any {
+  assertSarifShape(sarifOutput);
+
+  const suppressions = sarifOutput.runs[0].results.filter(
+    (result: any) => result.suppressions,
+  );
+  expect(suppressions.length).toBe(expectedIgnoredFindings);
+
+  return sarifOutput;
+}
+
 describe('snyk secrets test', () => {
   describe('output formats', () => {
     it('should display human-readable output by default', async () => {
@@ -117,6 +136,7 @@ describe('snyk secrets test', () => {
     );
 
     const sarifOutput = JSON.parse(stdout);
+    assertSarifShape(sarifOutput);
 
     // examples/ contains a single critical-severity private key, which is kept at
     // --severity-threshold=critical; any lower-severity findings would be filtered out.
@@ -420,5 +440,100 @@ describe('snyk secrets test', () => {
         expect(code).toBe(EXIT_CODES.ERROR);
       },
     );
+  });
+
+  describe('with ignored issues', () => {
+    // semgrep-rules-examples provides enough varied findings to ignore
+    const expectedIgnoredCritical = 1;
+    const expectedIgnoredTotal = 2;
+
+    it('filters below-threshold ignored findings with --severity-threshold', async () => {
+      const { stdout, stderr, code } = await runSnykCLI(
+        `secrets test ${TEMP_LOCAL_PATH}/semgrep-rules-examples --severity-threshold=critical --sarif`,
+        { env },
+      );
+
+      expect(stderr).toBe('');
+      expect(code).toBe(EXIT_CODES.VULNS_FOUND);
+
+      const sarifOutput = checkSarif(
+        JSON.parse(stdout),
+        expectedIgnoredCritical,
+      );
+
+      // SARIF level "error" covers both critical and high, so it can't distinguish them on its own.
+      // The per-result message text carries the actual severity word ("critical severity")
+      const results = sarifOutput.runs[0].results;
+      expect(results.length).toBeGreaterThan(0);
+      results.forEach((result: any) => {
+        expect(result.message?.text).toMatch(/critical severity/i);
+        expect(result.message?.text).not.toMatch(/(high|medium|low) severity/i);
+      });
+    });
+
+    it('renders ignore metadata in human-readable output with --include-ignores', async () => {
+      const { stdout, stderr, code } = await runSnykCLI(
+        `secrets test ${TEMP_LOCAL_PATH}/semgrep-rules-examples --include-ignores`,
+        { env },
+      );
+
+      expect(stderr).toBe('');
+      expect(code).toBe(EXIT_CODES.VULNS_FOUND);
+
+      // Each ignored finding renders an [IGNORED] marker.
+      const ignoredMarkers = stdout.match(/\[\s*IGNORED\s*\]/gi) || [];
+      expect(ignoredMarkers.length).toBe(expectedIgnoredTotal);
+      expect(stdout).toMatch(/Ignored:\s*\d+/);
+
+      // Ignore metadata is rendered for every ignored finding.
+      expect(stdout).toMatch(/Reason:\s+\S+/);
+      expect(stdout).toMatch(
+        /Expiration:\s+(?:[A-Z][a-z]+\s+\d{1,2},\s+\d{4}|never)/,
+      );
+      expect(stdout).toMatch(/Ignored on:\s+[A-Z][a-z]+\s+\d{1,2},\s+\d{4}/);
+    });
+
+    it('emits suppressions in SARIF', async () => {
+      const { stdout, stderr, code } = await runSnykCLI(
+        `secrets test ${TEMP_LOCAL_PATH}/semgrep-rules-examples --sarif`,
+        { env },
+      );
+
+      expect(stderr).toBe('');
+      expect(code).toBe(EXIT_CODES.VULNS_FOUND);
+
+      const sarifOutput = checkSarif(JSON.parse(stdout), expectedIgnoredTotal);
+
+      // SARIF suppressions carry the core ignore metadata fields.
+      const ignoredResults = sarifOutput.runs[0].results.filter(
+        (result: any) => result.suppressions,
+      );
+      ignoredResults.forEach((result: any) => {
+        expect(result.suppressions.length).toBeGreaterThan(0);
+        result.suppressions.forEach((suppression: any) => {
+          expect(suppression).toHaveProperty('status');
+          expect(suppression).toHaveProperty('justification');
+          expect(suppression).toHaveProperty('kind');
+        });
+      });
+    });
+
+    it('omits ignored findings from human-readable output by default', async () => {
+      const { stdout, stderr, code } = await runSnykCLI(
+        `secrets test ${TEMP_LOCAL_PATH}/semgrep-rules-examples`,
+        { env },
+      );
+
+      expect(stderr).toBe('');
+      expect(code).toBe(EXIT_CODES.VULNS_FOUND);
+
+      // Per-finding ignore output ([IGNORED] markers and metadata) is suppressed
+      // unless --include-ignores is passed. The summary line still reports a count.
+      expect(stdout).not.toMatch(/\[\s*IGNORED\s*\]/i);
+      expect(stdout).not.toMatch(/Reason:\s+\S+/);
+      expect(stdout).not.toMatch(
+        /Ignored on:\s+[A-Z][a-z]+\s+\d{1,2},\s+\d{4}/,
+      );
+    });
   });
 });


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
This PR adds acceptance tests for secrets ignore output in both human-readable and SARIF formats.

## Where should the reviewer start?
- `test/jest/acceptance/snyk-secrets/snyk-secrets-test-user-journey.spec.ts`: the new `describe('with ignored issues')` block and the `checkSarif` helper.

## How should this be manually tested?
1. Create a local build of CLI. 
2. On your org, ignore the following findings from this repo:
- `Finding ID: 44bb9a70-90e3-533b-9574-0f41820d8cc5`
- `Finding ID: 2b43f56b-9abf-5ca2-b158-7385d5dd14fc`

The findings are from [this repository](https://github.com/leaktk/fake-leaks) at HEAD `366ae0080cc67973619584080fc85734ba2658b2` in the `semgrep-rules-examples` subfolder;

- Run the test file `test/jest/acceptance/snyk-secrets/snyk-secrets-test-user-journey.spec.ts` and all tests should pass.

## What's the product update that needs to be communicated to CLI users?
N/A

## Risk assessment (Low | Medium | High)?
Low - extends the existing test suite for secrets.

## Any background context you want to provide?
This change implements the follow-up testing strategy from [#6803](https://github.com/snyk/cli/pull/6803#discussion_r3266759155). By ignoring select secrets findings at the org level, the tests can now successfully validate against those expected ignored issues.

## What are the relevant tickets?
- [PS-669](https://snyksec.atlassian.net/browse/PS-669)

## Screenshots (if appropriate)
N/A

[PS-669]: https://snyksec.atlassian.net/browse/PS-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ