### PR TITLE
fix: upgrade GAF and handle retry notifications

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -217,7 +217,7 @@ require (
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 // indirect
-	github.com/snyk/go-application-framework v0.1.1-0.20260528144555-42dd115b13bf // indirect
+	github.com/snyk/go-application-framework v0.1.1-0.20260529100338-4fceab88ea93 // indirect
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -589,8 +589,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 h1:j2ZPhi78wKIHTiL9EFTNVXMIbsk56FVF2d5Sy1ZwSYk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.1.1-0.20260528144555-42dd115b13bf h1:PPIXGApRw2m806/hL7crqbsLs8vppnr0DzEZAGNYsnk=
-github.com/snyk/go-application-framework v0.1.1-0.20260528144555-42dd115b13bf/go.mod h1:yTGCJKf6RmqdwrNs5B9zmukL9x1D8EhfSK8mzaPB1Rk=
+github.com/snyk/go-application-framework v0.1.1-0.20260529100338-4fceab88ea93 h1:xFCe8NtNYdi+EvGtHmEV87U3B7QCNyF/B/UFFkoq8U4=
+github.com/snyk/go-application-framework v0.1.1-0.20260529100338-4fceab88ea93/go.mod h1:yTGCJKf6RmqdwrNs5B9zmukL9x1D8EhfSK8mzaPB1Rk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.27.0
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663
-	github.com/snyk/go-application-framework v0.1.1-0.20260528144555-42dd115b13bf
+	github.com/snyk/go-application-framework v0.1.1-0.20260529100338-4fceab88ea93
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260529103026-b999aa3e3447

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -563,8 +563,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 h1:j2ZPhi78wKIHTiL9EFTNVXMIbsk56FVF2d5Sy1ZwSYk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.1.1-0.20260528144555-42dd115b13bf h1:PPIXGApRw2m806/hL7crqbsLs8vppnr0DzEZAGNYsnk=
-github.com/snyk/go-application-framework v0.1.1-0.20260528144555-42dd115b13bf/go.mod h1:yTGCJKf6RmqdwrNs5B9zmukL9x1D8EhfSK8mzaPB1Rk=
+github.com/snyk/go-application-framework v0.1.1-0.20260529100338-4fceab88ea93 h1:xFCe8NtNYdi+EvGtHmEV87U3B7QCNyF/B/UFFkoq8U4=
+github.com/snyk/go-application-framework v0.1.1-0.20260529100338-4fceab88ea93/go.mod h1:yTGCJKf6RmqdwrNs5B9zmukL9x1D8EhfSK8mzaPB1Rk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -6,6 +6,7 @@ import _ "github.com/snyk/go-application-framework/pkg/networking/fips_enable"
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -462,6 +463,22 @@ func displayError(err error, userInterface ui.UserInterface, config configuratio
 	}
 }
 
+func handleRetryNotification(engine workflow.Engine, logger *zerolog.Logger, err error) {
+	if ui := engine.GetUserInterface(); ui != nil {
+		if outputErr := ui.OutputError(err); outputErr != nil {
+			logger.Warn().Err(outputErr).Msg("failed to show rate-limit retry warning")
+		}
+	} else {
+		logger.Warn().Msg("rate-limit retry warning not shown: user interface not attached")
+	}
+
+	if analytics := engine.GetAnalytics(); analytics != nil {
+		analytics.AddError(err)
+	} else {
+		logger.Warn().Msg("rate-limit retry not recorded in analytics: collector not initialized")
+	}
+}
+
 // tearDown handles sending analytics and instrumentation
 // It is used both for normal exit and signal-triggered exit
 func tearDown(err error, errorList []error, startTime time.Time, ua networking.UserAgentInfo, cliAnalytics analytics.Analytics, networkAccess networking.NetworkAccess) int {
@@ -564,6 +581,15 @@ func mainWithErrorCode(additionalExts []workflow.ExtensionInit) int {
 		if err == nil {
 			return nil
 		}
+
+		// Retry notifications arrive as catalog errors with RetryAttemptError as cause.
+		// Show UI warning, record in analytics, but don't collect as a command error.
+		var retryErr *middleware.RetryAttemptError
+		if errors.As(err, &retryErr) {
+			handleRetryNotification(globalEngine, globalLogger, err)
+			return nil
+		}
+
 		errorListMutex.Lock()
 		defer errorListMutex.Unlock()
 

--- a/test/jest/acceptance/resilience.spec.ts
+++ b/test/jest/acceptance/resilience.spec.ts
@@ -195,7 +195,7 @@ const RESILIENCE_SCENARIOS: ResilienceScenario[] = [
   {
     name: 'rate-limit-reset-retry-recovery',
     description:
-      '429 with X-RateLimit-Reset (seconds remaining): retry middleware backs off then succeeds',
+      '429 with X-RateLimit-Reset (seconds remaining): shows retry warning, backs off, then succeeds',
     setup: ({ server }) => {
       const throttleBody = {
         jsonapi: { version: '1.0' },
@@ -232,12 +232,19 @@ const RESILIENCE_SCENARIOS: ResilienceScenario[] = [
       SNYK_MAX_ATTEMPTS: '10',
     },
     onlyCommands: ['whoami --experimental'],
-    assert: ({ server }) => {
+    assert: ({ server, result }) => {
       const selfHits = server
         .getRequests()
         .filter((r) => (r.url ?? '').includes('/rest/self'));
       // eslint-disable-next-line jest/no-standalone-expect
       expect(selfHits.length).toBeGreaterThanOrEqual(3);
+
+      // Retry warnings use the catalog error code (stable); avoid asserting on prose.
+      // eslint-disable-next-line jest/no-standalone-expect
+      expect(result.stdout).toContain('SNYK-0001');
+      const rateLimitWarnings = result.stdout.match(/SNYK-0001/g);
+      // eslint-disable-next-line jest/no-standalone-expect
+      expect(rateLimitWarnings?.length ?? 0).toBeGreaterThanOrEqual(2);
     },
   },
 ];


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Upgrades GAF and adds retry notification handling in the CLI error handler.

When the network layer encounters HTTP 429 rate-limiting during retries, the error handler now:
- Shows a compact `WARN Rate limited` message to the user
- Records the event in analytics/instrumentation
- Does **not** collect it as a command error

GAF PR: https://github.com/snyk/go-application-framework/pull/612

## Where should the reviewer start?

`cliv2/cmd/cliv2/main.go` — the `AddErrorHandler` callback now handles `RetryAttemptError`.

## How should this be manually tested?

Use a mock 429 server or try to reproduce a rate-limit scenario.