### PR TITLE
chore: Fix noisy errors in Windows CI build logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,8 @@ commands:
                     New-Item -Path $bashEnvScript -ItemType File -Force | Out-Null
                   }
                   $bashPath = $goBin.Replace('\', '/').Replace('C:', '/c')
-                  'export PATH="' + $bashPath + ':$PATH"' | Out-File -FilePath $bashEnvScript -Append -Encoding UTF8
+                  $bashLine = 'export PATH="' + $bashPath + ':$PATH"'
+                  [System.IO.File]::AppendAllText($bashEnvScript, $bashLine + "`n", (New-Object System.Text.UTF8Encoding $false))
 
   install-deps-windows-native-build:
     steps:
@@ -276,7 +277,7 @@ commands:
       - restore_cache:
           name: Restoring Windows tools cache
           keys:
-            - windows-tools-cache-v4-{{ arch }}-{{ checksum ".nvmrc" }}
+            - windows-tools-cache-v5-{{ arch }}-{{ checksum ".nvmrc" }}
       - run:
           name: Install Node.js (native)
           shell: powershell
@@ -315,7 +316,7 @@ commands:
             .\scripts\windows\ensure-python-uv.ps1
       - save_cache:
           name: Saving Windows tools cache
-          key: windows-tools-cache-v4-{{ arch }}-{{ checksum ".nvmrc" }}
+          key: windows-tools-cache-v5-{{ arch }}-{{ checksum ".nvmrc" }}
           paths:
             - << pipeline.parameters.windows_cache_dir >>
             - C:\ProgramData\nvm

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,11 @@ SHASUM_CMD = shasum
 GOHOSTOS = $(shell go env GOHOSTOS)
 export PYTHON = python
 
-PYTHON_VERSION = $(shell python3 --version)
-ifneq (, $(PYTHON_VERSION))
-	PYTHON = python3
+ifneq ($(GOHOSTOS), windows)
+	PYTHON_VERSION = $(shell python3 --version 2>/dev/null)
+	ifneq (, $(PYTHON_VERSION))
+		PYTHON = python3
+	endif
 endif
 
 ifeq ($(GOHOSTOS), windows)

--- a/cliv2/Makefile
+++ b/cliv2/Makefile
@@ -62,7 +62,7 @@ CACHE_DIR = $(WORKING_DIR)/_cache
 LS_PROTOCOL_VERSION_FILE = $(CACHE_DIR)/ls-protocol-version
 LS_COMMIT_HASH_FILE = $(CACHE_DIR)/ls-commit-hash
 LS_COMMIT_HASH = $(if $(wildcard $(LS_COMMIT_HASH_FILE)),$(shell cat $(LS_COMMIT_HASH_FILE)),determined during LS metadata generation)
-SRCS = $(shell find $(WORKING_DIR) -type f -name '*.go')
+SRCS = $(shell $(GOCMD) list -f '{{range .GoFiles}}{{$$.Dir}}/{{.}} {{end}}' ./...)
 
 # load cached variables if available
 -include $(CACHE_DIR)/variables.mk

--- a/scripts/windows/install-dotnet-sdk.ps1
+++ b/scripts/windows/install-dotnet-sdk.ps1
@@ -87,7 +87,7 @@ try {
     $bashUpdateLine = 'export PATH="' + $bashPath + ':$PATH"'
     $bashExisting = Get-Content -Path $bashEnvScript -ErrorAction SilentlyContinue
     if (-not $bashExisting -or -not ($bashExisting -contains $bashUpdateLine)) {
-      $bashUpdateLine | Out-File -FilePath $bashEnvScript -Append -Encoding UTF8
+      [System.IO.File]::AppendAllText($bashEnvScript, $bashUpdateLine + "`n", (New-Object System.Text.UTF8Encoding $false))
     }
   }
   catch {

--- a/scripts/windows/install-gradle.ps1
+++ b/scripts/windows/install-gradle.ps1
@@ -101,7 +101,7 @@ try {
     $bashUpdateLine = 'export PATH="' + $bashPath + ':$PATH"'
     $bashExisting = Get-Content -Path $bashEnvScript -ErrorAction SilentlyContinue
     if (-not $bashExisting -or -not ($bashExisting -contains $bashUpdateLine)) {
-      $bashUpdateLine | Out-File -FilePath $bashEnvScript -Append -Encoding UTF8
+      [System.IO.File]::AppendAllText($bashEnvScript, $bashUpdateLine + "`n", (New-Object System.Text.UTF8Encoding $false))
     }
   }
   catch {

--- a/scripts/windows/install-make.ps1
+++ b/scripts/windows/install-make.ps1
@@ -131,7 +131,7 @@ try {
     $bashUpdateLine = 'export PATH="' + $bashPath + ':$PATH"'
     $bashExisting = Get-Content -Path $bashEnvScript -ErrorAction SilentlyContinue
     if (-not $bashExisting -or -not ($bashExisting -contains $bashUpdateLine)) {
-      $bashUpdateLine | Out-File -FilePath $bashEnvScript -Append -Encoding UTF8
+      [System.IO.File]::AppendAllText($bashEnvScript, $bashUpdateLine + "`n", (New-Object System.Text.UTF8Encoding $false))
     }
   }
   catch {

--- a/scripts/windows/install-maven.ps1
+++ b/scripts/windows/install-maven.ps1
@@ -102,7 +102,7 @@ try {
     $bashUpdateLine = 'export PATH="' + $bashPath + ':$PATH"'
     $bashExisting = Get-Content -Path $bashEnvScript -ErrorAction SilentlyContinue
     if (-not $bashExisting -or -not ($bashExisting -contains $bashUpdateLine)) {
-      $bashUpdateLine | Out-File -FilePath $bashEnvScript -Append -Encoding UTF8
+      [System.IO.File]::AppendAllText($bashEnvScript, $bashUpdateLine + "`n", (New-Object System.Text.UTF8Encoding $false))
     }
   }
   catch {

--- a/scripts/windows/install-python3.ps1
+++ b/scripts/windows/install-python3.ps1
@@ -86,14 +86,14 @@ try {
       $bashDir = $selectedDir.Replace('\', '/').Replace('C:', '/c')
       $bashLineBase = 'export PATH="' + $bashDir + ':$PATH"'
       if (-not $bashExisting -or -not ($bashExisting -contains $bashLineBase)) {
-        $bashLineBase | Out-File -FilePath $bashEnvScript -Append -Encoding UTF8
+        [System.IO.File]::AppendAllText($bashEnvScript, $bashLineBase + "`n", (New-Object System.Text.UTF8Encoding $false))
       }
 
       if (Test-Path $scriptsDir) {
         $bashScriptsDir = $scriptsDir.Replace('\', '/').Replace('C:', '/c')
         $bashLineScripts = 'export PATH="' + $bashScriptsDir + ':$PATH"'
         if (-not $bashExisting -or -not ($bashExisting -contains $bashLineScripts)) {
-          $bashLineScripts | Out-File -FilePath $bashEnvScript -Append -Encoding UTF8
+          [System.IO.File]::AppendAllText($bashEnvScript, $bashLineScripts + "`n", (New-Object System.Text.UTF8Encoding $false))
         }
       }
     }


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Fixes four categories of noisy error messages that appear in the `build windows amd64` CI logs. None were breaking the build, but they were confusing and one masked a latent issue with the bash PATH setup.

1. **`export: command not found`** — PowerShell `Out-File -Encoding UTF8` writes a UTF-8 BOM that breaks bash `source`. Replaced with `[System.IO.File]::AppendAllText()` using BOM-free UTF-8 in all scripts that write to `snyk-env.sh`.

2. **`CreateProcess(NULL, python3 --version, ...) failed` + `pipe: Bad file descriptor`** — Root Makefile unconditionally runs `python3 --version` via `$(shell ...)`, which fails on Windows (no `python3.exe`). Moved the probe inside an `ifneq ($(GOHOSTOS), windows)` guard.

3. **`File not found - *.go`** — `cliv2/Makefile` uses Unix `find` to populate `SRCS`, but Windows resolves `find` to its built-in text-search tool. Replaced with `$(GOCMD) list` which is cross-platform.

4. **Cache key bump** — Bumped `windows-tools-cache-v4` → `v5` to flush any cached BOM-prefixed `snyk-env.sh` files.

## Where should the reviewer start?

- `Makefile` — python3 probe guard (smallest change)
- `cliv2/Makefile` — `SRCS` now uses `go list` instead of Unix `find`
- `scripts/windows/install-*.ps1` — BOM-free writing pattern
- `.circleci/config.yml` — BOM fix in `install-go` + cache key bump

## How should this be manually tested?

The changes are CI-only. Validation:
1. Merge and let the `build windows amd64` job run
2. Verify the error messages no longer appear in the build logs
3. Verify the build still succeeds

## What's the product update that needs to be communicated to CLI users?

None. Internal CI build cleanup with no user-facing changes.

<!---
## Risk assessment (Low | Medium | High)?

Low — All changes are in build tooling / CI scripts. No runtime code is modified.

## Any background context you want to provide?

The errors stem from Windows/Unix impedance mismatches: PowerShell's UTF-8 BOM encoding vs bash, Windows `find.exe` vs Unix `find`, and missing `python3.exe` on Windows (it's just `python`).

## What are the relevant tickets?

[CLI-1492](https://snyksec.atlassian.net/browse/CLI-1492)

## Screenshots (if appropriate)

N/A
--->

[CLI-1492]: https://snyksec.atlassian.net/browse/CLI-1492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ