### PR TITLE
fix: bump cli-extension-os-flows to include unified scanners improvements

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -13,10 +13,10 @@ require (
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260505093105-90d9442ea939
 	github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603
 	github.com/snyk/cli-extension-ai-redteam v0.0.0-20260331152502-ce341aeaff9e
-	github.com/snyk/cli-extension-dep-graph v1.20.0
+	github.com/snyk/cli-extension-dep-graph v1.22.1
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e
-	github.com/snyk/cli-extension-os-flows v0.0.0-20260521083512-a0cf223c14df
+	github.com/snyk/cli-extension-os-flows v0.0.0-20260526152725-59c9ce00d48b
 	github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa
 	github.com/snyk/cli-extension-secrets v0.0.0-20260519130658-5bc07275ad09
 	github.com/snyk/code-client-go v1.27.0
@@ -43,7 +43,6 @@ require (
 	cloud.google.com/go/monitoring v1.24.3 // indirect
 	cloud.google.com/go/storage v1.61.3 // indirect
 	dario.cat/mergo v1.0.2 // indirect
-	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -22,8 +22,6 @@ cloud.google.com/go/trace v1.11.7 h1:kDNDX8JkaAG3R2nq1lIdkb7FCSi1rCmsEtKVsty7p+U
 cloud.google.com/go/trace v1.11.7/go.mod h1:TNn9d5V3fQVf6s4SCveVMIBS2LJUqo73GACmq/Tky0s=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
-github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
-github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 h1:sBEjpZlNHzK1voKq9695PJSX2o5NEXl7/OL3coiIY0c=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 h1:UnDZ/zFfG1JhH/DqxIZYU/1CUAlTUScoXD/LcM2Ykk8=
@@ -541,14 +539,14 @@ github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603 h1:uZyw9
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603/go.mod h1:RnMP+tFTeKygfXSx7z+heyMZoOps67u5HFytjptHjuk=
 github.com/snyk/cli-extension-ai-redteam v0.0.0-20260331152502-ce341aeaff9e h1:WZ4Ph3iX+fAu3/HgblVnA+AXfKiEvrgHsZq8GHjnzzo=
 github.com/snyk/cli-extension-ai-redteam v0.0.0-20260331152502-ce341aeaff9e/go.mod h1:445d735F53IuegetHs/S4GyWyng4Crd9TPj4vosmFmM=
-github.com/snyk/cli-extension-dep-graph v1.20.0 h1:wFZHfVV0UJwjdOty7DIRkdOhev0QkXKwP4NXrWQETxY=
-github.com/snyk/cli-extension-dep-graph v1.20.0/go.mod h1:+dNp/k/G/RXr67AsUMAcr0KRmSYC1HtEgffHF7ifjrg=
+github.com/snyk/cli-extension-dep-graph v1.22.1 h1:jT4hNnTx1XIjRGNQy4BnEjs8Zgu6tP6IAQvtjNkCKiM=
+github.com/snyk/cli-extension-dep-graph v1.22.1/go.mod h1:+dNp/k/G/RXr67AsUMAcr0KRmSYC1HtEgffHF7ifjrg=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSoQL0zYyFcGQjEPZcQgDkzM5PcgIHlIgzRuhg=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e h1:HE22F5/ivTJ4TlTUnjasZqfkDKVyfmYjf36RaIZqrs4=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e/go.mod h1:YN+M0+nNZ5VoQN2SxSvZSoTxs/PkdLgfNfUWvsKVL7o=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260521083512-a0cf223c14df h1:q3AVDtSsi5S/p7DDNO9VujngaVLMOV/aLWCKVjRIhgQ=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260521083512-a0cf223c14df/go.mod h1:2tiBPPmFfHJYPOtqbozIkwBYF1UqQ4PdG9qjFY9ZegI=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260526152725-59c9ce00d48b h1:9OywntXDdS6wxU3odsOCFn1clmcezzEbRJT0g2R02Ts=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260526152725-59c9ce00d48b/go.mod h1:mf78b4rqqbaPuj+zB2N8q7JgKJi/UE+ctmo7KyReAL0=
 github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa h1:9GSKXrRCaRkBAj+jglUBuhO09I1xs2G5GxwrPxlj34M=
 github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa/go.mod h1:SJ624HENWG4yjM6jNuLebTeNsMriozf1LcKhMYVm1aY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260519130658-5bc07275ad09 h1:B5RFt9zJeGsyQdKllKGNKGGCKxW6WR/ZyIYn/DxAcs4=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
Bumps  the version of `github.com/snyk/cli-extension-os-flows` to import the latest version of the unified scanners (this brings in the latest version of `github.com/snyk/cli-extension-dep-graph`). 
This brings in the latests changes needed so end to end tests can begin and requires a ff sets to be able to use. This wont affect any customer as no one will have access to this feature till a later date.

## Where should the reviewer start?
`go.mod` and `go.sum` — this is a pure dependency bump, no logic changes in this repo.

## How should this be manually tested?
You can just run a `snyk test` against any project but this requires a ff in the ff service to be set. 

