### PR TITLE
chore: Resolve flaky .snyk file filtering test race condition

### DIFF
--- a/test/jest/acceptance/snyk-code/snyk-code-user-journey.spec.ts
+++ b/test/jest/acceptance/snyk-code/snyk-code-user-journey.spec.ts
@@ -935,58 +935,62 @@ describe('snyk code test', () => {
             it('should support .snyk file filtering', async () => {
               const ignoredFile1 = 'JWTVotesEndpoint.java';
               const ignoredFile2 = 'HashingAssignment.java';
-
-              // run initial snyk code and verify issues are there
-              const initialCodeTestCmd = await runSnykCLI(
-                `code test ${projectWithIssuesAndDotSnykFile} --severity-threshold=high`,
-                {
-                  env: {
-                    ...process.env,
-                    ...integrationEnv,
-                  },
-                },
+              const projectPath = await ensureUniqueBundleIsUsed(
+                projectWithIssuesAndDotSnykFile,
               );
 
-              // before creating the .snyk file, issues in these files should be there
-              expect(initialCodeTestCmd.stdout).toContain(ignoredFile1);
-              expect(initialCodeTestCmd.stdout).toContain(ignoredFile2);
+              try {
+                const testEnv = {
+                  ...process.env,
+                  ...integrationEnv,
+                };
 
-              // create ignores
-              await Promise.all([
-                runSnykCLI(
-                  `ignore --file-path=${ignoredFile1} --file-path-group=code --policy-path=${projectWithIssuesAndDotSnykFile}`,
-                ),
-                runSnykCLI(
-                  `ignore --file-path=${ignoredFile2} --expiry=3000-12-31T00:00:00.000Z --file-path-group=code --policy-path=${projectWithIssuesAndDotSnykFile}`,
-                ),
-              ]);
+                // run initial snyk code and verify issues are there
+                const initialCodeTestCmd = await runSnykCLI(
+                  `code test ${projectPath} --severity-threshold=high`,
+                  { env: testEnv },
+                );
 
-              /** .snyk file in sut should look something like:
-               * # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-                  version: v1.25.1
-                  ignore: {}
-                  patch: {}
-                  exclude:
-                    code:
-                      - JWTVotesEndpoint.java
-                      - HashingAssignment.java:
-                          expires: 3000-12-31T00:00:00.000Z
-                          created: 2026-01-28T11:59:32.489Z
-               */
+                // before creating the .snyk file, issues in these files should be there
+                expect(initialCodeTestCmd.stdout).toContain(ignoredFile1);
+                expect(initialCodeTestCmd.stdout).toContain(ignoredFile2);
 
-              // test
-              const codeTestCmd = await runSnykCLI(
-                `code test ${projectWithIssuesAndDotSnykFile} --severity-threshold=high`,
-                {
-                  env: {
-                    ...process.env,
-                    ...integrationEnv,
-                  },
-                },
-              );
+                // create ignores sequentially to avoid concurrent read-modify-write on .snyk
+                const ignore1 = await runSnykCLI(
+                  `ignore --file-path=${ignoredFile1} --file-path-group=code --policy-path=${projectPath}`,
+                );
+                expect(ignore1.code).toEqual(0);
 
-              expect(codeTestCmd.stdout).not.toContain(ignoredFile1);
-              expect(codeTestCmd.stdout).not.toContain(ignoredFile2);
+                const ignore2 = await runSnykCLI(
+                  `ignore --file-path=${ignoredFile2} --expiry=3000-12-31T00:00:00.000Z --file-path-group=code --policy-path=${projectPath}`,
+                );
+                expect(ignore2.code).toEqual(0);
+
+                expect(existsSync(join(projectPath, '.snyk'))).toBe(true);
+
+                /** .snyk file in sut should look something like:
+                 * # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+                    version: v1.25.1
+                    ignore: {}
+                    patch: {}
+                    exclude:
+                      code:
+                        - JWTVotesEndpoint.java
+                        - HashingAssignment.java:
+                            expires: 3000-12-31T00:00:00.000Z
+                            created: 2026-01-28T11:59:32.489Z
+                 */
+
+                const codeTestCmd = await runSnykCLI(
+                  `code test ${projectPath} --severity-threshold=high`,
+                  { env: testEnv },
+                );
+
+                expect(codeTestCmd.stdout).not.toContain(ignoredFile1);
+                expect(codeTestCmd.stdout).not.toContain(ignoredFile2);
+              } finally {
+                fs.removeSync(projectPath);
+              }
             });
           });
         }


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Fixes the flaky `should support .snyk file filtering` test in `snyk-code-user-journey.spec.ts`. The test had three issues causing intermittent CI failures:

1. **Race condition:** Two `snyk ignore` commands ran concurrently via `Promise.all`, both doing read-modify-write on the same `.snyk` file. The last write could overwrite the first, losing one exclude rule.
2. **Shared mutable fixture:** The `.snyk` file was written directly into the checked-in fixture directory (`shallow_sast_webgoat_with_dotSnyk`), so a failed run would leave stale state that breaks subsequent runs.
3. **No cleanup:** The generated `.snyk` file was never removed, polluting the fixture for other tests and re-runs.

### Changes

- Run `snyk ignore` commands **sequentially** instead of concurrently
- Use `ensureUniqueBundleIsUsed()` to copy the fixture to a temp directory (matching other tests in the file)
- Add `try/finally` cleanup with `fs.removeSync`
- Assert exit code 0 on both `ignore` commands to catch silent failures
- Assert `.snyk` file existence after creation for better diagnostics

## Where should the reviewer start?

`test/jest/acceptance/snyk-code/snyk-code-user-journey.spec.ts` — the `should support .snyk file filtering` test (line ~935)

## How should this be manually tested?

Run the test in a loop to confirm it no longer flakes:

```bash
for i in $(seq 1 10); do
  echo "=== run $i ==="
  TEST_SNYK_COMMAND=<path-to-snyk-binary> \
  npm run test:acceptance -- \
    --testPathPattern=snyk-code-user-journey \
    -t "should support .snyk file filtering" \
  || { echo "FAILED on run $i"; break; }
done