### PR TITLE
chore: updated doc paths to README and CLI help files in syncs

### DIFF
--- a/.github/workflows/sync-cli-help-to-user-docs.yml
+++ b/.github/workflows/sync-cli-help-to-user-docs.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Copy help documentation from user-docs to CLI
         run: |
-          cp ./user-docs/docs/developer-tools/snyk-cli/commands/*.md ./cli/help/cli-commands/
+          cp ./user-docs/developer-tools/snyk-cli/commands/*.md ./cli/help/cli-commands/
 
       - name: Format help files with Prettier
         run: |

--- a/.github/workflows/sync-cli-readme.yml
+++ b/.github/workflows/sync-cli-readme.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Retrieve GitBook content and update README
         run: |
-          cp ./user-docs/docs/developer-tools/snyk-cli/getting-started-with-the-snyk-cli.md ./cli/README.md
+          cp ./user-docs/developer-tools/snyk-cli/getting-started-with-the-snyk-cli.md ./cli/README.md
 
           # GitBook Markdown files often use relative paths for assets (e.g., images)
           # like `../.gitbook/assets/image.png`. When this README.md is viewed directly
@@ -70,7 +70,7 @@ jobs:
           # - `-e`: Specifies the script to be executed. In this case, it's the 's'
           #         (substitute) command which replaces the old path with the new URL.
           sed -i \
-              -e "s|../.gitbook/assets/|https://github.com/snyk/user-docs/raw/HEAD/docs/.gitbook/assets/|g" \
+              -e "s|../.gitbook/assets/|https://github.com/snyk/user-docs/raw/HEAD/developer-tools/.gitbook/assets/|g" \
               ./cli/README.md
 
       - name: Format README with Prettier


### PR DESCRIPTION
## Pull Request Submission Checklist

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

This PR is to update the README sync automation and the CLI helo automation to account for the new paths introduced in the user-docs repo with the new site architecture on May 28.

The README source file is moving from `docs/developer-tools/snyk-cli/getting-started-with-the-snyk-cli.md` to `developer-tools/snyk-cli/getting-started-with-the-snyk-cli.md`.

The CLI help source files are moving from `docs/developer-tools/snyk-cli/commands/*.md` to `developer-tools/snyk-cli/commands/*.md`.

## Where should the reviewer start?

## How should this be manually tested?

## What's the product update that needs to be communicated to CLI users?

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
