### PR TITLE
feat: Upgrade `snyk-gradle-plugin` to `v7.0.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "snyk-cpp-plugin": "^2.24.3",
         "snyk-docker-plugin": "9.7.0",
         "snyk-go-plugin": "2.1.1",
-        "snyk-gradle-plugin": "6.0.0",
+        "snyk-gradle-plugin": "7.0.0",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "^4.7.0",
         "snyk-nodejs-lockfile-parser": "2.7.1",
@@ -19974,9 +19974,9 @@
       }
     },
     "node_modules/snyk-gradle-plugin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-6.0.0.tgz",
-      "integrity": "sha512-QyQTKEGuaiwPg9qzzePpmTFuQpfGFJwCBUXnhEv4ETXGtK7dWKsniEnDUu8oFq63G8wEX1py9YBptXAdeL/neQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-7.0.0.tgz",
+      "integrity": "sha512-wVuEWgHk+4HDgawLEhjz+zZw8Lvo7qo7O1D3TZ/xLHx//HDFYxuFtT11CVJ06Wc9Z6ioKfjwqoYkkbAmJko4/w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@common.js/yocto-queue": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "snyk-cpp-plugin": "^2.24.3",
     "snyk-docker-plugin": "9.7.0",
     "snyk-go-plugin": "2.1.1",
-    "snyk-gradle-plugin": "6.0.0",
+    "snyk-gradle-plugin": "7.0.0",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "^4.7.0",
     "snyk-nodejs-lockfile-parser": "2.7.1",


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasising _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___) — n/a
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Upgrades `snyk-gradle-plugin` from v6.x to [v7.0.0](https://github.com/snyk/snyk-gradle-plugin/releases/tag/v7.0.0).

The only notable functional change in v7.0.0 is the Gradle dependency resolver in `lib/init.gradle`, which switches from the legacy v5 `ResolvedConfiguration` API to the modern `ResolutionResult` + `ArtifactView` APIs (see [snyk/snyk-gradle-plugin#337](https://github.com/snyk/snyk-gradle-plugin/pull/337)). The other commits in the release (`#339`, `#340`) are publishing / CI changes with no runtime impact on the CLI.

The `JSONDEPS` schema is unchanged and `lib/graph.ts` in the plugin is untouched, so the CLI's downstream consumption of the dep graph is unaffected.

Highlights of the resolver rewrite:

- **Cross-project conflict resolution** — versions reported per project now match what Gradle actually puts on the classpath (same machinery as `gradle dependencyInsight`).
- **Multi-config walk** — each resolvable configuration is walked separately; deps appearing on multiple classpaths produce one real node and one `:pruned` placeholder per additional arrival path.
- **Multi-parent edges** — components with multiple artifacts (e.g. classifier variants) attach their transitives under each artifact, preserving v5's per-classifier arrival paths.
- **No-artifact components skipped** — BOMs, Gradle platforms, and project deps with no jar are no longer emitted as logical nodes; their transitives attach to the BOM's parent instead.
- **Publication configs skipped** — Gradle's auto-created `default` / `archives` configs aren't walked.
- **Lock-rejection noise suppressed** — `UnresolvedDependencyResult` entries for rejected requests under strict locks are dropped.
- **Deterministic output** — `ResolutionResult.dependencies` is sorted by selector display name before iteration.
- **Preserved artifact types (Gradle 5.1+)** — reads `artifact.variant.attributes.artifactType` so `java-classes-directory`, `java-resources-directory`, etc. are reported instead of defaulting to `jar`.

### Behavioural impact on `snyk test` / `snyk monitor` for Gradle projects

The net change across the plugin's fixture suite is **+5 packages gained, 0 lost**:

| Fixture                | Δ pkgs | Why                                                                       |
| ---------------------- | ------ | ------------------------------------------------------------------------- |
| version-catalog-toml   | +3     | BOM transitives v5's stale-metadata walk missed                           |
| init-gradle/app        | +1     | `junit-jupiter-engine` via the junit BOM, also missed by v5               |
| basic-with-failed-dep  | +1     | declared-but-failed dep (`axis:axis@badVersion-7.7`) — v5 silently dropped |

Five additional fixtures gain `:pruned` placeholders (no new packages — multi-config walk surfaces arrival paths v5 had flattened away).

### Breaking changes

- **Plugin major version bump (v6 → v7)** because the resolution algorithm fundamentally changes. There are no CLI-facing API changes — the `JSONDEPS` schema is identical.
- The plugin's internal `nodeId` format changed from `name@version` to `name:type@version`. This is **not** observed by the CLI: only the `pkgs` array is consumed downstream of the plugin.

## Where should the reviewer start?

1. The dependency bump itself: `package.json` and `package-lock.json`.
2. The upstream PR — [snyk/snyk-gradle-plugin#337](https://github.com/snyk/snyk-gradle-plugin/pull/337) — for the full set of walker changes and fixture diffs.
3. The plugin's own regression / fixture suite, which exercises the new walker against Gradle 4-9 on JDK 8 / 17.

## How should this be manually tested?

Smoke-test `snyk test` and `snyk monitor` against a reasonably complex open-source Gradle project and compare v6 vs v7 output. A good go-to is [`android/nowinandroid`](https://github.com/android/nowinandroid) — multi-module, uses version catalogs, BOMs, and the AGP, so it exercises most of the new walker behaviour. Any other non-trivial OSS Gradle/Java project works too.

```bash
npm ci && npm run build-cli:prod

./bin/snyk test --all-sub-projects --print-deps /path/to/nowinandroid
./bin/snyk monitor --all-sub-projects /path/to/nowinandroid
```

Expect `:pruned` placeholders on configurations sharing transitives, potentially **more** packages than v6 (BOM-managed transitives previously dropped), and 0 packages lost.

## What's the product update that needs to be communicated to CLI users?

**`snyk test` / `snyk monitor` (Gradle)**: modernised dependency resolver — scans now include BOM-managed and previously-dropped transitives, producing more complete dep graphs.

## Risk assessment

**Medium.** We're confident in the change — the upstream PR has expanded fixture coverage across Gradle 4-9 on JDK 8 / 17, the `JSONDEPS` schema is unchanged, and the net fixture delta is +5 packages / 0 lost. The "medium" rating reflects that dep graphs **will** change for real projects as a consequence — typically by gaining dependencies (BOM transitives, declared-but-failed deps, multi-config arrival paths) rather than losing them.

## Any background context you want to provide?

`ResolvedConfiguration.getFirstLevelModuleDependencies()` is marked as legacy by Gradle and known to return stale per-project metadata for project deps with multiple variants. The new APIs (`ResolutionResult` + `ArtifactView`) are what `gradle dependencyInsight` itself uses.

## What are the relevant tickets?

- [OSM-3545](https://snyksec.atlassian.net/browse/OSM-3545)
- [snyk/snyk-gradle-plugin#337](https://github.com/snyk/snyk-gradle-plugin/pull/337)
- [snyk-gradle-plugin v7.0.0 release](https://github.com/snyk/snyk-gradle-plugin/releases/tag/v7.0.0)


[OSM-3545]: https://snyksec.atlassian.net/browse/OSM-3545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ