### PR TITLE
fix: handle 'none' severity in getSeverityValue, drop duplicate assignment in handleError

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -99,7 +99,6 @@ async function handleError(args, error) {
     error.userMessage = error.nestedUserMessage || error.userMessage;
     error.code = error.nestedCode || error.code;
     error.strCode = error.nestedStrCode || error.strCode;
-    error.userMessage = error.nestedUserMessage || error.userMessage;
   }
 
   let command = 'bad-command';

--- a/src/lib/formatters/get-severity-value.ts
+++ b/src/lib/formatters/get-severity-value.ts
@@ -1,5 +1,5 @@
 import { SEVERITIES, SEVERITY } from '../snyk-test/common';
 
 export function getSeverityValue(severity: SEVERITY | 'none'): number {
-  return SEVERITIES.find((s) => s.verboseName === severity)!.value;
+  return SEVERITIES.find((s) => s.verboseName === severity)?.value ?? 0;
 }

--- a/test/jest/unit/lib/formatters/get-severity-value.spec.ts
+++ b/test/jest/unit/lib/formatters/get-severity-value.spec.ts
@@ -14,4 +14,7 @@ describe('getSeverityValue', () => {
   it('Low returns 4', () => {
     expect(getSeverityValue(SEVERITY.LOW)).toEqual(1);
   });
+  it('none returns 0', () => {
+    expect(getSeverityValue('none')).toEqual(0);
+  });
 });


### PR DESCRIPTION
## What

Two small bugs fixed:

**1. `getSeverityValue` crashes on `'none'` severity**

The function signature accepts `SEVERITY | 'none'`, but `'none'` isn't in the `SEVERITIES` array. The `!` non-null assertion turns that missing entry into a runtime `TypeError`.

Reproduce:
```ts
getSeverityValue('none') // TypeError: Cannot read properties of undefined (reading 'value')
```

IaC code already treats `'none'` as a real severity value (see `results-formatter.ts` filtering `violatedPolicy.severity !== 'none'`), so this path is reachable. Fix: swap `!.value` for `?.value ?? 0` — returns 0 for `'none'`, which fits naturally below `low` (1).

**2. Duplicate assignment in `handleError`**

`error.userMessage = error.nestedUserMessage || error.userMessage` appears twice in a row (lines 99 and 102), no mutation between them. Second line is dead code, introduced as a copy-paste leftover.

## Changes

- `src/lib/formatters/get-severity-value.ts`: replace unsafe non-null assertion with optional chaining + nullish coalescing
- `src/cli/main.ts`: remove duplicate `userMessage` assignment
- `test/jest/unit/lib/formatters/get-severity-value.spec.ts`: add test case for `'none'` input