### PR TITLE
chore: bump snyk-ls to 84f36cac (LdxSyncService)

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -219,7 +219,7 @@ require (
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
-	github.com/snyk/snyk-ls v0.0.0-20260521200407-f9b48c0d538f // indirect
+	github.com/snyk/snyk-ls v0.0.0-20260528082243-84f36cac4221 // indirect
 	github.com/snyk/studio-mcp v1.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -595,8 +595,8 @@ github.com/snyk/remy-cli-extension v1.9.4 h1:ZY462W/cMjB+1MrSuPfmG9Q2e8sHrm04e9/
 github.com/snyk/remy-cli-extension v1.9.4/go.mod h1:rKngIMi88TMBqG69FfOaZma1I/W6SlcweVs5VxKcs30=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260521200407-f9b48c0d538f h1:osO4WDs6XBo0zD6lAUEQwpoPGQdW/SGTjWuuS7ZfZZk=
-github.com/snyk/snyk-ls v0.0.0-20260521200407-f9b48c0d538f/go.mod h1:v/YhFS7Nm9G7U3s88lE3vsdkLp2K74wQCiPnO4+HtW0=
+github.com/snyk/snyk-ls v0.0.0-20260528082243-84f36cac4221 h1:1ovHqz9Gx9rr/B0Hde0InGIKxT7LSkNil61dcWbyE8U=
+github.com/snyk/snyk-ls v0.0.0-20260528082243-84f36cac4221/go.mod h1:v/YhFS7Nm9G7U3s88lE3vsdkLp2K74wQCiPnO4+HtW0=
 github.com/snyk/studio-mcp v1.11.0 h1:WfvWqqHu5+Stb/y+LTVdWWiazc0i4BapxqMCJyGRArA=
 github.com/snyk/studio-mcp v1.11.0/go.mod h1:CiMKFs/PJrAMjG8Zjkvx+XwuM0XlxGJ7jP5yCr5hm5w=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/snyk/go-application-framework v0.0.0-20260521100148-fa5bb2f17d49
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20260521200407-f9b48c0d538f
+	github.com/snyk/snyk-ls v0.0.0-20260528082243-84f36cac4221
 	github.com/snyk/studio-mcp v1.11.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -567,8 +567,8 @@ github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhk
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260521200407-f9b48c0d538f h1:osO4WDs6XBo0zD6lAUEQwpoPGQdW/SGTjWuuS7ZfZZk=
-github.com/snyk/snyk-ls v0.0.0-20260521200407-f9b48c0d538f/go.mod h1:v/YhFS7Nm9G7U3s88lE3vsdkLp2K74wQCiPnO4+HtW0=
+github.com/snyk/snyk-ls v0.0.0-20260528082243-84f36cac4221 h1:1ovHqz9Gx9rr/B0Hde0InGIKxT7LSkNil61dcWbyE8U=
+github.com/snyk/snyk-ls v0.0.0-20260528082243-84f36cac4221/go.mod h1:v/YhFS7Nm9G7U3s88lE3vsdkLp2K74wQCiPnO4+HtW0=
 github.com/snyk/studio-mcp v1.11.0 h1:WfvWqqHu5+Stb/y+LTVdWWiazc0i4BapxqMCJyGRArA=
 github.com/snyk/studio-mcp v1.11.0/go.mod h1:CiMKFs/PJrAMjG8Zjkvx+XwuM0XlxGJ7jP5yCr5hm5w=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=


### PR DESCRIPTION
## Summary

- Bump `github.com/snyk/snyk-ls` from `v0.0.0-20260521200407-f9b48c0d538f` to `v0.0.0-20260528082243-84f36cac4221` in both `cliv2/` and `cliv2-private/`.
- `84f36cac4221` is snyk-ls' `refactor(configuration): LdxSyncService from ctx [IDE-1974]` (#1297), which is the commit the CI build script already resolves dynamically (`commit-hash-based resolution from github.com/snyk/snyk-ls@84f36cac4221`).

## Why

Recent builds on macOS / Linux are failing at link time with:

```
cliv2/pkg/core/main.go:66:2: missing go.sum entry for module providing package
github.com/snyk/snyk-ls/ls_extension (imported by github.com/snyk/cli/cliv2/pkg/core); to add:
    go get github.com/snyk/cli/cliv2/pkg/core@v0.0.0
make[1]: *** [/Users/distiller/project/cliv2/_bin/snyk-macos-arm64] Error 1
```

Example failed job: https://app.circleci.com/pipelines/gh/snyk/cli/37440/workflows/b1d34976-545e-492e-bdb3-99d54c05c84c/jobs/583703

The cause is that `go.mod` was pinned to `f9b48c0d` while the build pulls in `84f36cac`, leaving no matching `go.sum` checksum. Running `go get github.com/snyk/snyk-ls@84f36cac4221225d7c90b6d8b4364b8ae1d2e1fb && go mod tidy` in both modules produces this minimal diff.

## Test plan

- [ ] CircleCI `build macOS arm64` (and the other Go-link jobs) pass on this branch.
- [ ] No unrelated dependency churn — only `snyk-ls` lines change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[IDE-1974]: https://snyksec.atlassian.net/browse/IDE-1974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ