### PR TITLE
chore: Update version number for public builds and improve usability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -546,7 +546,9 @@ workflows:
                 - '/^docs\/.*/'
 
       - prepare-build:
-          context: devex_cli_docker_hub
+          context:
+            - devex_cli_docker_hub
+            - go-private-modules
           requires:
             - secrets-scan
           filters:
@@ -610,7 +612,7 @@ workflows:
           context:
             - devex_cli_docker_hub
           requires:
-            - prepare-build
+            - secrets-scan
           filters:
             branches:
               ignore:
@@ -1377,6 +1379,7 @@ jobs:
     executor: docker-amd64
     steps:
       - checkout
+      - setup-go-private-modules
       - restore_cache:
           name: Restore npm cache
           keys:
@@ -1520,7 +1523,7 @@ jobs:
           command: make openboxtest
 
   build-public:
-    description: Verify the open source (public) CLI build compiles
+    description: Verify the open source (public) CLI build compiles from scratch
     executor: docker-amd64
     parameters:
       go_os:
@@ -1535,21 +1538,29 @@ jobs:
         type: string
         default: '.'
     steps:
-      - prepare-workspace
-      - install-go:
-          go_os: << parameters.go_os >>
-          go_target_os: << parameters.go_target_os >>
-          go_arch: << parameters.go_arch >>
-          base_url: << parameters.go_download_base_url >>
-          extraction_path: << parameters.install_path >>
+      - checkout
+      - restore_cache:
+          name: Restore npm cache (public build)
+          keys:
+            - public-build-npm-deps-{{ checksum "package-lock.json" }}
+            - public-build-npm-deps
+      - run:
+          name: Installing dependencies
+          command: npm ci --no-audit --no-progress --cache .npm --prefer-offline
+      - save_cache:
+          name: Save npm cache (public build)
+          key: public-build-npm-deps-{{ checksum "package-lock.json" }}
+          paths:
+            - .npm
       - make-binary:
           go_arch: << parameters.go_arch >>
           go_target_os: << parameters.go_target_os >>
           make_target: build BUILD_MODE=public
       - run:
-          name: Verify public CLI runs
+          name: Verify public CLI runs and has -oss suffix
           command: |
             ./binary-releases/snyk-linux --version
+            ./binary-releases/snyk-linux --version 2>&1 | grep -q "\oss" || (echo "ERROR: Version should contain oss suffix for public build" && exit 1)
             ./binary-releases/snyk-linux --help
 
   test-legacy-tap:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,35 @@ Then run `ls binary-releases` to confirm the name of the binary. For instance, i
 ./binary-releases/snyk-macos-arm64 --version
 ```
 
+### Public vs Private Builds
+
+The CLI supports two build modes:
+
+- **Private build** (default): The full-featured build including proprietary extensions. Requires access to private repositories.
+- **Public/OSS build**: Contains only open-source extensions. This is the fallback for external contributors without access to private repos.
+
+The build system auto-detects which mode to use based on your access to the `cliv2-private` module. You can also explicitly set the mode:
+
+```sh
+# Force public build
+make build BUILD_MODE=public
+
+# Force private build (will fail if you don't have access)
+make build BUILD_MODE=private
+```
+
+To check which build you have, run:
+
+```sh
+./binary-releases/snyk-macos-arm64 --version
+# Private: 1.1234.0
+# Public:  1.1234.0-oss
+```
+
+### Managing Go Dependencies
+
+When updating Go dependencies, run `make tidy` to tidy both the public and private Go modules.
+
 ## Debugging the go binary with VSCode
 
 1. Build the cli using `make build-debug`
@@ -428,7 +457,7 @@ If you have made changes to the `go-application-framework`, you can run
 
 - Fetch the most recent commit from the `main` branch of the framework
 - Go get that version of the framework
-- Run `go mod tidy` to ensure the `go.mod` file matches the source code in the module
+- Run `make tidy` to ensure the `go.mod` files match the source code in both modules
 
 You can then raise a pr with the relevant changes.
 

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,14 @@ $(BINARY_OUTPUT_FOLDER)/experimental: $(BINARY_OUTPUT_FOLDER)
 $(BINARY_RELEASES_FOLDER_TS_CLI):
 	@mkdir -p $(BINARY_RELEASES_FOLDER_TS_CLI)
 
+# BUILD_MODE is auto-detected in cliv2/Makefile based on access to cliv2-private.
+# We use the same detection logic here for consistency.
+PRIVATE_DIR = $(WORKING_DIR)/cliv2-private
+_CAN_BUILD_PRIVATE = $(shell if [ -f "$(PRIVATE_DIR)/go.mod" ] && cd "$(PRIVATE_DIR)" && go mod download > /dev/null 2>&1; then echo yes; fi)
+BUILD_MODE ?= $(if $(_CAN_BUILD_PRIVATE),private,public)
+
 $(BINARY_RELEASES_FOLDER_TS_CLI)/version: | $(BINARY_RELEASES_FOLDER_TS_CLI)
-	./release-scripts/next-version.sh > $(BINARY_RELEASES_FOLDER_TS_CLI)/version
+	BUILD_MODE=$(BUILD_MODE) ./release-scripts/next-version.sh > $(BINARY_RELEASES_FOLDER_TS_CLI)/version
 
 $(BINARY_OUTPUT_FOLDER)/experimental/version: $(BINARY_RELEASES_FOLDER_TS_CLI)/version $(BINARY_OUTPUT_FOLDER)/experimental
 	@cp $(BINARY_RELEASES_FOLDER_TS_CLI)/version $(BINARY_OUTPUT_FOLDER)/experimental/version
@@ -244,22 +250,22 @@ pre-build: pre-build-binary-wrapper $(BINARY_RELEASES_FOLDER_TS_CLI) $(BINARY_RE
 
 .PHONY: build-fips
 build-fips: pre-build $(BINARY_OUTPUT_FOLDER)/fips/version
-	@cd $(EXTENSIBLE_CLI_DIR); $(MAKE) fips build-full install bindir=$(WORKING_DIR)/$(BINARY_OUTPUT_FOLDER)/fips USE_LEGACY_EXECUTABLE_NAME=1
+	@cd $(EXTENSIBLE_CLI_DIR); $(MAKE) fips build-full install bindir=$(WORKING_DIR)/$(BINARY_OUTPUT_FOLDER)/fips USE_LEGACY_EXECUTABLE_NAME=1 BUILD_MODE=$(BUILD_MODE)
 	@$(MAKE) clean-package-files
 
 .PHONY: build-experimental
 build-experimental: pre-build $(BINARY_OUTPUT_FOLDER)/experimental/version
-	@cd $(EXTENSIBLE_CLI_DIR); $(MAKE) experimental build-full install bindir=$(WORKING_DIR)/$(BINARY_OUTPUT_FOLDER)/experimental USE_LEGACY_EXECUTABLE_NAME=1
+	@cd $(EXTENSIBLE_CLI_DIR); $(MAKE) experimental build-full install bindir=$(WORKING_DIR)/$(BINARY_OUTPUT_FOLDER)/experimental USE_LEGACY_EXECUTABLE_NAME=1 BUILD_MODE=$(BUILD_MODE)
 	@$(MAKE) clean-package-files
 
 .PHONY: build
 build: pre-build
-	@cd $(EXTENSIBLE_CLI_DIR); $(MAKE) build-full install bindir=$(WORKING_DIR)/$(BINARY_OUTPUT_FOLDER) USE_LEGACY_EXECUTABLE_NAME=1
+	@cd $(EXTENSIBLE_CLI_DIR); $(MAKE) build-full install bindir=$(WORKING_DIR)/$(BINARY_OUTPUT_FOLDER) USE_LEGACY_EXECUTABLE_NAME=1 BUILD_MODE=$(BUILD_MODE)
 	@$(MAKE) clean-package-files
 
 .PHONY: build-debug
 build-debug: pre-build
-	@cd $(EXTENSIBLE_CLI_DIR); $(MAKE) debug build-full install bindir=$(WORKING_DIR)/$(BINARY_OUTPUT_FOLDER) USE_LEGACY_EXECUTABLE_NAME=1
+	@cd $(EXTENSIBLE_CLI_DIR); $(MAKE) debug build-full install bindir=$(WORKING_DIR)/$(BINARY_OUTPUT_FOLDER) USE_LEGACY_EXECUTABLE_NAME=1 BUILD_MODE=$(BUILD_MODE)
 	@$(MAKE) clean-package-files
 
 .PHONY: sign
@@ -314,9 +320,14 @@ release-mgt-create:
 
 .PHONY: format
 format:
+	@$(MAKE) tidy
 	@echo "-- Formatting code"
 	@npm run format
 	@pushd $(EXTENSIBLE_CLI_DIR); $(MAKE) format; popd
+
+.PHONY: tidy
+tidy:
+	@cd $(EXTENSIBLE_CLI_DIR); $(MAKE) tidy
 
 .PHONY: ls-protocol-metadata
 ls-protocol-metadata: $(BINARY_RELEASES_FOLDER_TS_CLI)/version

--- a/cliv2/Makefile
+++ b/cliv2/Makefile
@@ -19,15 +19,14 @@ export LS_PROTOCOL_VERSION=
 STATIC_NODE_BINARY = false
 CGO_ENABLED = 1
 
-# Auto-detect build mode by checking whether the private module's dependencies
-# can actually be resolved (i.e. the developer has access to the private repos).
-# Defaults to private when possible, falls back to public.
+# BUILD_MODE is typically set by the root Makefile. When running cliv2/Makefile
+# directly, it defaults to auto-detection based on access to cliv2-private.
 # Can be overridden: make build BUILD_MODE=public
-# NOTE: When BUILD_MODE=private is explicitly set (e.g., in CI), the build will
-# fail if private dependencies cannot be resolved, rather than silently falling back.
 PRIVATE_DIR = $(WORKING_DIR)/../cliv2-private
-_CAN_BUILD_PRIVATE = $(shell if [ -f "$(PRIVATE_DIR)/go.mod" ] && cd "$(PRIVATE_DIR)" && $(GOCMD) mod download > /dev/null 2>&1; then echo yes; fi)
-BUILD_MODE ?= $(if $(_CAN_BUILD_PRIVATE),private,public)
+ifndef BUILD_MODE
+  _CAN_BUILD_PRIVATE = $(shell if [ -f "$(PRIVATE_DIR)/go.mod" ] && cd "$(PRIVATE_DIR)" && $(GOCMD) mod download > /dev/null 2>&1; then echo yes; fi)
+  BUILD_MODE = $(if $(_CAN_BUILD_PRIVATE),private,public)
+endif
 BUILD_ROOT_DIR = $(if $(filter private,$(BUILD_MODE)),$(PRIVATE_DIR),$(WORKING_DIR))
 
 # Validation target for BUILD_MODE=private (called by build targets, not at parse time)
@@ -261,6 +260,19 @@ $(TOOLS_BIN)/golangci-lint:
 format:
 	gofmt -w -l -e .
 
+# Tidy both public and private modules. The private module depends on the public
+# module via a replace directive, so we tidy the public module first.
+.PHONY: tidy
+tidy:
+	@echo "$(LOG_PREFIX) Running go mod tidy in cliv2 (public)"
+	@cd $(WORKING_DIR) && $(GOCMD) mod tidy
+	@if [ -f "$(PRIVATE_DIR)/go.mod" ]; then \
+		echo "$(LOG_PREFIX) Running go mod tidy in cliv2-private"; \
+		cd "$(PRIVATE_DIR)" && $(GOCMD) mod tidy; \
+	else \
+		echo "$(LOG_PREFIX) Skipping cliv2-private (not found or no access)"; \
+	fi
+
 .PHONY: SIGN_SCRIPT
 SIGN_SCRIPT:
 	@echo "$(LOG_PREFIX) Running $(SIGN_SCRIPT) ( $(BUILD_DIR) )"
@@ -335,6 +347,7 @@ help:
 	@echo "\n Main targets (Golang only):"
 	@echo "$(LOG_PREFIX) lint"
 	@echo "$(LOG_PREFIX) format"
+	@echo "$(LOG_PREFIX) tidy                       Run go mod tidy in both cliv2 and cliv2-private"
 	@echo "$(LOG_PREFIX) fips"
 	@echo "$(LOG_PREFIX) build"
 	@echo "$(LOG_PREFIX) sign"
@@ -350,5 +363,6 @@ help:
 	@echo "$(LOG_PREFIX) GOARCH                     Specify Architecture to compile for (see golang GOARCH, default=$(GOARCH))"
 	@echo "$(LOG_PREFIX) CLI_V1_VERSION_TAG         Version of the CLIv1 to bundle"
 	@echo "$(LOG_PREFIX) CLI_V1_LOCATION            Filesystem location of CLIv1 binaries to bundle, if specified, CLI_V1_VERSION_TAG is also required"
+	@echo "$(LOG_PREFIX) BUILD_MODE                 Build mode: 'public' (default) or 'private' (auto-detected based on access)"
 	@echo "$(LOG_PREFIX) prefix                     Installation prefix (default=$(prefix))"
 	@echo "$(LOG_PREFIX) DESTDIR                    For staged installations"

--- a/cliv2/cmd/cliv2/main.go
+++ b/cliv2/cmd/cliv2/main.go
@@ -6,6 +6,9 @@ import (
 	"github.com/snyk/cli/cliv2/pkg/core"
 )
 
+// main is the entry point for the CLI application.
+// * To register public workflows, see pkg/core/workflows.go
+// * To register private workflows, see /cliv2-private/cmd/cliv2/main.go
 func main() {
 	os.Exit(core.Run())
 }

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -16,17 +16,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
-	"github.com/snyk/cli-extension-agent-scan/pkg/agentscan"
-	"github.com/snyk/cli-extension-ai-bom/pkg/aibom"
-	"github.com/snyk/cli-extension-ai-redteam/pkg/redteam"
-	"github.com/snyk/cli-extension-dep-graph/pkg/depgraph"
-	"github.com/snyk/cli-extension-iac-rules/iacrules"
-	"github.com/snyk/cli-extension-iac/pkg/iac"
-	"github.com/snyk/cli-extension-os-flows/pkg/osflows"
-	"github.com/snyk/cli-extension-sbom/pkg/sbom"
-	"github.com/snyk/cli-extension-secrets/pkg/secrets"
-	"github.com/snyk/code-client-go/pkg/code"
-	"github.com/snyk/container-cli/pkg/container"
 	"github.com/snyk/error-catalog-golang-public/cli"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -49,12 +38,6 @@ import (
 	"github.com/snyk/go-application-framework/pkg/local_workflows/config_utils"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/network_utils"
 
-	"github.com/snyk/go-httpauth/pkg/httpauth"
-	"github.com/snyk/snyk-iac-capture/pkg/capture"
-
-	workflows "github.com/snyk/go-application-framework/pkg/local_workflows/connectivity_check_extension"
-
-	ignoreworkflow "github.com/snyk/go-application-framework/pkg/local_workflows/ignore_workflow"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/output_workflow"
 	"github.com/snyk/go-application-framework/pkg/networking"
 	"github.com/snyk/go-application-framework/pkg/networking/middleware"
@@ -62,9 +45,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/ui"
 	"github.com/snyk/go-application-framework/pkg/utils"
 	"github.com/snyk/go-application-framework/pkg/workflow"
-
-	snykls "github.com/snyk/snyk-ls/ls_extension"
-	"github.com/snyk/studio-mcp/pkg/mcp"
+	"github.com/snyk/go-httpauth/pkg/httpauth"
 
 	cli_errors "github.com/snyk/cli/cliv2/internal/errors"
 	"github.com/snyk/cli/cliv2/pkg/basic_workflows"
@@ -478,35 +459,6 @@ func displayError(err error, userInterface ui.UserInterface, config configuratio
 				globalLogger.Err(uiError).Msg("ui failed to show error")
 			}
 		}
-	}
-}
-
-func initExtensions(engine workflow.Engine, config configuration.Configuration, additionalExts []workflow.ExtensionInit) {
-	engine.AddExtensionInitializer(basic_workflows.Init)
-	engine.AddExtensionInitializer(osflows.Init)
-	engine.AddExtensionInitializer(iac.Init)
-	engine.AddExtensionInitializer(sbom.Init)
-	engine.AddExtensionInitializer(aibom.Init)
-	engine.AddExtensionInitializer(redteam.Init)
-	engine.AddExtensionInitializer(depgraph.Init)
-	engine.AddExtensionInitializer(capture.Init)
-	engine.AddExtensionInitializer(iacrules.Init)
-	engine.AddExtensionInitializer(snykls.Init)
-	engine.AddExtensionInitializer(mcp.Init)
-	engine.AddExtensionInitializer(container.Init)
-	engine.AddExtensionInitializer(code.Init)
-	engine.AddExtensionInitializer(workflows.InitConnectivityCheckWorkflow)
-	engine.AddExtensionInitializer(ignoreworkflow.InitIgnoreWorkflows)
-	engine.AddExtensionInitializer(agentscan.Init)
-	engine.AddExtensionInitializer(secrets.Init)
-
-	// Register additional extensions injected via Run(WithAdditionalExtensions(...))
-	for _, ext := range additionalExts {
-		engine.AddExtensionInitializer(ext)
-	}
-
-	if config.GetBool(configuration.PREVIEW_FEATURES_ENABLED) {
-		config.Set("INTERNAL_USE_UFM_PRESENTER", true)
 	}
 }
 

--- a/cliv2/pkg/core/workflows.go
+++ b/cliv2/pkg/core/workflows.go
@@ -1,0 +1,53 @@
+package core
+
+import (
+	"github.com/snyk/cli-extension-agent-scan/pkg/agentscan"
+	"github.com/snyk/cli-extension-ai-bom/pkg/aibom"
+	"github.com/snyk/cli-extension-ai-redteam/pkg/redteam"
+	"github.com/snyk/cli-extension-dep-graph/pkg/depgraph"
+	"github.com/snyk/cli-extension-iac-rules/iacrules"
+	"github.com/snyk/cli-extension-iac/pkg/iac"
+	"github.com/snyk/cli-extension-os-flows/pkg/osflows"
+	"github.com/snyk/cli-extension-sbom/pkg/sbom"
+	"github.com/snyk/cli-extension-secrets/pkg/secrets"
+	"github.com/snyk/code-client-go/pkg/code"
+	"github.com/snyk/container-cli/pkg/container"
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/connectivity_check_extension"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/ignore_workflow"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+	"github.com/snyk/snyk-iac-capture/pkg/capture"
+	"github.com/snyk/snyk-ls/ls_extension"
+	"github.com/snyk/studio-mcp/pkg/mcp"
+
+	"github.com/snyk/cli/cliv2/pkg/basic_workflows"
+)
+
+func initExtensions(engine workflow.Engine, config configuration.Configuration, additionalExts []workflow.ExtensionInit) {
+	engine.AddExtensionInitializer(basic_workflows.Init)
+	engine.AddExtensionInitializer(osflows.Init)
+	engine.AddExtensionInitializer(iac.Init)
+	engine.AddExtensionInitializer(sbom.Init)
+	engine.AddExtensionInitializer(aibom.Init)
+	engine.AddExtensionInitializer(redteam.Init)
+	engine.AddExtensionInitializer(depgraph.Init)
+	engine.AddExtensionInitializer(capture.Init)
+	engine.AddExtensionInitializer(iacrules.Init)
+	engine.AddExtensionInitializer(ls_extension.Init)
+	engine.AddExtensionInitializer(mcp.Init)
+	engine.AddExtensionInitializer(container.Init)
+	engine.AddExtensionInitializer(code.Init)
+	engine.AddExtensionInitializer(workflows.InitConnectivityCheckWorkflow)
+	engine.AddExtensionInitializer(ignore_workflow.InitIgnoreWorkflows)
+	engine.AddExtensionInitializer(agentscan.Init)
+	engine.AddExtensionInitializer(secrets.Init)
+
+	// Register additional extensions injected via Run(WithAdditionalExtensions(...))
+	for _, ext := range additionalExts {
+		engine.AddExtensionInitializer(ext)
+	}
+
+	if config.GetBool(configuration.PREVIEW_FEATURES_ENABLED) {
+		config.Set("INTERNAL_USE_UFM_PRESENTER", true)
+	}
+}

--- a/release-scripts/next-version.sh
+++ b/release-scripts/next-version.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 # Checks the latest version of Snyk CLI on npm and decides the next version.
 # Only output the next version to stdout. All other output should go to stderr.
+#
+# Environment variables:
+#   BUILD_MODE - "public" or "private" (default: "private")
+#                Public builds get an "-oss" suffix appended to the version.
 
 NEXT_VERSION="$(convco version --bump)"
 CURRENT_TAG="$(git describe --tags `git rev-list --tags --max-count=1`)"
@@ -22,7 +26,21 @@ fi
 
 NEXT_VERSION="${NEXT_VERSION}${postfix}"
 
+# Append oss suffix for public/OSS builds
+# - For stable versions (no pre-release): use "-oss" to create a pre-release
+# - For pre-release versions: use ".oss" to add another identifier
+if [ "${BUILD_MODE:-}" == "public" ]; then
+  if [[ "$NEXT_VERSION" == *-* ]]; then
+    # Already has pre-release, append as dot-separated identifier
+    NEXT_VERSION="${NEXT_VERSION}.oss"
+  else
+    # Stable version, start pre-release with hyphen
+    NEXT_VERSION="${NEXT_VERSION}-oss"
+  fi
+fi
+
 echo "Current version: ${CURRENT_TAG/v/}" 1>&2
 echo "Next version:    ${NEXT_VERSION}" 1>&2
+echo "Build mode:      ${BUILD_MODE:-private}" 1>&2
 
 echo "${NEXT_VERSION}"

--- a/scripts/upgrade-snyk-go-dependencies.go
+++ b/scripts/upgrade-snyk-go-dependencies.go
@@ -91,9 +91,9 @@ func upgradeGoMod(name, commitSHA string) error {
 		return err
 	}
 
-	fmt.Println("🧹 Running go mod tidy...")
-	cmd = exec.Command("go", "mod", "tidy")
-	cmd.Dir = "./cliv2"
+	fmt.Println("🧹 Running make tidy...")
+	cmd = exec.Command("make", "tidy")
+	cmd.Dir = "."
 	if err := cmd.Run(); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Improves developer experience around public vs private CLI builds:

1. **Version differentiation**: Public/OSS builds now include an `-oss` suffix in the version number (e.g., `1.1234.0-oss`) to clearly distinguish them from private builds. The suffix is semver-compliant.

2. **Centralized BUILD_MODE detection**: The root Makefile now auto-detects whether to build public or private based on access to `cliv2-private`. This is passed through to [next-version.sh](cci:7://file:///Users/peterschafer/Documents/dev/cli/cli/release-scripts/next-version.sh:0:0-0:0) and [cliv2/Makefile](cci:7://file:///Users/peterschafer/Documents/dev/cli/cli/cliv2/Makefile:0:0-0:0).

3. **`make tidy` convenience target**: Added a `make tidy` command that runs `go mod tidy` in both the public (`cliv2`) and private (`cliv2-private`) modules.

4. **Documentation**: Updated CONTRIBUTING.md with guidance on public vs private builds.

## Where should the reviewer start?

- [release-scripts/next-version.sh](cci:7://file:///Users/peterschafer/Documents/dev/cli/cli/release-scripts/next-version.sh:0:0-0:0) - version suffix logic
- [Makefile](cci:7://file:///Users/peterschafer/Documents/dev/cli/cli/Makefile:0:0-0:0) - BUILD_MODE detection and tidy target
- [CONTRIBUTING.md](cci:7://file:///Users/peterschafer/Documents/dev/cli/cli/CONTRIBUTING.md:0:0-0:0) - documentation updates

## How should this be manually tested?

```sh
# Test public build version
rm binary-releases/version
make binary-releases/version BUILD_MODE=public
# Should output something like: 1.1306.0-oss or 1.1306.0-dev.abc123.oss

# Test private build version  
rm binary-releases/version
make binary-releases/version BUILD_MODE=private
# Should output: 1.1306.0 or 1.1306.0-dev.abc123

# Test make tidy
make tidy