### PR TITLE
chore(language-server): integrate LS

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -220,7 +220,7 @@ require (
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
-	github.com/snyk/snyk-ls v0.0.0-20260529103026-b999aa3e3447 // indirect
+	github.com/snyk/snyk-ls v0.0.0-20260615092228-ad265b63c4d1 // indirect
 	github.com/snyk/studio-mcp v1.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -597,8 +597,8 @@ github.com/snyk/remy-cli-extension v1.15.1-0.20260612100621-e413ec9dadef h1:rXUM
 github.com/snyk/remy-cli-extension v1.15.1-0.20260612100621-e413ec9dadef/go.mod h1:ps0TXsNLxFYGFUj+63Py3Djf0hSq7eAMR7dKn+cUL30=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260529103026-b999aa3e3447 h1:/i1g1NrQlGoXObznpV34e8fJZUoIz6MvdSBA/31b/w8=
-github.com/snyk/snyk-ls v0.0.0-20260529103026-b999aa3e3447/go.mod h1:BMlsv1iD7iO+fJYnIUIbBB/XqBNjBFgm5EX8UdGpfe8=
+github.com/snyk/snyk-ls v0.0.0-20260615092228-ad265b63c4d1 h1:ACWySN/zVhzcIOqUsksiZR72XQiK/AxqX3AJ/EocTGo=
+github.com/snyk/snyk-ls v0.0.0-20260615092228-ad265b63c4d1/go.mod h1:QBytkxUN7uy47X2QhjcWmQ4WEwYksrn2Kqs1dfCBBR8=
 github.com/snyk/studio-mcp v1.11.0 h1:WfvWqqHu5+Stb/y+LTVdWWiazc0i4BapxqMCJyGRArA=
 github.com/snyk/studio-mcp v1.11.0/go.mod h1:CiMKFs/PJrAMjG8Zjkvx+XwuM0XlxGJ7jP5yCr5hm5w=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/snyk/go-application-framework v0.3.2
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20260529103026-b999aa3e3447
+	github.com/snyk/snyk-ls v0.0.0-20260615092228-ad265b63c4d1
 	github.com/snyk/studio-mcp v1.11.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -571,8 +571,8 @@ github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhk
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260529103026-b999aa3e3447 h1:/i1g1NrQlGoXObznpV34e8fJZUoIz6MvdSBA/31b/w8=
-github.com/snyk/snyk-ls v0.0.0-20260529103026-b999aa3e3447/go.mod h1:BMlsv1iD7iO+fJYnIUIbBB/XqBNjBFgm5EX8UdGpfe8=
+github.com/snyk/snyk-ls v0.0.0-20260615092228-ad265b63c4d1 h1:ACWySN/zVhzcIOqUsksiZR72XQiK/AxqX3AJ/EocTGo=
+github.com/snyk/snyk-ls v0.0.0-20260615092228-ad265b63c4d1/go.mod h1:QBytkxUN7uy47X2QhjcWmQ4WEwYksrn2Kqs1dfCBBR8=
 github.com/snyk/studio-mcp v1.11.0 h1:WfvWqqHu5+Stb/y+LTVdWWiazc0i4BapxqMCJyGRArA=
 github.com/snyk/studio-mcp v1.11.0/go.mod h1:CiMKFs/PJrAMjG8Zjkvx+XwuM0XlxGJ7jP5yCr5hm5w=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit ad265b63c4d1856c8d5dad0d00c746bfd449c7fe
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Mon Jun 15 10:22:28 2026 +0100

    chore: pre-commit hook to log in to ggshield (#1339)
    
    Before the hook would just fail, now it brings up the browser to log in if you aren't logged in.

M	.pre-commit-config.yaml

commit 365a6ea989f6fb993770d95ba8251433943d79bf
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Thu Jun 11 16:38:15 2026 +0100

    refactor: panic on feature flag access without ConfigResolver [IDE-1974] (#1337)
    
    Remove silent false/no-op when FolderConfig has no ConfigResolver in
    GetFeatureFlag and SetFeatureFlag. Wire ConfigResolver in tests that
    were constructing incomplete FolderConfigs and not exercising flag reads.
    
    ---------
    
    Co-authored-by: Cursor <cursoragent@cursor.com>

M	domain/ide/command/logout_test.go
M	domain/scanstates/summary_html_external_test.go
M	infrastructure/configuration/config_html_test.go
M	infrastructure/oss/oss_test.go
M	internal/types/folder_config.go
M	internal/types/folder_config_test.go

commit 6fe1f35b3a04722852525c8ad5876efde32d2a5c
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Wed Jun 10 15:53:51 2026 +0200

    fix: remove "Closed Beta" label from Snyk Secrets setting [IDE-2116] (#1335)
    
    Remove the deprecated-label span from Snyk Secrets UI entries in the
    settings dialog template and generated fixture. Feature flag gates remain
    intact — this is a UI text change only.

M	infrastructure/configuration/template/config.html
M	scripts/config-dialog/config_output_multi_project.html

commit 1e36594778bd1b763baf586b6cae2cacd4d6e1ef
Author: nick-y-snyk <nikita.yasnohorodskyi@snyk.io>
Date:   Wed Jun 10 13:48:19 2026 +0200

    fix(treeview): use folder-level IssueViewOptions for info node message [IDE-2123] (#1334)
    
    * chore: bump GAF to v0.3.1 to fix concurrent map race [IDE-1988]
    
    v0.3.1 adds a mutex to AddExtension and clones the extension map before
    serialization, fixing the fatal concurrent map writes that caused
    smoke-race and race-test failures in CI.
    
    * fix(treeview): use folder-level IssueViewOptions for info node message [IDE-2123]
    
    The "Open and Ignored issues are disabled!" info node read from a
    builder-wide global field (b.issueViewOptions) set once from global
    config. Folder-level overrides were ignored, so the message contradicted
    the visible issue list which already filtered correctly per-folder.
    
    Expose IssueViewOptions() on the Folder interface (matching the existing
    IsDeltaFindingsEnabled/DisplayableIssueTypes pattern), delegating to the
    already-correct IssueViewOptionsForFolder resolver. Use it in BuildTree
    instead of the global field. Remove the now-dead SetIssueViewOptions
    setter and issueViewOptions field from TreeBuilder.
    
    * chore: update go.sum [IDE-2123]
    
    * revert: undo go.sum change from wrong branch [IDE-2123]
    
    * test(treeview): exercise IVO branch with SnykCodeConsistentIgnores flag [IDE-2123]
    
    TestTreeScanStateEmitter_FolderLevelIssueViewOptions passed vacuously
    because the fake feature flag service had SnykCodeConsistentIgnores=false,
    causing zeroIssuesText to early-return before reaching the IVO branch.
    
    Add SetupWorkspaceWithFeatureFlags to workspaceutil so tests can inject
    a pre-configured FakeFeatureFlagService into folder creation. The test
    now overrides SnykCodeConsistentIgnores=true so the IVO branch is
    actually exercised and the regression is caught.
    
    * refactor(treeview): document global/folder IVO split and dedupe FolderConfigReadOnly call [IDE-2123]
    
    FilterState intentionally uses global IVO (filter panel = workspace-wide);
    per-folder info nodes use folder-level IVO via BuildTree. Add comments
    documenting this policy in tree_scan_emitter.go and toggle_tree_filter.go.
    
    Extract FolderConfigReadOnly() call in tree_builder.go to avoid calling
    it twice per folder (was called once via f.IssueViewOptions() and again
    explicitly for ConsistentIgnoresEnabled).
    
    * refactor(treeview): dedupe FolderConfigReadOnly via *FromConfig interface methods [IDE-2123]
    
    Add IssueViewOptionsFromConfig, IsDeltaFindingsEnabledFromConfig, and
    DisplayableIssueTypesFromConfig to the Folder interface and implement
    them on *Folder, each delegating to the existing private *ForFolder
    helper. Update tree_builder.go BuildTree to call FolderConfigReadOnly()
    once per folder and thread the result through all three field assignments.
    
    * test(treeview,workspace): strengthen IVO assertions and add IssueViewOptions unit tests [IDE-2123]
    
    Make the NotContains assertion non-vacuous by also asserting a positive
    marker (congrats text) in TestTreeScanStateEmitter_FolderLevelIssueViewOptions.
    Add sibling test asserting the disabled message DOES appear when global
    IVO is disabled with no folder override.
    
    Add TestFolder_IssueViewOptions covering nil-cfg fallback, global-only,
    and folder-level override cases for the new IssueViewOptions() method.

M	domain/ide/command/toggle_tree_filter.go
M	domain/ide/treeview/tree_builder.go
M	domain/ide/treeview/tree_scan_emitter.go
M	domain/ide/treeview/tree_scan_emitter_test.go
M	domain/ide/workspace/folder.go
M	domain/ide/workspace/folder_test.go
M	go.sum
M	internal/testutil/workspaceutil/workspace.go
M	internal/types/mock_types/workspace_mock.go
M	internal/types/workspace.go

commit 1c2bfc07627998e5e21089ebd79ee2950b05db44
Author: nick-y-snyk <nikita.yasnohorodskyi@snyk.io>
Date:   Tue Jun 9 14:31:36 2026 +0200

    feat: block unauthenticated Snyk API requests via GAF middleware [IDE-1988] (#1333)
    
    * feat: block unauthenticated Snyk API requests via GAF middleware [IDE-1988]
    
    Bumps GAF to v0.3.0 which includes the opt-in auth-header middleware.
    Enables STOP_REQUESTS_WITHOUT_AUTH so requests to Snyk API URLs without
    an Authorization header are intercepted with a synthetic 401 in-memory —
    no wire call, no latency, no log spam during unauthenticated sessions.
    
    * chore: bump GAF to v0.3.1 to fix concurrent map race [IDE-1988]
    
    v0.3.1 adds a mutex to AddExtension and clones the extension map before
    serialization, fixing the fatal concurrent map writes that caused
    smoke-race and race-test failures in CI.

M	application/di/init.go
M	go.mod
M	go.sum

commit de433876ec53634f43ddb358ec3ab42c6d8ea0cf
Author: mikeromard <146881896+mikeromard@users.noreply.github.com>
Date:   Mon Jun 8 08:55:57 2026 -0300

    Updated docs path in compatibility matrix automation (#1291)
    
    Co-authored-by: Bastian Doetsch <bastian.doetsch@snyk.io>

M	.github/workflows/update-compatibility-matrix.yaml

commit f504abef40660d14424f7b02447e60d742ca8393
Author: Knut Funkel <knut.funkel@snyk.io>
Date:   Mon Jun 8 14:34:46 2026 +0300

    fix: correct env var typo SNYK_DEBUG_LEVEL to SNYK_LOG_LEVEL in README [IDE-2066] (#1322)
    
    The README referenced a made-up env var SNYK_DEBUG_LEVEL. The actual
    env var read by application/config/config.go for setting log level is
    SNYK_LOG_LEVEL. Fixes the docs so the example works.

M	README.md

commit 96778c90f0d420f9178b127babcc564ce8eef7e6
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Wed Jun 3 17:46:08 2026 +0200

    fix: eliminate data race in fflags.LoadFeatureFlags() [IDE-2103] (#1318)
    
    Replace the unprotected package-level write with sync.Once memoisation.
    Extract parseFeatureFlags for testability. Return a per-call shallow copy
    so callers cannot mutate cached state. Rename errOnce → errCached to
    satisfy the errname linter. Add invariant comment on the shallow copy.
    Make TestLoadFeatureFlags_concurrent reset package state so it exercises
    the once.Do init path in any test-run order.

M	.gitignore
M	internal/fflags/features.go
M	internal/fflags/features_test.go

commit c4bf185229e083660016924d10e3dda0f4b13fc7
Author: Knut Funkel <knut.funkel@snyk.io>
Date:   Wed Jun 3 18:10:55 2026 +0300

    fix(treeview): pair hover background and foreground for readability [IDE-2078] (#1314)
    
    * test(treeview): assert hover row sets both background and color [IDE-2078]
    
    Add TestTreeHtmlRenderer_TreeHoverRow_PairsBackgroundAndForeground which
    asserts the rendered HTML defines --list-hover-foreground and that the
    .tree-node-row:hover rule block sets both background-color and color.
    Test intentionally fails until the CSS fix lands in Checkpoint 2.
    
    * fix(treeview): pair hover background and foreground via theme variables [IDE-2078]
    
    Add --list-hover-foreground to :root, sourced from --vscode-list-hoverForeground
    with a fallback to --list-active-selection-foreground. Apply it alongside
    background-color in .tree-node-row:hover plus an outline using --focus-border.
    
    The two redundant .tree-node-issue .tree-node-row:hover and
    .tree-node-location .tree-node-row:hover rules were deleted: they only
    repeated the same background-color as the base .tree-node-row:hover and
    added nothing unique. Deleting them keeps the base rule as the single
    source of truth. Specificity is unchanged — issue and location rows are
    still matched by the base selector — and any IDE-injected rule via
    ${ideStyle} still overrides at the same specificity as before.
    
    * docs(requirements): capture tree-hover readability requirements [IDE-2078]
    
    Append four atomic requirements for IDE-2078 covering: paired bg/fg via
    theme variables, active-selection fallback, no hard-coded colours, and
    correctness under IDE-injected ${ideStyle} overrides.
    
    * fix(treeview): spell color (en-US) in IDE-2078 test comment
    
    Lint (misspell) flagged "colour" as a misspelling of "color".
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * test(treeview): drop hover assertion test [IDE-2078]
    
    The assert.Contains on "color" was already satisfied by "background-color"
    in the same CSS block, so it could not detect a missing color: property
    — flagged in review by @bastiandoetsch and @rrama as not load-bearing.
    The CSS change in 3079ba1a stands on its own.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * fix(treeview): tighten hover styles per review [IDE-2078]
    
    Three small adjustments to the hover styling, all from PR #1314 review:
    
    - .tree-node-row-info:hover now also resets color to inherit so info
      rows stay fully inert on hover (background was already neutralised).
    - Drop the outline / outline-offset from .tree-node-row:hover. The
      background + foreground pair already signals hover; --focus-border
      is the focus-ring token and using it for pointer hover conflated
      two interaction states.
    - --list-active-selection-foreground fallback #0066cc -> inherit so
      hover/selected text inherits the body colour in a plain browser
      (no IDE injection), aligning with the "no hard-coded colour values"
      requirement.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    ---------
    
    Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

M	docs/requirements/requirements.md
M	domain/ide/treeview/template/styles.css

commit ffc06a9fa2501937ccbe9c4479667937722329a3
Author: Knut Funkel <knut.funkel@snyk.io>
Date:   Wed Jun 3 13:33:47 2026 +0300

    feat(folder): emit failure analytics for failed scans [IDE-1668] (#1308)
    
    * feat(folder): emit failure analytics for failed scans [IDE-1668]
    
    Previously, when a scan returned an error, snyk-ls dropped the analytics
    emission entirely:
    
    - ProcessResults short-circuited via sendScanError before sendAnalytics ran
    - sendAnalytics had its own data.Err != nil early-return guard
    - The Status field was hardcoded to gafanalytics.Success
    
    The "Is Snyk OK?" Datadog dashboard's IDE panel filters on
    @analytics-service.interaction.status:failure @analytics-service.runtime.application.name:snyk-ls
    and was empty in production despite real scan failures.
    
    This change:
    
    - Calls sendAnalytics from the error branch of ProcessResults, with the same
      reference-baseline guard the success path uses.
    - Removes the data.Err early-return in sendAnalytics.
    - Derives Status from data.Err — Failure when set, Success otherwise.
    - Adds two extension fields on failure events:
        error_category — Snyk error catalog prefix (e.g. "SNYK-CLI") for
                         low-cardinality dashboard rollups; "unknown" for
                         non-catalog errors.
        error_code     — full catalog code (e.g. "SNYK-CLI-0008") for
                         drill-downs.
    
    New helpers categorizeError and errorCode use the snyk_errors package from
    github.com/snyk/error-catalog-golang-public, already imported in three
    other snyk-ls call sites.
    
    Raw err.Error() strings are never passed to analytics fields — only stable
    catalog identifiers, to keep events free of file paths, repo URLs, and
    other PII.
    
    RFC: https://snyksec.atlassian.net/wiki/spaces/IDE/pages/4827676673/RFC+Emit+Errors+from+Snyk+Language+Server
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * fix(analytics): address review feedback on failure analytics [IDE-1668]
    
    - Gate failure analytics on IsNonFailingScanError so auth-not-set and
      "product disabled" outcomes don't inflate the failure rate.
    - Drop the inverted reference-scan guard in the error branch; rely on
      the SendAnalytics:false short-circuit in sendAnalytics.
    - Skip emission entirely for context.Canceled / DeadlineExceeded so
      routine cancellations don't count as either status.
    - Default zero TimestampFinished to time.Now().UTC() so the failure
      path never emits a negative epoch.
    - Route pre-scan-command failures through processResults so the
      scan-blocking failure surfaces on the "Is Snyk OK?" dashboard.
    - Consolidate categorizeError/errorCode into classifyError; harden
      catalog-code split against trailing-dash codes like "SNYK-".
    - Add RequireNeverReceive helper + replace sleep-based negative
      assertions; add coverage for non-failing errors and cancellation.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * fix(analytics): drop sendAnalytics complexity + spell canceled [IDE-1668]
    
    - Extract isCancellationError helper into analytics_errors.go to bring
      sendAnalytics cyclomatic complexity back under the 15 threshold.
    - Spell "canceled" (one L) — matches the Go stdlib (context.Canceled)
      and the misspell linter.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * chore: drop IDE-1668 prefix from code comments [IDE-1668]
    
    Reviewer feedback — ticket ids belong in commits/PRs, not code comments.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * refactor(analytics): consolidate emit policy + explicit pre-scan SendError [IDE-1668]
    
    Address PR #1308 review feedback:
    
    - Add shouldEmitAnalytics() predicate covering SendAnalytics, empty Product,
      IsNonFailingScanError, and cancellation. Both ProcessResults call sites gate
      the goroutine spawn on the predicate; duplicate guards inside sendAnalytics
      are removed (callers must gate).
    - Restore explicit sc.scanNotifier.SendError on the pre-scan-command failure
      path so the user notification doesn't depend on the ScanResultProcessor
      implementation. Add ScanData.UserNotified so sendScanError skips its own
      SendError when the caller has already notified.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * fix(lint): spell canceled per misspell linter [IDE-1668]
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * fix(analytics): address PR #1308 round 2 review feedback [IDE-1668]
    
    - ProcessResults skips sendScanError entirely when UserNotified is set so
      pre-scan-command failures no longer fire an unexpected SendErrorDiagnostic
      (red squiggle). Restores pre-PR behavior; sendScanError reverts to its
      single 2-arg form. Adds regression test asserting ErrorCalls=0 and
      SendErrorDiagnosticCount=0 while analytics still emit.
    - scanner.go records preScanStart and emits Duration on the failure ScanData
      so pre-scan-command failures no longer carry durationMs:0.
    - Replace brittle assert.NotContains(payload, "\"timestampMs\":-") with
      JSON-parse + assert.Positive on data.attributes.interaction.timestamp_ms;
      the prior camelCase substring was vacuous against the snake_case GAF schema.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * fix(lint): spell serializes per misspell linter [IDE-1668]
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    ---------
    
    Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

A	domain/ide/workspace/analytics_errors.go
A	domain/ide/workspace/analytics_errors_test.go
M	domain/ide/workspace/folder.go
A	domain/ide/workspace/folder_failure_analytics_test.go
M	domain/snyk/scanner/scanner.go
M	internal/testsupport/channels.go
M	internal/types/scan.go

commit 9ab8e15096d2b99b20c3d27ffb3a22bc586b995a
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Wed Jun 3 10:32:59 2026 +0200

    test: add TDD contract tests for context-based DI injection [IDE-1898] (#1303)
    
    * test(server): add TDD contract tests for context-based DI injection [IDE-1898]
    
    Add di_context_injection_test.go proving that handler functions read
    dependencies from context (via withContext middleware) rather than from
    di.*() global accessors. Tests cover:
    
    - Test_withContext_injectsHoverService_isolatedFromGlobal: uses two
      distinct sentinels — one in the di global, one in deps — to prove
      the handler reads from the context-injected value, not the global.
    - Test_withContext_injectsNewHandlerDependencies: verifies HoverService,
      ScanPersister, and ErrorReporter are injected by withContext with
      assert.Equal identity checks on each field.
    
    * fix(test): update DI contract tests to compile after rebase onto main [IDE-1898]
    
    - Rename sentinelHoverService → diTestHoverService to avoid redeclaration
      with the same type in server_test.go (both are in package server)
    - Add nil *jrpc2.Server arg to withContext calls; signature gained this param
      in the squash-merged IDE-1898 DI refactor (srv is nil-guarded in production)
    - Use di.TestInit(nil) to prime global DI state so validateMandatoryDeps
      inside withContext passes, then override the three fields under test on the
      returned struct copy — proves context injection uses the deps struct, not
      the di package globals (the core guarantee of IDE-1898)
    - Add diTestScanPersister pointer stub and use assert.Same throughout so
      assertions verify reference identity, not just value equality

A	application/server/di_context_injection_test.go

commit 375752803cb8b27e8e050167a65142e46dd5da33
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Tue Jun 2 08:46:15 2026 +0200

    fix: save settings on panel close when text field or combo box is focused [IDE-1992] (#1294)
    
    fix: save settings on close [IDE-1992]
    
    fix(config): apply PR review cleanups to save-on-close [IDE-1992]
    
    - auto-save.js: call formState.triggerChangeHandlers() directly instead of
      active.blur(), removing the element-type allow-list (per @nick-y-snyk).
      SELECT values are read live by collectChangedData(), so no blur is needed.
    - app.js: route the visibilitychange listener through the dom.addEvent
      compatibility wrapper instead of document.addEventListener directly.
    - regenerate config_output_*.html fixtures to match the templates.
    
    docs(requirements): clarify IDE-1992 reqs — remove contradiction, scope per IDE flow [IDE-1992]
    
    Reqs 1 and 3 previously contradicted each other: Req 1 used "closing"
    broadly (which includes Cancel/X) while Req 3 said Cancel/X must not
    save. Fix resolves this by scoping each requirement explicitly:
    
    - Req 1: scoped to auto-save IDEs (VS Code) — panel hidden/closed by IDE
    - Req 2: scoped to OK/Cancel IDEs (IntelliJ, Eclipse, Visual Studio)
    - Req 3: adds Escape key, clarifies it is handled natively by the IDE
      dialog container, not the webview
    - Req 4: replaced blanket "all IDEs" with per-scope delegation to avoid
      contradiction with the now-scoped Reqs 1 and 3
    - Req 6: expanded to cover auto-save-on-hide alongside save-on-OK and
      cancel-discard, matching the dual-mode fallback implementation
    
    Also removes "checkbox" from the input control parenthetical in Reqs 1
    and 2 — checkboxes are intentionally excluded from the blur-before-commit
    guard because they commit on change, not blur.
    
    docs: add requirements from IDE-1992 (#1298)
    
    * docs: capture requirements for IDE-1992
    
    User-facing acceptance criteria for the HTML settings panel focus-loss
    bug and fallback HTML distribution automation.
    
    * docs: scope settings requirements to all surfaces, clarify distribution scope [IDE-1992]
    
    Requirements 1-3 apply to both the LS-served and fallback HTML settings
    panels. Added parenthetical on req 5 explaining why distribution is
    fallback-only: the LS-served panel ships with the LS binary, not as a
    separately bundled artifact.
    
    fix(settings): extend blur-before-save to SELECT elements [IDE-1992]
    
    JCEF (IntelliJ/Eclipse) native dropdowns update el.value without firing
    a change event before the IDE calls the OK button's Java bridge. Because
    SELECT elements were excluded from the blur-before-collect guard, the
    pending selection was silently dropped on the getAndSaveIdeConfig() call.
    
    Fix adds SELECT to the tagName check in both auto-save.js (LS-served
    config page) and settings-fallback.html (already merged via rebase
    conflict resolution). Blurring a SELECT does not trigger the change
    listener wired in form-state.js, but collectChangedData() reads el.value
    directly, so the pending change is captured without needing the event.
    
    Also strengthens the two existing SELECT test assertions from !==undefined
    to strict boolean equality, and adds SELECT regression tests to the
    fallback test suite (cli_release_channel). All 111 JS tests pass.
    
    fix(settings): exclude hidden, read-only, and disabled inputs from blur-before-save [IDE-1992]
    
    The active-element blur filter already excluded checkboxes, radios, and
    buttons. Extend it to also skip type=hidden inputs and read-only/disabled
    fields — these cannot hold uncommitted user input, so blurring them adds
    unnecessary overhead on the save path.
    
    fix(settings): save on panel close when text field is still focused [IDE-1992]
    
    Closing the VS Code settings webview without first clicking away from a
    text input never fires the blur event, so the typed value is silently
    discarded. Fix adds two complementary mechanisms:
    
    1. visibilitychange listener – when the panel hides and auto-save is
       enabled, calls getAndSaveIdeConfig() so the save happens regardless
       of blur.
    
    2. blur-before-collect – getAndSaveIdeConfig() explicitly blurs the
       focused text input before reading form values, ensuring the value is
       committed on the non-auto-save OK-button path as well.
    
    A _isSaving re-entrance guard prevents the blur event from recursively
    triggering a second save. Both the LS-served config page (auto-save.js /
    app.js) and the standalone fallback (settings-fallback.html) receive the
    same treatment. Regression tests cover all three ticket cases for both
    code paths (86 JS tests total, all passing).

M	docs/requirements/requirements.md
M	infrastructure/configuration/template/js/app.js
M	infrastructure/configuration/template/js/features/auto-save.js
M	js-tests/helpers.mjs
A	js-tests/visibility-change-save-fallback.test.mjs
A	js-tests/visibility-change-save.test.mjs
M	scripts/config-dialog/config_output_multi_project.html
M	scripts/config-dialog/config_output_no_projects.html
M	scripts/config-dialog/config_output_single_solution.html
M	shared_ide_resources/ui/html/settings-fallback.html

commit 4f1f50a8bf9203fdd3320495727595c7dee91ff1
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Mon Jun 1 23:02:34 2026 +0100

    fix(ci): use SSH for private repos (#1315)
    
    Plus some other script improvements while I (the AI) was at it.

M	.github/create-cli-pr.sh

commit 24ddc5230ba5ca00165453a024d91ffb55d3df83
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Mon Jun 1 22:39:21 2026 +0100

    fix: Go 1.26 & upgrade golang.org/x/net for idna CVE [IDE-2097] (#1317)

M	go.mod
M	go.sum

commit 785365dddef67ec242f900901bb8ea31a804d799
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Mon Jun 1 17:51:44 2026 +0200

    refactor: migrate LSP handler deps from di.*() globals to context injection [IDE-1898] (#1302)
    
    * refactor(di): migrate handler di.*() calls to context injection [IDE-1898]
    
    Replace all di.*() accessor calls in LSP handler functions with
    context-based dependency injection via withContext middleware.
    
    - Expand di.Dependencies struct with Scanner, HoverService,
      ScanNotifier, ScanPersister, FileWatcher, ErrorReporter,
      CodeActionService, and FeatureFlagService fields
    - Update withContext to inject all deps into handler context
    - Add DepHoverService/DepFileWatcher/DepCodeActionService/
      DepFeatureFlagService constants to internal/context/context.go
    - Typed context helpers (hoverServiceFromContext, etc.) in server.go
    - Remove all di.*() calls from: server.go, codeaction_handlers.go,
      configuration.go, notification.go
    - Fix nil-safety: command.ApplyEndpointChange/ApplyAuthMethodChange
      now guard against nil authService internally
    - Fix refreshLdxSyncOnTokenChange to use soft-fail context extractors
      instead of panicking must* variants
    - Add nil guard to notifyLockedFieldsRejected for missing notifier
    - Restore logError error-reporter capture with correct Msg() flush
    - Fix misleading registerNotifier log when notifier is nil
    - Fix Test_UpdateSettings_LockedFields_EmitsExactlyOneNotification to
      use local notifier instead of di.Notifier() for test isolation
    - Update tests to inject required deps into context where di.TestInit
      previously set globals
    
    Keeps di.Init(), di.DisposeTreeEmitter(), and di.*() accessors intact
    for non-handler code (setup, lifecycle, non-parallel tests).
    
    TDD contract tests (di_context_injection_test.go) follow in next PR.
    
    (cherry picked from commit 837cd60c35cba9a114a94eff47dbe94a9f5bce61)
    (cherry picked from commit 38fb2f5cba5d4d1f36de3477f0348f0c2d462e56)
    (cherry picked from commit 435fa0747d612c0cbd4a544aeea8c842f5b0610c)
    
    * fix(di): suppress gocyclo lint; remove dead struct fields; add clarifying docs [IDE-1898]
    
    - Add //nolint:gocyclo to withContext (server.go) and TestInit
      (test_init.go): complexity is inherent — one nil-check per dep field
    - Remove Installer and Initializer from di.Dependencies and
      currentDependencies(): neither is injected per-request by withContext;
      global di.Installer()/di.Initializer() accessors remain for startup use
    - Document in Dependencies struct why Installer/Initializer are absent
    - Document in withContext that each new Dependencies field must be
      registered there, and note the data-driven table follow-up
    
    (cherry picked from commit e587cb8f61db9764b975133d3a356260855e2b2c)
    (cherry picked from commit 2a539532c6c4cd01e7ff8b4a5886dabd33166c5c)
    (cherry picked from commit 117986953fcc98d7e71f2902c7f465bdaf1a466b)
    
    * fix(server): address bot review findings on DI context injection [IDE-1898]
    
    - withContext: defensive clone of deps map with accurate comment explaining
      the hypothetical future-jrpc2 scenario it guards against
    - withContext/workspaceDidChangeWorkspaceFoldersHandler: accurate comment
      clarifying deps are injected by withContext if non-nil in DI wiring
    - addWorkspaceFolders: fail-fast guard with per-dep boolean log fields so
      operators can identify which of the 8 mandatory deps is missing
    - ApplyEndpointChange: visible error log when authService is nil post-init;
      previously the nil case was silently ignored
    - add test TestApplyEndpointChange_NilAuthService_LSPInitialized_ReturnsChangedWithoutPanic
    
    (cherry picked from commit 319696ce5fc21d0f920117cdb1455da405fd876f)
    (cherry picked from commit 771cfa657583cfb475ee927fe8fecc4e360b569c)
    (cherry picked from commit 2f3ba298c4fe69f1f6f04668027e297ff2cba1bc)
    
    * test(di): fix stale Installer/Initializer assertions in init_test [IDE-1898]
    
    Installer and Initializer were intentionally removed from di.Dependencies
    (process-lifecycle deps, not per-request). Replace the now-broken struct
    field assertions with direct di.Installer() / di.Initializer() accessor
    checks so the globals are still covered after Init.
    
    (cherry picked from commit 54c484ee620108b84d146c1d084e46dc8a71a6a3)
    (cherry picked from commit e170cbbe264497884e6b08ff448686853c6df406)
    (cherry picked from commit 78eef699a88e452525f8202de1da778f7ad402ca)
    (cherry picked from commit 59bc4a4796c92e4d191156d4592ffa02d7ae4e2e)
    
    * fix(server): remove unused mustScanNotifierFromContext [IDE-1898]
    
    The function had no call sites after addWorkspaceFolders was refactored
    to the graceful (ok) accessor pattern. Removing it fixes the golangci-lint
    unused diagnostic. Added a comment explaining the no-must-variant convention
    for ScanNotifier to avoid future confusion.
    
    (cherry picked from commit c68044515e38e686f56d35b0a43ef214ea495d02)
    (cherry picked from commit c167932975e15405be7a99c69b26c88583bf7aa1)
    (cherry picked from commit 99a9800a01a899ff722e7e8e9d52dd6e6c2ab5a2)
    (cherry picked from commit 84646ffbc821251d4eff03753420a7ebef9c715c)
    
    * fix: handle missing notifier context dep explicitly in server config [IDE-1898]
    
    Replace `notifier, _ := notifierFromContext(ctx)` patterns in
    InitializeSettings, UpdateSettings, processConfigSettings, and
    refreshLdxSyncOnTokenChange with proper ok-checks that emit a
    Warn-level log when the notifier is absent from context.
    
    Add Test_refreshLdxSyncOnTokenChange_NotifierAbsentFromContext_StillCallsRefresh
    to verify refresh still proceeds (with nil notifier) when notifier is
    missing from context.
    
    Update Test_UpdateSettings/All_settings_are_updated to use di.TestInit
    returned deps instead of di.AuthenticationService() package global accessor.
    
    (cherry picked from commit 05c3c506d3d555428e53db4c06025c43238ac678)
    (cherry picked from commit 7e1358dedfdec54c190a7d18a41e5d0405cf91e5)
    (cherry picked from commit 1f5cf1e2e22ecf72d2a24d635bc75ebd88272fbf)
    (cherry picked from commit 224d767a82149e70e4e3bbcf0b0d353f4a217af7)
    
    * fix: preserve config on nil authService in apply_auth_config [IDE-1898]
    
    ApplyEndpointChange: return false (not `changed`) when authService is
    nil so callers do not treat a skipped logout as a successful change.
    
    ApplyAuthMethodChange: call SetGlobalUser unconditionally so the new
    auth method is persisted across restarts even when authService is nil;
    guard ConfigureProviders behind a nil-check with a Warn log.
    
    (cherry picked from commit 4884de3d72379b785eae57b8121f67cac38fd701)
    (cherry picked from commit 2aad724829a9fb2af553a66a61ad800d9d1bbc0c)
    (cherry picked from commit 85f4b9c941b4e4df4386c4def3fc330197a06532)
    (cherry picked from commit dcbadf7a8a228deab9d6040568c465c62dde7119)
    
    * fix: log warning/panic on nil service in server handlers [IDE-1898]
    
    GetCodeActionHandler: add nil guard for svc at the top of the returned
    closure; return nil, nil with a Warn log instead of panicking on the
    next dereference.
    
    registerNotifier: add an explicit panic when notifier is nil to surface
    the wiring error at initialization time rather than silently doing
    nothing when n.CreateListener is eventually called.
    
    (cherry picked from commit 70fbd80eb74958972ad67cc4ca99c1b2a328b260)
    (cherry picked from commit 858cc2eb8c594864d7e616475bd7e46ffb5c61cd)
    (cherry picked from commit 52da940e1c61479818fe95b731cdad613bb1df27)
    (cherry picked from commit 79bd3a9f61633a6d07df313d8da911533f84d804)
    
    * fix: address bot review findings — endpoint state, withContext deps, lint [IDE-1898]
    
    - ApplyEndpointChange: return `changed` (not false) when authService nil; config
      was already mutated so telemetry must reflect the actual endpoint update;
      update test to assert true and document the new contract
    - withContext: eliminate per-request map clone by building a fresh dep map;
      inject conf and engine directly into ctxDeps to avoid dropping DepEngine/
      DepConfiguration; move ConfigResolver into injectCoreServicesIntoMap
    - addWorkspaceFolders: keep graceful error-log-and-return (panic is unsafe in
      a jrpc2 handler — no recover() in dispatch path; would crash the LSP server)
    - notification_test.go: fix 'behaviour' → 'behavior' misspelling (lint)
    
    (cherry picked from commit 11faea240cd1b99729d141ecc6e9896c23084c47)
    (cherry picked from commit 5ca4a1f6855c32b14140538c18303f81f9a95e1a)
    (cherry picked from commit 8fe1d8dd6e8be96bcf450a52ad343ff8c5f53ff8)
    (cherry picked from commit 35758b55c3cdedd73d00b5b5849fe60534f2601c)
    
    * fix: addWorkspaceFolders returns error to initializeHandler on missing deps [IDE-1898]
    
    When mandatory context deps (scanner, hoverService, scanNotifier, notifier,
    scanPersister, scanStateAggregator, featureFlagService, configResolver) are
    absent, the function now returns a jrpc2 ResponseError instead of silently
    succeeding — the IDE receives an initialize failure rather than looping in
    a zombie state where initialization appeared to succeed but no folders were
    added and scanning was silently disabled.
    
    Structured dep-missing detail is logged at Error level; the wire-facing error
    message is a short fixed string to avoid leaking internals to IDE clients.
    
    (cherry picked from commit 0aa02ffc878be7d19a66d7f3082e33500312d752)
    (cherry picked from commit 939331147c84f8b0f082f4b7aac7bf5ce88ca17f)
    (cherry picked from commit 656d459246efaaa2fc1f070f4d1979a72314044f)
    (cherry picked from commit d07a20e2b62bfaf050a3f93f2bc3a00efff14d7d)
    
    * fix: prevent session leakage and correct logic signals in endpoint/auth-method changes [IDE-1898]
    
    - ApplyEndpointChange: guard authService nil BEFORE config mutation — previously
      the endpoint was written to config then logout was skipped, leaving new-endpoint
      config with old-environment credentials (split-brain / session leakage risk);
      now the config mutation is skipped entirely when LSP is initialized and logout
      cannot be performed; add tests for both nil-authService paths (init/no-init)
    - configuration.go: promote featureFlagService-missing log to Error (was Debug) —
      featureFlagService is always wired in production; missing context means DI wiring
      bug, and stale flags for a new token is a correctness concern worth surfacing
    - ApplyAuthMethodChange: return authMethod != previousMethod (not false) when
      authService is nil — SetGlobalUser already persisted the new method so the
      return value must reflect that the state changed
    
    (cherry picked from commit 41bcfaf428f0fa3c8ef39b6ebedba3d04ea62945)
    (cherry picked from commit 590956115e393c3d416be4736462bff44630fcb6)
    
    * fix: return errors when configResolver missing from context [IDE-1898]
    
    InitializeSettings now returns error (propagated to LSP client via
    initializeHandler) when configResolver is absent from context.
    handlePushModel and handlePullModel do the same for
    workspace/didChangeConfiguration.
    
    All test call sites updated with contextWithResolver helper (safe
    map-copy, no parent mutation) and require.NoError assertions.
    
    * test: verify missing DI dep propagates as LSP error to client [IDE-1898]
    
    Adds TestInitializeHandler_MissingDep_PropagatesLSPError with three
    subtests (missing AuthenticationService, LdxSyncService, ConfigResolver)
    to confirm that when a required dependency is absent from the DI wiring,
    initializeHandler returns a jrpc2.Error to the LSP client rather than
    silently failing or crashing.
    
    * fix: validate mandatory DI deps in withContext; stop server on failure [IDE-1898]
    
    Adds validateMandatoryDeps to withContext: if any mandatory dependency
    is nil, the handler returns a jrpc2 error to the LSP client and stops
    the server (100ms delay so the response is transmitted first). This
    eliminates all silent failures in the injection path without any
    per-handler guard code.
    
    Adds mustAuthenticationServiceFromContext, replaces per-handler soft
    checks in initializeHandler with the guaranteed must* variants, and
    converts the notifier warn+skip patterns in InitializeSettings,
    UpdateSettings and applyMcpConfiguration to must* (safe: all test
    contexts inject a notifier).
    
    TestInitializeHandler_MissingDep_PropagatesLSPError updated to assert
    the new withContext-level error message.
    
    Note: featureFlagService and ldxSyncService soft-warn paths in
    UpdateSettings remain — they are unreachable in production (withContext
    validates before any handler runs) and will be addressed by wiring
    them as explicit parameters in a follow-up.
    
    * fix: use sync.Once in withContext to bound Stop() goroutines [IDE-1898]
    
    Concurrent requests hitting a missing-dep error each previously spawned
    an independent srv.Stop() goroutine. sync.Once (per handler registration)
    limits this to at most one Stop() per registered handler, regardless of
    request concurrency. Also documents the 100ms timing trade-off.
    
    * fix: replace soft-warn patterns with must*FromContext in token-change path [IDE-1898]
    
    UpdateSettings and refreshLdxSyncOnTokenChange now use
    mustFeatureFlagServiceFromContext and mustLdxSyncServiceFromContext
    directly — consistent with withContext's mandatory-dep validation gate.
    
    refreshLdxSyncOnTokenChange takes an explicit notifier param (already
    captured in UpdateSettings) to avoid a second context lookup.
    
    Test contexts for all token-change subtests now inject
    DepFeatureFlagService from deps returned by di.TestInit, not di.*
    globals. folderConfigTestSetup gains a deps field for the same reason.
    
    Stale test name and doc comment corrected.
    
    * fix: recover() in withContext makes it the single failure-handling point [IDE-1898]
    
    Any synchronous panic inside a handler is now caught by defer/recover,
    converted to a jrpc2 error returned to the LSP client, and triggers
    srv.Stop() via the same stopOnce guard used for missing-dep errors.
    
    This eliminates the second strategy (must*FromContext panics crash the
    process with no error to client) and makes withContext the only place
    that handles dep-injection failures.
    
    Changes:
    - stop closure no longer takes logger as parameter (closes over it)
    - debug.Stack() logged on panic for crash diagnosis
    - Comment clarifies only synchronous panics in h's call stack are caught
    - TestWithContext_HandlerPanic_ReturnsJRPC2Error verifies the path
    
    * fix: eliminate all remaining soft-warn dep patterns; add CodeActionsService to mandatory deps [IDE-1898]
    
    - Adds CodeActionsService to validateMandatoryDeps; removes the now-dead
      nil guard in codeaction_handlers.go and the stale test that validated
      the old soft behaviour.
    - workspaceDidChangeWorkspaceFolders: replaces six dep, _ := blank-discard
      patterns with must*FromContext, removes the redundant nil guards.
    - execute_command.go: reporter, _ := → mustErrorReporterFromContext.
    - processConfigSettings: authService, _ := → mustAuthenticationServiceFromContext.
    - processFolderConfigs/processSingleLspFolderConfig: if ok guards for
      ScanStateAggregator and FeatureFlagService → must*.
    - injectCoreServicesIntoMap: removes dead nil guard for CodeActionService
      (validated upfront by validateMandatoryDeps).
    - Introduces testCtx(t, ctx, engine, tokenService) — a unified test context
      builder that injects all mandatory deps from explicit parameters (no
      di.* globals). Registers t.Cleanup(authSvc.Shutdown) to avoid goroutine
      leaks. Replaces all contextWithNotifier + contextWithResolver usages in
      UpdateSettings/InitializeSettings call sites.
    
    * fix: eliminate all remaining soft-warn dep patterns; add CodeActionsService to mandatory deps [IDE-1898]
    
    - Adds CodeActionsService to validateMandatoryDeps; removes the now-dead
      nil guard in codeaction_handlers.go and the stale test that validated
      the old soft behaviour.
    - workspaceDidChangeWorkspaceFolders: replaces six dep, _ := blank-discard
      patterns with must*FromContext, removes the redundant nil guards.
    - execute_command.go: reporter, _ := → mustErrorReporterFromContext.
    - processConfigSettings: authService, _ := → mustAuthenticationServiceFromContext.
    - processFolderConfigs/processSingleLspFolderConfig: if ok guards for
      ScanStateAggregator and FeatureFlagService → must*.
    - injectCoreServicesIntoMap: removes dead nil guard for CodeActionService.
    - Introduces testCtx(t, ctx, engine, tokenService) — a unified test context
      builder with t.Cleanup(authSvc.Shutdown) to avoid goroutine leaks.
      Removes the now-unused contextWithNotifier and contextWithResolver.
      Merges two duplicate integration tests into a table-driven test.
    
    * fix: drop dead nil guard in notifyLockedFieldsRejected [IDE-1898]
    
    All callers now use mustNotifierFromContext, so notifier is
    guaranteed non-nil before the function runs. The nil guard
    was unreachable dead code.
    
    * chore: remove AI-generated comment from scanNotifierFromContext [IDE-1898]
    
    * fix: remove dead nil guard from ApplyAuthMethodChange [IDE-1898]
    
    authService is guaranteed non-nil by mustAuthenticationServiceFromContext
    before any handler runs. The nil guard was dead code.
    
    * fix: remove dead nil guard from ApplyAuthMethodChange [IDE-1898]
    
    authService is guaranteed non-nil by mustAuthenticationServiceFromContext
    before any handler runs. The nil guard was dead code. Removes the test
    that validated the old nil-guard behavior.

M	application/di/init.go
M	application/di/init_test.go
M	application/di/test_init.go
A	application/server/codeaction_handlers_test.go
M	application/server/configuration.go
M	application/server/configuration_test.go
M	application/server/execute_command.go
M	application/server/notification.go
M	application/server/notification_test.go
M	application/server/server.go
M	application/server/server_test.go
M	domain/ide/command/apply_auth_config.go
M	domain/ide/command/apply_auth_config_test.go
M	internal/context/context.go

commit 4b1315e6a91d2bb74b06c7141d751974fcaf90bc
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Mon Jun 1 16:00:18 2026 +0200

    fix(oss): suppress --all-projects when --maven-aggregate-project is set [IDE-1730] (#1312)
    
    --maven-aggregate-project and --all-projects are mutually exclusive per the
    Snyk CLI docs. When a customer sets --maven-aggregate-project as an additional
    parameter, snyk-ls was still appending --all-projects, causing each pom.xml in
    a multimodule project to receive the full aggregate vulnerability count (4x
    duplication observed in the field).
    
    Add --maven-aggregate-project to allProjectsParamBlacklist so prepareScanCommand
    suppresses the auto-appended --all-projects when this flag is present.

M	infrastructure/oss/cli_scanner.go
M	infrastructure/oss/cli_scanner_test.go

commit e92cb4cf06bee389303e45062e450796998990b3
Author: Knut Funkel <knut.funkel@snyk.io>
Date:   Mon Jun 1 11:52:48 2026 +0300

    fix(snyk-ls): hide ignore form on load and fix input backgrounds [IDE-2019] (#1309)
    
    * fix(snyk-ls): hide ignore form on load and fix input backgrounds [IDE-2019]
    
    ignore_styles.css is concatenated AFTER the panel stylesheet, so a
    component rule (`.sn-ignore-issue-container { display: flex }`) wins
    over `.hidden { display: none }` on source order — making the form
    visible on load. Pinning `.hidden` with `!important` makes the utility
    class authoritative against component-level display overrides.
    
    Also: .sn-select / .sn-input / .sn-textarea were using `--input-border`
    as their `background-color`, collapsing background and border to the
    same value (especially bad in Eclipse where `--input-border` is dark).
    Switched the three rules to `--input-background`.
    
    Adds regression tests in code_html_test.go and secrets_html_test.go
    asserting both CSS invariants against the rendered panel HTML.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * fix(snyk-ls): address PR review feedback for IDE-2019
    
    - strip ticket references from test comments
    - remove redundant NotRegexp assertions for --input-border
      (the Regexp checks on --input-background are sufficient)
    - expand !important comments in panel styles.css to explain why
      reversing the CSS concat order isn't chosen and to guide
      future panel additions
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    ---------
    
    Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

M	infrastructure/code/code_html_test.go
M	infrastructure/code/template/styles.css
M	infrastructure/secrets/secrets_html_test.go
M	infrastructure/secrets/template/styles.css
M	internal/html/ignore/ignore_styles.css

commit a2f116024ff5f705721fe085d028ef6bb1937255
Author: nick-y-snyk <nikita.yasnohorodskyi@snyk.io>
Date:   Fri May 29 17:15:35 2026 +0200

    fix(tree-view): prevent tree jump on manual issue selection [IDE-2077] (#1310)
    
    * fix(tree-view): preserve horizontal scroll on programmatic node select [IDE-2077]
    
    __selectTreeNode__ used scrollIntoView(false) which scrolled both axes
    unconditionally. Replace with scrollIntoView({block:'nearest',inline:'nearest'})
    + restore container.scrollLeft so horizontal position is never changed and
    vertical scroll only triggers when the row is off-screen.
    
    * fix(tree-view): drop IE11 constraint, center row on programmatic select [IDE-2077]
    
    Visual Studio webview migrated to Chromium — IE11 no longer a target.
    - Use block:'center' (was block:'nearest') so programmatic selection
      centers the row in the viewport; update doc and JS test to match.
    - Remove dead !container guard in scrollRowIntoViewVerticalOnly.
    - Add comment documenting scroll-behavior:smooth must not be set on
      #treeContainer or the scrollLeft restore will be overwritten.
    - Update IE11 Compatibility sections in docs/tree-view.md and
      docs/ui-rendering.md to reflect the dropped constraint.
    
    * fix(tree-view): revert block:center to block:nearest to prevent manual-click jump [IDE-2077]
    
    block:center always scrolls even when the row is already visible, causing
    jarring movement when the IDE calls __selectTreeNode__ in response to a
    manual click. block:nearest is a no-op when the row is already in view.

M	docs/tree-view.md
M	docs/ui-rendering.md
M	domain/ide/treeview/template/tree.js
M	js-tests/tree-runtime.test.mjs

commit 9a6901931df5a7b7de0338e07f79353be074d9a9
Author: Knut Funkel <knut.funkel@snyk.io>
Date:   Fri May 29 16:54:38 2026 +0300

    fix(treeview): position scan-error overlay using measured height [IDE-1808] (#1305)
    
    * fix(treeview): position scan-error overlay using measured height [IDE-1808]
    
    The flip-above branch in `showErrorOverlay` was effectively dead for tall
    overlays: it compared `topPos + 200 > vh` using a hardcoded `200` while
    real overlays (especially with long error messages) routinely exceed
    300px. When the comparison did fire, it set `top = rect.top - 4` — which
    placed the overlay's *top* 4px above the row's top, so the overlay still
    extended downward past the row.
    
    Restructure `showErrorOverlay` to defer positioning until the overlay is
    in the DOM and measurable:
    
    - Append the overlay with `visibility: hidden` so we can read its real
      `getBoundingClientRect().height` without a visible flash.
    - Extract `positionErrorOverlay(overlay, row)` that defaults to placing
      the overlay below the row, and flips above only when there isn't room
      below AND there is room above. If neither fits cleanly, stay below
      (clipped beats overlapping the row).
    - When flipping above, use `rect.top - overlayH - gap` so the overlay's
      bottom sits a gap above the row's top.
    - Clear `bottom` and `transform` defensively when writing `top` so a
      future style source can't stretch the overlay between opposing anchors.
    - Add a `window.resize` listener that re-runs the positioning, with
      matching teardown in `dismissErrorOverlay`.
    
    Without this, all four IDE clients (VS Code, IntelliJ, Eclipse, Visual
    Studio) showed the overlay clipped by panels below the tree view when a
    product-error row sat near the bottom of the sidebar. The VS Code
    extension previously carried a `treeViewOverlayPositioner` shim to work
    around it; that shim can now be removed in a follow-up once IDEs pin to
    an LS release containing this fix.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * fix(treeview): prefer-above policy for scan-error overlay [IDE-1808]
    
    Verified manually in IntelliJ that the previous "prefer below, flip when
    below doesn't fit" policy still drew the overlay too low for a Secrets
    row near the bottom of the tree — even with the measured-height logic
    from the previous commit, the LS-rendered overlay was clipped by panels
    below the tree view.
    
    Switch to the policy used by the previous VS Code-side shim: prefer
    above whenever there is room above the row, fall back to below
    otherwise. Tree views in IDEs typically have more chrome below them
    (status bars, help panels) than above, so above is the safer default.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * fix(treeview): address PR review on positionErrorOverlay [IDE-1808]
    
    - inline ERROR_OVERLAY_GAP as a local var to match the function's other
      hard-coded numbers
    - annotate the 600 / 4 / 520 / 16 / 8 magic numbers
    - drop the unused vh declaration
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * fix(treeview): measure overlay height after applying width and add scroll listener [IDE-1808]
    
    The <pre> message wraps, so applying width to 520px after measuring
    height made topPos use a stale (taller, post-wrap) layout and the
    overlay could overlap the row. Apply width before measuring.
    
    Also add a scroll listener (capture phase, so any scrollable ancestor
    fires it) so the overlay tracks its row when the tree container is
    scrolled, instead of staying pinned in the viewport.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    ---------
    
    Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

M	domain/ide/treeview/template/tree.js

commit 63bfc7d7be2d5b7a65f4e5050cee5efe87290a45
Author: nick-y-snyk <nikita.yasnohorodskyi@snyk.io>
Date:   Fri May 29 13:44:40 2026 +0200

    feat(ignore): refresh tree view immediately after ignore action [IDE-2000] (#1304)
    
    * feat(ignore): refresh tree view immediately after ignore action [IDE-2000]
    
    After ignore/unignore completes, emit a tree view update from the existing
    TreeScanStateEmitter so the Ignored badge appears without requiring a rescan.
    Expanded node state is preserved via the server-side GlobalExpandState singleton.
    
    * refactor(ignore): pass treeEmitter via context instead of direct param [IDE-2000]
    
    Export treeRefresher as TreeEmitter, add DepTreeEmitter to internal/context,
    store in ctx via withContext, retrieve in CreateFromCommandData via
    treeEmitterFromContext. Removes treeEmitter from NewService and
    CreateFromCommandData signatures.

M	application/di/init.go
M	application/server/server.go
M	domain/ide/command/command_factory.go
M	domain/ide/command/command_service.go
M	domain/ide/command/ignores_request.go
M	domain/ide/command/ignores_request_test.go
M	internal/context/context.go
```

[IDE-1974]: https://snyksec.atlassian.net/browse/IDE-1974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-2116]: https://snyksec.atlassian.net/browse/IDE-2116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ