### PR TITLE
fix(scripts): make upgrade of go deps exit on errors [CLIA-1423] [IDA-733]

### DIFF
--- a/scripts/upgrade-snyk-go-dependencies.go
+++ b/scripts/upgrade-snyk-go-dependencies.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"os/exec"
 	"regexp"
 )
@@ -84,17 +85,28 @@ func getLatestCommitSHA(name string) (string, error) {
 	return commits[0].SHA, nil
 }
 
+func runStep(stepName string, cmd *exec.Cmd) error {
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	if len(output) > 0 {
+		return fmt.Errorf("%s failed (%w):\n%s", stepName, err, output)
+	}
+	return fmt.Errorf("%s failed (%w)", stepName, err)
+}
+
 func upgradeGoMod(name, commitSHA string) error {
 	cmd := exec.Command("go", "get", fmt.Sprintf("github.com/snyk/%s@%s", name, commitSHA))
 	cmd.Dir = "./cliv2"
-	if err := cmd.Run(); err != nil {
+	if err := runStep("go get", cmd); err != nil {
 		return err
 	}
 
 	fmt.Println("🧹 Running make tidy...")
 	cmd = exec.Command("make", "tidy")
 	cmd.Dir = "."
-	if err := cmd.Run(); err != nil {
+	if err := runStep("make tidy", cmd); err != nil {
 		return err
 	}
 
@@ -115,20 +127,22 @@ func upgradeDep(name string) error {
 	return nil
 }
 
+func upgradeDepExitOnError(name string) {
+	err := upgradeDep(name)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "An error occurred while upgrading %s: %v\n", name, err)
+		os.Exit(1)
+	}
+}
+
 func main() {
 	name := flag.String("name", "", "Repository name to download from (e.g., go-application-framework)")
 	flag.Parse()
 
 	if *name == "" {
-		if err := upgradeDep("go-application-framework"); err != nil {
-			fmt.Printf("An error occurred: %v\n", err)
-		}
-		if err := upgradeDep("snyk-ls"); err != nil {
-			fmt.Printf("An error occurred: %v\n", err)
-		}
+		upgradeDepExitOnError("go-application-framework")
+		upgradeDepExitOnError("snyk-ls")
 	} else {
-		if err := upgradeDep(*name); err != nil {
-			fmt.Printf("An error occurred: %v\n", err)
-		}
+		upgradeDepExitOnError(*name)
 	}
 }


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Previously the script would pass on errors, which covered up issues, this ensures it doesn't.
Also, an attempt has been made to try and ensure the reason for a `make tidy` failure isn't lost, like it was in this CI run: https://github.com/snyk/snyk-ls/actions/runs/26645512499/job/78529860600#step:18:575

## Where should the reviewer start?

## How should this be manually tested?

## What's the product update that needs to be communicated to CLI users?

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
