### PR TITLE
fix: skip reachability upload when no supported files are present

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -210,7 +210,7 @@ require (
 	github.com/snyk/cli-extension-dep-graph v1.23.0 // indirect
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 // indirect
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e // indirect
-	github.com/snyk/cli-extension-os-flows v0.0.0-20260528140040-b7cfe6ad82fc // indirect
+	github.com/snyk/cli-extension-os-flows v0.0.0-20260601094021-c1b88a8181fe // indirect
 	github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa // indirect
 	github.com/snyk/cli-extension-secrets v0.0.0-20260519130658-5bc07275ad09 // indirect
 	github.com/snyk/code-client-go v1.27.0 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -575,8 +575,8 @@ github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSo
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e h1:HE22F5/ivTJ4TlTUnjasZqfkDKVyfmYjf36RaIZqrs4=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e/go.mod h1:YN+M0+nNZ5VoQN2SxSvZSoTxs/PkdLgfNfUWvsKVL7o=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260528140040-b7cfe6ad82fc h1:Hy+NJbo21CdmEiBf5oeKXP7aBtRr4Mgpq84CHzDJ6bQ=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260528140040-b7cfe6ad82fc/go.mod h1:QzRkfB301w+pPow7mznBWd/uXtk0v909AUullT4XSA0=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260601094021-c1b88a8181fe h1:Q8zqyT9F0nDL62/nLJfDzt4J4a0K0QY1wrYROguZNDE=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260601094021-c1b88a8181fe/go.mod h1:QzRkfB301w+pPow7mznBWd/uXtk0v909AUullT4XSA0=
 github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa h1:9GSKXrRCaRkBAj+jglUBuhO09I1xs2G5GxwrPxlj34M=
 github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa/go.mod h1:SJ624HENWG4yjM6jNuLebTeNsMriozf1LcKhMYVm1aY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260519130658-5bc07275ad09 h1:B5RFt9zJeGsyQdKllKGNKGGCKxW6WR/ZyIYn/DxAcs4=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/snyk/cli-extension-dep-graph v1.23.0
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e
-	github.com/snyk/cli-extension-os-flows v0.0.0-20260528140040-b7cfe6ad82fc
+	github.com/snyk/cli-extension-os-flows v0.0.0-20260601094021-c1b88a8181fe
 	github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa
 	github.com/snyk/cli-extension-secrets v0.0.0-20260519130658-5bc07275ad09
 	github.com/snyk/code-client-go v1.27.0

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -549,8 +549,8 @@ github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSo
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e h1:HE22F5/ivTJ4TlTUnjasZqfkDKVyfmYjf36RaIZqrs4=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e/go.mod h1:YN+M0+nNZ5VoQN2SxSvZSoTxs/PkdLgfNfUWvsKVL7o=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260528140040-b7cfe6ad82fc h1:Hy+NJbo21CdmEiBf5oeKXP7aBtRr4Mgpq84CHzDJ6bQ=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260528140040-b7cfe6ad82fc/go.mod h1:QzRkfB301w+pPow7mznBWd/uXtk0v909AUullT4XSA0=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260601094021-c1b88a8181fe h1:Q8zqyT9F0nDL62/nLJfDzt4J4a0K0QY1wrYROguZNDE=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260601094021-c1b88a8181fe/go.mod h1:QzRkfB301w+pPow7mznBWd/uXtk0v909AUullT4XSA0=
 github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa h1:9GSKXrRCaRkBAj+jglUBuhO09I1xs2G5GxwrPxlj34M=
 github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa/go.mod h1:SJ624HENWG4yjM6jNuLebTeNsMriozf1LcKhMYVm1aY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260519130658-5bc07275ad09 h1:B5RFt9zJeGsyQdKllKGNKGGCKxW6WR/ZyIYn/DxAcs4=

--- a/test/jest/acceptance/snyk-test/reachability-user-journey.spec.ts
+++ b/test/jest/acceptance/snyk-test/reachability-user-journey.spec.ts
@@ -211,7 +211,7 @@ describe('snyk test --reachability', () => {
     expect(code).toBe(EXIT_CODES.VULNS_FOUND);
   });
 
-  test('renders a warning if no files were uploaded', async () => {
+  test('warns and still returns results when source dir has no reachability-supported files', async () => {
     const pathWithNoValidFiles = join(
       __dirname,
       '../../../fixtures/npm/with-vulnerable-lodash-dep',
@@ -228,7 +228,7 @@ describe('snyk test --reachability', () => {
 
     expect(stdout).not.toBe('');
     expect(stderr).toContainText(
-      'failed to upload source code for reachability analysis',
+      'no reachability-supported source files were found; skipping reachability analysis',
     );
 
     const jsonOutput = JSON.parse(stdout);


### PR DESCRIPTION
When the --reachability param is specified, the CLI now detects the absence of supported files upfront, skips the upload, and emits a clear warning:

"no reachability-supported source files were found; skipping reachability analysis"

The scan continues and vulnerability results are still returned.

Picks up the reachability source presence check feature (PR #246) and associated fixes landed since the last bump.