### PR TITLE
chore: adds org lookup type to instrumentation data

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -217,7 +217,7 @@ require (
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 // indirect
-	github.com/snyk/go-application-framework v0.1.1-0.20260529100338-4fceab88ea93 // indirect
+	github.com/snyk/go-application-framework v0.2.0 // indirect
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
@@ -288,4 +288,26 @@ require (
 // For local development, point to the sibling public module:
 replace github.com/snyk/cli/cliv2 => ../cliv2
 
-//replace github.com/snyk/remy-cli-extension => ../../remy-cli-extension
+// replace github.com/snyk/remy-cli-extension => ../../remy-cli-extension
+
+// replace github.com/snyk/go-application-framework => ../../go-application-framework
+
+// replace github.com/snyk/snyk-ls => ../../snyk-ls
+
+// replace github.com/snyk/code-client-go => ../../code-client-go
+
+// replace github.com/snyk/cli-extension-iac => ../../cli-extension-iac
+
+// replace github.com/snyk/cli-extension-os-flows => ../../cli-extension-os-flows
+
+// replace github.com/snyk/cli-extension-ai-bom => ../../cli-extension-ai-bom
+
+// replace github.com/snyk/cli-extension-ai-redteam => ../../cli-extension-ai-redteam
+
+// replace github.com/snyk/studio-mcp => ../../studio-mcp
+
+// replace github.com/snyk/cli-extension-agent-scan => ../../cli-extension-agent-scan
+
+// replace github.com/snyk/cli-extension-sbom => ../../cli-extension-sbom
+
+// replace github.com/snyk/cli-extension-secrets => ../../cli-extension-secrets

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -589,8 +589,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 h1:j2ZPhi78wKIHTiL9EFTNVXMIbsk56FVF2d5Sy1ZwSYk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.1.1-0.20260529100338-4fceab88ea93 h1:xFCe8NtNYdi+EvGtHmEV87U3B7QCNyF/B/UFFkoq8U4=
-github.com/snyk/go-application-framework v0.1.1-0.20260529100338-4fceab88ea93/go.mod h1:yTGCJKf6RmqdwrNs5B9zmukL9x1D8EhfSK8mzaPB1Rk=
+github.com/snyk/go-application-framework v0.2.0 h1:kzJq7ofLt23XW+RT5bUGVW4ZFXJX8dlp++Tk2Y2lYaA=
+github.com/snyk/go-application-framework v0.2.0/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.27.0
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663
-	github.com/snyk/go-application-framework v0.1.1-0.20260529100338-4fceab88ea93
+	github.com/snyk/go-application-framework v0.2.0
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260529103026-b999aa3e3447
@@ -276,14 +276,15 @@ require (
 // version 2491eb6c1c75 contains a valid license
 replace github.com/mattn/go-localereader v0.0.1 => github.com/mattn/go-localereader v0.0.2-0.20220822084749-2491eb6c1c75
 
-//replace github.com/snyk/go-application-framework => ../../go-application-framework
+// replace github.com/snyk/go-application-framework => ../../go-application-framework
 
-//replace github.com/snyk/snyk-ls => ../../snyk-ls
-//replace github.com/snyk/code-client-go => ../../code-client-go
+// replace github.com/snyk/snyk-ls => ../../snyk-ls
 
-//replace github.com/snyk/cli-extension-iac => ../../cli-extension-iac
+// replace github.com/snyk/code-client-go => ../../code-client-go
 
-//replace github.com/snyk/cli-extension-os-flows => ../../cli-extension-os-flows
+// replace github.com/snyk/cli-extension-iac => ../../cli-extension-iac
+
+// replace github.com/snyk/cli-extension-os-flows => ../../cli-extension-os-flows
 
 // replace github.com/snyk/cli-extension-ai-bom => ../../cli-extension-ai-bom
 
@@ -295,4 +296,4 @@ replace github.com/mattn/go-localereader v0.0.1 => github.com/mattn/go-localerea
 
 // replace github.com/snyk/cli-extension-sbom => ../../cli-extension-sbom
 
-//replace github.com/snyk/cli-extension-secrets => ../../cli-extension-secrets
+// replace github.com/snyk/cli-extension-secrets => ../../cli-extension-secrets

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -563,8 +563,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 h1:j2ZPhi78wKIHTiL9EFTNVXMIbsk56FVF2d5Sy1ZwSYk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.1.1-0.20260529100338-4fceab88ea93 h1:xFCe8NtNYdi+EvGtHmEV87U3B7QCNyF/B/UFFkoq8U4=
-github.com/snyk/go-application-framework v0.1.1-0.20260529100338-4fceab88ea93/go.mod h1:yTGCJKf6RmqdwrNs5B9zmukL9x1D8EhfSK8mzaPB1Rk=
+github.com/snyk/go-application-framework v0.2.0 h1:kzJq7ofLt23XW+RT5bUGVW4ZFXJX8dlp++Tk2Y2lYaA=
+github.com/snyk/go-application-framework v0.2.0/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -604,10 +604,6 @@ func mainWithErrorCode(additionalExts []workflow.ExtensionInit) int {
 	)
 	network_utils.AddSnykRequestId(networkAccess)
 
-	if debugEnabled {
-		writeLogHeader(globalConfiguration, networkAccess)
-	}
-
 	// initialize the extensions -> they register themselves at the engine
 	initExtensions(globalEngine, globalConfiguration, additionalExts)
 
@@ -616,6 +612,7 @@ func mainWithErrorCode(additionalExts []workflow.ExtensionInit) int {
 
 	// We want to scrub the debug log of sensitive information. Since we have a list of commands we know can occur, we can intersect that with arguments we don't recognize, and automatically scrub all those from the logs.
 	if debugEnabled {
+		writeLogHeader(globalConfiguration, networkAccess)
 		knownTerms, _ := instrumentation.GetKnownCommandsAndFlags(globalEngine)
 		knownTerms = append(knownTerms, globalConfiguration.GetString(configuration.API_URL), globalConfiguration.GetString(configuration.ORGANIZATION), globalConfiguration.GetString(configuration.ORGANIZATION_SLUG))
 		termsToRedact := cliv2utils.GetUnknownParameters(os.Args[1:], os.Environ(), knownTerms)


### PR DESCRIPTION
## Pull Request Submission Checklist

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
This PR adds some new instrumentation data to measure how we perform organisation lookups in GAF.

## Where should the reviewer start?
Related GAF PR

## How should this be manually tested?
Run the following commands and check for the instrumentation entry:
```
command: `snyk test --org=86616ead-043b-4ef3-8c8d-81ecdf5ac751 -d` // valid UUID but org does not exist
instrumentation: "gaf.app.defaultfunc.organization.lookup": "provided_id" // should be "provided_id_failed"

command: `snyk test --org=be9221c6-5f63-4339-a07e-43d38b3ecb8z -d` // this is not actually a valid UUID and will be considered a slugname in code
instrumentation: "gaf.app.defaultfunc.organization.lookup": "provided_slug_failed"

command: `snyk test --org=<VALID_ORG_ID> -d` // valid UUID and org exists
instrumentation: "gaf.app.defaultfunc.organization.lookup": "provided_id"

command: `snyk test --org=<VALID_ORG_SLUG> -d`
instrumentation: "gaf.app.defaultfunc.organization.lookup": "provided_slug"

command: `snyk test --org=fake -d`
instrumentation: "gaf.app.defaultfunc.organization.lookup": "provided_slug_failed"

command: `snyk test -d`
instrumentation: "gaf.app.defaultfunc.organization.lookup": "default"
```

Note that:
```
command: `snyk test --org=86616ead-043b-4ef3-8c8d-81ecdf5ac751 -d` // valid UUID but org does not exist
instrumentation: "gaf.app.defaultfunc.organization.lookup": "provided_id" // should be "provided_id_failed"
```
Outputs the wrong instrumentation data as outlined in `RFC: Consistent Organization Resolution`.

## What's the product update that needs to be communicated to CLI users?
N/A - internal change

## Risk assessment (Low | Medium | High)?
Low - changes to instrumentation data

<!---

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
