### PR TITLE
docs(cli): document --project-tags for snyk code test

### DIFF
--- a/help/cli-commands/code-test.md
+++ b/help/cli-commands/code-test.md
@@ -63,6 +63,18 @@ Example of setting to the latest Git tag:
 
 `snyk code test --report --target-reference="$(git describe --tags --abbrev=0)"`
 
+### `--project-tags=<TAG>[,<TAG>]...>`
+
+This can be used in combination with the `--report` option.
+
+Set the project tags to one or more values (comma-separated key value pairs with an "=" separator).
+
+Example: `--project-tags=department=finance,team=alpha`
+
+To clear the project tags set `--project-tags=`
+
+For more information including allowable characters see [Project tags](https://docs.snyk.io/snyk-platform-administration/snyk-projects/project-tags)
+
 ### `--remote-repo-url=<URL>`
 
 Set or override the remote URL for the repository.


### PR DESCRIPTION
## What does this PR do?

Adds a `--project-tags` option section to the `snyk code test` help documentation in `cli/help/cli-commands/code-test.md`, matching the wording and structure already used in `iac-test.md`, `monitor.md`, and `container-monitor.md`.

The flag is implemented in `code-client-go` and wired into the Code workflow (`code-client-go/pkg/code/code.go` registers `--project-tags`, `internal/commands/code_workflow/native_workflow.go` calls `GenerateProjectTags` and forwards them via `codeclient.WithProjectTags`), but was not yet surfaced in `snyk code test --help` or the CLI command docs.

`snyk code test --help` is rendered directly from this markdown by `cli/src/cli/commands/help/index.ts`, so no source code changes are required here.

## Where should the reviewer start?

- `cli/help/cli-commands/code-test.md` - the new `### --project-tags=<TAG>[,<TAG>]...` section, placed between `--target-reference` and `--remote-repo-url` to sit with the other project metadata / report options.
- Wording mirrors `cli/help/cli-commands/iac-test.md` (which already documents this flag with `--report`).

## How should this be manually tested?

```sh
make build
./binary-releases/snyk-macos-arm64 code test --help | grep -A 10 'project-tags'
```

Expected: the new section appears, with the example `--project-tags=department=finance,team=alpha` and the clear-by-empty-value note.

Functional behaviour of the flag is covered by existing tests in `code-client-go`:

- `code-client-go/internal/commands/code_workflow/project_tags_test.go` - parsing / validation of the flag value
- `code-client-go/internal/analysis/analysis_test.go::TestAnalysis_RunTest_WithProjectTags` - tags forwarded to the test API

## What's the product update that needs to be communicated to CLI users?

None for this PR specifically - this only documents an already-implemented flag. The product-facing announcement belongs with the PR that added `--project-tags` support to `snyk code test`.

## Risk assessment

**Low** - markdown-only change, no code paths affected, prettier passes, no test or behaviour changes.

## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low)
- [ ] Highlights breaking API changes (if applicable) - **N/A**, no API changes
- [ ] Links to automated tests covering new functionality - **N/A for this PR** (docs only); existing tests in `code-client-go` linked under "How should this be manually tested?"
- [x] Includes manual testing instructions
- [x] Updates relevant GitBook documentation (PR link: https://github.com/snyk/user-docs/pull/1311) - the CLI help files are synced **from** `snyk/user-docs` weekly via [`sync-cli-help-to-user-docs.yml`](https://github.com/snyk/cli/blob/main/.github/workflows/sync-cli-help-to-user-docs.yml). Without the companion user-docs PR, this change would be reverted by the next sync.
- [ ] Includes product update to be announced in the next stable release notes - **N/A for this PR** (docs only); the product announcement belongs with the PR that added `--project-tags` support to Code.