### PR TITLE
chore: upgrade @snyk/snyk-hex-plugin to 2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@snyk/fix": "file:packages/snyk-fix",
         "@snyk/gemfile": "1.2.0",
         "@snyk/snyk-cocoapods-plugin": "3.1.1",
-        "@snyk/snyk-hex-plugin": "2.1.1",
+        "@snyk/snyk-hex-plugin": "2.2.1",
         "@types/marked": "^4.0.0",
         "abbrev": "^1.1.1",
         "adm-zip": "^0.5.9",
@@ -3829,9 +3829,9 @@
       }
     },
     "node_modules/@snyk/snyk-hex-plugin": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@snyk/snyk-hex-plugin/-/snyk-hex-plugin-2.1.1.tgz",
-      "integrity": "sha512-mOnhGij1XlfMjSFrUR/RN2TDVnl5TdV8XbHjGWdlPHAAUbi6r3csoVVgvBfED/TdIpikOd1uld+Za/9t/3OZoQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@snyk/snyk-hex-plugin/-/snyk-hex-plugin-2.2.1.tgz",
+      "integrity": "sha512-0Xq/WG1AUMO8REZagswbkKbkaM2pITEr0Y8RJ2XDJmJoUXmPvkkCknwhnWChkv98z2zWuHmI6DbPITAfBzrWsQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@snyk/dep-graph": "^1.28.0",
@@ -3843,7 +3843,8 @@
         "upath": "2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@snyk/snyk-hex-plugin/node_modules/@snyk/dep-graph": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@snyk/fix": "file:packages/snyk-fix",
     "@snyk/gemfile": "1.2.0",
     "@snyk/snyk-cocoapods-plugin": "3.1.1",
-    "@snyk/snyk-hex-plugin": "2.1.1",
+    "@snyk/snyk-hex-plugin": "2.2.1",
     "@types/marked": "^4.0.0",
     "abbrev": "^1.1.1",
     "adm-zip": "^0.5.9",


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are release-note ready, emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable) — none
- [ ] Links to automated tests covering new functionality — N/A (dependency bump, no new functionality)
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___) — N/A
- [x] Includes product update to be announced in the next stable release notes — N/A

## What does this PR do?

Upgrades the `@snyk/snyk-hex-plugin` dependency from `2.1.0` to `2.2.1` (latest), keeping `package-lock.json` in sync with a minimal update.

- `package.json`: `@snyk/snyk-hex-plugin` `2.1.0` → `2.2.1`
- `package-lock.json`: updated `version` / `resolved` / `integrity` for the plugin; its `tmp` dependency declaration moves to `^0.2.7`, which is satisfied by the already-hoisted `tmp@0.2.7` — so **no new packages are added**. The lockfile update is idempotent (re-running `npm install --package-lock-only` produces no further changes).

## Where should the reviewer start?

The `package.json` change (around line 74) and the corresponding `package-lock.json` diff — both are scoped entirely to `@snyk/snyk-hex-plugin`.

## How should this be manually tested?

Take a look at the [unit tests](https://github.com/snyk/snyk-hex-plugin/tree/master/test).

## What's the product update that needs to be communicated to CLI users?

Fixes scan issues for hex > 1.19.

## Risk assessment (Low | Medium | High)

**Low** — a single pinned dependency minor/patch bump with a minimal, idempotent lockfile change and no source-code changes.