### PR TITLE
chore: Use CircleCI native timing-based test splitting for acceptance shards

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -965,6 +965,7 @@ workflows:
           go_os: darwin
           go_arch: arm64
           go_download_base_url: << pipeline.parameters.go_download_base_url >>
+          shards: 6
           context:
             - nodejs-install
             - team_hammerhead-cli
@@ -1002,9 +1003,12 @@ workflows:
           install_deps_extension: windows-native-build
           dont_skip_tests: 0
           shards: 8
-          shard_calc_cmd: '$([int]$env:CIRCLE_NODE_INDEX + 1)'
           pre_test_cmds: |
             if (Test-Path '<< pipeline.parameters.windows_cache_dir >>/<< pipeline.parameters.windows_env_script >>') { . '<< pipeline.parameters.windows_cache_dir >>/<< pipeline.parameters.windows_env_script >>' }
+          test_cmd: |
+            Get-ChildItem -Recurse -Path test/jest/acceptance,ts-binary-wrapper/test/acceptance -Filter *.spec.ts |
+              ForEach-Object { (Resolve-Path -Relative $_.FullName) -replace '\\', '/' -replace '^\./', '' } |
+              circleci tests run --command "xargs npx jest --maxWorkers=1 --selectProjects coreCli --reporters=jest-junit --reporters=default --" --split-by=timings --timings-type=file
 
       - sign:
           name: sign windows amd64
@@ -1692,10 +1696,15 @@ jobs:
         default: 'echo Running tests'
       shards:
         type: integer
-        default: 4
-      shard_calc_cmd:
+        default: 6
+      test_cmd:
         type: string
-        default: '$(expr $CIRCLE_NODE_INDEX + 1)'
+        default: |
+          find test/jest/acceptance ts-binary-wrapper/test/acceptance -name '*.spec.ts' \
+            | circleci tests run \
+                --command="xargs npx jest --maxWorkers=1 --selectProjects coreCli --reporters=jest-junit --reporters=default --" \
+                --split-by=timings \
+                --timings-type=file
     executor: << parameters.executor >>
     parallelism: << parameters.shards >>
     environment:
@@ -1724,13 +1733,17 @@ jobs:
           no_output_timeout: 30m
           command: |
             << parameters.pre_test_cmds >>
-            npm run test:acceptance "--" --selectProjects coreCli --shard=<< parameters.shard_calc_cmd >>/<< parameters.shards >>
+            << parameters.test_cmd >>
           environment:
             TEST_SNYK_FIPS: << parameters.fips >>
             TEST_SNYK_COMMAND: << parameters.test_snyk_command >>
             TEST_SNYK_DONT_SKIP_ANYTHING: << parameters.dont_skip_tests >>
             JEST_JUNIT_OUTPUT_DIR: test/reports
             NODE_OPTIONS: --max-old-space-size=4096
+      - run:
+          name: Normalize junit file paths for timing data
+          when: always
+          command: node scripts/normalize-junit-file-paths.js test/reports
       - store_test_results:
           path: test/reports
       - store_artifacts:

--- a/package.json
+++ b/package.json
@@ -222,6 +222,7 @@
     "access": "public"
   },
   "jest-junit": {
-    "reportTestSuiteErrors": "true"
+    "reportTestSuiteErrors": "true",
+    "addFileAttribute": "true"
   }
 }

--- a/scripts/normalize-junit-file-paths.js
+++ b/scripts/normalize-junit-file-paths.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * Normalize the `file="..."` attribute in jest-junit XML reports to use forward
+ * slashes.
+ *
+ * jest-junit builds that attribute with Node's path APIs, so on Windows it
+ * contains backslashes (e.g. file="test\jest\acceptance\foo.spec.ts"). CircleCI
+ * keys its test-timing data on this attribute, but our pipeline feeds
+ * forward-slash paths to `circleci tests run --timings-type=file`. The backslash
+ * keys therefore never match and Windows falls back to name-based splitting.
+ *
+ * Rewriting just the `file=` attribute to forward slashes makes the stored
+ * timing keys match the query, enabling timing-based splitting on Windows. Only
+ * the `file=` attribute is touched, so backslashes inside test names or failure
+ * messages are left untouched. This is a no-op on Linux/macOS.
+ *
+ * Usage: node scripts/normalize-junit-file-paths.js [reportsDir]
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const reportsDir = process.argv[2] || 'test/reports';
+
+if (!fs.existsSync(reportsDir)) {
+  process.exit(0);
+}
+
+const fileAttrPattern = /file="[^"]*"/g;
+
+for (const entry of fs.readdirSync(reportsDir)) {
+  if (!entry.endsWith('.xml')) {
+    continue;
+  }
+
+  const filePath = path.join(reportsDir, entry);
+  try {
+    const original = fs.readFileSync(filePath, 'utf8');
+    const normalized = original.replace(fileAttrPattern, (match) =>
+      match.split('\\').join('/'),
+    );
+
+    if (normalized !== original) {
+      fs.writeFileSync(filePath, normalized);
+    }
+  } catch (err) {
+    console.error(`Failed to process ${filePath}:`, err.message);
+    // Continue processing other files
+  }
+}


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Replaces Jest's `--shard` with CircleCI's native `circleci tests run --split-by=timings` so acceptance test shards are automatically balanced by historic runtime data — no manually maintained weight files needed.

- Replaces `--shard=<index>/<total>` with `circleci tests glob | circleci tests run --split-by=timings --timings-type=file` in the `acceptance-tests` job.
- Adds `addFileAttribute: true` to `jest-junit` config so JUnit XML includes `file="..."` on each `<testsuite>`, which CircleCI needs for file-based timing matching.

## Where should the reviewer start?

- `.circleci/config.yml` — the `acceptance-tests` job definition (replaced `shard_calc_cmd` parameter with `test_shell`, new `circleci tests run` command)
- `package.json` — `addFileAttribute` addition in `jest-junit` config

## How should this be manually tested?

1. Push branch and trigger CI.
2. Check that acceptance tests run on all platforms (linux, macOS, Windows).
3. Compare shard wall times — after 1-2 runs, CircleCI accumulates timing data and balances shards automatically.

## What's the product update that needs to be communicated to CLI users?

None. CI-only change; no CLI behavior change for end users.

## Risk assessment (Low | Medium | High)?

Medium — changes how tests are distributed across CI shards on all platforms including Windows (shell change). First run may use name-based splitting until CircleCI accumulates timing data from JUnit reports.

## Any background context you want to provide?

CircleCI stores timing data per job name across all branches, so existing `store_test_results` uploads from `main` should provide immediate timing data. The `addFileAttribute` flag makes `jest-junit` emit the `file` attribute on each `<testsuite>`, enabling CircleCI to match timing history to spec files. See [CircleCI docs: Test splitting and parallelism](https://circleci.com/docs/guides/optimize/parallelism-faster-jobs/).

## What are the relevant tickets?

[CLI-1482](https://snyksec.atlassian.net/browse/CLI-1482)

## Screenshots (if appropriate)

Before (main) X [Now](https://app.circleci.com/pipelines/gh/snyk/cli/37806/workflows/ed79eeae-a564-4486-9b08-50f423689b7e) (chore/CLI-1482-circleci-native-test-splitting):

<img width="297" height="627" alt="image" src="https://github.com/user-attachments/assets/18b48cd5-d785-454b-95ba-3116836ab04e" /><img width="301" height="639" alt="image" src="https://github.com/user-attachments/assets/712baec4-ae7f-4c5c-bdbf-6ee849162718" />

Before (feat/CLI-1482-balance-acceptance-test-shards) X [Now](https://app.circleci.com/pipelines/gh/snyk/cli/37806/workflows/ed79eeae-a564-4486-9b08-50f423689b7e) (chore/CLI-1482-circleci-native-test-splitting)

<img width="294" height="654" alt="image" src="https://github.com/user-attachments/assets/b6930178-f32d-45f6-a001-e64c09c458c4" />
<img width="301" height="639" alt="image" src="https://github.com/user-attachments/assets/9cbc1e84-6e0b-415b-98cd-8ee1f831f4e9" />

<!-- <img width="304" height="656" alt="image" src="https://github.com/user-attachments/assets/45cd2dd9-bf50-4931-82b7-55fe669516ff" /> -->

[CLI-1482]: https://snyksec.atlassian.net/browse/CLI-1482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ