### PR TITLE
fix: relativise absolute --file path against root for uv monitor

### DIFF
--- a/src/lib/plugins/uv/index.ts
+++ b/src/lib/plugins/uv/index.ts
@@ -58,7 +58,7 @@ export async function inspect(
     throw createDepgraphError(extractErrorDetail(result));
   }
 
-  const resolvedTargetFile = getResolvedTargetFile(targetFile);
+  const resolvedTargetFile = getResolvedTargetFile(root, targetFile);
 
   let scannedProjects: ScannedProjectCustom[];
   try {
@@ -115,6 +115,27 @@ export async function inspect(
   };
 }
 
+// Return the manifest path used for uv project identity. Keep it relative to
+// root so TS monitor and Go test use the same targetFile for absolute --file.
+export function getResolvedTargetFile(
+  root: string,
+  targetFile: string,
+): string {
+  if (path.basename(targetFile) !== UV_LOCKFILE_NAME) {
+    return targetFile;
+  }
+
+  const resolvedRoot = path.resolve(root);
+  const resolvedLockfile = path.resolve(resolvedRoot, targetFile);
+  const relativeLockfile = path.relative(resolvedRoot, resolvedLockfile);
+
+  const targetFileDir = path.dirname(relativeLockfile);
+  if (targetFileDir === '.') {
+    return PYPROJECT_MANIFEST_NAME;
+  }
+  return path.join(targetFileDir, PYPROJECT_MANIFEST_NAME);
+}
+
 function createDepgraphError(detail: string): CustomError {
   const error = new CustomError(detail);
   error.userMessage = detail;
@@ -136,13 +157,4 @@ function extractErrorDetail(result: GoCommandResult): string {
     }
   }
   return result.stderr || 'Unable to process dependency information';
-}
-
-function getResolvedTargetFile(targetFile: string): string {
-  if (path.basename(targetFile) !== UV_LOCKFILE_NAME) {
-    return targetFile;
-  }
-
-  const targetFileDir = path.dirname(targetFile);
-  return path.join(targetFileDir, PYPROJECT_MANIFEST_NAME);
 }

--- a/src/lib/plugins/uv/uv.spec.ts
+++ b/src/lib/plugins/uv/uv.spec.ts
@@ -1,7 +1,8 @@
 import { DepGraphData } from '@snyk/dep-graph';
 import { CLI, ProblemError } from '@snyk/error-catalog-nodejs-public';
+import * as path from 'path';
 import { CustomError } from '../../errors';
-import { inspect } from './index';
+import { inspect, getResolvedTargetFile } from './index';
 import * as goBridge from '../../go-bridge';
 
 const MOCK_DEP_GRAPH_DATA: DepGraphData = {
@@ -388,6 +389,84 @@ describe('uv plugin', () => {
     expect(result.scannedProjects[0].depGraph?.rootPkg).toEqual({
       name: 'uv-project',
       version: '0.1.0',
+    });
+  });
+
+  // Regression coverage for absolute --file project identity.
+  describe('absolute --file paths (UNIFY-1419)', () => {
+    it('strips an absolute --file prefix when the lockfile sits at the project root', async () => {
+      const root = path.resolve('/tmp/builds/smb-api');
+      const absLockfile = path.join(root, 'uv.lock');
+
+      const result = await inspect(root, absLockfile);
+
+      expect(result.plugin.targetFile).toBe('pyproject.toml');
+      expect(result.scannedProjects[0].targetFile).toBe('pyproject.toml');
+      expect((result.scannedProjects[0] as any).plugin?.targetFile).toBe(
+        'pyproject.toml',
+      );
+    });
+
+    it('relativises an absolute --file in a nested project dir', async () => {
+      const root = path.resolve('/tmp/builds/smb-api');
+      const absLockfile = path.join(root, 'nested', 'uv.lock');
+
+      const result = await inspect(root, absLockfile);
+
+      const expected = path.join('nested', 'pyproject.toml');
+      expect(result.plugin.targetFile).toBe(expected);
+      expect(result.scannedProjects[0].targetFile).toBe(expected);
+    });
+
+    it('forwards the original --file value to the Go subprocess', async () => {
+      const root = path.resolve('/tmp/builds/smb-api');
+      const absLockfile = path.join(root, 'uv.lock');
+
+      await inspect(root, absLockfile);
+
+      expect(execGoCommandSpy).toHaveBeenCalledWith(
+        [
+          'depgraph',
+          `--file=${absLockfile}`,
+          '--use-sbom-resolution',
+          '--json',
+        ],
+        { cwd: root },
+      );
+    });
+
+    it('absolute and relative --file produce identical identity', async () => {
+      const root = path.resolve('/tmp/builds/smb-api');
+
+      const relResult = await inspect(root, 'uv.lock');
+      const absResult = await inspect(root, path.join(root, 'uv.lock'));
+
+      expect(absResult.plugin.targetFile).toBe(relResult.plugin.targetFile);
+      expect(absResult.scannedProjects[0].targetFile).toBe(
+        relResult.scannedProjects[0].targetFile,
+      );
+    });
+
+    it('getResolvedTargetFile is a pure function with the documented contract', () => {
+      const root = path.resolve('/tmp/builds/smb-api');
+
+      expect(getResolvedTargetFile(root, 'uv.lock')).toBe('pyproject.toml');
+
+      expect(getResolvedTargetFile(root, 'pkg/uv.lock')).toBe(
+        path.join('pkg', 'pyproject.toml'),
+      );
+
+      expect(getResolvedTargetFile(root, path.join(root, 'uv.lock'))).toBe(
+        'pyproject.toml',
+      );
+
+      expect(
+        getResolvedTargetFile(root, path.join(root, 'pkg', 'uv.lock')),
+      ).toBe(path.join('pkg', 'pyproject.toml'));
+
+      expect(getResolvedTargetFile(root, 'pyproject.toml')).toBe(
+        'pyproject.toml',
+      );
     });
   });
 });


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Fixes UNIFY-1419: UI-applied ignores were silently no-op'd for UV projects in CI when --file was an absolute path (the GitLab CI default). snyk monitor was registering the project under one name (<root>:/builds/.../pyproject.toml) and snyk test was looking it up under another (<root>:pyproject.toml), so the test-time project lookup missed and the policy never loaded.
The fix changes getResolvedTargetFile in the TS UV plugin to relativise the lockfile path against the project root before swapping the basename to pyproject.toml, matching the npm/yarn workspaces convention. Monitor and test now send byte-identical project identities for the same uv.lock, regardless of whether --file was absolute or relative.

## Where should the reviewer start?

src/lib/plugins/uv/index.ts — the new getResolvedTargetFile(root, targetFile) function is the whole fix. 

## How should this be manually tested?

In an org with enableUvCLI enabled, against any UV project:
PROJ=$(pwd)
snyk monitor --org=<org> --file=$PROJ/uv.lock
# Apply an ignore on one vulnerability in the UI
snyk test --org=<org> --file=$PROJ/uv.lock
Expected: the test summary shows the ignored vuln as Ignored: 1, not Open. Before this fix it would show as Open because the test lookup couldn't find the project.

## What's the product update that needs to be communicated to CLI users?

UV (early access): UI-applied ignore policies now apply correctly when snyk monitor and snyk test are invoked with an absolute --file path 

## Risk assessment (Low)

Gated behind uv feature flag

## What are the relevant tickets?

https://snyksec.atlassian.net/browse/UNIFY-1419
