### PR TITLE
docs: add missing command help docs

### DIFF
--- a/cliv2/pkg/core/help_docs_audit_test.go
+++ b/cliv2/pkg/core/help_docs_audit_test.go
@@ -1,0 +1,56 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/snyk/go-application-framework/pkg/configuration"
+	"github.com/snyk/go-application-framework/pkg/workflow"
+	"github.com/stretchr/testify/require"
+)
+
+type registeredCommandForHelpAudit struct {
+	Command string `json:"command"`
+	Visible bool   `json:"visible"`
+}
+
+func TestPrintRegisteredCommandTreeForHelpAudit(t *testing.T) {
+	if os.Getenv("SNYK_HELP_AUDIT_PRINT_COMMANDS") != "1" {
+		t.Skip("set SNYK_HELP_AUDIT_PRINT_COMMANDS=1 to print registered commands")
+	}
+
+	config := configuration.New()
+	engine := workflow.NewWorkFlowEngine(config)
+	initExtensions(engine, config, nil)
+	require.NoError(t, engine.Init())
+
+	commands := []registeredCommandForHelpAudit{}
+	for _, workflowID := range engine.GetWorkflows() {
+		command := workflow.GetCommandFromWorkflowIdentifier(workflowID)
+		if command == "" {
+			continue
+		}
+
+		entry, ok := engine.GetWorkflow(workflowID)
+		if !ok {
+			continue
+		}
+
+		commands = append(commands, registeredCommandForHelpAudit{
+			Command: command,
+			Visible: entry.IsVisible(),
+		})
+	}
+
+	sort.Slice(commands, func(i, j int) bool {
+		return commands[i].Command < commands[j].Command
+	})
+
+	output, err := json.Marshal(commands)
+	require.NoError(t, err)
+
+	fmt.Printf("SNYK_HELP_AUDIT_COMMANDS=%s\n", output)
+}

--- a/help/cli-commands/about.md
+++ b/help/cli-commands/about.md
@@ -1,0 +1,15 @@
+# About
+
+## Usage
+
+`snyk about`
+
+## Description
+
+The `snyk about` command prints open source attribution information for the Snyk CLI.
+
+The output includes the package names, versions, licenses, authors, source package locations, and license text for third-party packages bundled with the CLI.
+
+## Debug
+
+Use the `-d` option to output the debug logs.

--- a/help/cli-commands/agent-scan.md
+++ b/help/cli-commands/agent-scan.md
@@ -1,0 +1,65 @@
+# Agent scan
+
+**Warning:** The `snyk agent-scan` command is experimental. The `--experimental` flag is required. Behavior and options may change in future releases without notice.
+
+## Usage
+
+`snyk agent-scan --experimental [<PATH>] [<OPTIONS>]`
+
+## Description
+
+The `snyk agent-scan` command scans agent-related assets, including MCP server configuration and skills, and can upload scan results to Snyk Evo.
+
+If you provide a path, the command scans that path. If you do not provide a subcommand, the CLI runs the default `scan` action.
+
+The command downloads and runs the platform-specific `agent-scan` binary when needed.
+
+## Options
+
+### `--experimental`
+
+Required. Acknowledges that this command is experimental.
+
+### `--client-id=<UUID>`
+
+Specify the client ID to use when uploading scan results.
+
+If you do not specify `--client-id`, the CLI attempts to discover one from your authenticated Snyk account.
+
+### `--tenant-id=<UUID>`
+
+Specify the tenant ID to use for client ID discovery.
+
+You can also set the tenant ID with the `SNYK_TENANT_ID` environment variable.
+
+### `--json`
+
+Print the output as JSON.
+
+When using `--json`, provide `--tenant-id` if client ID discovery is required.
+
+### `--skills[=<PATH>]`
+
+Scan skills in addition to MCP servers.
+
+You can use this option as a boolean flag or provide a folder path.
+
+### `--no-upload`
+
+Do not upload scan results to Snyk Evo.
+
+This option requires authentication.
+
+## Examples
+
+Scan the current directory:
+
+`$ snyk agent-scan --experimental`
+
+Scan a specific directory:
+
+`$ snyk agent-scan --experimental ./my-agent`
+
+Scan skills and print JSON:
+
+`$ snyk agent-scan --experimental --skills --json --tenant-id=<UUID>`

--- a/help/cli-commands/fix.md
+++ b/help/cli-commands/fix.md
@@ -1,0 +1,49 @@
+# Fix
+
+## Usage
+
+`snyk fix [<PATH>] [<OPTIONS>]`
+
+## Description
+
+The `snyk fix` command applies available fixes for open-source vulnerabilities in supported projects.
+
+The command first runs `snyk test` for the target project and then applies supported remediation actions.
+
+## Configure the Snyk CLI
+
+You can use environment variables to configure the Snyk CLI and set variables for connecting with the Snyk API. See [Configure the Snyk CLI](https://docs.snyk.io/snyk-cli/configure-the-snyk-cli)
+
+## Debug
+
+Use the `-d` option to output the debug logs.
+
+## Options
+
+### `--dry-run`
+
+Preview the fixes that would be applied without changing files.
+
+### `--quiet`
+
+Reduce command output.
+
+### `--sequential`
+
+Apply fixes sequentially.
+
+### Options used by `snyk test`
+
+The `snyk fix` command uses `snyk test` to find vulnerabilities before applying fixes. Supported `snyk test` options can be used to control project detection and dependency resolution.
+
+For more information, see the [`snyk test` help](test.md); `snyk test --help`.
+
+## Examples
+
+Preview available fixes:
+
+`$ snyk fix --dry-run`
+
+Apply fixes in the current directory:
+
+`$ snyk fix`

--- a/help/cli-commands/iac-rules-repl.md
+++ b/help/cli-commands/iac-rules-repl.md
@@ -1,0 +1,43 @@
+# IaC rules repl
+
+## Usage
+
+**Feature availability:** This feature is in Early Access.
+
+`snyk iac rules repl [<OPTIONS>]`
+
+## Description
+
+The `snyk iac rules repl` command starts an interactive Rego REPL for an IaC custom rules project.
+
+Run the command from an IaC custom rules project directory. You can load an input file and run initialization commands when the REPL starts.
+
+For a list of related commands run `snyk iac --help`.
+
+## Configure the Snyk CLI
+
+You can use environment variables and set variables for connecting with the Snyk API; see [Configure the Snyk CLI](https://docs.snyk.io/snyk-cli/configure-the-snyk-cli)
+
+## Debug
+
+Use the `-d` option to output the debug logs.
+
+## Options
+
+### `--repl-init=<COMMAND>`
+
+Run commands on REPL initialization.
+
+This option can be provided more than once.
+
+### `--repl-input=<FILE_PATH>`
+
+Load an IaC input file into the REPL.
+
+## Example
+
+Start the REPL with an input file:
+
+```
+snyk iac rules repl --repl-input=input.json
+```

--- a/help/cli-commands/ignore-create.md
+++ b/help/cli-commands/ignore-create.md
@@ -1,0 +1,61 @@
+# Ignore create
+
+## Usage
+
+`snyk ignore create [<OPTIONS>]`
+
+## Description
+
+The `snyk ignore create` command creates an ignore request for a finding in a Snyk Organization.
+
+This command creates an ignore request through the Snyk ignore workflow. It does not edit the local `.snyk` policy file. To add ignores to a local policy file, use the `snyk ignore` command.
+
+In interactive mode, the command prompts for missing values. In non-interactive mode, provide the required options.
+
+## Options
+
+### `--finding-id=<FINDING_ID>`
+
+The ID of the finding to ignore. Required when `--interactive=false`.
+
+### `--ignore-type=<IGNORE_TYPE>`
+
+The ignore type to create. Required when `--interactive=false`.
+
+Supported values:
+
+- `not-vulnerable`
+- `wont-fix`
+- `temporary-ignore`
+
+### `--reason=<REASON>`
+
+The reason for the ignore. Required when `--interactive=false`.
+
+### `--expiration=<EXPIRATION>`
+
+The ignore expiration date. Use `YYYY-MM-DD` format, or `never` for no expiration. Required when `--interactive=false`.
+
+### `--remote-repo-url=<URL>`
+
+The remote repository URL for the project. The command detects this value automatically when possible.
+
+### `--interactive=<true|false>`
+
+Run the command in interactive mode.
+
+Default: `true`
+
+### `--org=<ORG_ID>`
+
+Specify the Snyk Organization ID to use for the ignore request. The value must be an Organization UUID.
+
+## Examples
+
+Create an ignore request interactively:
+
+`$ snyk ignore create`
+
+Create a temporary ignore request without prompts:
+
+`$ snyk ignore create --finding-id=<FINDING_ID> --ignore-type=temporary-ignore --reason='Temporarily accepted risk' --expiration=2026-07-01 --interactive=false`

--- a/help/cli-commands/ignore.md
+++ b/help/cli-commands/ignore.md
@@ -10,6 +10,10 @@ The `snyk ignore` command modifies the `.snyk` policy file to ignore a specified
 
 **Note:** Ignoring issues or vulnerabilities using the `.snyk` file is not supported for Snyk Code.
 
+### Create ignore requests
+
+[`snyk ignore create`](ignore-create.md); `snyk ignore create --help`: creates an ignore request for a finding.
+
 ### Exclude
 
 `snyk ignore [--expiry=] [--reason=] [--policy-path=<PATH_TO_POLICY_FILE>] [--file-path=<PATH_TO_RESOURCE>] [OPTIONS]`

--- a/help/cli-commands/redteam-get.md
+++ b/help/cli-commands/redteam-get.md
@@ -1,0 +1,52 @@
+# Redteam get
+
+**Warning:** The `snyk redteam get` command is experimental. The `--experimental` flag is required. Behavior and options may change in future releases without notice.
+
+`snyk redteam` will be deprecated on May 31, 2026.
+
+## Prerequisites
+
+- Snyk CLI v1.1303.1 or later.
+- Authenticated Snyk CLI; run `snyk auth`.
+
+## Usage
+
+`snyk redteam get --experimental --id=<SCAN_ID> [<OPTIONS>]`
+
+## Description
+
+The `snyk redteam get` command retrieves results for a previously completed red team scan.
+
+For more information about red team scans and configuration, see the [`snyk redteam` help](redteam.md); `snyk redteam --help`.
+
+## Options
+
+### `--experimental`
+
+Required. Acknowledges that this command is experimental.
+
+### `--id=<SCAN_ID>`
+
+Required. The UUID of the scan to retrieve results for.
+
+### `--html`
+
+Output the scan report in HTML format instead of JSON.
+
+### `--html-file-output=<FILE_PATH>`
+
+Write the HTML report to the specified file path. Implies HTML output.
+
+### `--json-file-output=<FILE_PATH>`
+
+Write the JSON report to the specified file path.
+
+### `--tenant-id=<UUID>`
+
+Specify the Snyk tenant ID. The CLI attempts to discover the tenant ID from your authenticated Snyk account if it is not provided.
+
+## Example
+
+Retrieve scan results:
+
+`$ snyk redteam get --experimental --id=<SCAN_ID>`

--- a/help/cli-commands/redteam-ping.md
+++ b/help/cli-commands/redteam-ping.md
@@ -1,0 +1,58 @@
+# Redteam ping
+
+**Warning:** The `snyk redteam ping` command is experimental. The `--experimental` flag is required. Behavior and options may change in future releases without notice.
+
+`snyk redteam` will be deprecated on May 31, 2026.
+
+## Prerequisites
+
+- Snyk CLI v1.1303.1 or later.
+- Authenticated Snyk CLI; run `snyk auth`.
+
+## Usage
+
+`snyk redteam ping --experimental [<OPTIONS>]`
+
+## Description
+
+The `snyk redteam ping` command sends a test request to the configured target endpoint.
+
+Use this command to verify target connectivity and response parsing before running a full red team scan.
+
+For more information about red team configuration, see the [`snyk redteam` help](redteam.md); `snyk redteam --help`.
+
+## Options
+
+### `--experimental`
+
+Required. Acknowledges that this command is experimental.
+
+### `--config=<FILE_PATH>`
+
+Path to the YAML configuration file.
+
+Default: `redteam.yaml` in the current directory.
+
+### `--target-url=<URL>`
+
+URL of the target endpoint to test. Overrides `target.settings.url` from the configuration file.
+
+### `--request-body-template=<TEMPLATE>`
+
+JSON template for the HTTP request body sent to the target. Must contain the `{{prompt}}` placeholder.
+
+### `--response-selector=<JMESPATH_EXPRESSION>`
+
+JMESPath expression used to extract the AI response from the target's JSON response body.
+
+### `--header=<"KEY: VALUE">`
+
+HTTP header to include in requests to the target.
+
+This flag is repeatable.
+
+## Example
+
+Ping the target from `redteam.yaml`:
+
+`$ snyk redteam ping --experimental --config=redteam.yaml`

--- a/help/cli-commands/redteam-setup.md
+++ b/help/cli-commands/redteam-setup.md
@@ -1,0 +1,46 @@
+# Redteam setup
+
+**Warning:** The `snyk redteam setup` command is experimental. The `--experimental` flag is required. Behavior and options may change in future releases without notice.
+
+`snyk redteam` will be deprecated on May 31, 2026.
+
+## Prerequisites
+
+- Snyk CLI v1.1303.1 or later.
+- Authenticated Snyk CLI; run `snyk auth`.
+
+## Usage
+
+`snyk redteam setup --experimental [<OPTIONS>]`
+
+## Description
+
+The `snyk redteam setup` command launches a local web-based setup wizard for red team target configuration.
+
+The wizard guides you through target endpoint, header, goal, and strategy configuration, then produces a `redteam.yaml` file for `snyk redteam`.
+
+For more information about red team scans and configuration, see the [`snyk redteam` help](redteam.md); `snyk redteam --help`.
+
+## Options
+
+### `--experimental`
+
+Required. Acknowledges that this command is experimental.
+
+### `--config=<FILE_PATH>`
+
+Load an existing configuration file to edit.
+
+Default: `redteam.yaml` in the current directory.
+
+### `--port=<NUMBER>`
+
+Port for the setup wizard's local web server.
+
+Default: `8484`
+
+## Example
+
+Launch the setup wizard:
+
+`$ snyk redteam setup --experimental`

--- a/help/cli-commands/secrets-test.md
+++ b/help/cli-commands/secrets-test.md
@@ -1,0 +1,111 @@
+# Secrets test
+
+## Usage
+
+`snyk secrets test [<PATH>] [<OPTIONS>]`
+
+## Description
+
+The `snyk secrets test` command scans a local path for secrets and reports discovered issues.
+
+If you do not provide a path, the command scans the current directory.
+
+## Exit codes
+
+Possible exit codes and their meaning:
+
+**0**: success, no issues found\
+**1**: action_needed, issues found\
+**2**: failure, try to re-run the command. Use `-d` to output the debug logs.
+
+## Configure the Snyk CLI
+
+You can use environment variables to configure the Snyk CLI and set variables for connecting with the Snyk API. See [Configure the Snyk CLI](https://docs.snyk.io/snyk-cli/configure-the-snyk-cli)
+
+## Debug
+
+Use the `-d` option to output the debug logs.
+
+## Options
+
+### `--json`
+
+Print results on the console as a JSON data structure.
+
+### `--sarif`
+
+Return results in SARIF format.
+
+### `--json-file-output=<FILE_PATH>`
+
+Save test output as a JSON data structure directly to the specified file, regardless of whether or not you use the `--json` option.
+
+### `--sarif-file-output=<FILE_PATH>`
+
+Save test output in SARIF format directly to the specified file, regardless of whether or not you use the `--sarif` option.
+
+### `--severity-threshold=<low|medium|high|critical>`
+
+Report only issues at the specified level or higher.
+
+### `--include-ignores`
+
+Show all discovered issues, including issues that have been previously ignored.
+
+### `--exclude=<NAME>[,<NAME>...]`
+
+Ignore issues originating from the specified file or directory names.
+
+The value must be a comma-separated list of names and cannot contain paths.
+
+### `--report`
+
+Share results with the Snyk Web UI.
+
+### `--remote-repo-url=<URL>`
+
+Set or override the remote URL for the repository.
+
+### `--target-name=<TARGET_NAME>`
+
+Used with `--report` to set or override the project name for the repository.
+
+### `--target-reference=<REFERENCE>`
+
+Used with `--report` to specify a reference that differentiates this project, for example a branch name or version.
+
+### `--project-business-criticality=<VALUE>[,<VALUE>...]`
+
+Used with `--report` to set the project business criticality.
+
+Supported values: `critical`, `high`, `medium`, `low`.
+
+### `--project-environment=<VALUE>[,<VALUE>...]`
+
+Used with `--report` to set the project environment.
+
+Supported values: `frontend`, `backend`, `internal`, `external`, `mobile`, `saas`, `onprem`, `hosted`, `distributed`.
+
+### `--project-lifecycle=<VALUE>[,<VALUE>...]`
+
+Used with `--report` to set the project lifecycle.
+
+Supported values: `production`, `development`, `sandbox`.
+
+### `--project-tags=<KEY=VALUE>[,<KEY=VALUE>...]`
+
+Used with `--report` to set project tags.
+
+## Examples
+
+Scan the current directory:
+
+`$ snyk secrets test`
+
+Scan a specific directory and output SARIF:
+
+`$ snyk secrets test ./src --sarif-file-output=secrets.sarif`
+
+Share results with project attributes:
+
+`$ snyk secrets test --report --target-reference=main --project-lifecycle=production`

--- a/help/cli-commands/tools-connectivity-check.md
+++ b/help/cli-commands/tools-connectivity-check.md
@@ -1,0 +1,49 @@
+# Tools connectivity-check
+
+**Warning:** The `snyk tools connectivity-check` command is experimental. Behavior and options may change in future releases without notice.
+
+## Usage
+
+`snyk tools connectivity-check --experimental [<OPTIONS>]`
+
+## Description
+
+The `snyk tools connectivity-check` command runs diagnostic checks for Snyk CLI network connectivity.
+
+Use this command to help troubleshoot access to Snyk API endpoints, Organization data, and related network dependencies.
+
+## Debug
+
+Use the `-d` option to output the debug logs.
+
+## Options
+
+### `--experimental`
+
+Required. Acknowledges that this command is experimental.
+
+### `--json`
+
+Output results in JSON format.
+
+### `--no-color`
+
+Disable colored output.
+
+### `--timeout=<SECONDS>`
+
+Timeout in seconds for each connection test.
+
+Default: `10`
+
+### `--max-org-count=<NUMBER>`
+
+Maximum number of Organizations to retrieve during connectivity checks.
+
+Default: `100`
+
+## Example
+
+Run connectivity diagnostics:
+
+`$ snyk tools connectivity-check --experimental`

--- a/help/cli-commands/tools-ide-directory-check.md
+++ b/help/cli-commands/tools-ide-directory-check.md
@@ -1,0 +1,31 @@
+# Tools ide-directory-check
+
+## Usage
+
+`snyk tools ide-directory-check [<OPTIONS>]`
+
+## Description
+
+The `snyk tools ide-directory-check` command runs directory diagnostics used by Snyk IDE tooling.
+
+Use this command to inspect whether the current directory can be processed correctly by Snyk IDE integrations.
+
+## Debug
+
+Use the `-d` option to output the debug logs.
+
+## Options
+
+### `--json`
+
+Output results in JSON format.
+
+### `--no-color`
+
+Disable colored output.
+
+## Example
+
+Run directory diagnostics:
+
+`$ snyk tools ide-directory-check`

--- a/help/cli-commands/version.md
+++ b/help/cli-commands/version.md
@@ -1,0 +1,15 @@
+# Version
+
+## Usage
+
+`snyk version`
+
+## Description
+
+The `snyk version` command prints the installed Snyk CLI version.
+
+You can also print the version with `snyk --version`.
+
+## Debug
+
+Use the `-d` option to output the debug logs.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "clean": "npx rimraf node_modules dist binary-releases test-results *.tgz tsconfig.tsbuildinfo .eslintcache pysrc packages/*/node_modules packages/*/dist packages/*/tsconfig.tsbuildinfo packages/*/*.tgz",
     "format": "prettier --write '**/*.{js,ts,json,yaml,yml,md}' && npm run lint:js -- --fix",
     "format:changes": "./scripts/format/prettier-changes.sh",
+    "help:audit": "node scripts/audit-cli-help-docs.js",
     "lint": "npm-run-all --serial --continue-on-error lint:*",
     "lint:js": "eslint --quiet --color --cache '**/*.{js,ts}'",
     "lint:formatting": "prettier --check '**/*.{js,ts,json,yaml,yml,md}'",

--- a/scripts/audit-cli-help-docs.js
+++ b/scripts/audit-cli-help-docs.js
@@ -20,6 +20,19 @@ const internalCommands = new Set([
   'reportanalytics',
 ]);
 
+const commandsWithoutStandaloneHelp = new Set([
+  'container depgraph',
+  'depgraph',
+  'describe',
+  'protect',
+  'unmanaged',
+  'unmanaged monitor',
+  'unmanaged test',
+  'update-exclude-policy',
+  'wizard',
+  'woof',
+]);
+
 function readFile(relativePath) {
   return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
 }
@@ -144,6 +157,7 @@ function collectCommands() {
 const docs = helpFiles();
 const missing = collectCommands()
   .filter((entry) => includeInternal || !internalCommands.has(entry.command))
+  .filter((entry) => !commandsWithoutStandaloneHelp.has(entry.command))
   .filter((entry) => includeHidden || entry.visible)
   .filter((entry) => !docs.has(expectedHelpFile(entry.command)))
   .sort((a, b) => a.command.localeCompare(b.command));

--- a/scripts/audit-cli-help-docs.js
+++ b/scripts/audit-cli-help-docs.js
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const helpDir = path.join(repoRoot, 'help', 'cli-commands');
+const failOnMissing = process.argv.includes('--fail-on-missing');
+const includeHidden = process.argv.includes('--include-hidden');
+const includeInternal = process.argv.includes('--include-internal');
+
+const internalCommands = new Set([
+  'datatransformation',
+  'filter',
+  'help',
+  'internal cleanup',
+  'legacycli',
+  'output',
+  'reportanalytics',
+]);
+
+function readFile(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+function expectedHelpFile(command) {
+  return `${command.replace(/\s+/g, '-')}.md`;
+}
+
+function addCommand(commands, command, source, visible = true) {
+  const normalizedCommand = command.trim().replace(/\s+/g, ' ');
+  if (!normalizedCommand) {
+    return;
+  }
+
+  if (!commands.has(normalizedCommand)) {
+    commands.set(normalizedCommand, {
+      command: normalizedCommand,
+      sources: new Set(),
+      visible,
+    });
+  }
+
+  const entry = commands.get(normalizedCommand);
+  entry.sources.add(source);
+  entry.visible = entry.visible || visible;
+}
+
+function legacyCommands() {
+  const commands = new Map();
+  const commandIndex = readFile('src/cli/commands/index.js');
+
+  for (const match of commandIndex.matchAll(
+    /^\s*(?:'([^']+)'|"([^"]+)"|([a-zA-Z][\w-]*)):\s*async/gm,
+  )) {
+    addCommand(commands, match[1] || match[2] || match[3], 'legacy command');
+  }
+
+  const modes = readFile('src/cli/modes.ts');
+  for (const match of modes.matchAll(
+    /^\s{2}([a-zA-Z][\w-]*):\s*{\s*allowedCommands:\s*\[([^\]]*)\]/gm,
+  )) {
+    const mode = match[1];
+    const allowedCommands = Array.from(
+      match[2].matchAll(/'([^']+)'|"([^"]+)"/g),
+      (allowedCommandMatch) => allowedCommandMatch[1] || allowedCommandMatch[2],
+    );
+
+    addCommand(commands, mode, 'legacy mode');
+    for (const allowedCommand of allowedCommands) {
+      addCommand(commands, `${mode} ${allowedCommand}`, 'legacy mode');
+    }
+  }
+
+  return commands;
+}
+
+function nativeCommands() {
+  const result = spawnSync(
+    'go',
+    [
+      'test',
+      './pkg/core',
+      '-run',
+      'TestPrintRegisteredCommandTreeForHelpAudit',
+      '-count=1',
+      '-v',
+    ],
+    {
+      cwd: path.join(repoRoot, 'cliv2'),
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        SNYK_HELP_AUDIT_PRINT_COMMANDS: '1',
+      },
+    },
+  );
+
+  if (result.status !== 0) {
+    process.stderr.write(result.stdout);
+    process.stderr.write(result.stderr);
+    process.exit(result.status || 1);
+  }
+
+  const match = result.stdout.match(/SNYK_HELP_AUDIT_COMMANDS=(\[.*\])/);
+  if (!match) {
+    process.stderr.write(result.stdout);
+    process.stderr.write(result.stderr);
+    throw new Error('Could not find registered command audit output.');
+  }
+
+  return JSON.parse(match[1]);
+}
+
+function helpFiles() {
+  return new Set(
+    fs
+      .readdirSync(helpDir)
+      .filter(
+        (fileName) => fileName.endsWith('.md') && fileName !== 'README.md',
+      ),
+  );
+}
+
+function collectCommands() {
+  const commands = legacyCommands();
+
+  for (const nativeCommand of nativeCommands()) {
+    addCommand(
+      commands,
+      nativeCommand.command,
+      nativeCommand.visible ? 'native workflow' : 'native workflow hidden',
+      nativeCommand.visible,
+    );
+  }
+
+  return Array.from(commands.values()).map((entry) => ({
+    ...entry,
+    sources: Array.from(entry.sources).sort(),
+  }));
+}
+
+const docs = helpFiles();
+const missing = collectCommands()
+  .filter((entry) => includeInternal || !internalCommands.has(entry.command))
+  .filter((entry) => includeHidden || entry.visible)
+  .filter((entry) => !docs.has(expectedHelpFile(entry.command)))
+  .sort((a, b) => a.command.localeCompare(b.command));
+
+if (missing.length === 0) {
+  console.log('All discovered CLI commands have help docs.');
+  process.exit(0);
+}
+
+console.log('CLI commands without help docs:');
+for (const entry of missing) {
+  console.log(
+    `- snyk ${entry.command} -> help/cli-commands/${expectedHelpFile(
+      entry.command,
+    )} (${entry.sources.join(', ')})`,
+  );
+}
+
+if (failOnMissing) {
+  process.exit(1);
+}

--- a/test/jest/acceptance/help.spec.ts
+++ b/test/jest/acceptance/help.spec.ts
@@ -57,6 +57,23 @@ describe('help', () => {
       expect(stderr).toBe('');
     });
 
+    it('prints specific help info for ignore', async () => {
+      const { stdout, code, stderr } = await runSnykCLI('ignore --help');
+
+      expect(stdout).toContain('snyk ignore create');
+      expect(code).toBe(0);
+      expect(stderr).toBe('');
+    });
+
+    it('prints specific help info for ignore create', async () => {
+      const { stdout, code, stderr } = await runSnykCLI('ignore create --help');
+
+      expect(stdout).toContain('Ignore create');
+      expect(stdout).toContain('snyk ignore create [<OPTIONS>]');
+      expect(code).toBe(0);
+      expect(stderr).toBe('');
+    });
+
     it('prints specific help info when called with flag and equals sign', async () => {
       const { stdout, code, stderr } = await runSnykCLI('--help=iac');
 


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_. 
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [x] Updates relevant GitBook documentation (PR link: this PR updates synced CLI help docs)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Stacked on #6892.

Adds help pages for visible CLI commands identified by `npm run help:audit`, including `about`, `agent-scan`, `fix`, `iac rules repl`, redteam subcommands, `secrets test`, tools diagnostics, and `version`.

It also excludes command entries that should not require standalone help pages: implementation-only aliases, deprecated stubs, legacy unmanaged mode aliases, and internal helper workflows.

Risk assessment: Low. Documentation-only plus help-audit classification.

Breaking API changes: None.

## Where should the reviewer start?

Start with `scripts/audit-cli-help-docs.js` for the exclusion list, then review the new files in `help/cli-commands/`.

## How should this be manually tested?

Run:

```sh
npm run help:audit -- --fail-on-missing
```

Validation already run locally:

```sh
make format
make lint
make build BUILD_MODE=public
npm run help:audit -- --fail-on-missing
```

## What's the product update that needs to be communicated to CLI users?

CLI help coverage has been expanded for additional visible commands.
