### PR TITLE
chore: Disable Homebrew 6.0.0 interactive install prompt in macOS CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -446,7 +446,7 @@ commands:
       - run:
           name: Installing sdks and tools via homebrew
           command: |
-            brew install << parameters.items >>
+            HOMEBREW_NO_ASK=1 brew install << parameters.items >>
             echo 'export PATH="/opt/homebrew/opt/gradle@9/bin:$PATH"' >> "$BASH_ENV"
       - save_cache:
           key: acceptance-tests-macos-<< parameters.items >>


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Sets `HOMEBREW_NO_ASK=1` on the macOS Homebrew install step so `brew install` no longer stops on an interactive confirmation prompt.

Homebrew 6.0.0 (released ~Jun 10, 2026, pulled into CI via brew's runtime auto-update) made "ask mode" the default, so `brew install` now prints `Do you want to proceed with the installation? [y/n]`. CI has no TTY to answer it, so the step produced no output and hit the 10-minute no-output timeout. See [Homebrew/brew#22645](https://github.com/Homebrew/brew/issues/22645).

## Where should the reviewer start?

- `.circleci/config.yml` — the macOS `Installing sdks and tools via homebrew` step (`HOMEBREW_NO_ASK=1 brew install …`).

## How should this be manually tested?

1. Trigger CI on a branch that runs the macOS acceptance/build jobs.
2. Confirm the Homebrew install step completes without hanging on a `[y/n]` prompt and within the normal time budget.

## What's the product update that needs to be communicated to CLI users?

None. CI-only change; no CLI behavior change for end users.

## Risk assessment (Low | Medium | High)?

Low — a single environment variable on one macOS CI step; no product or runtime change.

## Any background context you want to provide?

Other approaches were ruled out: `HOMEBREW_NO_AUTO_UPDATE=1` froze brew's metadata and caused a separate `Utils::Bottles.load_tab` crash (brew advised running `brew update`); `NONINTERACTIVE=1` only governs the Homebrew installer script (passwords), not the `brew install` ask prompt. `HOMEBREW_NO_ASK=1` is the documented toggle for this prompt and keeps auto-update enabled (so metadata stays fresh).

## What are the relevant tickets?

[CLI-1582](https://snyksec.atlassian.net/browse/CLI-1582)

## Screenshots (if appropriate)

N/A

[CLI-1582]: https://snyksec.atlassian.net/browse/CLI-1582