### PR TITLE
chore(fix): bump remy to 1.15.1

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/snyk/cli/cliv2 v0.0.0
-	github.com/snyk/remy-cli-extension v1.15.0
+	github.com/snyk/remy-cli-extension v1.15.1-0.20260612100621-e413ec9dadef
 )
 
 require (

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -593,8 +593,8 @@ github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyR
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
-github.com/snyk/remy-cli-extension v1.15.0 h1:U/8LfyMYvh5OPSthSRVmOdPf9CL20TH83Or4Fw/upgQ=
-github.com/snyk/remy-cli-extension v1.15.0/go.mod h1:ps0TXsNLxFYGFUj+63Py3Djf0hSq7eAMR7dKn+cUL30=
+github.com/snyk/remy-cli-extension v1.15.1-0.20260612100621-e413ec9dadef h1:rXUM5zUEwgl4C4r2NJeBBT1cVRQ7WPUb6llEk+sYWxo=
+github.com/snyk/remy-cli-extension v1.15.1-0.20260612100621-e413ec9dadef/go.mod h1:ps0TXsNLxFYGFUj+63Py3Djf0hSq7eAMR7dKn+cUL30=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
 github.com/snyk/snyk-ls v0.0.0-20260529103026-b999aa3e3447 h1:/i1g1NrQlGoXObznpV34e8fJZUoIz6MvdSBA/31b/w8=


### PR DESCRIPTION
# Changes
1. Replace `code` argument with `sast` for remy.