### PR TITLE
docs: add Cursor Cloud dev environment notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,3 +188,54 @@ extension/
 - ❌ Domain logic inside the callback — extract into domain packages
 - ❌ Passing `InvocationContext` into domain code — pass concrete values
 - ❌ Deep workflow call chains — keep composition flat
+
+## Cursor Cloud specific instructions
+
+The startup update script runs `npm install` only. Everything below is context for running
+things by hand; the standard commands themselves live in the sections above and in `package.json`.
+
+### Toolchain notes (already provisioned in the VM image)
+
+- **Node/npm**: `npm` is upgraded to `>=11.10` (required by `.npmrc` `engine-strict=true`; the
+  base image ships npm 10.x which would make `npm install` fail). `node` is `^22` and satisfies
+  `engines`. Do not downgrade npm.
+- **Go**: the system `go` is older than `cliv2/go.mod`'s `go` directive. `GOTOOLCHAIN=auto`
+  (the default) transparently downloads the pinned toolchain from `proxy.golang.org` on first
+  `go`/`make` invocation — leave it on. No manual Go install is needed.
+- **`convco`**: required by `make build` (via `release-scripts/next-version.sh`). Installed at
+  `/usr/local/cargo/bin/convco`. Pin is `0.6.2` — newer `convco` needs a newer `rustc` than the
+  image provides.
+
+### Build the CLI — `make build BUILD_MODE=public`
+
+- Always use `BUILD_MODE=public`. `cliv2-private/` is present but its modules need private
+  GitHub access that this VM does not have, so private auto-detection / `BUILD_MODE=private`
+  fails.
+- TS unit tests need the workspace packages built first (`@snyk/fix`, `@snyk/protect`):
+  run `npm run build --workspaces` once, otherwise a few suites fail with
+  `Cannot find module '@snyk/fix'`. `make build` does this for you.
+
+### Network egress is restricted — expected failures
+
+Outbound HTTPS to most non-package hosts is blocked (`go.dev`, `downloads.snyk.io`,
+`api.snyk.io` all fail; npm registry and `proxy.golang.org` work).
+
+- **`make build` license step**: `cliv2/scripts/prepare_licenses.go` fetches a license from
+  `go.dev` and aborts the build. Workaround used here: pre-seed it from the local Go toolchain —
+  `cp "$(cd cliv2 && go env GOROOT)/LICENSE" cliv2/internal/embedded/_data/licenses/go.dev/LICENSE`
+  before `make build` (the script skips any license file that already exists). `make clean`
+  removes it, so re-seed after cleaning. Allowing `go.dev` egress removes the need for this.
+- **Tests that need the Snyk API / a token**: a handful of `npm run test:unit` suites and the
+  Go `internal/proxy` tests reach `api.snyk.io` / `downloads.snyk.io` and fail with network
+  errors or `MissingApiTokenError`. This is environment-only; ~1050/1076 unit tests pass.
+- **Acceptance tests** spin up a local fake server (`test/acceptance/fake-server.ts`) and run
+  fully offline against the built binary, e.g.
+  `TEST_SNYK_COMMAND="$PWD/binary-releases/snyk-linux" npx jest --maxWorkers=1 test/jest/acceptance/print-graph.spec.ts`.
+
+### Running the built CLI directly
+
+The Go wrapper performs an auth/feature-flag preflight to `api.snyk.io` on startup, so direct
+`snyk test`/`snyk iac test` invocations fail without network + a token. For an offline smoke
+test of real scanning logic, use the acceptance harness above (it builds real dependency graphs)
+or point `SNYK_API` at a local fake server. The TS-only dev entrypoint (`npm run dev -- ...`)
+runs without building the Go binary.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the development environment for the Snyk CLI (hybrid TypeScript + Go) in Cursor Cloud and documents the non-obvious setup caveats discovered while doing so. The only code change is a new `## Cursor Cloud specific instructions` section in `AGENTS.md`.

## Environment setup performed

- **npm upgraded to `>=11.10`** — `.npmrc` sets `engine-strict=true` and `package.json` requires npm `^11.10`, but the base image ships npm 10.x, which makes `npm install` fail outright.
- **Go toolchain** — `cliv2/go.mod` pins a `go` version newer than the system `go`. `GOTOOLCHAIN=auto` downloads the pinned toolchain from `proxy.golang.org` automatically; no manual install needed.
- **`convco@0.6.2`** installed via cargo (required by `make build` → `release-scripts/next-version.sh`). Newer `convco` needs a newer `rustc` than the image provides.

Startup update script: `npm install`.

## Verified

| Area | Command | Result |
| --- | --- | --- |
| Lint (TS) | `npm run lint` | pass |
| Unit tests (TS) | `npm run test:unit` | 1051/1076 pass (remainder need Snyk API token / blocked egress) |
| Tests (Go) | `cd cliv2 && make test` | pass except `internal/proxy` (blocked egress to `downloads.snyk.io`) |
| Build | `make build BUILD_MODE=public` | builds `binary-releases/snyk-linux` |
| Run / hello-world | `print-graph` acceptance test against the built binary | pass (real dependency-graph extraction end-to-end) |

## Notes for future agents (captured in AGENTS.md)

- Use `BUILD_MODE=public` (private modules need GitHub access this VM lacks).
- `make build`'s license step fetches a `go.dev` license; egress is blocked, so pre-seed it from the local Go toolchain (`cp "$(cd cliv2 && go env GOROOT)/LICENSE" cliv2/internal/embedded/_data/licenses/go.dev/LICENSE`).
- TS unit tests need workspace packages built first (`npm run build --workspaces`).
- Direct `snyk test` invocations do an `api.snyk.io` preflight (blocked); use the acceptance fake-server harness for offline scanning smoke tests.

[snyk_hello_world.log](https://cursor.com/agents/bc-378b6e76-4a86-4af2-a76e-80b88852d428/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsnyk_hello_world.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-378b6e76-4a86-4af2-a76e-80b88852d428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-378b6e76-4a86-4af2-a76e-80b88852d428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

