### PR TITLE
fix(ci): add tag for npm preview publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -441,6 +441,9 @@ commands:
       - run:
           name: Installing Rosetta
           command: softwareupdate --install-rosetta --agree-to-license
+      - run:
+          name: Update Homebrew
+          command: brew update
       - restore_cache:
           key: acceptance-tests-macos-<< parameters.items >>
       - run:
@@ -1874,7 +1877,7 @@ jobs:
               pattern: '^macos.*'
               value: << parameters.executor >>
           steps:
-            - run: brew install coreutils curl python3
+            - run: brew update && HOMEBREW_NO_ASK=1 brew install coreutils curl python3
       - when:
           condition:
             matches:

--- a/release-scripts/upload-artifacts.sh
+++ b/release-scripts/upload-artifacts.sh
@@ -104,18 +104,24 @@ upload_github() {
 }
 
 upload_npm() {
+  # For non-stable releases, specify --tag to avoid npm's prerelease version error
+  local npm_tag_arg=""
+  if [ -n "${RELEASE_CHANNEL}" ] && [ "${RELEASE_CHANNEL}" != "stable" ]; then
+    npm_tag_arg="--tag ${RELEASE_CHANNEL}"
+  fi
+
   if [ "${DRY_RUN}" == true ]; then
     echo "DRY RUN: uploading to npm..."
     npm config set '//registry.npmjs.org/:_authToken' "${HAMMERHEAD_NPM_TOKEN}"
-    npm publish --dry-run ./binary-releases/snyk-fix.tgz
-    npm publish --dry-run ./binary-releases/snyk-protect.tgz
-    npm publish --dry-run ./binary-releases/snyk.tgz
+    npm publish --dry-run ${npm_tag_arg} ./binary-releases/snyk-fix.tgz
+    npm publish --dry-run ${npm_tag_arg} ./binary-releases/snyk-protect.tgz
+    npm publish --dry-run ${npm_tag_arg} ./binary-releases/snyk.tgz
   else
     echo "Uploading to npm..."
     npm config set '//registry.npmjs.org/:_authToken' "${HAMMERHEAD_NPM_TOKEN}"
-    npm publish ./binary-releases/snyk-fix.tgz
-    npm publish ./binary-releases/snyk-protect.tgz
-    npm publish ./binary-releases/snyk.tgz
+    npm publish ${npm_tag_arg} ./binary-releases/snyk-fix.tgz
+    npm publish ${npm_tag_arg} ./binary-releases/snyk-protect.tgz
+    npm publish ${npm_tag_arg} ./binary-releases/snyk.tgz
   fi
 }
 


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
With the recent upgrade to npm 11, npm publish might error when the version is a preview version. This fix provides the missing `--tag` parameter.

## Where should the reviewer start?

## How should this be manually tested?
N/A

## What's the product update that needs to be communicated to CLI users?
N/A

## Risk assessment (Low | Medium | High)?
The change is minimal and defensive. 
