### PR TITLE
chore: remove rate-limit retry warnings from test stderr

### DIFF
--- a/test/jest/util/runCommand.ts
+++ b/test/jest/util/runCommand.ts
@@ -1,5 +1,6 @@
 import { SpawnOptionsWithoutStdio } from 'child_process';
 import { spawn } from 'cross-spawn';
+import { stripRetryWarnings } from './stripRetryWarnings';
 
 type RunCommandResult = {
   code: number;
@@ -50,7 +51,11 @@ const runCommand = (
         result.stderrBuffer = Buffer.concat(stderr);
       } else {
         result.stdout = Buffer.concat(stdout).toString('utf-8');
-        result.stderr = Buffer.concat(stderr).toString('utf-8');
+        // Remove rate-limit retry warnings from stderr so tests expecting
+        // empty stderr don't fail when CI is throttled. Real failures stay.
+        result.stderr = stripRetryWarnings(
+          Buffer.concat(stderr).toString('utf-8'),
+        );
       }
 
       if (options?.logErrors && result.code !== 0) {

--- a/test/jest/util/stripRetryWarnings.spec.ts
+++ b/test/jest/util/stripRetryWarnings.spec.ts
@@ -1,0 +1,93 @@
+import { stripRetryWarnings } from './stripRetryWarnings';
+
+// A recovered retry notification. Trailing middle dots (·) mimic the renderer
+// padding to verify the matcher tolerates it.
+const makeRetryBlock = (attempt = 1, total = 3): string =>
+  [
+    ' WARN    Service temporarily throttled (SNYK-0001)······························',
+    `           Automatically retrying in 60 seconds... (attempt ${attempt}/${total}).··············`,
+    ' Status:  429 Too Many Requests·',
+    ' Docs:    https://docs.snyk.io/scan-with-snyk/error-catalog#snyk-0001··········',
+  ].join('\n');
+
+const retryBlock = makeRetryBlock(1, 3);
+
+// A terminal SNYK-0001 failure (retries exhausted): includes the description
+// line but no retry marker, so it must always be preserved.
+const terminalThrottleBlock = [
+  ' ERROR   Service temporarily throttled (SNYK-0001)······························',
+  '           The request rate limit has been exceeded. Wait a few minutes, then try again.',
+  ' Status:  429 Too Many Requests·',
+  ' Docs:    https://docs.snyk.io/scan-with-snyk/error-catalog#snyk-0001··········',
+].join('\n');
+
+describe('stripRetryWarnings', () => {
+  it('removes a single transient retry block (a)', () => {
+    const stderr = `\n${retryBlock}\n`;
+    expect(stripRetryWarnings(stderr)).toBe('');
+  });
+
+  it('removes multiple stacked transient retry blocks (b)', () => {
+    const stderr = `\n${retryBlock}\n${retryBlock}\n`;
+    expect(stripRetryWarnings(stderr)).toBe('');
+  });
+
+  it('removes a retry block regardless of the attempt counter (e.g. 2/3)', () => {
+    const stderr = `\n${makeRetryBlock(2, 3)}\n`;
+    expect(stripRetryWarnings(stderr)).toBe('');
+  });
+
+  it('removes a realistic 1/3 -> 2/3 -> success sequence', () => {
+    // Two backed-off attempts, then success: nothing else on stderr.
+    const stderr = `\n${makeRetryBlock(1, 3)}\n${makeRetryBlock(2, 3)}\n`;
+    expect(stripRetryWarnings(stderr)).toBe('');
+  });
+
+  it('leaves a real error without the retry marker unchanged (c)', () => {
+    const stderr = ' ERROR   Something else went wrong (SNYK-CLI-1234)\n';
+    expect(stripRetryWarnings(stderr)).toBe(stderr);
+  });
+
+  it('keeps only the trailing real error when mixed with a retry block (d)', () => {
+    const realError = ' ERROR   Something else went wrong (SNYK-CLI-1234)';
+    const stderr = `\n${retryBlock}\n\n${realError}\n`;
+    expect(stripRetryWarnings(stderr)).toBe(realError);
+  });
+
+  it('preserves a terminal post-retry failure block (safeguard) (e)', () => {
+    // Gate triggered by the recovered retry, but the terminal failure survives.
+    const stderr = `\n${retryBlock}\n\n${terminalThrottleBlock}\n`;
+    expect(stripRetryWarnings(stderr)).toBe(terminalThrottleBlock);
+  });
+
+  it('preserves the terminal failure after a 1/3 -> 2/3 -> fail sequence', () => {
+    // Retries exhausted: notifications stripped, terminal failure stays.
+    const stderr = `\n${makeRetryBlock(1, 3)}\n${makeRetryBlock(
+      2,
+      3,
+    )}\n\n${terminalThrottleBlock}\n`;
+    expect(stripRetryWarnings(stderr)).toBe(terminalThrottleBlock);
+  });
+
+  it('leaves a standalone terminal failure (no retry anywhere) verbatim', () => {
+    const stderr = `\n${terminalThrottleBlock}\n`;
+    expect(stripRetryWarnings(stderr)).toBe(stderr);
+  });
+
+  it('leaves empty and ordinary stderr unchanged (f)', () => {
+    expect(stripRetryWarnings('')).toBe('');
+    const ordinary = 'some unrelated diagnostic output\n';
+    expect(stripRetryWarnings(ordinary)).toBe(ordinary);
+  });
+
+  it('tolerates ANSI color codes around the rendered block', () => {
+    const ansiRetryBlock = [
+      '\u001b[33m WARN    Service temporarily throttled (SNYK-0001)\u001b[39m',
+      '\u001b[33m           Automatically retrying in 60 seconds... (attempt 1/3).\u001b[39m',
+      '\u001b[33m Status:  429 Too Many Requests\u001b[39m',
+      '\u001b[33m Docs:    https://docs.snyk.io/scan-with-snyk/error-catalog#snyk-0001\u001b[39m',
+    ].join('\n');
+    const stderr = `\n${ansiRetryBlock}\n`;
+    expect(stripRetryWarnings(stderr)).toBe('');
+  });
+});

--- a/test/jest/util/stripRetryWarnings.ts
+++ b/test/jest/util/stripRetryWarnings.ts
@@ -1,0 +1,80 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const stripAnsi = require('strip-ansi');
+
+// Marks a transient retry notification. A terminal failure (retries exhausted)
+// lacks this line, so we can strip only recovered retries.
+const RETRY_MARKER = /Automatically retrying in/;
+
+// Header line of a rendered SNYK-0001 block (WARN or ERROR variant).
+const BLOCK_HEADER =
+  /(?:WARN|ERROR)\b.*\(SNYK-0001\)|Service temporarily throttled \(SNYK-0001\)/i;
+
+// Trailing "Docs:" line that closes a rendered SNYK-0001 block.
+const DOCS_LINE = /^\s*Docs:\s*https?:\/\/\S*snyk-0001/i;
+
+/**
+ * Removes transient rate-limit retry notifications from a captured stderr.
+ *
+ * Block-scoped and marker-gated: a SNYK-0001 block is stripped only when it
+ * contains the "Automatically retrying in" line, so a genuine post-retry
+ * failure is preserved and still surfaces in tests.
+ */
+export function stripRetryWarnings(stderr: string): string {
+  if (!stderr) {
+    return stderr;
+  }
+
+  // Gate: only touch stderr that contains a transient retry notification.
+  if (!RETRY_MARKER.test(stripAnsi(stderr))) {
+    return stderr;
+  }
+
+  const lines = stderr.split('\n');
+  const clean = lines.map((line) => stripAnsi(line));
+  const keep: boolean[] = new Array(lines.length).fill(true);
+
+  let i = 0;
+  while (i < lines.length) {
+    if (!BLOCK_HEADER.test(clean[i])) {
+      i++;
+      continue;
+    }
+
+    // Find the extent of this block: ends at its Docs line or the next header.
+    let end = i;
+    let hasRetryMarker = false;
+    for (let j = i; j < lines.length; j++) {
+      if (RETRY_MARKER.test(clean[j])) {
+        hasRetryMarker = true;
+      }
+      if (j > i && BLOCK_HEADER.test(clean[j])) {
+        end = j - 1;
+        break;
+      }
+      end = j;
+      if (DOCS_LINE.test(clean[j])) {
+        break;
+      }
+    }
+
+    if (hasRetryMarker) {
+      for (let k = i; k <= end; k++) {
+        keep[k] = false;
+      }
+    }
+
+    i = end + 1;
+  }
+
+  const filtered = lines.filter((_, idx) => keep[idx]);
+
+  // Drop blank lines left dangling at the edges by removed blocks.
+  while (filtered.length > 0 && filtered[0].trim() === '') {
+    filtered.shift();
+  }
+  while (filtered.length > 0 && filtered[filtered.length - 1].trim() === '') {
+    filtered.pop();
+  }
+
+  return filtered.join('\n');
+}


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Stops acceptance tests from failing when CI is briefly rate-limited. CLI-1512 prints a `SNYK-0001` retry warning to stderr; if the request succeeds after retry, tests that expect empty stderr still fail.

The shared test runner now removes those transient retry warnings from captured stderr. Only blocks with `Automatically retrying in` are removed, so real failures after retries are still shown.

## Where should the reviewer start?

- `test/jest/util/stripRetryWarnings.ts` - stripping logic
- `test/jest/util/runCommand.ts` - applies it to captured stderr
- `test/jest/util/stripRetryWarnings.spec.ts` - unit tests

## How should this be manually tested?

1. `npx jest test/jest/util/stripRetryWarnings.spec.ts`
2. Confirm all 11 tests pass, including `1/3 -> 2/3 -> success` and `1/3 -> 2/3 -> fail`.

## What's the product update that needs to be communicated to CLI users?

None. Test-only change.

<!---
## Risk assessment (Low | Medium | High)?

Low

## Any background context you want to provide?

Test-only change. No production CLI behavior is modified.

## What are the relevant tickets?

[CLI-1587](https://snyksec.atlassian.net/browse/CLI-1587)
--->

[CLI-1587]: https://snyksec.atlassian.net/browse/CLI-1587