### PR TITLE
chore(language-server): integrate LS

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -221,7 +221,7 @@ require (
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
-	github.com/snyk/snyk-ls v0.0.0-20260615092228-ad265b63c4d1 // indirect
+	github.com/snyk/snyk-ls v0.0.0-20260619144009-adcbe94634e1 // indirect
 	github.com/snyk/studio-mcp v1.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -599,8 +599,8 @@ github.com/snyk/remy-cli-extension v1.15.1-0.20260612100621-e413ec9dadef h1:rXUM
 github.com/snyk/remy-cli-extension v1.15.1-0.20260612100621-e413ec9dadef/go.mod h1:ps0TXsNLxFYGFUj+63Py3Djf0hSq7eAMR7dKn+cUL30=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260615092228-ad265b63c4d1 h1:ACWySN/zVhzcIOqUsksiZR72XQiK/AxqX3AJ/EocTGo=
-github.com/snyk/snyk-ls v0.0.0-20260615092228-ad265b63c4d1/go.mod h1:QBytkxUN7uy47X2QhjcWmQ4WEwYksrn2Kqs1dfCBBR8=
+github.com/snyk/snyk-ls v0.0.0-20260619144009-adcbe94634e1 h1:KMUjwT5ALjsOUSQxfBSmQX4SPTRknJMpQwKSOckN4ow=
+github.com/snyk/snyk-ls v0.0.0-20260619144009-adcbe94634e1/go.mod h1:QBytkxUN7uy47X2QhjcWmQ4WEwYksrn2Kqs1dfCBBR8=
 github.com/snyk/studio-mcp v1.11.0 h1:WfvWqqHu5+Stb/y+LTVdWWiazc0i4BapxqMCJyGRArA=
 github.com/snyk/studio-mcp v1.11.0/go.mod h1:CiMKFs/PJrAMjG8Zjkvx+XwuM0XlxGJ7jP5yCr5hm5w=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/snyk/go-application-framework v0.5.0
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20260615092228-ad265b63c4d1
+	github.com/snyk/snyk-ls v0.0.0-20260619144009-adcbe94634e1
 	github.com/snyk/studio-mcp v1.11.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -573,8 +573,8 @@ github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhk
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260615092228-ad265b63c4d1 h1:ACWySN/zVhzcIOqUsksiZR72XQiK/AxqX3AJ/EocTGo=
-github.com/snyk/snyk-ls v0.0.0-20260615092228-ad265b63c4d1/go.mod h1:QBytkxUN7uy47X2QhjcWmQ4WEwYksrn2Kqs1dfCBBR8=
+github.com/snyk/snyk-ls v0.0.0-20260619144009-adcbe94634e1 h1:KMUjwT5ALjsOUSQxfBSmQX4SPTRknJMpQwKSOckN4ow=
+github.com/snyk/snyk-ls v0.0.0-20260619144009-adcbe94634e1/go.mod h1:QBytkxUN7uy47X2QhjcWmQ4WEwYksrn2Kqs1dfCBBR8=
 github.com/snyk/studio-mcp v1.11.0 h1:WfvWqqHu5+Stb/y+LTVdWWiazc0i4BapxqMCJyGRArA=
 github.com/snyk/studio-mcp v1.11.0/go.mod h1:CiMKFs/PJrAMjG8Zjkvx+XwuM0XlxGJ7jP5yCr5hm5w=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit adcbe94634e1cd97fcaf40a4a668b545c3ead502
Author: Bastian Doetsch <bastian.doetsch@gmx.de>
Date:   Fri Jun 19 16:40:09 2026 +0200

    feat: auto-refresh HTML settings page on state changes [IDE-1954] (#1345)
    
    * feat(settings): auto-refresh HTML settings page on state changes [IDE-1954]
    
    Send a $/snyk.refreshHtmlSettings signal notification to the IDE when
    authentication, org, or workspace folder state changes, so the HTML
    settings panel re-renders without the user closing and reopening it.
    
    Three trigger paths:
    - Auth: after credentials update in updateCredentials (gated on LSP init)
    - Org change: after applyOrganization returns true in processConfigSettings
    - Folders: after add/remove in ChangeWorkspaceFolders (gated on LSP init)
    
    The notification carries an empty payload; the IDE re-requests the full
    HTML via the existing snyk.workspace.configuration command. This keeps
    all trigger logic on the LS side with zero ongoing IDE maintenance per
    new trigger.
    
    * fix(settings): correct HTML settings refresh notification reliability [IDE-1954]
    
    - Consolidate RefreshHtmlSettings send to after processFolderConfigs so
      the client always receives fully-settled state on org change
    - Add token-change trigger: applyToken returns tokenChanged bool;
      UpdateSettings sends RefreshHtmlSettings when token or org changes
    - Fix credential write regression: UpdateCredentials always runs on
      reconnect (Changed=false only suppresses the notification, not the write)
    - Remove pre-init guard from auth_service_impl: notifier WaitForLspInitialized
      defers delivery instead of dropping, matching AuthenticationParams behavior
    - Add nil guard for tokenFromIde in applyToken
    - Use post-write comparison to detect OAuth-rejected writes
    - Add comprehensive tests covering: combined-change exactly-once, unchanged
      token, reconnect recovery, Changed-flag guard, pre-init suppression
    
    * refactor(settings): clean up HTML refresh tests and document delivery contract [IDE-1954]
    
    - Remove redundant NewLspInitializedChannel call from deferred-delivery test
      (initialize RPC already creates the channel via initializeHandler)
    - Update notification.go comment to accurately describe call-site guard
      semantics: pre-init events never reach the switch arm (not dropped by
      the notifier itself)
    
    * refactor(settings): use $/snyk.configuration for HTML settings refresh [IDE-1954]
    
    Replace the bespoke $/snyk.refreshHtmlSettings notification with
    $/snyk.configuration so the IDE HTML settings page auto-refreshes
    using the existing settings-push mechanism.
    
    Key changes:
    - Remove RefreshHtmlSettingsParams type and SnykRefreshHtmlSettings constant
    - UpdateSettings always sends LspConfigurationParam post-init, covering
      token changes, org changes, and all workspace/didChangeConfiguration
      triggers (replaces the removed conditional RefreshHtmlSettings send)
    - registerNotifier sends $/snyk.configuration after $/snyk.hasAuthenticated
      to cover auth flows that don't go through workspace/didChangeConfiguration
    - Restore applyToken nil guard (tokenFromIde == nil); simplify back to
      original form (no bool return, no Changed check, no post-write comparison)
    - workspace.go: remove RefreshHtmlSettings send (HandleFolders already
      sends LspConfigurationParam on folder add/remove via sendFolderConfigs)
    - Add test coverage for new behaviors
    
    ---------
    
    Co-authored-by: Bastian Doetsch <bastian.doetsch@snyk.io>

M	application/server/configuration.go
M	application/server/configuration_test.go
M	application/server/notification.go
M	application/server/notification_test.go
M	application/server/server.go
M	application/server/trust_test.go

commit e255d0ac5bb47c454af6d1eafe24f48ff40d9582
Author: nick-y-snyk <nikita.yasnohorodskyi@snyk.io>
Date:   Fri Jun 19 11:13:49 2026 +0200

    feat(config-dialog): add additional_parameters and additional_environment to Project Defaults tab [IDE-2110] (#1340)
    
    * feat(oss): apply folder-level additional_environment to CLI subprocess [IDE-2110]
    
    Merge folder-scoped additional_environment into the SDK env map in
    updateArgs(), so per-folder KEY=VALUE pairs reach the CLI subprocess.
    Global env (via os.Setenv) is already captured in the map by
    GetEnvFromSystemAndConfiguration; folder values are additive on top —
    same-key folder wins, all other keys survive untouched.
    
    * feat(config-dialog): add additional_parameters and additional_environment to Project Defaults tab [IDE-2110]
    
    - Add collapsible Advanced section to the Project Defaults (#fallbacks-pane) tab in config.html,
      containing global additional_parameters and additional_environment inputs with an info-box
      explaining values combine with per-project entries rather than replacing them.
    - Pre-populate both fields in ConstructSettingsFromConfig: params read from
      SettingCliAdditionalOssParameters ([]string, joined with spaces); env read from
      SettingAdditionalEnvironment at UserGlobalKey.
    - Persist global env string via SetGlobalUser in applyEnvironment so the dialog can
      repopulate the field on reopen (os.Setenv alone is not readable back from config).
    - Wire global env format validation in validation.js using the existing validateAdditionalEnv
      validator and validateAndShowError helper.
    - UX copy is a placeholder pending Tars finalizing wording (IDE-2110 comment 2026-06-05).
    
    * fix(config-dialog): align Project Defaults Advanced section width with section cards [IDE-2110]
    
    Add .tab-pane > .section to the existing direct-child gutter rule so the Advanced
    block gets the same 10px left/right margin as sections inside col-md-6 columns.
    
    * test(js): update form-payload snapshot for global additional_environment/parameters fields [IDE-2110]
    
    * fix(config-dialog): address review on additional_environment handling [IDE-2110]
    
    - applyEnvironment: handle empty-value clear path and unset env keys
      dropped on re-save (os.Setenv was one-way, leaking removed keys into
      CLI subprocesses); guard on !ok only since settingStr encodes Changed
    - validation.js: relax env VALUE regex [^;=]* -> [^;]* to match the Go
      strings.Cut backend (values may contain '='); regen HTML snapshots
    - cli_scanner: document the global-tier os.Setenv -> os.Environ ->
      updateSDKs(env) contract on the folder env merge block
    - tests: add clear-path, sequential-drop, malformed-entry, no-op and
      equals-in-value cases; drop trailing t.Cleanup for t.Setenv; rename
      SNYK_TEST_IDE2110_* env vars to remove ticket reference from code
    - add js-tests/validation-additional-env.test.mjs
    
    * fix(test): pass missing configResolver arg to NewConfigHtmlRenderer [IDE-2110]

M	application/server/configuration.go
M	application/server/configuration_test.go
M	docs/configuration-dialog.md
M	docs/configuration.md
M	domain/ide/command/configuration_command.go
M	domain/ide/command/configuration_command_test.go
M	infrastructure/configuration/config_html_test.go
M	infrastructure/configuration/template/config.html
M	infrastructure/configuration/template/js/features/validation.js
M	infrastructure/configuration/template/styles.css
M	infrastructure/oss/cli_scanner.go
M	infrastructure/oss/cli_scanner_test.go
M	js-tests/snapshots/form-payload.json
A	js-tests/validation-additional-env.test.mjs
M	scripts/config-dialog/config_output_multi_project.html
M	scripts/config-dialog/config_output_no_projects.html
M	scripts/config-dialog/config_output_single_solution.html

commit 7bda4576f0e17a7d39319ec8d7eaf966b37eaa69
Author: Knut Funkel <knut.funkel@snyk.io>
Date:   Thu Jun 18 14:05:39 2026 +0300

    feat: per-project user-override indicator on HTML settings page [IDE-1994] (#1341)
    
    * feat: per-project user-override indicator on HTML settings page [IDE-1994]
    
    Render a bust/silhouette icon (👤) next to settings whose value comes
    from a per-project user override, mirroring the existing 🏢 building
    icon used for org-level values. Adds the user-override case to both
    sourceToClass (CSS hook source-user-override) and tmplSourceIndicator
    (tooltip 'Overridden at project level').
    
    UX agreed with Tars (per Ben Durrans, 2026-06-05): icon-only, no border;
    per-project tab only.
    
    Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
    
    * chore: regenerate config-dialog HTML fixture [IDE-1994]
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * feat: show user-override indicator at Project Defaults level too [IDE-1994]
    
    Project Defaults previously rolled its own resolution (UserGlobalKey-only,
    no LDX-Sync awareness) and never rendered the sourceIndicator. Fix the
    precedence by delegating to ConfigResolver.GetEffectiveValue with no
    folder context (Locked LDX-Sync > User Override > LDX-Sync > Default),
    then add {{sourceIndicator}} calls across the Project Defaults template.
    
    At the Project Defaults level a user-global value is itself a user
    override of the org/built-in default, so remap source 'global' to
    'user-override' before rendering. Folder-pane semantics are unchanged.
    
    Thread ConfigResolver through NewConfigHtmlRenderer so the renderer
    can resolve without depending on a folder.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * fix(config): split tooltip text for project defaults vs per-project user override [IDE-1994]
    
    Per-project user override → "Set by you at project level".
    Project-defaults user override → "Set by you at project defaults level".
    
    Introduce `user-override-defaults` source sentinel emitted by
    computeProjectDefaultScopes; tmplSourceIndicator renders the
    defaults-scope tooltip variant. sourceToClass shares the
    source-user-override CSS class for both.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * fix(config): regenerate golden config-dialog HTML for tooltip text change [IDE-1994]
    
    go generate ./scripts/config-dialog/... — snapshot HTML now matches new
    per-project vs project-defaults user-override tooltips.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    ---------
    
    Co-authored-by: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>

M	domain/ide/command/configuration_command.go
M	infrastructure/configuration/config_html.go
M	infrastructure/configuration/config_html_test.go
M	infrastructure/configuration/template/config.html
M	scripts/config-dialog/config_output_multi_project.html
M	scripts/config-dialog/config_output_no_projects.html
M	scripts/config-dialog/config_output_single_solution.html
M	scripts/config-dialog/main.go

commit 59d33d0691051f3f661b277aee6a21a5d946ff7b
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Wed Jun 17 15:01:32 2026 +0200

    fix(iac): return empty results when CLI produces no output [IDE-2105] (#1320)
    
    * fix(iac): return empty results when CLI produces no output
    
    When `snyk iac test` runs on a directory with no IaC files it exits 0
    with empty stdout. Previously, doScan passed that empty byte slice to
    unmarshal(), which called json.Unmarshal on nil/empty input and returned
    "unexpected end of JSON input", surfaced to the user as:
    
      "Cannot unmarshal: Unexpected end of JSON input"
    
    Guard len(res) == 0 before the unmarshal call and return an empty result
    set instead, matching the same treatment as an unsupported path or a
    product-disabled scan.
    
    Fixes IDE-2105 (American Petroleum Institute – myCertsCore, ASP.NET Core
    project with no IaC files).
    
    * fix(iac): return non-nil empty slice when CLI produces no output [IDE-2105]
    
    Normalise the empty-output code path so Scan() always returns []types.Issue{}
    (not nil) when the scan ran but found no issues, matching the ProductScanner
    contract and the convention used by OSS and Secrets scanners.
    
    - doScan: return []iacScanResult{} (explicit non-nil) instead of the nil
      named-return on the empty-stdout guard
    - Scan: add nil-to-empty-slice normalisation after retrieveIssues
    - Test: add assert.NotNil alongside assert.Empty to pin the contract
    - golangci.yaml: disable govet inline analyzer (false positive on generics)

M	.gitignore
M	.golangci.yaml
M	infrastructure/iac/iac.go
M	infrastructure/iac/iac_test.go

commit 07f9771388bfdd967bc3e2b56e187164a22d3908
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Mon Jun 15 14:38:29 2026 +0100

    fix: fallback to global org for LDX-Sync API call [IDE-1974] (#1236)
    
    But only when `OrgSetByUser` is `true` and `PreferredOrg` is `""`.
    When changing the global org in this scenario, also refresh from LDX-Sync for the applicable folder configs.
    On init, handle the IDE config before fetching from LDX-Sync so we have the correct API endpoint, global org, etc.
    Revert back to the global org just being stored in GAF, as the changes to use `UserGlobalKey` were getting out of hand for a scope we don't even support.
    Do not send any diagnostics on initialisation while we're still half loading the IDE config in.
    Make the FF service use the standard method for getting a folder's org, as the logic did not have the global org fallback logic correct.
    Only fetch FFs and config from LDX-Sync on folder level org changes if LS is initialised. This prevents redundant API calls for the wrong org (plus, as mentioned above, changed to get all orgs after IDE configuration is loaded).

M	application/config/config.go
M	application/config/config_test.go
M	application/server/configuration.go
M	application/server/configuration_test.go
M	application/server/server.go
M	application/server/server_smoke_test.go
M	application/server/server_test.go
M	domain/ide/command/configuration_command.go
M	domain/ide/command/folder_handler_test.go
M	domain/ide/command/ldx_sync_service.go
M	domain/ide/command/ldx_sync_service_test.go
M	domain/ide/command/login_test.go
M	domain/ide/command/mock/ldx_sync_service_mock.go
M	infrastructure/cli/cli_extension_executor_test.go
M	infrastructure/featureflag/fake_featureflag.go
M	infrastructure/featureflag/featureflag.go
M	infrastructure/featureflag/featureflag_test.go
M	internal/types/config_readers.go
A	internal/types/config_readers_test.go
M	internal/types/config_resolver.go
M	internal/types/config_resolver_delegation_test.go
M	internal/types/config_resolver_test.go
M	internal/types/folder_config.go
A	internal/util/ternary.go
A	internal/util/ternary_test.go
```

[IDE-1954]: https://snyksec.atlassian.net/browse/IDE-1954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1954]: https://snyksec.atlassian.net/browse/IDE-1954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1954]: https://snyksec.atlassian.net/browse/IDE-1954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ