### PR TITLE
fix: Honor environment variables for memory threshold when WithConfiguration is omitted

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -217,7 +217,7 @@ require (
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 // indirect
-	github.com/snyk/go-application-framework v0.3.2 // indirect
+	github.com/snyk/go-application-framework v0.4.2 // indirect
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -589,8 +589,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 h1:j2ZPhi78wKIHTiL9EFTNVXMIbsk56FVF2d5Sy1ZwSYk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.3.2 h1:ygqwjm39MNr9bi//KNSTisgsE+VilPix3Jvd5nsY93Y=
-github.com/snyk/go-application-framework v0.3.2/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
+github.com/snyk/go-application-framework v0.4.2 h1:Q8KsL1mUoSV27JDNNWeOUneZwfH+/RewJKRBuHaNgXo=
+github.com/snyk/go-application-framework v0.4.2/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.27.0
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663
-	github.com/snyk/go-application-framework v0.3.2
+	github.com/snyk/go-application-framework v0.4.2
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260615092228-ad265b63c4d1

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -565,8 +565,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 h1:j2ZPhi78wKIHTiL9EFTNVXMIbsk56FVF2d5Sy1ZwSYk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.3.2 h1:ygqwjm39MNr9bi//KNSTisgsE+VilPix3Jvd5nsY93Y=
-github.com/snyk/go-application-framework v0.3.2/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
+github.com/snyk/go-application-framework v0.4.2 h1:Q8KsL1mUoSV27JDNNWeOUneZwfH+/RewJKRBuHaNgXo=
+github.com/snyk/go-application-framework v0.4.2/go.mod h1:fMJZ6RJN6CyjBt/6KaP0jG/WvPSZFtFnmmDb/NjdF7Y=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps `go-application-framework` dependency to pick up [GAF #627](https://github.com/snyk/go-application-framework/pull/627), so `INTERNAL_IN_MEMORY_THRESHOLD_BYTES` is honored even when workflow data is created without an explicit WithConfiguration call.

## Where should the reviewer start?

## How should this be manually tested?

```sh
⋊> ~/g/c/cliv2 on fix/CLI-1509 ⨯ INTERNAL_IN_MEMORY_THRESHOLD_BYTES=100 ./binary-releases/snyk-macos-arm64 test -d --log-level=trace
[...]
2026-06-16T11:17:15Z analytics.report:3 - checking if payload is []byte
2026-06-16T11:17:15Z analytics.report:3 - payload is []byte, comparing payload size (1680 bytes) to threshold (100 bytes)
2026-06-16T11:17:15Z analytics.report:3 - payload is larger than threshold, writing it to disk
2026-06-16T11:17:15Z analytics.report:3 - Setting file permissions for file: ***workflow.analytics.report.3626122142
2026-06-16T11:17:15Z analytics.report:3 - Writing payload to file: ***workflow.analytics.report.3626122142
2026-06-16T11:17:15Z analytics.report:3 - Payload written to file: ***workflow.analytics.report.3626122142
2026-06-16T11:17:15Z analytics.report:3 - payload is on disk, nil payload in memory for cleanup
[...]
⋊> ~/g/cli on fix/CLI-1509 ◦ ./binary-releases/snyk-macos-arm64 test -d --log-level=trace
[...]
2026-06-16T11:25:01Z analytics.report:3 - checking if payload is []byte
2026-06-16T11:25:01Z analytics.report:3 - payload is []byte, comparing payload size (1680 bytes) to threshold (536870912 bytes)
2026-06-16T11:25:01Z analytics.report:3 - payload is lower than threshold, keeping it in memory
[...]
```

## What's the product update that needs to be communicated to CLI users?

Setting `INTERNAL_IN_MEMORY_THRESHOLD_BYTES` now reliably controls when large workflow payloads are kept in memory vs written to the temp directory (default remains 512 MB).

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
