### PR TITLE
chore: use reserved domains in tests

### DIFF
--- a/src/lib/apps/constants.ts
+++ b/src/lib/apps/constants.ts
@@ -42,7 +42,7 @@ export const CreateAppPromptData = {
   SNYK_APP_REDIRECT_URIS: {
     name: SNYK_APP_REDIRECT_URIS,
     message: `Your Snyk App's redirect URIs (comma seprated list. ${chalk.yellowBright(
-      ' Ex: https://example1.com,https://example2.com',
+      ' Ex: https://example.com,https://example.net',
     )})?: `,
   },
   SNYK_APP_SCOPES: {

--- a/test/jest/acceptance/api-auto-detect.spec.ts
+++ b/test/jest/acceptance/api-auto-detect.spec.ts
@@ -4,7 +4,7 @@ jest.setTimeout(1000 * 10);
 
 describe('Auto detect API URL', () => {
   it('Based on OAuth token claim', async () => {
-    const expectedApiUrl = 'https://api.my.special.url.io';
+    const expectedApiUrl = 'https://api.my.special.url.invalid';
     const payload = {
       sub: '1234567890',
       name: 'John Doe',

--- a/test/jest/acceptance/auth.spec.ts
+++ b/test/jest/acceptance/auth.spec.ts
@@ -184,7 +184,7 @@ describe('Auth', () => {
         env: {
           ...env,
           // SNYK_API will actually be used up until the auth workflow
-          SNYK_API: 'https://api.this.should.not.be.used.io',
+          SNYK_API: 'https://api.this.should.not.be.used.invalid',
           // override the auth host regex check, else fakeServerHost will be rejected
           INTERNAL_OAUTH_ALLOWED_HOSTS: '.*',
         },

--- a/test/jest/acceptance/debuglog.spec.ts
+++ b/test/jest/acceptance/debuglog.spec.ts
@@ -45,12 +45,12 @@ describe('debug log', () => {
         DEBUG: '*',
         SNYK_LOG_LEVEL: 'trace',
         SNYK_TOKEN: token,
-        HTTP_PROXY: 'http://user:password@myproxy.com',
+        HTTP_PROXY: 'http://user:password@myproxy.invalid',
       },
     });
 
     expect(stderr).not.toContain(token);
-    expect(stderr).not.toContain('http://user:password@myproxy.com');
+    expect(stderr).not.toContain('http://user:password@myproxy.invalid');
   });
 
   it('redacts token from config file', async () => {
@@ -65,12 +65,12 @@ describe('debug log', () => {
         DEBUG: '*',
         SNYK_LOG_LEVEL: 'trace',
         SNYK_TOKEN: token,
-        HTTP_PROXY: 'http://user:password@myproxy.com',
+        HTTP_PROXY: 'http://user:password@myproxy.invalid',
       },
     });
 
     expect(stderr).not.toContain(token);
-    expect(stderr).not.toContain('http://user:password@myproxy.com');
+    expect(stderr).not.toContain('http://user:password@myproxy.invalid');
   });
 
   it('redacts token from config file', async () => {

--- a/test/jest/acceptance/pat.spec.ts
+++ b/test/jest/acceptance/pat.spec.ts
@@ -67,7 +67,7 @@ describe('PAT', () => {
     const whoamicmd = await runSnykCLI(`whoami --experimental -d`, {
       env: {
         ...env,
-        SNYK_API: 'https://api.this.should.not.be.used.io',
+        SNYK_API: 'https://api.this.should.not.be.used.invalid',
       },
       logErrors: true,
     });

--- a/test/jest/acceptance/snyk-apps/config.spec.ts
+++ b/test/jest/acceptance/snyk-apps/config.spec.ts
@@ -11,7 +11,7 @@ describe('config', () => {
   const orgId = '4e0828f9-d92a-4f54-b005-6b9d8150b75f';
   const testData = {
     appName: 'Test',
-    redirectURIs: 'https://example.com,https://example1.com',
+    redirectURIs: 'https://example.com,https://example.net',
     scopes: 'org.read',
     orgId,
   };

--- a/test/jest/acceptance/snyk-apps/create-app.spec.ts
+++ b/test/jest/acceptance/snyk-apps/create-app.spec.ts
@@ -42,7 +42,7 @@ describe('snyk-apps: create app', () => {
   const orgId = '4e0828f9-d92a-4f54-b005-6b9d8150b75f';
   const testData = {
     appName: 'Test',
-    redirectURIs: 'https://example.com,https://example1.com',
+    redirectURIs: 'https://example.com,https://example.net',
     scopes: 'org.read',
     orgId,
   };

--- a/test/jest/unit/iac/url-utils.spec.ts
+++ b/test/jest/unit/iac/url-utils.spec.ts
@@ -5,9 +5,9 @@ describe('url-utils.ts', function () {
     describe('Given a valid URL', function () {
       describe('With a protocol - it returns true', function () {
         it.each([
-          'https://valid.io/url',
-          'https://valid.io/url:latest',
-          'https://valid.io/url:0.1.0',
+          'https://valid.example/url',
+          'https://valid.example/url:latest',
+          'https://valid.example/url:0.1.0',
         ])('%s', function (urlStr) {
           // Act
           const result = isValidUrl(urlStr);
@@ -18,16 +18,17 @@ describe('url-utils.ts', function () {
       });
 
       describe('Without a protocol - it returns true', function () {
-        it.each(['valid.io/url', 'valid.io/url:latest', 'valid.io/url:0.1.0'])(
-          '%s',
-          function (urlStr) {
-            // Act
-            const result = isValidUrl(urlStr);
+        it.each([
+          'valid.example/url',
+          'valid.example/url:latest',
+          'valid.example/url:0.1.0',
+        ])('%s', function (urlStr) {
+          // Act
+          const result = isValidUrl(urlStr);
 
-            // Assert
-            expect(result).toBe(true);
-          },
-        );
+          // Assert
+          expect(result).toBe(true);
+        });
       });
     });
 

--- a/test/jest/unit/snyk-code/snyk-code-test.spec.ts
+++ b/test/jest/unit/snyk-code/snyk-code-test.spec.ts
@@ -941,7 +941,7 @@ describe('Test snyk code', () => {
     const sastSettings = {
       sastEnabled: true,
       localCodeEngine: {
-        url: 'http://foo.bar',
+        url: 'http://foo.invalid',
         allowCloudUpload: true,
         enabled: true,
       },
@@ -960,7 +960,7 @@ describe('Test snyk code', () => {
     const firstArgumentOfMakeRequest = makeRequestMock.mock.calls[0][0];
     expect(firstArgumentOfMakeRequest).toEqual({
       method: 'get',
-      url: 'http://foo.bar/status',
+      url: 'http://foo.invalid/status',
     });
   });
 


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Replaces real-looking placeholder domains in tests and prompts with reserved domains from RFC 2606 / RFC 6761.

## How should this be manually tested?

At minimum:
```
npx jest --maxWorkers=1 \
  test/jest/acceptance/api-auto-detect.spec.ts \
  test/jest/acceptance/auth.spec.ts \
  test/jest/acceptance/pat.spec.ts \
  test/jest/acceptance/snyk-apps/config.spec.ts \
  test/jest/acceptance/snyk-apps/create-app.spec.ts
```

## What's the product update that needs to be communicated to CLI users?

N/A

## What are the relevant tickets?

[CLI-1155](https://snyksec.atlassian.net/browse/CLI-1155)

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?



## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->


[CLI-1155]: https://snyksec.atlassian.net/browse/CLI-1155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ