### PR TITLE
fix: Bump GAF to fix request body loss on 429 retry and connection leaks

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -216,7 +216,7 @@ require (
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 // indirect
-	github.com/snyk/go-application-framework v0.6.1 // indirect
+	github.com/snyk/go-application-framework v0.6.2 // indirect
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -585,8 +585,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 h1:j2ZPhi78wKIHTiL9EFTNVXMIbsk56FVF2d5Sy1ZwSYk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.6.1 h1:cTTgoN5n0kG55SEAvTmaN79Rn0Q9PXYr2tSToyvvWkA=
-github.com/snyk/go-application-framework v0.6.1/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
+github.com/snyk/go-application-framework v0.6.2 h1:grVccp5mzmctL2hpo9fTnonAEUeMqX+tGczXnECu3j4=
+github.com/snyk/go-application-framework v0.6.2/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.27.0
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663
-	github.com/snyk/go-application-framework v0.6.1
+	github.com/snyk/go-application-framework v0.6.2
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260626083941-77c2abaeaaaa

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -547,8 +547,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 h1:j2ZPhi78wKIHTiL9EFTNVXMIbsk56FVF2d5Sy1ZwSYk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.6.1 h1:cTTgoN5n0kG55SEAvTmaN79Rn0Q9PXYr2tSToyvvWkA=
-github.com/snyk/go-application-framework v0.6.1/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
+github.com/snyk/go-application-framework v0.6.2 h1:grVccp5mzmctL2hpo9fTnonAEUeMqX+tGczXnECu3j4=
+github.com/snyk/go-application-framework v0.6.2/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps `go-application-framework` to include fixes for [CLI-1591](https://snyksec.atlassian.net/browse/CLI-1591):

1. **Request body preserved on retry** — the retry middleware now always prepares a replayable body, so per-status-code retry overrides (e.g. 429 → 3 attempts) re-send the full body. Previously, body buffering was gated on `maxAttempts > 1`, but the default is 1 — the 429 override to 3 attempts only kicks in after the first response, by which point the body was consumed and never buffered. This caused POST retries (e.g. `snyk test` dep graphs) to silently send empty bodies.

2. **Intermediate response bodies closed between retries** — previously, each retry discarded the prior response without closing its body, leaking one TCP connection per retry. Now matches stdlib's `Client.do` behavior (drain + close).

3. **Orphaned transport body closed on permanent 503** — `getErrorList` reads and replaces the response body for 503 responses but never closed the original. The transport body is now properly closed when it's been replaced.

## Where should the reviewer start?

- `cliv2/go.mod` — GAF version bump
- GAF PR: https://github.com/snyk/go-application-framework/pull/629

## How should this be manually tested?

1. Build the CLI from this branch
2. Run `snyk test` against a project that triggers rate limiting (429)
3. Verify the CLI retries and succeeds (or exhausts retries cleanly) instead of failing immediately with an empty-body error

## Risk assessment (Low | Medium | High)?

Medium — changes are in the retry middleware's core request/response lifecycle, affecting every network request that hits a retryable status code. While each fix is additive (buffering bodies that weren't buffered, closing bodies that weren't closed), the retry path is critical infrastructure and regressions could impact any CLI command that makes API calls.

## What are the relevant tickets?

[CLI-1591](https://snyksec.atlassian.net/browse/CLI-1591)

[CLI-1591]: https://snyksec.atlassian.net/browse/CLI-1591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLI-1591]: https://snyksec.atlassian.net/browse/CLI-1591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ