### PR TITLE
chore(instrumentation): add persona.interactive analytics extension

### DIFF
--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gofrs/flock v0.13.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
+	github.com/mattn/go-isatty v0.0.20
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.34.0
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260505093105-90d9442ea939
@@ -178,7 +179,6 @@ require (
 	github.com/manifoldco/promptui v0.9.0 // indirect
 	github.com/mark3labs/mcp-go v0.31.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.20 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/cliv2/internal/utils/interactive.go
+++ b/cliv2/internal/utils/interactive.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"os"
+
+	"github.com/mattn/go-isatty"
+)
+
+// isTerminal reports whether the given file is attached to a terminal. It
+// covers both native terminals and cygwin/msys2 terminals (e.g. git-bash on
+// Windows), which are detected by a separate code path in go-isatty.
+func isTerminal(f *os.File) bool {
+	return isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
+}
+
+// IsInteractive reports whether the CLI is running interactively, i.e. stdin
+// is attached to a terminal.
+func IsInteractive() bool {
+	return isTerminal(os.Stdin)
+}

--- a/cliv2/internal/utils/interactive_test.go
+++ b/cliv2/internal/utils/interactive_test.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_isTerminal_pipeIsNotATerminal(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	defer r.Close()
+	defer w.Close()
+
+	assert.False(t, isTerminal(r), "read end of a pipe is not a terminal")
+	assert.False(t, isTerminal(w), "write end of a pipe is not a terminal")
+}
+
+func Test_isTerminal_regularFileIsNotATerminal(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "interactive-test")
+	require.NoError(t, err)
+	defer f.Close()
+
+	assert.False(t, isTerminal(f), "a regular file is not a terminal")
+}
+
+func Test_IsInteractive_underTestIsNonInteractive(t *testing.T) {
+	// The go test runner does not allocate a TTY for stdin, so the CLI must
+	// consider itself non-interactive in this environment.
+	assert.False(t, IsInteractive())
+}

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -648,6 +648,7 @@ func mainWithErrorCode(additionalExts []workflow.ExtensionInit) int {
 	cliAnalytics.GetInstrumentation().SetCategory(instrumentation.DetermineCategory(os.Args, globalEngine))
 	cliAnalytics.GetInstrumentation().SetStage(instrumentation.DetermineStage(cliAnalytics.IsCiEnvironment()))
 	cliAnalytics.GetInstrumentation().SetStatus(analytics.Success)
+	cliAnalytics.AddExtensionBoolValue("persona.interactive", cliv2utils.IsInteractive())
 
 	setTimeout(globalConfiguration, func() {
 		tearDownOnce.Do(func() {


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Adds a `IsInteractive()` utility that detects whether the CLI is running in an interactive terminal (by checking if stdin is attached to a TTY, including Cygwin/msys2 on Windows). Wires the result into analytics as the `persona.interactive` extension value.

## How should this be manually tested?

Please test it on macOS, Windows, and Linux.

You can check persona.interactive value by running the binary with `-d`.

## What's the product update that needs to be communicated to CLI users?

N/A

## What are the relevant tickets?

[CLI-1585](https://snyksec.atlassian.net/browse/CLI-1585)

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->


[CLI-1585]: https://snyksec.atlassian.net/browse/CLI-1585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ