### PR TITLE
chore: bump secrets extension [PS-602]

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -212,7 +212,7 @@ require (
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e // indirect
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260617143547-fe76369c867a // indirect
 	github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa // indirect
-	github.com/snyk/cli-extension-secrets v0.0.0-20260610073002-c53205f61449 // indirect
+	github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3 // indirect
 	github.com/snyk/code-client-go v1.27.5 // indirect
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -579,8 +579,8 @@ github.com/snyk/cli-extension-os-flows v0.0.0-20260617143547-fe76369c867a h1:FDs
 github.com/snyk/cli-extension-os-flows v0.0.0-20260617143547-fe76369c867a/go.mod h1:VYr9m4jlJmVOEd8gMYUPCGA8CAgz75xlRgnP/mLZEmI=
 github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa h1:9GSKXrRCaRkBAj+jglUBuhO09I1xs2G5GxwrPxlj34M=
 github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa/go.mod h1:SJ624HENWG4yjM6jNuLebTeNsMriozf1LcKhMYVm1aY=
-github.com/snyk/cli-extension-secrets v0.0.0-20260610073002-c53205f61449 h1:SQioCm++bYUnpHBPyPJQ2+G/V1HLwHgqQKtiLShLbec=
-github.com/snyk/cli-extension-secrets v0.0.0-20260610073002-c53205f61449/go.mod h1:D/Bk0EH8np/d6c1tG7wazpHI6iU9m8KzxytFcIQkEvQ=
+github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3 h1:wBYQm4YP65FTZ4rZ0iunhsIUYBindUEnfRWRi+Rugag=
+github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3/go.mod h1:D/Bk0EH8np/d6c1tG7wazpHI6iU9m8KzxytFcIQkEvQ=
 github.com/snyk/code-client-go v1.27.5 h1:fog+j64VKoj5TH/sGehJ5AXe52q7LpOJtKEhwQrcXx4=
 github.com/snyk/code-client-go v1.27.5/go.mod h1:SdASBkLVYjmY4PSm8A65XHW5mRph2ktGKwdE6n2Fci0=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea h1:/v48hCMPiZVjplylgE2FX1ib8Qd8LN/vf8ZIKfA+wkI=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260617143547-fe76369c867a
 	github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa
-	github.com/snyk/cli-extension-secrets v0.0.0-20260610073002-c53205f61449
+	github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3
 	github.com/snyk/code-client-go v1.27.0
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -555,8 +555,8 @@ github.com/snyk/cli-extension-os-flows v0.0.0-20260617143547-fe76369c867a h1:FDs
 github.com/snyk/cli-extension-os-flows v0.0.0-20260617143547-fe76369c867a/go.mod h1:VYr9m4jlJmVOEd8gMYUPCGA8CAgz75xlRgnP/mLZEmI=
 github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa h1:9GSKXrRCaRkBAj+jglUBuhO09I1xs2G5GxwrPxlj34M=
 github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa/go.mod h1:SJ624HENWG4yjM6jNuLebTeNsMriozf1LcKhMYVm1aY=
-github.com/snyk/cli-extension-secrets v0.0.0-20260610073002-c53205f61449 h1:SQioCm++bYUnpHBPyPJQ2+G/V1HLwHgqQKtiLShLbec=
-github.com/snyk/cli-extension-secrets v0.0.0-20260610073002-c53205f61449/go.mod h1:D/Bk0EH8np/d6c1tG7wazpHI6iU9m8KzxytFcIQkEvQ=
+github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3 h1:wBYQm4YP65FTZ4rZ0iunhsIUYBindUEnfRWRi+Rugag=
+github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3/go.mod h1:D/Bk0EH8np/d6c1tG7wazpHI6iU9m8KzxytFcIQkEvQ=
 github.com/snyk/code-client-go v1.27.0 h1:FOX4JzgHssm5fei4ALyrBAIL9eJGnG52yTkqWcM1Qew=
 github.com/snyk/code-client-go v1.27.0/go.mod h1:DQHr0nRchfrc54aciYyrveKWEpBhJwUoc1XoDhWt6W4=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea h1:/v48hCMPiZVjplylgE2FX1ib8Qd8LN/vf8ZIKfA+wkI=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps the cli-secrets-extension version. The latest version checks if an users either has the `isSecretsEnabled` FF on OR the secrets settings and secrets entitlement on.

## Where should the reviewer start?

Changes in the extension: https://github.com/snyk/cli-extension-secrets/pull/83

## How should this be manually tested?

Build the cli locally and try to run a secrets scan with different configurations:
- isSecretsEnabled true, secrets settings false, enableSecrets entitlement false -> scan should run
-  isSecretsEnabled false, secrets settings true, enableSecrets entitlement true -> scan should run
- isSecretsEnabled false, secrets settings false, enableSecrets entitlement true -> scan should not run
- isSecretsEnabled false, secrets settings true, enableSecrets entitlement false -> scan should not run
- isSecretsEnabled false, secrets settings false, enableSecrets entitlement false -> scan should not run

The `enableSecrets` entitlement can be turned on/off via Snyk admin.
The secrets setting can be turned on/off (provided that the `enableSecrets` entitlement is on) via the following API V3 endpoint:

UPDATE
`curl -s -w "\nHTTP %{http_code}\n" -X PATCH \
  -H "Authorization: token $TOKEN" \
  -H "Content-Type: application/vnd.api+json" \
  -d "{\"data\":{\"id\":\"$ORG\",\"type\":\"secrets_settings\",\"attributes\":{\"secrets_enabled\":true}}}" \
  "https://api.dev.snyk.io/rest/orgs/$ORG/settings/secrets?version=2026-03-25"`

 GET
  `curl  \
    "https://api.dev.snyk.io/rest/orgs/$ORG/settings/secrets?version=2026-03-25" \
    -H "Authorization: token $TOKEN"`

## What's the product update that needs to be communicated to CLI users?

Nothing to communicate to the users.

## What are the relevant tickets?
https://snyksec.atlassian.net/browse/PS-602

## Screenshots (if appropriate)
<img width="609" height="179" alt="Screenshot 2026-06-19 at 10 25 26" src="https://github.com/user-attachments/assets/44bd69eb-3329-4e7b-a4e5-88af828b89b1" />


## Any background context you want to provide?
This is a change we are doing in preparation of Secrets GA, the Secrets functionality will be gated by entitlements and settings. We are planning on gradually removing the `isSecretsEnabled` FF. A follow-up PR will removed the FF check altogether from the extension.
<!---
## Risk assessment (Low | Medium | High)?




Uncomment and fill in any sections above that are relevant to your PR.
--->
