### PR TITLE
feat: [ADS-391] Log Machine IDs

### DIFF
--- a/cliv2/pkg/core/instrumentation.go
+++ b/cliv2/pkg/core/instrumentation.go
@@ -57,6 +57,12 @@ func addNetworkingDetails(instrumentor analytics.InstrumentationCollector, confi
 	instrumentor.AddExtension("network-request-attempts", config.GetInt(middleware.ConfigurationKeyRequestAttempts))
 }
 
+func addClientMachineId(instrumentor analytics.InstrumentationCollector, config configuration.Configuration) {
+	if id := config.GetString("internal_snyk_client_machine_id"); id != "" {
+		instrumentor.AddExtension("studio::client_machine_id", id)
+	}
+}
+
 func updateInstrumentationDataBeforeSending(cliAnalytics analytics.Analytics, startTime time.Time, ua networking.UserAgentInfo, exitCode int) {
 	targetId, targetIdError := instrumentation.GetTargetId(globalConfiguration.GetString(configuration.INPUT_DIRECTORY), instrumentation.AutoDetectedTargetId, instrumentation.WithConfiguredRepository(globalConfiguration))
 	if targetIdError != nil {
@@ -70,6 +76,7 @@ func updateInstrumentationDataBeforeSending(cliAnalytics analytics.Analytics, st
 
 	addRuntimeDetails(cliAnalytics.GetInstrumentation(), ua)
 	addNetworkingDetails(cliAnalytics.GetInstrumentation(), globalConfiguration)
+	addClientMachineId(cliAnalytics.GetInstrumentation(), globalConfiguration)
 
 	cliAnalytics.GetInstrumentation().AddExtension("exitcode", exitCode)
 	if exitCode == 2 {

--- a/cliv2/pkg/core/instrumentation_test.go
+++ b/cliv2/pkg/core/instrumentation_test.go
@@ -26,3 +26,50 @@ func Test_shallSendInstrumentation(t *testing.T) {
 	actual = shallSendInstrumentation(config, instrumentor)
 	assert.False(t, actual)
 }
+
+func Test_addClientMachineId(t *testing.T) {
+	t.Run("emits studio::client_machine_id when INTERNAL_SNYK_CLIENT_MACHINE_ID env var is set", func(t *testing.T) {
+		// Mirrors how Studio sets the env var before exec'ing the snyk binary
+		// (studio-internal/.../scan_worker.py: env["INTERNAL_SNYK_CLIENT_MACHINE_ID"] = _machine_id)
+		// and the prod config in cliv2/pkg/core/main.go uses WithSupportedEnvVarPrefixes("snyk_", "internal_", ...)
+		t.Setenv("INTERNAL_SNYK_CLIENT_MACHINE_ID", "studio-device-id-abc")
+		config := configuration.NewWithOpts(
+			configuration.WithSupportedEnvVarPrefixes("snyk_", "internal_", "test_"),
+		)
+		instrumentor := analytics.NewInstrumentationCollector()
+
+		addClientMachineId(instrumentor, config)
+
+		obj, err := analytics.GetV2InstrumentationObject(instrumentor)
+		assert.NoError(t, err)
+		assert.NotNil(t, obj.Data.Attributes.Interaction.Extension)
+		assert.Equal(t, "studio-device-id-abc", (*obj.Data.Attributes.Interaction.Extension)["studio::client_machine_id"])
+	})
+
+	t.Run("emits studio::client_machine_id when config key is set directly", func(t *testing.T) {
+		config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
+		config.Set("internal_snyk_client_machine_id", "test-machine-123")
+		instrumentor := analytics.NewInstrumentationCollector()
+
+		addClientMachineId(instrumentor, config)
+
+		obj, err := analytics.GetV2InstrumentationObject(instrumentor)
+		assert.NoError(t, err)
+		assert.NotNil(t, obj.Data.Attributes.Interaction.Extension)
+		assert.Equal(t, "test-machine-123", (*obj.Data.Attributes.Interaction.Extension)["studio::client_machine_id"])
+	})
+
+	t.Run("omits studio::client_machine_id when env var and config are empty", func(t *testing.T) {
+		config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
+		instrumentor := analytics.NewInstrumentationCollector()
+
+		addClientMachineId(instrumentor, config)
+
+		obj, err := analytics.GetV2InstrumentationObject(instrumentor)
+		assert.NoError(t, err)
+		if obj.Data.Attributes.Interaction.Extension != nil {
+			_, present := (*obj.Data.Attributes.Interaction.Extension)["studio::client_machine_id"]
+			assert.False(t, present)
+		}
+	})
+}


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Adds logging for a client_machine_id field from the SNYK_CLIENT_MACHINE_ID environment variable. To be used for mapping analytics telemetry to client devices.

## Where should the reviewer start?

 cliv2/pkg/core/instrumentation.go:  New helper method `addClientMachineId` 
Tests added in cliv2/pkg/core/instrumentation_test.go

## How should this be manually tested?

set env SNYK_CLIENT_MACHINE_ID and ensure data is passed through

## What's the product update that needs to be communicated to CLI users?

Internal telemetry only.  No user facing changes

## Risk assessment (Low | Medium | High)? 
Low 

## Any background context you want to provide?
This is needed for Snyk Studio as part of ADS GA so that we can get proper measurement of client machines using our ADS products.

## What are the relevant tickets?
https://snyksec.atlassian.net/browse/ADS-391

