### PR TITLE
feat: bump cocoapods plugin to address vuln

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@snyk/error-catalog-nodejs-public": "^5.79.0",
         "@snyk/fix": "file:packages/snyk-fix",
         "@snyk/gemfile": "1.2.0",
-        "@snyk/snyk-cocoapods-plugin": "3.1.0",
+        "@snyk/snyk-cocoapods-plugin": "3.1.1",
         "@snyk/snyk-hex-plugin": "2.1.1",
         "@types/marked": "^4.0.0",
         "abbrev": "^1.1.1",
@@ -3140,79 +3140,47 @@
       }
     },
     "node_modules/@snyk/cocoapods-lockfile-parser": {
-      "version": "3.6.2",
+      "version": "3.10.3",
+      "resolved": "https://registry.npmjs.org/@snyk/cocoapods-lockfile-parser/-/cocoapods-lockfile-parser-3.10.3.tgz",
+      "integrity": "sha512-2zUriOBG4reg80xxpmlsjPg1wvKmHz/dUqQpglPiIjgyu+eky9O539SPGgtJkNIRsCTaeYbBeyDVCiHPVIUnTA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@snyk/dep-graph": "^1.23.1",
+        "@snyk/dep-graph": "^2.3.0",
         "@types/js-yaml": "^3.12.1",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^4.2.0",
         "tslib": "^1.10.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/@snyk/cocoapods-lockfile-parser/node_modules/@snyk/dep-graph": {
-      "version": "1.31.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "event-loop-spinner": "^2.1.0",
-        "lodash.clone": "^4.5.0",
-        "lodash.constant": "^3.0.0",
-        "lodash.filter": "^4.6.0",
-        "lodash.foreach": "^4.5.0",
-        "lodash.isempty": "^4.4.0",
-        "lodash.isequal": "^4.5.0",
-        "lodash.isfunction": "^3.0.9",
-        "lodash.isundefined": "^3.0.1",
-        "lodash.keys": "^4.2.0",
-        "lodash.map": "^4.6.0",
-        "lodash.reduce": "^4.6.0",
-        "lodash.size": "^4.2.0",
-        "lodash.transform": "^4.6.0",
-        "lodash.union": "^4.6.0",
-        "lodash.values": "^4.3.0",
-        "object-hash": "^2.0.3",
-        "semver": "^7.0.0",
-        "tslib": "^1.13.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+    "node_modules/@snyk/cocoapods-lockfile-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
-    "node_modules/@snyk/cocoapods-lockfile-parser/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@snyk/cocoapods-lockfile-parser/node_modules/object-hash": {
-      "version": "2.2.0",
+    "node_modules/@snyk/cocoapods-lockfile-parser/node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@snyk/cocoapods-lockfile-parser/node_modules/semver": {
-      "version": "7.5.4",
-      "license": "ISC",
       "dependencies": {
-        "lru-cache": "^6.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/@snyk/cocoapods-lockfile-parser/node_modules/yallist": {
-      "version": "4.0.0",
-      "license": "ISC"
     },
     "node_modules/@snyk/code-client": {
       "version": "4.23.5",
@@ -3592,11 +3560,13 @@
       "license": "MIT"
     },
     "node_modules/@snyk/snyk-cocoapods-plugin": {
-      "version": "3.1.0",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@snyk/snyk-cocoapods-plugin/-/snyk-cocoapods-plugin-3.1.1.tgz",
+      "integrity": "sha512-d0Il5JoRL6ynRHRuODnUPm4WqacL4Mhy2CrWG988MZ43+dGpAWAZa775dAAhkP1k7u1h74YArPqx2M6KQnozQQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@snyk/cli-interface": "^2.11.0",
-        "@snyk/cocoapods-lockfile-parser": "3.6.2",
+        "@snyk/cocoapods-lockfile-parser": "3.10.3",
         "@snyk/dep-graph": "^1.23.1",
         "shescape": "2.1.6",
         "source-map-support": "^0.5.7",
@@ -5119,7 +5089,9 @@
       "license": "MIT"
     },
     "node_modules/@types/js-yaml": {
-      "version": "3.12.7",
+      "version": "3.12.10",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.10.tgz",
+      "integrity": "sha512-/Mtaq/wf+HxXpvhzFYzrzCqNRcA958sW++7JOFC8nPrZcvfi/TrzOaaGbvt27ltJB2NQbHVAg5a1wUCsyMH7NA==",
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@snyk/error-catalog-nodejs-public": "^5.79.0",
     "@snyk/fix": "file:packages/snyk-fix",
     "@snyk/gemfile": "1.2.0",
-    "@snyk/snyk-cocoapods-plugin": "3.1.0",
+    "@snyk/snyk-cocoapods-plugin": "3.1.1",
     "@snyk/snyk-hex-plugin": "2.1.1",
     "@types/marked": "^4.0.0",
     "abbrev": "^1.1.1",


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps `@snyk/snyk-cocoapods-plugin` to `3.1.1`, bringing the library bumps from https://github.com/snyk/cocoapods-lockfile-parser/pull/54 which address vulnerabilities in the `js-yaml` library, see https://security.snyk.io/package/npm/js-yaml/3.13.1.

## What's the product update that needs to be communicated to CLI users?

Patches `@snyk/snyk-cocoapods-plugin` to resolve vulns in [js-yaml](https://security.snyk.io/package/npm/js-yaml/3.13.1):
- [CVE-2025-64718](https://www.cve.org/CVERecord?id=CVE-2025-64718)
- [CVE-2026-53550](https://www.cve.org/CVERecord?id=CVE-2026-53550)

## Risk assessment (Low ~| Medium | High~)?

Low — the internal Snyk dependency bumped has no breaking change