### PR TITLE
chore(language-server): integrate LS

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -227,7 +227,7 @@ require (
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
-	github.com/snyk/snyk-ls v0.0.0-20260619144009-adcbe94634e1 // indirect
+	github.com/snyk/snyk-ls v0.0.0-20260623152106-4b5823e48c66 // indirect
 	github.com/snyk/studio-mcp v1.13.2 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -613,8 +613,8 @@ github.com/snyk/remy-cli-extension v1.20.0 h1:3vOZSt+6aH+Eqk2xpcvd+1qEarNphX7Lst
 github.com/snyk/remy-cli-extension v1.20.0/go.mod h1:qpL64pAGKDAbApnP8CLIAIOLPD6R+Ge6qA4m0L2auKo=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260619144009-adcbe94634e1 h1:KMUjwT5ALjsOUSQxfBSmQX4SPTRknJMpQwKSOckN4ow=
-github.com/snyk/snyk-ls v0.0.0-20260619144009-adcbe94634e1/go.mod h1:QBytkxUN7uy47X2QhjcWmQ4WEwYksrn2Kqs1dfCBBR8=
+github.com/snyk/snyk-ls v0.0.0-20260623152106-4b5823e48c66 h1:Sh+relqRXe+LE/kouxqjBMm1aD4ySDjiBq8n3vFNuFY=
+github.com/snyk/snyk-ls v0.0.0-20260623152106-4b5823e48c66/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
 github.com/snyk/studio-mcp v1.13.2 h1:oGTAar33yZ8ILHsfO6Zqcek1k4tjMH5zbjiN0oTA8xw=
 github.com/snyk/studio-mcp v1.13.2/go.mod h1:S5utY5ieoPd7axW1yB2Kz3TeN8nRQ8iEDx4jGBdCygQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/snyk/go-application-framework v0.5.0
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20260619144009-adcbe94634e1
+	github.com/snyk/snyk-ls v0.0.0-20260623152106-4b5823e48c66
 	github.com/snyk/studio-mcp v1.13.2
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -573,8 +573,8 @@ github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhk
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260619144009-adcbe94634e1 h1:KMUjwT5ALjsOUSQxfBSmQX4SPTRknJMpQwKSOckN4ow=
-github.com/snyk/snyk-ls v0.0.0-20260619144009-adcbe94634e1/go.mod h1:QBytkxUN7uy47X2QhjcWmQ4WEwYksrn2Kqs1dfCBBR8=
+github.com/snyk/snyk-ls v0.0.0-20260623152106-4b5823e48c66 h1:Sh+relqRXe+LE/kouxqjBMm1aD4ySDjiBq8n3vFNuFY=
+github.com/snyk/snyk-ls v0.0.0-20260623152106-4b5823e48c66/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
 github.com/snyk/studio-mcp v1.13.2 h1:oGTAar33yZ8ILHsfO6Zqcek1k4tjMH5zbjiN0oTA8xw=
 github.com/snyk/studio-mcp v1.13.2/go.mod h1:S5utY5ieoPd7axW1yB2Kz3TeN8nRQ8iEDx4jGBdCygQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit 4b5823e48c66769813c938bf51317eefa3d1b595
Author: nick-y-snyk <nikita.yasnohorodskyi@snyk.io>
Date:   Tue Jun 23 17:21:06 2026 +0200

    feat: per-folder reset overrides + fix webview no-op [IDE-1945] (#1344)
    
    * feat: implement per-folder reset overrides [IDE-1945]
    
    Make the per-folder "Reset overrides" button in the HTML config dialog
    visible and functional end-to-end.
    
    - Show the button (drop display:none) and move it into the folder
      disclaimer banner, right-aligned, red.
    - Fix JS reset bugs: key resets by folderPath instead of the compacted
      folder index, and emit a reset-only folder even when it has no other
      edits. Emit flat null for all 14 org-scope folder fields (now incl.
      preferred_org); the IDE maps null -> {value:null, changed:true}.
    - Make preferred_org resettable in applyPreferredOrg: a null reset Unsets
      both user:folder:preferred_org and user:folder:org_set_by_user so the
      folder reverts to its auto-determined / global org.
    - Add JS folder-reset tests, a Go unit test for the org reset, and an
      end-to-end UpdateSettings reset test.
    - Document the folder-override reset contract in configuration.md and
      configuration-dialog.md.
    - Regenerate config dialog HTML fixtures.
    
    * fix: make reset overrides work in VSCode webview + clear all overrides [IDE-1945]
    
    Two defects stopped 'Reset overrides' from working:
    
    1. No-op in sandboxed webview. VSCode renders the settings dialog in a
       sandboxed iframe without 'allow-modals', so window.confirm() is silently
       ignored and returns false. Both reset handlers gated their work behind
       confirm(), so the click bailed and nothing happened. Remove the confirm()
       prompts (reset is reversible and the dialog shows a disclaimer banner).
    
    2. Incomplete reset. additional_parameters, additional_environment and
       scan_command_config are folder overrides editable in the dialog but were
       never cleared: the JS omitted them from FOLDER_RESET_FIELDS, and on the LS
       side they are processed by applyBasicFolderFields (marked handled), so the
       generic null-reset loop skipped them while their own handlers ignored a
       nil value -- making the reset unreachable. Add the three keys to
       FOLDER_RESET_FIELDS and teach applyStringField / applyStringSliceField /
       applyScanCommandConfig to Unset the override on {Changed:true, Value:nil}.
    
    Extend the end-to-end reset test to cover the three non-scalar fields and
    drop the dead win.confirm stubs / section-name formatter.
    
    * refactor: simplify preferred_org reset using isFolderReset + unsetFolderOverride
    
    Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
    
    * fix: address PR review feedback on docs, tests, and test names
    
    - docs: update reset field count 14→17, add additional_parameters,
      additional_environment, scan_command_config to the reset field list
    - docs: correct incorrect claim that scan_command_config null-reset is
      a no-op; the LS handler now honours it via unsetFolderOverride
    - tests: mirror FOLDER_RESET_FIELDS in RESET_FIELDS (14→17 entries)
    - tests: remove AI-style bug annotation from test name
    - tests: update "14 nulls" count to "17 nulls" in DOM-driven test name
    - tests: rename test to say "auto-org" not "global org"
    
    Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
    
    * test: replace duplicate reset test with dirty-tracker clean assertion
    
    Remove the duplicate "clicking reset triggers a save even with no other
    edits" test (already covered by the DOM-driven no-edits test above it)
    and add a test asserting the dirty tracker returns to clean after a
    successful reset save.
    
    Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
    
    * fix: update stale 14→17 counts and remove iteration label in test names
    
    Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
    
    * fix: guard updateFolderConfigOrg from re-adding keys after a reset
    
    After applyPreferredOrg unsets preferred_org and org_set_by_user,
    updateFolderConfigOrg was calling SetPreferredOrgAndOrgSetByUser("",false)
    which re-added both keys as {Value:""/false, Changed:true} — making
    HasUserOverride return true even though the user had just reset the
    overrides.
    
    Add a guard: only normalise to empty/false when at least one of the
    keys is still present (i.e. a non-reset transition). If both are
    already absent the call is a no-op for resolution purposes but creates
    a spurious active-override entry in the store.
    
    Also add SettingIsLspInitialized=true and DepScanStateAggregator to the
    end-to-end reset test so it exercises the production code path through
    updateFolderOrgIfNeeded.
    
    Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
    
    * fix: apply HasUserOverride guard to else-if branch in updateFolderConfigOrg
    
    The else-if !currentSnap.OrgSetByUser branch was missing the same guard
    added to the orgSetByUserJustChanged branch. After a reset clears both
    overrides, a subsequent update changing only AutoDeterminedOrg would
    trigger this branch and re-add preferred_org / org_set_by_user as
    explicit {Value:""/false, Changed:true} entries, making HasUserOverride
    return true again.
    
    Apply the same guard: skip the normalisation call when both keys are
    already absent. Add a regression test that seeds the exact scenario:
    reset → AutoDeterminedOrg change → assert keys stay absent.
    
    Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
    
    * refactor: add comment clarifying updateFolderConfigOrg unset guard
    
    ---------
    
    Co-authored-by: Ben Durrans <Benjamin.Durrans@snyk.io>
    Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>

M	application/server/configuration.go
M	application/server/configuration_test.go
M	docs/configuration-dialog.md
M	docs/configuration.md
M	infrastructure/configuration/template/config.html
M	infrastructure/configuration/template/js/ui/form-handler.js
M	infrastructure/configuration/template/js/ui/reset-handler.js
M	infrastructure/configuration/template/styles.css
M	internal/types/config_resolver_test.go
M	internal/types/folder_config.go
A	js-tests/folder-reset.test.mjs
M	scripts/config-dialog/config_output_multi_project.html
M	scripts/config-dialog/config_output_no_projects.html
M	scripts/config-dialog/config_output_single_solution.html

commit 9491c8256379b158fc0fa30b424324d8714d65eb
Author: Andrew Robinson Hodges <andrew.robinsonhodges@snyk.io>
Date:   Tue Jun 23 15:58:50 2026 +0100

    feat: update html tree view with UI changes for ga [IDE-2117] (#1316)

M	domain/ide/command/command_factory.go
M	domain/ide/command/toggle_tree_filter.go
M	domain/ide/command/toggle_tree_filter_test.go
M	domain/ide/treeview/icons.go
M	domain/ide/treeview/template/styles.css
M	domain/ide/treeview/template/tree.html
M	domain/ide/treeview/template/tree.js
M	domain/ide/treeview/tree_builder.go
M	domain/ide/treeview/tree_builder_test.go
M	domain/ide/treeview/tree_html.go
M	domain/ide/treeview/tree_html_test.go
M	domain/ide/treeview/tree_node.go
M	domain/ide/treeview/tree_scan_emitter.go
M	domain/ide/treeview/tree_scan_emitter_test.go
M	infrastructure/configuration/config_html.go
M	infrastructure/configuration/config_html_test.go
M	infrastructure/configuration/template/config.html
A	infrastructure/configuration/template/js/features/filter-sync.js
M	infrastructure/oss/cli_scanner.go
M	internal/context/context.go
M	internal/types/config_readers.go
M	internal/types/config_writers.go
M	scripts/config-dialog/config_output_multi_project.html
M	scripts/config-dialog/config_output_no_projects.html
M	scripts/config-dialog/config_output_single_solution.html

commit 66b8bcdc4ce9b4102b1ccbedcaad90efbce901e2
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Tue Jun 23 14:03:23 2026 +0100

    fix: sec bumps (#1351)
    
    * fix: sec bumps
    
    Pin prodsec-orb since newer version had an issue.
    
    * fix: lower prodsec orb version to fix CI
    
    To bypass the check that requires the orb to be pinned to @1.

M	.circleci/config.yml
M	go.mod
M	go.sum
```

[IDE-1945]: https://snyksec.atlassian.net/browse/IDE-1945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1945]: https://snyksec.atlassian.net/browse/IDE-1945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1945]: https://snyksec.atlassian.net/browse/IDE-1945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ