### PR TITLE
fix: bump snyk-nuget-plugin to 4.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20281,16 +20281,16 @@
       "license": "ISC"
     },
     "node_modules/snyk-nuget-plugin": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-4.2.0.tgz",
-      "integrity": "sha512-EUVmfoDXBOXCmmOo7yL8zoRR9VWpCI+BlZZ1wQ2sI8Bj0IQnXCeBFSro9BpsaxaNyK9FApj+yCMCdx0GLTEf9A==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-4.2.3.tgz",
+      "integrity": "sha512-UyikzoHsA0cIzl1kfufRXLYgWkk66n/7prGJq7fbC+2MsaL1rc5AEBEuzNstWtFp+I2T9OYNwxcu8oDJYrNm+A==",
       "dependencies": {
         "@snyk/cli-interface": "^2.14.0",
         "@snyk/dep-graph": "^2.8.1",
         "debug": "^4.3.4",
         "dotnet-deps-parser": "6.1.0",
         "jszip": "3.10.1",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "node-cache": "^5.1.2",
         "snyk-paket-parser": "1.6.0",
         "tslib": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "snyk-mvn-plugin": "^4.7.0",
     "snyk-nodejs-lockfile-parser": "2.8.1",
     "snyk-nodejs-plugin": "^2.0.1",
-    "snyk-nuget-plugin": "4.2.0",
+    "snyk-nuget-plugin": "4.2.3",
     "snyk-php-plugin": "1.12.1",
     "snyk-policy": "^4.1.6",
     "snyk-python-plugin": "^3.2.1",


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps `snyk-nuget-plugin` from `4.2.0` to `4.2.3`.

Release: https://github.com/snyk/snyk-nuget-plugin/releases/tag/v4.2.3

- Handles a missing `dotnet` CLI during runtime resolution scans
- Transitively bumps `lodash` to `^4.18.1` as required by the plugin

## Where should the reviewer start?

`package.json` and `package-lock.json`.

## How should this be manually tested?

Run `snyk test` / `snyk monitor` against a .NET project, including one where the
`dotnet` CLI is unavailable, to confirm runtime resolution scans no longer fail.

## What's the product update that needs to be communicated to CLI users?

None.

<!---
## Risk assessment (Low | Medium | High)?

Low — patch-level dependency bump, no CLI code changes.
--->
