### PR TITLE
chore(MCP): promote breakability to default profile

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -228,7 +228,7 @@ require (
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
 	github.com/snyk/snyk-ls v0.0.0-20260623152106-4b5823e48c66 // indirect
-	github.com/snyk/studio-mcp v1.13.2 // indirect
+	github.com/snyk/studio-mcp v1.14.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect
 	github.com/spf13/afero v1.14.0 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -615,8 +615,8 @@ github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRX
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
 github.com/snyk/snyk-ls v0.0.0-20260623152106-4b5823e48c66 h1:Sh+relqRXe+LE/kouxqjBMm1aD4ySDjiBq8n3vFNuFY=
 github.com/snyk/snyk-ls v0.0.0-20260623152106-4b5823e48c66/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
-github.com/snyk/studio-mcp v1.13.2 h1:oGTAar33yZ8ILHsfO6Zqcek1k4tjMH5zbjiN0oTA8xw=
-github.com/snyk/studio-mcp v1.13.2/go.mod h1:S5utY5ieoPd7axW1yB2Kz3TeN8nRQ8iEDx4jGBdCygQ=
+github.com/snyk/studio-mcp v1.14.0 h1:9Z7JPHFNtd5m8fmosBgTzLMFXmjImKvkAtvsjejy4qQ=
+github.com/snyk/studio-mcp v1.14.0/go.mod h1:3ZISZCgorkGg/iLQrryvmP34Db4KkvtfAARi7vMqM/4=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260623152106-4b5823e48c66
-	github.com/snyk/studio-mcp v1.13.2
+	github.com/snyk/studio-mcp v1.14.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -575,8 +575,8 @@ github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRX
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
 github.com/snyk/snyk-ls v0.0.0-20260623152106-4b5823e48c66 h1:Sh+relqRXe+LE/kouxqjBMm1aD4ySDjiBq8n3vFNuFY=
 github.com/snyk/snyk-ls v0.0.0-20260623152106-4b5823e48c66/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
-github.com/snyk/studio-mcp v1.13.2 h1:oGTAar33yZ8ILHsfO6Zqcek1k4tjMH5zbjiN0oTA8xw=
-github.com/snyk/studio-mcp v1.13.2/go.mod h1:S5utY5ieoPd7axW1yB2Kz3TeN8nRQ8iEDx4jGBdCygQ=
+github.com/snyk/studio-mcp v1.14.0 h1:9Z7JPHFNtd5m8fmosBgTzLMFXmjImKvkAtvsjejy4qQ=
+github.com/snyk/studio-mcp v1.14.0/go.mod h1:3ZISZCgorkGg/iLQrryvmP34Db4KkvtfAARi7vMqM/4=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=


### PR DESCRIPTION
# Changes
- Use new breakability endpoint `2025-11-05`
- Promote breakability MCP tool to the default `full` profile