### PR TITLE
chore(language-server): integrate LS

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -227,7 +227,7 @@ require (
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
-	github.com/snyk/snyk-ls v0.0.0-20260623152106-4b5823e48c66 // indirect
+	github.com/snyk/snyk-ls v0.0.0-20260624084253-57d422709963 // indirect
 	github.com/snyk/studio-mcp v1.13.2 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -613,8 +613,8 @@ github.com/snyk/remy-cli-extension v1.20.0 h1:3vOZSt+6aH+Eqk2xpcvd+1qEarNphX7Lst
 github.com/snyk/remy-cli-extension v1.20.0/go.mod h1:qpL64pAGKDAbApnP8CLIAIOLPD6R+Ge6qA4m0L2auKo=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260623152106-4b5823e48c66 h1:Sh+relqRXe+LE/kouxqjBMm1aD4ySDjiBq8n3vFNuFY=
-github.com/snyk/snyk-ls v0.0.0-20260623152106-4b5823e48c66/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
+github.com/snyk/snyk-ls v0.0.0-20260624084253-57d422709963 h1:hqWMhYoveuJl3eDUMDYhnQlbXrgIdETrmG8kGFFFTdg=
+github.com/snyk/snyk-ls v0.0.0-20260624084253-57d422709963/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
 github.com/snyk/studio-mcp v1.13.2 h1:oGTAar33yZ8ILHsfO6Zqcek1k4tjMH5zbjiN0oTA8xw=
 github.com/snyk/studio-mcp v1.13.2/go.mod h1:S5utY5ieoPd7axW1yB2Kz3TeN8nRQ8iEDx4jGBdCygQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/snyk/go-application-framework v0.5.0
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20260623152106-4b5823e48c66
+	github.com/snyk/snyk-ls v0.0.0-20260624084253-57d422709963
 	github.com/snyk/studio-mcp v1.13.2
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -573,8 +573,8 @@ github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhk
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260623152106-4b5823e48c66 h1:Sh+relqRXe+LE/kouxqjBMm1aD4ySDjiBq8n3vFNuFY=
-github.com/snyk/snyk-ls v0.0.0-20260623152106-4b5823e48c66/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
+github.com/snyk/snyk-ls v0.0.0-20260624084253-57d422709963 h1:hqWMhYoveuJl3eDUMDYhnQlbXrgIdETrmG8kGFFFTdg=
+github.com/snyk/snyk-ls v0.0.0-20260624084253-57d422709963/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
 github.com/snyk/studio-mcp v1.13.2 h1:oGTAar33yZ8ILHsfO6Zqcek1k4tjMH5zbjiN0oTA8xw=
 github.com/snyk/studio-mcp v1.13.2/go.mod h1:S5utY5ieoPd7axW1yB2Kz3TeN8nRQ8iEDx4jGBdCygQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit 57d422709963b677c9c7dcf7577cec6fe2e43fc6
Author: nick-y-snyk <nikita.yasnohorodskyi@snyk.io>
Date:   Wed Jun 24 10:42:53 2026 +0200

    feat: implement global (Project Defaults) reset overrides [IDE-2149] (#1348)
    
    * feat: implement global (Project Defaults) reset overrides [IDE-2149]
    
    Add a "Reset overrides" action for the global / Project Defaults scope in
    the HTML settings page, mirroring the per-folder reset (IDE-1945).
    
    On {changed:true, value:null} for an org-scope global setting, the LS now
    Unsets the user:global override so the effective value falls back through
    the resolver chain (LDX-Sync / org / flagset default). organization is
    reset via config.ResetOrganization (it is not stored at UserGlobalKey).
    
    - config_writers.go: UnsetGlobalUser, HasGlobalUserOverride,
      GlobalResettableSettings (14 org-scope keys; incl organization, excl
      folder-only preferred_org).
    - config_readers.go: userGlobalValue treats GAF's keyDeleted sentinel as
      absent, so a reset key correctly reads as "no override".
    - config.go: ResetOrganization (Unset ORGANIZATION + last_set_organization).
    - configuration.go: applyGlobalResets pre-pass in processConfigSettings,
      running before the typed appliers and deleting handled keys; extracted
      refreshFoldersForGlobalOrgChange shared with applyOrganization.
    - HTML/JS: reset-global-overrides-btn on the Project Defaults tab,
      GLOBAL_RESET_FIELDS + markGlobalForReset + applyGlobalResets emitting
      top-level nulls, wired through auto-save and reset-handler.
    - Regenerated config-dialog fixtures.
    - Tests: config_writers_test.go, Test_ProcessConfigSettings_GlobalReset,
      js-tests/global-reset.test.mjs. Docs updated.
    
    * fix: address PR review comments on global reset [IDE-2149]
    
    Fix 11 review items on the global reset feature:
    
    - Fix type-mismatch in analytics: GetGlobalBool was wrongly applied to
      int-registered (SettingRiskScoreThreshold) and string-registered
      (SettingScanNetNew) keys, always returning false and silently
      suppressing analytics. Add globalEffectiveValue() helper that
      dispatches GetGlobalInt / GetGlobalString / GetGlobalBool per key type.
    
    - Decouple filterReset from effectivelyChanged: diagnostics refresh now
      fires unconditionally for any globalResetFilterKeys entry whose user
      override is being removed, restoring pre-analytics behavior.
    
    - Unify refreshFoldersForGlobalOrgChange and
      refreshSpecificFoldersForOrgChange into one function with a preCaptured
      parameter. nil = query workspace live (applyOrganization path);
      non-nil = use pre-captured list (applyGlobalResets path, captured
      before ResetOrganization to avoid GetGlobalOrganization write-on-read
      side effect).
    
    - Fix flaky test: replace time.Sleep(50ms) with require.Eventually +
      atomic.AddInt32 counter for async goroutine assertion.
    
    - Fix misleading comments: pre-capture comment now names the actual
      concern (GetGlobalOrganization write-on-read side effect); stale
      refreshFoldersForGlobalOrgChange comment updated.
    
    - Remove stale confirm-dialog reference from docs/configuration-dialog.md.
    
    - JS: remove confirm() dialog from handleGlobalOverrideReset (VSCode
      webviews return false silently). Add immediate getAndSaveIdeConfig()
      call so reset commits without requiring a second user action.
    
    - CSS: fix reset button alignment (display:inline-block + align-self:
      flex-end instead of float:right).
    
    - Keep-in-sync comment added to GlobalResettableSettings doc.
    
    * fix(settings): only send $/snyk.configuration when effective config changes [IDE-1954]
    
    UpdateSettings sent $/snyk.configuration on every didChangeConfiguration with
    no change detection (only an LSP-init gate). With the HTML settings auto-refresh,
    a no-op save echoed the config back, the IDE re-rendered, auto-saved again, and
    looped forever. Clicking the SAST-gated Snyk Code checkbox in Project Defaults
    reproduced this: the effective value stays false, so the save was a no-op that
    still triggered an endless refresh and the checkbox flapped.
    
    Snapshot the effective config (BuildLspConfiguration) before applying settings
    and only send when it actually differs afterward (reflect.DeepEqual). The
    snapshot straddles both processConfigSettings and processFolderConfigs since
    folder configs also mutate the effective param. Write-only fields (token) are
    excluded from BuildLspConfiguration, so a token-only change is correctly a
    no-op; real auth/org/folder changes still alter the effective config and push
    exactly one notification.
    
    Test: failing-first integration test asserts a no-op save emits zero
    $/snyk.configuration while a real change emits exactly one; the prior IDE-1954
    "always sends" assertion is corrected (it encoded the looping behavior).
    
    * fix(settings): clear globalReset flag on blocked save to prevent override wipe [IDE-2149]
    
    Clicking "Reset overrides" sets window.ConfigApp.globalReset, consumed and
    cleared by applyGlobalResets during save. But getAndSaveIdeConfig returned
    early on a validation error (and on the collectData guard) BEFORE reaching
    applyGlobalResets, leaving the flag set. The next unrelated successful save
    then injected all 14 GLOBAL_RESET_FIELDS as null, silently wiping every
    global override the user never asked to reset.
    
    Clear the flag on both early-return paths so a reset intent is scoped to its
    own save attempt: if that save is blocked, the user re-clicks Reset overrides.
    The happy path (valid reset nulls the 14 fields) is unchanged.
    
    Regenerated the config-dialog HTML fixtures that inline the JS bundle.
    
    Test: js-tests/global-reset.test.mjs — failing-first test asserts the flag is
    cleared on a validation-blocked save and the nulls do not leak into a later
    unrelated save. make test-js green (124 pass, ES5 clean).
    
    * fix(settings): emit $/snyk.configuration once per folder-config change [IDE-1954]
    
    processFolderConfigs called sendFolderConfigUpdateIfNeeded, which built and
    sent the same BuildLspConfiguration payload that UpdateSettings' before/after
    DeepEqual guard now also sends — so a real folder-config change delivered TWO
    identical $/snyk.configuration notifications, causing redundant HTML settings
    re-renders.
    
    The inner send only ever fired on the non-Initialize path (it was already
    suppressed on Initialize), which is exactly where the outer guard runs. Since
    BuildLspConfiguration includes folder configs, the outer guard already covers
    folder changes and dedupes (sends only when the effective payload changes).
    Remove sendFolderConfigUpdateIfNeeded and its call, making the outer guard the
    single emission point. The non-Initialize implies lsp-initialized invariant is
    guaranteed by handlePushModel/handlePullModel, so no notification is dropped.
    
    Test: failing-first integration test asserts a folder-config change emits
    exactly one $/snyk.configuration (was two) and a no-op emits zero.
    
    * refactor(settings): drop unused featureFlagService param from BuildLspConfiguration [IDE-1954]
    
    BuildLspConfiguration, buildLspFolderConfigs, and sendFolderConfigs accepted a
    featureFlagService they never used — folder configs are read from already-
    populated conf state (HandleFolders runs populateFolderFeatureFlagsAndSastSettings
    first), so every caller passed nil and the value was ignored.
    
    The dead param was a footgun: it implied feature-flag state flowed through the
    builder, so a future change could wire it up and silently break the nil-passing
    callers (incl. the UpdateSettings before/after snapshot). Remove it and update
    all call sites. HandleFolders / populateFolderFeatureFlagsAndSastSettings keep
    their featureFlagService — they do the real population.
    
    Pure behavior-preserving refactor (compiler- and test-verified); no functional change.
    
    * refactor(settings): centralize reset-flag clearing in getAndSaveIdeConfig finally [IDE-2149]
    
    Reset marks (globalReset, folderResets) were cleared at scattered points: each
    early-return in getAndSaveIdeConfig and inside applyGlobalResets/applyFolderResets.
    That left exit paths uncovered (exceptions; the no-save path of
    handleGlobalOverrideReset), where a blocked reset could leak into a later
    unrelated save and silently null overrides.
    
    Clear both marks once in getAndSaveIdeConfig's finally — runs on every exit
    (validation-fail, collectData-guard, exception, happy path). apply* now only
    inject the nulls. handleGlobalOverrideReset's no-save branch clears both marks
    defensively (its finally never runs). Also !!-normalize isFolderMarkedForReset.
    
    ideBridge.saveConfig catches internally and returns false, so the try/finally
    needs no catch. Net fewer lines than the scattered approach.
    
    Test: failing-first exception-path and no-save-path tests; happy path and prior
    leak tests still green. make test-js: 132 pass, ES5 clean.
    
    * fix(settings): reset the correct folder by path, include reset-only folders [IDE-2149]
    
    Two correctness bugs in per-folder "Reset overrides":
    1. Wrong folder reset: collectChangedData compresses folderConfigs (only changed
       folders, re-indexed), but applyFolderResets matched by compressed array
       position against DOM-index-keyed marks — so a reset could hit the wrong folder.
    2. Reset-only folder dropped: a folder marked for reset with no other edits was
       omitted from folderConfigs, so its reset never reached the LS.
    
    Key reset marks by folderPath (stable identity) instead of array index:
    window.ConfigApp.folderResetPaths is a Set of paths; markFolderForReset resolves
    the path from the folder_<i>_folderPath hidden input (warns, no silent no-op, if
    missing); applyFolderResets matches by fc.folderPath; collectChangedData
    force-includes a reset-marked folder even with no other edits. The Set replaces
    the prior index+path object (no key collision, no prototype-pollution). finally
    and the defensive else clear the Set.
    
    Valid without IDE-plugin changes: the VS Code plugin keys folder data by
    folderPath and translates per-folder null to {changed:true,value:null}.
    
    Test: failing-first wrong-folder + reset-only tests (paths read from the DOM,
    not hardcoded); finally-clear regression guards tightened to strict Set checks.
    make test-js: 135 pass, ES5 clean.
    
    * fix(settings): scan_net_new reset analytics + Project Defaults reset button layout [IDE-2149]
    
    Addresses two PR-review comments.
    
    1) globalEffectiveValue read scan_net_new via GetGlobalString, but
       applyDeltaFindings stores it as a bool (SetGlobalDeferredFolderScope). The
       bool→string assertion silently failed → "" before and after → effectivelyChanged
       always false → the reset's SendConfigChangedAnalytics was dead code. Read it via
       GetGlobalBool (matching the stored shape). Test drives the reset through
       processConfigSettings and asserts the analytics event fires (RED on
       GetGlobalString, GREEN on GetGlobalBool).
    
    2) The "Reset overrides" button wrapped onto its own line. Scope the
       fallbacks-pane info-box to a flex row via the child combinator
       #fallbacks-pane > .info-box (so the nested Advanced info-box is unaffected);
       the button sits inline at the right. Regenerated config-dialog fixtures.
    
    * fix(settings): match global Reset overrides button to folder ghost style [IDE-2149]
    
    The Project Defaults "Reset overrides" button used a solid --error-background
    fill (a heavy salmon block). Restyle .reset-global-overrides-btn to the same
    outlined/ghost danger style as the per-folder .reset-overrides-btn: transparent
    background, --error-foreground border + text, white-space: nowrap, and fill-on-
    hover (background --error-foreground, text --background-color). Drop the no-op
    display: inline-block (it's a flex item in #fallbacks-pane > .info-box) and keep
    flex-shrink: 0. Regenerated the config-dialog HTML fixtures.
    
    ---------
    
    Co-authored-by: Bastian Doetsch <bastian.doetsch@snyk.io>
    Co-authored-by: Ben Durrans <Benjamin.Durrans@snyk.io>

M	application/config/config.go
M	application/server/configuration.go
M	application/server/configuration_test.go
M	application/server/notification.go
M	docs/configuration-dialog.md
M	docs/configuration.md
M	domain/ide/command/folder_handler.go
M	domain/ide/command/folder_handler_test.go
M	domain/ide/command/ldx_sync_service.go
M	domain/ide/command/login.go
M	domain/ide/command/toggle_tree_filter.go
M	infrastructure/configuration/template/config.html
M	infrastructure/configuration/template/js/features/auto-save.js
M	infrastructure/configuration/template/js/ui/form-handler.js
M	infrastructure/configuration/template/js/ui/reset-handler.js
M	infrastructure/configuration/template/styles.css
M	internal/types/config_readers.go
M	internal/types/config_writers.go
A	internal/types/config_writers_test.go
A	js-tests/global-reset.test.mjs
M	scripts/config-dialog/config_output_multi_project.html
M	scripts/config-dialog/config_output_no_projects.html
M	scripts/config-dialog/config_output_single_solution.html

commit 0db2a2ea1f1abdbc01b56f982f5e0e992c28b51a
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Wed Jun 24 07:05:09 2026 +0100

    fix: set prodsec orb back to @1 (#1360)

M	.circleci/config.yml
```

[IDE-2149]: https://snyksec.atlassian.net/browse/IDE-2149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-2149]: https://snyksec.atlassian.net/browse/IDE-2149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-2149]: https://snyksec.atlassian.net/browse/IDE-2149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ