### PR TITLE
chore(language-server): integrate LS

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -227,7 +227,7 @@ require (
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
-	github.com/snyk/snyk-ls v0.0.0-20260624084253-57d422709963 // indirect
+	github.com/snyk/snyk-ls v0.0.0-20260624144357-470296debe0f // indirect
 	github.com/snyk/studio-mcp v1.13.2 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -613,8 +613,8 @@ github.com/snyk/remy-cli-extension v1.20.0 h1:3vOZSt+6aH+Eqk2xpcvd+1qEarNphX7Lst
 github.com/snyk/remy-cli-extension v1.20.0/go.mod h1:qpL64pAGKDAbApnP8CLIAIOLPD6R+Ge6qA4m0L2auKo=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260624084253-57d422709963 h1:hqWMhYoveuJl3eDUMDYhnQlbXrgIdETrmG8kGFFFTdg=
-github.com/snyk/snyk-ls v0.0.0-20260624084253-57d422709963/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
+github.com/snyk/snyk-ls v0.0.0-20260624144357-470296debe0f h1:l7FSJlUnnuxjmbon6swh174Ildtwqj08GpX8htHJH+4=
+github.com/snyk/snyk-ls v0.0.0-20260624144357-470296debe0f/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
 github.com/snyk/studio-mcp v1.13.2 h1:oGTAar33yZ8ILHsfO6Zqcek1k4tjMH5zbjiN0oTA8xw=
 github.com/snyk/studio-mcp v1.13.2/go.mod h1:S5utY5ieoPd7axW1yB2Kz3TeN8nRQ8iEDx4jGBdCygQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/snyk/go-application-framework v0.5.0
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20260624084253-57d422709963
+	github.com/snyk/snyk-ls v0.0.0-20260624144357-470296debe0f
 	github.com/snyk/studio-mcp v1.13.2
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -573,8 +573,8 @@ github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhk
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260624084253-57d422709963 h1:hqWMhYoveuJl3eDUMDYhnQlbXrgIdETrmG8kGFFFTdg=
-github.com/snyk/snyk-ls v0.0.0-20260624084253-57d422709963/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
+github.com/snyk/snyk-ls v0.0.0-20260624144357-470296debe0f h1:l7FSJlUnnuxjmbon6swh174Ildtwqj08GpX8htHJH+4=
+github.com/snyk/snyk-ls v0.0.0-20260624144357-470296debe0f/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
 github.com/snyk/studio-mcp v1.13.2 h1:oGTAar33yZ8ILHsfO6Zqcek1k4tjMH5zbjiN0oTA8xw=
 github.com/snyk/studio-mcp v1.13.2/go.mod h1:S5utY5ieoPd7axW1yB2Kz3TeN8nRQ8iEDx4jGBdCygQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit 470296debe0f7f1f2b9fae22be251c2c1a0011d6
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Wed Jun 24 15:43:57 2026 +0100

    chore: add log for deduped issue count in summary panel [IDE-2141] (#1347)
    
    Add a single log line to help diagnose issues with summary panel deduping issues for the displayed count.

M	domain/scanstates/summary_html.go

commit 567374c26b424922401c5aad15fde590e6499d15
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Wed Jun 24 14:01:33 2026 +0200

    fix: make Workspace.Folders() return a deterministic order [IDE-2149] (#1361)
    
    Workspace.Folders() built its slice by ranging over the folders map, so
    the element order was randomized per call. The reflect.DeepEqual guard in
    processConfigSettings compares before/after BuildLspConfiguration to
    suppress no-op $/snyk.configuration sends; on workspaces with two or more
    folders the random order made that comparison spuriously unequal,
    re-triggering the infinite IDE settings refresh loop the guard was added
    to prevent (IDE-2149).
    
    Sort Folders() by folder.Path() at the source so every caller gets a
    stable order. The map snapshot is taken under RLock inside a
    defer-protected closure and the copy is sorted outside the lock, so the
    read lock is released even on panic and is not held during the sort.
    
    Add a workspace-layer unit test asserting Folders() returns sorted,
    stable order across consecutive calls, alongside the command-layer
    BuildLspConfiguration stability test. Correct two now-stale test comments
    that described Folders() as returning random order.

M	domain/ide/command/folder_handler_test.go
M	domain/ide/workspace/workspace.go
M	domain/ide/workspace/workspace_test.go
M	infrastructure/analytics/config_analytics_test.go
M	infrastructure/authentication/auth_service_impl_test.go

commit cc1110ad4d6f54e872d3d366021fcda465aa4622
Author: Andrew Robinson Hodges <andrew.robinsonhodges@snyk.io>
Date:   Wed Jun 24 10:48:25 2026 +0100

    fix: change filter icon colour and saturation to reflect filter state [IDE-2168] (#1359)

M	domain/ide/treeview/template/styles.css
```

[IDE-2141]: https://snyksec.atlassian.net/browse/IDE-2141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-2149]: https://snyksec.atlassian.net/browse/IDE-2149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-2168]: https://snyksec.atlassian.net/browse/IDE-2168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ