### PR TITLE
chore(language-server): integrate LS

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -227,7 +227,7 @@ require (
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
-	github.com/snyk/snyk-ls v0.0.0-20260624144357-470296debe0f // indirect
+	github.com/snyk/snyk-ls v0.0.0-20260625125828-bd282f0189b7 // indirect
 	github.com/snyk/studio-mcp v1.14.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -613,8 +613,8 @@ github.com/snyk/remy-cli-extension v1.20.1 h1:Y5h3oqbKghkkObRqwvF8qkX6OtmmKDAbh+
 github.com/snyk/remy-cli-extension v1.20.1/go.mod h1:qpL64pAGKDAbApnP8CLIAIOLPD6R+Ge6qA4m0L2auKo=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260624144357-470296debe0f h1:l7FSJlUnnuxjmbon6swh174Ildtwqj08GpX8htHJH+4=
-github.com/snyk/snyk-ls v0.0.0-20260624144357-470296debe0f/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
+github.com/snyk/snyk-ls v0.0.0-20260625125828-bd282f0189b7 h1:nAsiOM8/3sk7XguZeHj02j0Bbwfvl8s5B7/gVo5lzTo=
+github.com/snyk/snyk-ls v0.0.0-20260625125828-bd282f0189b7/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
 github.com/snyk/studio-mcp v1.14.0 h1:9Z7JPHFNtd5m8fmosBgTzLMFXmjImKvkAtvsjejy4qQ=
 github.com/snyk/studio-mcp v1.14.0/go.mod h1:3ZISZCgorkGg/iLQrryvmP34Db4KkvtfAARi7vMqM/4=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/snyk/go-application-framework v0.5.0
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20260624144357-470296debe0f
+	github.com/snyk/snyk-ls v0.0.0-20260625125828-bd282f0189b7
 	github.com/snyk/studio-mcp v1.14.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -573,8 +573,8 @@ github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhk
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260624144357-470296debe0f h1:l7FSJlUnnuxjmbon6swh174Ildtwqj08GpX8htHJH+4=
-github.com/snyk/snyk-ls v0.0.0-20260624144357-470296debe0f/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
+github.com/snyk/snyk-ls v0.0.0-20260625125828-bd282f0189b7 h1:nAsiOM8/3sk7XguZeHj02j0Bbwfvl8s5B7/gVo5lzTo=
+github.com/snyk/snyk-ls v0.0.0-20260625125828-bd282f0189b7/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
 github.com/snyk/studio-mcp v1.14.0 h1:9Z7JPHFNtd5m8fmosBgTzLMFXmjImKvkAtvsjejy4qQ=
 github.com/snyk/studio-mcp v1.14.0/go.mod h1:3ZISZCgorkGg/iLQrryvmP34Db4KkvtfAARi7vMqM/4=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit bd282f0189b7d87dafe497e4cb257c5e4fe3ca14
Author: Andrew Robinson Hodges <andrew.robinsonhodges@snyk.io>
Date:   Thu Jun 25 13:58:28 2026 +0100

    fix: update wording on folder config settings page to match new wording on global settings page [IDE-1966] (#1280)
    
    * fix: update wording on folder ocnfig settings page to match new wording on global settings page
    
    * refactor: remove extra whitespace
    
    * chore: update generated html

M	infrastructure/configuration/template/config.html
M	scripts/config-dialog/config_output_multi_project.html
M	scripts/config-dialog/config_output_single_solution.html

commit 30f94da1ef6a47f888647058d6fec285ba6c4cb7
Author: Knut Funkel <knut.funkel@snyk.io>
Date:   Thu Jun 25 09:21:07 2026 +0300

    fix: include underlying error in IAW repo-URL warning [IDE-1453] (#1323)
    
    * fix: include underlying error in IAW repo-URL warning [IDE-1453]
    
    When scan.NewRepositoryTarget fails to determine a repository URL,
    the IAW (ignore-approval-workflow) submission previously discarded the
    returned err: only a generic warning was logged and the user got an
    opaque validation failure.
    
    Now the warning logs the underlying err and the user receives an
    MTWarning notification "Could not determine repository URL: <cause>"
    via the existing notifier. Adds a test in infrastructure/code that
    asserts the warning is dispatched when the folder is not a git repo.
    
    * fix(iaw): scope repo-URL warning to ignore submission, not scan path [IDE-1453]
    
    Address PR #1323 review:
    
    - Remove the user-facing "Could not determine repository URL" popup from
      the universal Code-scan path (UploadAndAnalyze). Non-git, no-remote, or
      fresh-repo workspaces were getting a recurring popup on every scan and
      auto-scan-on-save — a regression from the previous log-only behaviour.
      Keep the enriched .Err(err) log line.
    - Surface the notification on the IAW ignore-submission boundary instead:
      submitIgnoreRequest.validateIgnoreRequest runs before the workflow type
      switch, blocks the action with an error, and shows a stable user-facing
      MTWarning constant (userMsgCannotDetermineRepoURL). Raw go-git error
      text stays in the structured log only — no filesystem-path leak risk.
    - Add Test_validateIgnoreRequest__notifies_user_when_repo_URL_cannot_be_determined
      exercising the IAW path with a non-git temp dir; the matching scan-path
      test is inverted to assert no MTWarning is sent during scan.
    
    * test(iaw): init folders as git repos in IgnoreOperations integration test [IDE-1453]
    
    Test_IgnoreOperations_UseFolderOrganization seeded each folder as a bare
    TempDir, which broke after the IDE-1453 validateIgnoreRequest gate started
    requiring scan.NewRepositoryTarget to resolve a repo URL on the IAW
    submit path. Add an initGitRepoWithRemote helper that does PlainInit +
    one commit + an origin remote, and call it for both folders before the
    workspace is set up. Rename the snyk-ls application/config import alias
    to lsconfig to avoid colliding with go-git's config package.
    
    * test(iaw): init folders as git repos in submitIgnoreRequest unit tests [IDE-1453]
    
    The new validateIgnoreRequest gate in submitIgnoreRequest.Execute calls
    scan.NewRepositoryTarget on the content root, which fails on a bare
    t.TempDir(). Mirror the ea3acc0e fix from the integration tests by
    initialising each test's folder as a git repo with a remote.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * style: goimports — group sglsp with other third-party imports [IDE-1453]
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * fix(iaw): scope repo-URL precheck to create workflow only [IDE-1453]
    
    Move validateIgnoreRequest into the create case so update and delete
    workflows no longer fail in non-git or detached-HEAD folders.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * fix(iaw): use GAF's git.RepoUrlFromDir for repo-URL precheck [IDE-1453]
    
    Replace scan.NewRepositoryTarget with git.RepoUrlFromDir — the same
    resolver GAF's remoteRepoUrlDefaultFunc uses — so the snyk-ls precheck
    and the workflow agree on what counts as a resolvable repo. Drops the
    implicit requirement for a commit ID and branch name, allowing
    detached-HEAD or fresh repos with a configured remote to submit ignores.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    ---------
    
    Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    Co-authored-by: Bastian Doetsch <bastian.doetsch@snyk.io>

M	domain/ide/command/ignores_integration_test.go
M	domain/ide/command/ignores_request.go
M	domain/ide/command/ignores_request_test.go
M	infrastructure/code/code.go
M	infrastructure/code/code_test.go

commit 5a7612220d75315f83c228898744d7433cd78231
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Thu Jun 25 07:13:25 2026 +0200

    ci: sign compatibility matrix commits [IDE-1796] (#1363)
    
    The update-compatibility-matrix workflow committed to snyk/user-docs as
    snyk-ls-bot with no signing configuration, producing unsigned commits.
    
    Mirror the CLI PR workflow (.github/create-cli-pr.sh): load the signing
    key into ssh-agent (TEAM_IDE_USER_SSH), enable SSH commit signing, and
    commit under the Snyk Team IDE identity (team-ide@snyk.io) that owns the
    key so GitHub marks the commit as Verified.
    
    Also make PR creation idempotent: the branch name embeds only the UTC date,
    so a same-day re-run must update the existing PR via gh pr edit rather than
    fail on a duplicate from gh pr create (422). Uses jq '... // empty' so the
    no-PR case yields an empty string and takes the create path.

M	.github/workflows/update-compatibility-matrix.yaml
```

[IDE-1966]: https://snyksec.atlassian.net/browse/IDE-1966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1453]: https://snyksec.atlassian.net/browse/IDE-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1453]: https://snyksec.atlassian.net/browse/IDE-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1453]: https://snyksec.atlassian.net/browse/IDE-1453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ