### PR TITLE
feat: [CMPA-604] Adds sbom component metadata for maven behind an internal flag

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -206,7 +206,7 @@ require (
 	github.com/skeema/knownhosts v1.3.2 // indirect
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260505093105-90d9442ea939 // indirect
 	github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603 // indirect
-	github.com/snyk/cli-extension-dep-graph/v2 v2.6.0 // indirect
+	github.com/snyk/cli-extension-dep-graph/v2 v2.7.1 // indirect
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 // indirect
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e // indirect
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260625140351-2bb6cb470073 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -565,8 +565,8 @@ github.com/snyk/cli-extension-agent-scan v0.0.0-20260505093105-90d9442ea939 h1:G
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260505093105-90d9442ea939/go.mod h1:+Znlgu2v7sOTNAVjsoldFjDZUIo8tpdKnFlMptZHzz0=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603 h1:uZyw9OvOGCMFloZy8Fyu6l4K5y77o4k0KdxHuUKAp8M=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603/go.mod h1:RnMP+tFTeKygfXSx7z+heyMZoOps67u5HFytjptHjuk=
-github.com/snyk/cli-extension-dep-graph/v2 v2.6.0 h1:tv21E++s5tVF8L54fJ485Grb9jo14lE3ubT3cXPHN3k=
-github.com/snyk/cli-extension-dep-graph/v2 v2.6.0/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
+github.com/snyk/cli-extension-dep-graph/v2 v2.7.1 h1:vnDp55PWtYBKYww8nQoCWfJ58huIR9iocax9jxvXe+Q=
+github.com/snyk/cli-extension-dep-graph/v2 v2.7.1/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSoQL0zYyFcGQjEPZcQgDkzM5PcgIHlIgzRuhg=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e h1:HE22F5/ivTJ4TlTUnjasZqfkDKVyfmYjf36RaIZqrs4=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260505093105-90d9442ea939
 	github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603
-	github.com/snyk/cli-extension-dep-graph/v2 v2.6.0
+	github.com/snyk/cli-extension-dep-graph/v2 v2.7.1
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260625140351-2bb6cb470073

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -527,8 +527,8 @@ github.com/snyk/cli-extension-agent-scan v0.0.0-20260505093105-90d9442ea939 h1:G
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260505093105-90d9442ea939/go.mod h1:+Znlgu2v7sOTNAVjsoldFjDZUIo8tpdKnFlMptZHzz0=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603 h1:uZyw9OvOGCMFloZy8Fyu6l4K5y77o4k0KdxHuUKAp8M=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603/go.mod h1:RnMP+tFTeKygfXSx7z+heyMZoOps67u5HFytjptHjuk=
-github.com/snyk/cli-extension-dep-graph/v2 v2.6.0 h1:tv21E++s5tVF8L54fJ485Grb9jo14lE3ubT3cXPHN3k=
-github.com/snyk/cli-extension-dep-graph/v2 v2.6.0/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
+github.com/snyk/cli-extension-dep-graph/v2 v2.7.1 h1:vnDp55PWtYBKYww8nQoCWfJ58huIR9iocax9jxvXe+Q=
+github.com/snyk/cli-extension-dep-graph/v2 v2.7.1/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSoQL0zYyFcGQjEPZcQgDkzM5PcgIHlIgzRuhg=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e h1:HE22F5/ivTJ4TlTUnjasZqfkDKVyfmYjf36RaIZqrs4=

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "snyk-go-plugin": "2.1.2",
         "snyk-gradle-plugin": "7.0.0",
         "snyk-module": "3.1.0",
-        "snyk-mvn-plugin": "^4.7.0",
+        "snyk-mvn-plugin": "4.8.0",
         "snyk-nodejs-lockfile-parser": "2.8.1",
         "snyk-nodejs-plugin": "^2.0.1",
         "snyk-nuget-plugin": "4.2.0",
@@ -20082,9 +20082,9 @@
       "license": "ISC"
     },
     "node_modules/snyk-mvn-plugin": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-4.7.0.tgz",
-      "integrity": "sha512-edSS9J3pE60IdDhe1La/CMH2D9+GoPWPLv22/6YSd6f+lEquSVBgO+P0F0DON2YKC4xqkfsr0Kw4m6GtTxt22w==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-4.8.0.tgz",
+      "integrity": "sha512-umRV3maCSpil4eZJzpYOP5ybH+EAss4ipog6caRN+xdrTE4YL2gs9JOCFki8en+3RMrwTi/W0Q8uKBMNfj9vwg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@common.js/yocto-queue": "^1.1.1",
@@ -20103,6 +20103,8 @@
     },
     "node_modules/snyk-mvn-plugin/node_modules/@snyk/cli-interface": {
       "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/@snyk/cli-interface/-/cli-interface-2.14.1.tgz",
+      "integrity": "sha512-7ooHTlw9tY96ZeLwd+ICzikkgj8Qc4ZyUuXaDEhQzI5Ap/3GStukRDcGsXpsVZp0e/SDMEb690qgK9PefUWz0Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/graphlib": "^2"
@@ -20113,10 +20115,14 @@
     },
     "node_modules/snyk-mvn-plugin/node_modules/packageurl-js": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-2.0.1.tgz",
+      "integrity": "sha512-N5ixXjzTy4QDQH0Q9YFjqIWd6zH6936Djpl2m9QNFmDv5Fum8q8BjkpAcHNMzOFE0IwQrFhJWex3AN6kS0OSwg==",
       "license": "MIT"
     },
     "node_modules/snyk-mvn-plugin/node_modules/tslib": {
       "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/snyk-nodejs-lockfile-parser": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "snyk-go-plugin": "2.1.2",
     "snyk-gradle-plugin": "7.0.0",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "^4.7.0",
+    "snyk-mvn-plugin": "4.8.0",
     "snyk-nodejs-lockfile-parser": "2.8.1",
     "snyk-nodejs-plugin": "^2.0.1",
     "snyk-nuget-plugin": "4.2.3",

--- a/src/lib/plugins/get-single-plugin-result.ts
+++ b/src/lib/plugins/get-single-plugin-result.ts
@@ -33,6 +33,15 @@ export async function getSinglePluginResult(
       cliDotnetRuntimeResolutionEnabled: featureFlags.has(
         CLI_DOTNET_RUNTIME_RESOLUTION,
       ),
+      // Internal/undocumented flag: surfaced to the plugin in camelCase here
+      // rather than via the user-facing arg transform list, so it stays off the
+      // documented CLI surface. Single convergence point for single- and
+      // multi-project (all-projects/aggregate) scans. Only added when set so the
+      // default plugin-options shape is unchanged (the flag is gateway-driven
+      // and absent for the vast majority of scans).
+      ...(options['include-component-metadata'] !== undefined && {
+        includeComponentMetadata: options['include-component-metadata'],
+      }),
     },
     snykHttpClient,
   );

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -56,6 +56,10 @@ export interface Options {
   mavenAggregateProject?: boolean;
   mavenSkipWrapper?: boolean;
   mavenVerboseIncludeAllVersions?: boolean;
+  // Internal/undocumented flag, read directly off the dashed key (see
+  // get-single-plugin-result.ts). Intentionally not part of
+  // SupportedUserReachableFacingCliArgs so it stays off the documented surface.
+  'include-component-metadata'?: boolean;
   includeProvenance?: boolean;
   fingerprintAlgorithm?: string;
   'project-name'?: string;

--- a/test/jest/acceptance/snyk-test/maven-include-component-metadata.spec.ts
+++ b/test/jest/acceptance/snyk-test/maven-include-component-metadata.spec.ts
@@ -1,0 +1,100 @@
+import { execFileSync } from 'child_process';
+
+import { createProjectFromFixture } from '../../util/createProject';
+import { runSnykCLI } from '../../util/runSnykCLI';
+import { fakeServer } from '../../../acceptance/fake-server';
+import { getAvailableServerPort } from '../../util/getServerPort';
+import { isWindowsOperatingSystem } from '../../../utils';
+
+jest.setTimeout(1000 * 60 * 5);
+
+// `--include-component-metadata` makes the maven plugin read the install-time
+// `.jar.sha1` companion files from the local Maven repository and surface them
+// as `hash:<algorithm>` labels on the dep-graph nodes. The artifacts must
+// therefore be resolved into the local repository first (via `mvn`), otherwise
+// there are no companion files to read.
+describe('`snyk test --include-component-metadata` (maven)', () => {
+  let server;
+  let env: Record<string, string>;
+
+  beforeAll(async () => {
+    const port = await getAvailableServerPort(process);
+    const baseApi = '/api/v1';
+    env = {
+      ...process.env,
+      SNYK_API: 'http://localhost:' + port + baseApi,
+      SNYK_HOST: 'http://localhost:' + port,
+      SNYK_TOKEN: '123456789',
+      SNYK_DISABLE_ANALYTICS: '1',
+    };
+    server = fakeServer(baseApi, env.SNYK_TOKEN);
+    await server.listenPromise(port);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    server.restore();
+  });
+
+  afterAll(
+    () =>
+      new Promise((res) => {
+        server.close(res);
+      }),
+  );
+
+  const hashLabelKeys = (printGraphStdout: string): string[] => {
+    const jsonDG = JSON.parse(
+      printGraphStdout.split('DepGraph data:')[1].split('DepGraph target:')[0],
+    );
+    return jsonDG.graph.nodes
+      .flatMap((node) => Object.keys(node.info?.labels ?? {}))
+      .filter((key) => key.startsWith('hash:'));
+  };
+
+  // mvn is required to resolve artifacts into the local repository first.
+  it('attaches `hash:<algorithm>` labels when artifacts are resolved', async () => {
+    const project = await createProjectFromFixture('maven-print-graph');
+
+    // Populate the local Maven repository so the `.jar.sha1` companion files
+    // the plugin reads are present.
+    execFileSync('mvn', ['dependency:resolve'], {
+      cwd: project.path(),
+      stdio: 'ignore',
+      shell: isWindowsOperatingSystem(),
+    });
+
+    const { code, stdout } = await runSnykCLI(
+      'test --include-component-metadata --print-graph',
+      {
+        cwd: project.path(),
+        env,
+      },
+    );
+
+    expect(code).toEqual(0);
+    expect(stdout).toContain('DepGraph data:');
+    expect(hashLabelKeys(stdout).length).toBeGreaterThan(0);
+  });
+
+  // Control: without the flag the same project must not produce hash labels,
+  // proving the labels are driven by `--include-component-metadata`.
+  it('does not attach hash labels without the flag', async () => {
+    const project = await createProjectFromFixture('maven-print-graph');
+
+    execFileSync('mvn', ['dependency:resolve'], {
+      cwd: project.path(),
+      stdio: 'ignore',
+      shell: isWindowsOperatingSystem(),
+    });
+
+    const { code, stdout } = await runSnykCLI('test --print-graph', {
+      cwd: project.path(),
+      env,
+    });
+
+    expect(code).toEqual(0);
+    expect(stdout).toContain('DepGraph data:');
+    expect(hashLabelKeys(stdout)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable) — none
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [x] Updates relevant GitBook documentation — N/A, intentionally undocumented (internal, restricted testing)
- [x] Includes product update to be announced in the next stable release notes — N/A, no client-visible change

## What does this PR do?

Plumbs the internal `--include-component-metadata` flag through the legacy CLI as part of
CMPA-604 (SBOM component metadata).

This flag is **not a user-facing command option**. It is sourced from the feature-flag
gateway inside `cli-extension-sbom`, passed down through the `cli-extension-dep-graph`
workflow into the legacy CLI, which forwards it to the `mvn`/`npm` legacy plugins. When
set, the plugins attach hash and distribution-URL information as labels on the DepGraph,
which `cli-extension-sbom` uses to populate `components[].hashes[]` and `externalUrls`
(distribution) entries in CycloneDX SBOM output.

Changes here:
- Registers `include-component-metadata` as a recognised argument so it is forwarded to
  the plugins (`src/cli/args.ts`, `src/lib/types.ts`). It is deliberately undocumented.
- Bumps `snyk-mvn-plugin` `^4.7.0` → `4.8.0` — adds Maven artifact checksum collection
  and the `includeComponentMetadata` plugin option (snyk/snyk-mvn-plugin#220,
  renamed from `includeHashes` in snyk/snyk-mvn-plugin#222).
- Bumps the cliv2 extensions that drive this: `cli-extension-sbom`
  (FF-gated activation + SBOM enrichment, snyk/cli-extension-sbom#192) and
  `cli-extension-dep-graph/v2` `v2.6.0` → `v2.7.1` (flag pass-through,
  snyk/cli-extension-dep-graph#222), with the accompanying `go.mod`/`go.sum` tidy across
  both `cliv2/` and `cliv2-private/`.

**The feature is in restricted testine-flag gateway —
clients will see no change unless it is explicitly enabled for them.**

## Where should the reviewer start?

`src/cli/args.ts` and `src/lib/types.ts` — the flag is only recognised and forwarded
here; the behaviour lives in the bumpnfirm the version bumps
in `package.json` and `cliv2*/go.mod`.

## How should this be manually tested?

The flag is FF-gated end-to-end, but the underlying plumbing can be exercised directly
against a Maven project (per snyk/sny

```bash
snyk test --include-component-metadata --print-graph <maven-project>
```

Confirm the flag is accepted and the printed DepGraph nodes carry hash:* labels, e.g.:
```
"info": { "labels": { "hash:sha-1": "c88fc1d8a96d4c3491f55d4317458ccad53ca663" } }
```
Without the flag (the default client path), confirm output is unchanged.

The full evaluation through the `snyk sbom` path can also be tested against `pre-prod` environments:
```
{
  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
  "bomFormat": "CycloneDX",
  "specVersion": "1.6",
  "serialNumber": "urn:uuid:482810b1-52e6-4b4e-8da3-5602a0ed5812",
  "version": 1,
  "metadata": {
    "timestamp": "2026-06-25T14:17:42Z",
    "tools": {
      "components": [
        {
          "type": "application",
          "author": "Snyk",
          "name": "snyk-cli",
          "version": "1.1306.0-dev.7914fd29a4b327a5400f7ac13d6629d46b59b5c1"
        }
      ],
      "services": [
        {
          "provider": {
            "name": "Snyk"
          },
          "name": "SBOM Export API",
          "version": "v1.131.0"
        }
      ]
    },
    "component": {
      "bom-ref": "1-io.snyk.os-managed:bad-resolution@1.0.0",
      "type": "application",
      "name": "io.snyk.os-managed:bad-resolution",
      "version": "1.0.0",
      "purl": "pkg:maven/io.snyk.os-managed/bad-resolution@1.0.0",
      "properties": [
        {
          "name": "snyk:maven:build_scope",
          "value": "unknown"
        }
      ]
    }
  },
  "components": [
    {
      "bom-ref": "2-org.jboss.resteasy:resteasy-core@6.2.12.Final",
      "type": "library",
      "group": "org.jboss.resteasy",
      "name": "org.jboss.resteasy:resteasy-core",
      "version": "6.2.12.Final",
      "hashes": [
        {
          "alg": "SHA-1",
          "content": "45c4596118651373c5c854c69ef1cfa1feaad3cc"
        }
      ],
      "licenses": [
        {
          "expression": "Apache-2.0"
        }
      ],
      "purl": "pkg:maven/org.jboss.resteasy/resteasy-core@6.2.12.Final",
      "properties": [
        {
          "name": "snyk:maven:build_scope",
          "value": "compile"
        }
      ]
    },
    {
      "bom-ref": "3-com.ibm.async:asyncutil@0.1.0",
      "type": "library",
      "group": "com.ibm.async",
      "name": "com.ibm.async:asyncutil",
      "version": "0.1.0",
      "hashes": [
        {
          "alg": "SHA-1",
          "content": "440941c382166029a299602e6c9ff5abde1b5143"
        }
      ],
      "licenses": [
        {
          "expression": "Apache-2.0"
        }
      ],
      "purl": "pkg:maven/com.ibm.async/asyncutil@0.1.0",
      "properties": [
        {
          "name": "snyk:maven:build_scope",
          "value": "compile"
        }
      ]
    },
    {
      "bom-ref": "4-jakarta.validation:jakarta.validation-api@3.0.2",
      "type": "library",
      "group": "jakarta.validation",
      "name": "jakarta.validation:jakarta.validation-api",
      "version": "3.0.2",
      "hashes": [
        {
          "alg": "SHA-1",
          "content": "92b6631659ba35ca09e44874d3eb936edfeee532"
        }
      ],
      "licenses": [
        {
          "expression": "Apache-2.0"
        }
      ],
      "purl": "pkg:maven/jakarta.validation/jakarta.validation-api@3.0.2",
      "properties": [
        {
          "name": "snyk:maven:build_scope",
          "value": "compile"
        }
      ]
    },
    {
      "bom-ref": "5-org.eclipse.angus:angus-activation@2.0.2",
      "type": "library",
      "group": "org.eclipse.angus",
      "name": "org.eclipse.angus:angus-activation",
      "version": "2.0.2",
      "hashes": [
        {
          "alg": "SHA-1",
          "content": "41f1e0ddd157c856926ed149ab837d110955a9fc"
        }
      ],
      "licenses": [
        {
          "expression": "EDL-1.0"
        }
      ],
      "purl": "pkg:maven/org.eclipse.angus/angus-activation@2.0.2",
      "properties": [
        {
          "name": "snyk:maven:build_scope",
          "value": "compile"
        }
      ]
    },
    {
      "bom-ref": "6-jakarta.activation:jakarta.activation-api@2.1.3",
      "type": "library",
      "group": "jakarta.activation",
      "name": "jakarta.activation:jakarta.activation-api",
      "version": "2.1.3",
      "hashes": [
        {
          "alg": "SHA-1",
          "content": "fa165bd70cda600368eee31555222776a46b881f"
        }
      ],
      "licenses": [
        {
          "expression": "EDL-1.0"
        }
      ],
      "purl": "pkg:maven/jakarta.activation/jakarta.activation-api@2.1.3",
      "properties": [
        {
          "name": "snyk:maven:build_scope",
          "value": "compile"
        }
      ]
    },
    {
      "bom-ref": "7-org.reactivestreams:reactive-streams@1.0.4",
      "type": "library",
      "group": "org.reactivestreams",
      "name": "org.reactivestreams:reactive-streams",
      "version": "1.0.4",
      "hashes": [
        {
          "alg": "SHA-1",
          "content": "3864a1320d97d7b045f729a326e1e077661f31b7"
        }
      ],
      "licenses": [
        {
          "expression": "MIT-0"
        }
      ],
      "purl": "pkg:maven/org.reactivestreams/reactive-streams@1.0.4",
      "properties": [
        {
          "name": "snyk:maven:build_scope",
          "value": "compile"
        }
      ]
    },
    {
      "bom-ref": "8-org.jboss.resteasy:resteasy-core-spi@6.2.12.Final",
      "type": "library",
      "group": "org.jboss.resteasy",
      "name": "org.jboss.resteasy:resteasy-core-spi",
      "version": "6.2.12.Final",
      "hashes": [
        {
          "alg": "SHA-1",
          "content": "dfdce6a2fa042c07975c8d4fa11d259ca883878a"
        }
      ],
      "licenses": [
        {
          "expression": "Apache-2.0"
        }
      ],
      "purl": "pkg:maven/org.jboss.resteasy/resteasy-core-spi@6.2.12.Final",
      "properties": [
        {
          "name": "snyk:maven:build_scope",
          "value": "compile"
        }
      ]
    },
    {
      "bom-ref": "9-jakarta.xml.bind:jakarta.xml.bind-api@3.0.1",
      "type": "library",
      "group": "jakarta.xml.bind",
      "name": "jakarta.xml.bind:jakarta.xml.bind-api",
      "version": "3.0.1",
      "hashes": [
        {
          "alg": "SHA-1",
          "content": "5257932df36ff3e4e6de50429dde946490a6a800"
        }
      ],
      "licenses": [
        {
          "expression": "EDL-1.0"
        }
      ],
      "purl": "pkg:maven/jakarta.xml.bind/jakarta.xml.bind-api@3.0.1",
      "properties": [
        {
          "name": "snyk:maven:build_scope",
          "value": "compile"
        }
      ]
    },
    {
      "bom-ref": "10-jakarta.ws.rs:jakarta.ws.rs-api@3.1.0",
      "type": "library",
      "group": "jakarta.ws.rs",
      "name": "jakarta.ws.rs:jakarta.ws.rs-api",
      "version": "3.1.0",
      "hashes": [
        {
          "alg": "SHA-1",
          "content": "15ce10d249a38865b58fc39521f10f29ab0e3363"
        }
      ],
      "licenses": [
        {
          "expression": "(EPL-2.0 OR GPL-2.0-with-classpath-exception)"
        }
      ],
      "purl": "pkg:maven/jakarta.ws.rs/jakarta.ws.rs-api@3.1.0",
      "properties": [
        {
          "name": "snyk:maven:build_scope",
          "value": "compile"
        }
      ]
    },
    {
      "bom-ref": "11-jakarta.annotation:jakarta.annotation-api@2.1.1",
      "type": "library",
      "group": "jakarta.annotation",
      "name": "jakarta.annotation:jakarta.annotation-api",
      "version": "2.1.1",
      "hashes": [
        {
          "alg": "SHA-1",
          "content": "48b9bda22b091b1f48b13af03fe36db3be6e1ae3"
        }
      ],
      "licenses": [
        {
          "expression": "(EPL-2.0 OR GPL-2.0-with-classpath-exception)"
        }
      ],
      "purl": "pkg:maven/jakarta.annotation/jakarta.annotation-api@2.1.1",
      "properties": [
        {
          "name": "snyk:maven:build_scope",
          "value": "compile"
        }
      ]
    },
    {
      "bom-ref": "12-org.jboss.logging:jboss-logging@3.5.3.Final",
      "type": "library",
      "group": "org.jboss.logging",
      "name": "org.jboss.logging:jboss-logging",
      "version": "3.5.3.Final",
      "hashes": [
        {
          "alg": "SHA-1",
          "content": "c88fc1d8a96d4c3491f55d4317458ccad53ca663"
        }
      ],
      "licenses": [
        {
          "expression": "Apache-2.0"
        }
      ],
      "purl": "pkg:maven/org.jboss.logging/jboss-logging@3.5.3.Final",
      "properties": [
        {
          "name": "snyk:maven:build_scope",
          "value": "compile"
        }
      ]
    },
    {
      "bom-ref": "13-org.jboss:jandex@2.4.5.Final",
      "type": "library",
      "group": "org.jboss",
      "name": "org.jboss:jandex",
      "version": "2.4.5.Final",
      "hashes": [
        {
          "alg": "SHA-1",
          "content": "9b4634d1fa28628549eb986b7c0c73f387090fba"
        }
      ],
      "licenses": [
        {
          "expression": "Apache-2.0"
        }
      ],
      "purl": "pkg:maven/org.jboss/jandex@2.4.5.Final",
      "properties": [
        {
          "name": "snyk:maven:build_scope",
          "value": "compile"
        }
      ]
    }
  ],
  "dependencies": [
    {
      "ref": "1-io.snyk.os-managed:bad-resolution@1.0.0",
      "dependsOn": [
        "2-org.jboss.resteasy:resteasy-core@6.2.12.Final"
      ]
    },
    {
      "ref": "2-org.jboss.resteasy:resteasy-core@6.2.12.Final",
      "dependsOn": [
        "3-com.ibm.async:asyncutil@0.1.0",
        "4-jakarta.validation:jakarta.validation-api@3.0.2",
        "5-org.eclipse.angus:angus-activation@2.0.2",
        "6-jakarta.activation:jakarta.activation-api@2.1.3",
        "7-org.reactivestreams:reactive-streams@1.0.4",
        "8-org.jboss.resteasy:resteasy-core-spi@6.2.12.Final",
        "13-org.jboss:jandex@2.4.5.Final",
        "9-jakarta.xml.bind:jakarta.xml.bind-api@3.0.1",
        "10-jakarta.ws.rs:jakarta.ws.rs-api@3.1.0",
        "11-jakarta.annotation:jakarta.annotation-api@2.1.1",
        "12-org.jboss.logging:jboss-logging@3.5.3.Final"
      ]
    },
    {
      "ref": "3-com.ibm.async:asyncutil@0.1.0"
    },
    {
      "ref": "4-jakarta.validation:jakarta.validation-api@3.0.2"
    },
    {
      "ref": "5-org.eclipse.angus:angus-activation@2.0.2"
    },
    {
      "ref": "6-jakarta.activation:jakarta.activation-api@2.1.3"
    },
    {
      "ref": "7-org.reactivestreams:reactive-streams@1.0.4"
    },
    {
      "ref": "8-org.jboss.resteasy:resteasy-core-spi@6.2.12.Final",
      "dependsOn": [
        "4-jakarta.validation:jakarta.validation-api@3.0.2",
        "7-org.reactivestreams:reactive-streams@1.0.4",
        "9-jakarta.xml.bind:jakarta.xml.bind-api@3.0.1",
        "10-jakarta.ws.rs:jakarta.ws.rs-api@3.1.0",
        "11-jakarta.annotation:jakarta.annotation-api@2.1.1",
        "12-org.jboss.logging:jboss-logging@3.5.3.Final"
      ]
    },
    {
      "ref": "9-jakarta.xml.bind:jakarta.xml.bind-api@3.0.1"
    },
    {
      "ref": "10-jakarta.ws.rs:jakarta.ws.rs-api@3.1.0"
    },
    {
      "ref": "11-jakarta.annotation:jakarta.annotation-api@2.1.1"
    },
    {
      "ref": "12-org.jboss.logging:jboss-logging@3.5.3.Final"
    },
    {
      "ref": "13-org.jboss:jandex@2.4.5.Final"
    }
  ]
}
```

## Risk assessment (Low | Medium | High)?

Low — additive and inert by default: the flag is FF-gated in cli-extension-sbom and not
documented, so no client behaviour ched. Residual risk is in
the plugin/extension version bumps, covered by their own suites.

## What are the relevant tickets?

- [CMPA-604](https://snyksec.atlassian.net/browse/CMPA-604)

Related PRs:
- snyk/cli-extension-dep-graph#222
- snyk/cli-extension-sbom#192
- snyk/snyk-mvn-plugin#220
- snyk/snyk-mvn-plugin#222

[CMPA-604]: https://snyksec.atlassian.net/browse/CMPA-604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ