### PR TITLE
chore: bump cli-extension-sbom [OSF-427]

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -217,7 +217,7 @@ require (
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 // indirect
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e // indirect
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260625140351-2bb6cb470073 // indirect
-	github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa // indirect
+	github.com/snyk/cli-extension-sbom v0.0.0-20260623143454-0e7dabd69db4 // indirect
 	github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3 // indirect
 	github.com/snyk/code-client-go v1.27.5 // indirect
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -591,8 +591,8 @@ github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e h1:HE
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e/go.mod h1:YN+M0+nNZ5VoQN2SxSvZSoTxs/PkdLgfNfUWvsKVL7o=
 github.com/snyk/cli-extension-os-flows v0.0.0-20260625140351-2bb6cb470073 h1:c1nvn9dDZBUQq9vikA//eSnusqybtRfGIleb2EPF4mk=
 github.com/snyk/cli-extension-os-flows v0.0.0-20260625140351-2bb6cb470073/go.mod h1:QdHPbvmQsUHfFylixIzyZlnchy33a8Qusaj5whzlIa8=
-github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa h1:9GSKXrRCaRkBAj+jglUBuhO09I1xs2G5GxwrPxlj34M=
-github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa/go.mod h1:SJ624HENWG4yjM6jNuLebTeNsMriozf1LcKhMYVm1aY=
+github.com/snyk/cli-extension-sbom v0.0.0-20260623143454-0e7dabd69db4 h1:Cn0TCkv52rC5j8m+rY0HLoz7Faq2lV4NCTlOgvBPGhA=
+github.com/snyk/cli-extension-sbom v0.0.0-20260623143454-0e7dabd69db4/go.mod h1:+wWswUQ/Hfgue1bLKT/amMd3B3xq1IVAiv+HakhVFYk=
 github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3 h1:wBYQm4YP65FTZ4rZ0iunhsIUYBindUEnfRWRi+Rugag=
 github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3/go.mod h1:D/Bk0EH8np/d6c1tG7wazpHI6iU9m8KzxytFcIQkEvQ=
 github.com/snyk/code-client-go v1.27.5 h1:fog+j64VKoj5TH/sGehJ5AXe52q7LpOJtKEhwQrcXx4=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260625140351-2bb6cb470073
-	github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa
+	github.com/snyk/cli-extension-sbom v0.0.0-20260623143454-0e7dabd69db4
 	github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3
 	github.com/snyk/code-client-go v1.27.0
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -553,8 +553,8 @@ github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e h1:HE
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e/go.mod h1:YN+M0+nNZ5VoQN2SxSvZSoTxs/PkdLgfNfUWvsKVL7o=
 github.com/snyk/cli-extension-os-flows v0.0.0-20260625140351-2bb6cb470073 h1:c1nvn9dDZBUQq9vikA//eSnusqybtRfGIleb2EPF4mk=
 github.com/snyk/cli-extension-os-flows v0.0.0-20260625140351-2bb6cb470073/go.mod h1:QdHPbvmQsUHfFylixIzyZlnchy33a8Qusaj5whzlIa8=
-github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa h1:9GSKXrRCaRkBAj+jglUBuhO09I1xs2G5GxwrPxlj34M=
-github.com/snyk/cli-extension-sbom v0.0.0-20260428131356-48881c6270fa/go.mod h1:SJ624HENWG4yjM6jNuLebTeNsMriozf1LcKhMYVm1aY=
+github.com/snyk/cli-extension-sbom v0.0.0-20260623143454-0e7dabd69db4 h1:Cn0TCkv52rC5j8m+rY0HLoz7Faq2lV4NCTlOgvBPGhA=
+github.com/snyk/cli-extension-sbom v0.0.0-20260623143454-0e7dabd69db4/go.mod h1:+wWswUQ/Hfgue1bLKT/amMd3B3xq1IVAiv+HakhVFYk=
 github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3 h1:wBYQm4YP65FTZ4rZ0iunhsIUYBindUEnfRWRi+Rugag=
 github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3/go.mod h1:D/Bk0EH8np/d6c1tG7wazpHI6iU9m8KzxytFcIQkEvQ=
 github.com/snyk/code-client-go v1.27.0 h1:FOX4JzgHssm5fei4ALyrBAIL9eJGnG52yTkqWcM1Qew=


### PR DESCRIPTION
Bumps the `cli-extension-sbom` dependency to `v0.0.0-20260623143454-0e7dabd69db4` in both `cliv2` and `cliv2-private` modules for OSF-427.