### PR TITLE
chore: reduce flakiness for test api equivalence spec

### DIFF
--- a/test/jest/acceptance/snyk-test/unified-test-api-equivalence.spec.ts
+++ b/test/jest/acceptance/snyk-test/unified-test-api-equivalence.spec.ts
@@ -13,30 +13,34 @@
  * Starter corpus. Expand per resolveDepgraphs-rollout-plan.md.
  */
 
-import { fakeServer } from '../../../acceptance/fake-server';
+import {
+  fakeServer,
+  getFirstIPv4Address,
+} from '../../../acceptance/fake-server';
 import { createProjectFromWorkspace } from '../../util/createProject';
-import { getServerPort } from '../../util/getServerPort';
+import { getAvailableServerPort } from '../../util/getServerPort';
 import { assertEquivalent, runBothFlows } from './equivalenceHelpers';
 
-jest.setTimeout(1000 * 60 * 3);
+jest.setTimeout(1000 * 60 * 5);
 
 describe('snyk test — unified test API equivalence (FF off vs on)', () => {
   let server;
   let env: Record<string, string>;
 
-  beforeAll((done) => {
-    const port = getServerPort(process);
+  beforeAll(async () => {
+    const port = await getAvailableServerPort(process);
     const baseApi = '/v1';
+    const fakeServerIp = getFirstIPv4Address();
     env = {
       ...process.env,
-      SNYK_API: 'http://localhost:' + port + baseApi,
-      SNYK_HOST: 'http://localhost:' + port,
+      SNYK_API: `http://${fakeServerIp}:${port}${baseApi}`,
+      SNYK_HOST: `http://${fakeServerIp}:${port}`,
       SNYK_TOKEN: '123456789',
       SNYK_DISABLE_ANALYTICS: '1',
       SNYK_HTTP_PROTOCOL_UPGRADE: '0',
     };
     server = fakeServer(baseApi, env.SNYK_TOKEN);
-    server.listen(port, () => done());
+    await server.listenPromise(port);
   });
 
   afterAll((done) => {


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Swap out the "localhost" for the IPv4 address to reduce the flakiness for the test-api-equivalence acceptance tests.

## Where should the reviewer start?

- `test/jest/acceptance/snyk-test/unified-test-api-equivalence.spec.ts`

## How should this be manually tested?

- Wait for CI to pass -  the changes should be aligned with some other acceptance tests that make use of this pattern.

## What's the product update that needs to be communicated to CLI users?

N/A - CI fix only.

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
