### PR TITLE
feat(fix): support OAuth for vertex and extra headers

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/snyk/cli/cliv2 v0.0.0
-	github.com/snyk/remy-cli-extension v1.22.1
+	github.com/snyk/remy-cli-extension v1.23.0
 )
 
 require (

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -591,8 +591,8 @@ github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyR
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
-github.com/snyk/remy-cli-extension v1.22.1 h1:Xd96DFvSXTu2RWtnZqSm/AgjlXkhI0EWFjlcnrkxKsM=
-github.com/snyk/remy-cli-extension v1.22.1/go.mod h1:qpL64pAGKDAbApnP8CLIAIOLPD6R+Ge6qA4m0L2auKo=
+github.com/snyk/remy-cli-extension v1.23.0 h1:cjfoltDIsJlunC2Zsx9hPN8EuJAAPUCZFDJvyg6Qj90=
+github.com/snyk/remy-cli-extension v1.23.0/go.mod h1:qpL64pAGKDAbApnP8CLIAIOLPD6R+Ge6qA4m0L2auKo=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
 github.com/snyk/snyk-ls v0.0.0-20260626083941-77c2abaeaaaa h1:qKLDBzWOoLLn06e69Cw7MLb6TtInLN+Y6IhD+oYVxdw=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps the bundled `remy-cli-extension` (the provider for `snyk fix --agentic`)
from **v1.22.1 → v1.23.0**.

v1.23.0 makes the agentic-fix LLM providers work behind an enterprise gateway
and adds bearer-token auth for the `vertex` provider. New environment variables:

- **`VERTEX_AUTH_TOKEN`** — authenticate the `vertex` provider with a bearer
  token instead of Google ADC (for a gateway that fronts Vertex). Works for both
  Gemini and Claude models.
- **`VERTEX_BASE_URL`** — point Vertex at a gateway/regional endpoint. Host +
  optional gateway prefix (e.g. `https://gw/vertex`), **without** the API version
  (the SDK appends `/v1beta1` for Gemini, `/v1` for Claude).
- **`ANTHROPIC_BASE_URL`** — point the `anthropic` provider at a gateway; `/v1`
  is auto-appended when the URL has no path.
- **`REMY_EXTRA_HEADERS`** — comma-separated `key=value` headers added to every
  cloud-provider request (e.g. a gateway identity header). Applies to
  `anthropic`, `openai`, `litellm`, and `vertex`.

The provider API key is now **optional**: when a gateway injects auth, a missing
key no longer fails at startup and the placeholder token is stripped on the wire.

Full extension changelog: snyk/remy-cli-extension#122
(release v1.23.0).

## Where should the reviewer start?

`cliv2-private/go.mod` (+ `go.sum`) — the only changes are the version bump of
`github.com/snyk/remy-cli-extension`.

## How should this be manually tested?

Build the CLI, then run the agentic fix against a project. Base command:

```bash
SNYK=./binary-releases/snyk-macos   # or your built CLI binary
APP=/path/to/project
FLAGS="fix --agentic --experimental --auto-approve"
```

Direct provider (unchanged, sanity check):

```bash
export ANTHROPIC_API_KEY=sk-ant-...
$SNYK $FLAGS --provider anthropic $APP
```

Vertex via bearer token through a gateway (new in this bump):

```bash
export VERTEX_BASE_URL=https://gateway.example.com/vertex   # no /v1
export VERTEX_AUTH_TOKEN="$(mint-oauth-token)"              # short-lived
export GOOGLE_CLOUD_PROJECT=my-proj GOOGLE_CLOUD_LOCATION=us-central1
$SNYK $FLAGS --provider vertex --model gemini-2.5-flash $APP
```

Optional gateway identity headers (combine with any provider):

```bash
export REMY_EXTRA_HEADERS="x-user-id=$USER,x-org-id=my-org"
```

Expected: the fix run authenticates through the gateway/bearer token and
produces fixes; with `VERTEX_AUTH_TOKEN` set, Google ADC is not used.

## What's the product update that needs to be communicated to CLI users?

**`snyk fix --agentic` can now run its AI providers behind an enterprise
gateway.** New environment variables let you route provider traffic through a
proxy and authenticate with a bearer token:

- `VERTEX_AUTH_TOKEN` — bearer auth for the `vertex` provider (Gemini and Claude),
  as an alternative to Google ADC.
- `VERTEX_BASE_URL` / `ANTHROPIC_BASE_URL` — send provider requests to a gateway
  or regional endpoint.
- `REMY_EXTRA_HEADERS` — attach custom `key=value` headers (comma-separated) to
  every provider request.

Provider API keys are now optional, so a gateway that injects authentication can
be used without setting a key locally.

## Risk assessment (Low | Medium | High)?

**Low.** Dependency version bump only; no CLI source changes. New behavior is
opt-in via environment variables and defaults are unchanged.
