### PR TITLE
chore: Split Windows build and FIPS into parallel jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1323,7 +1323,6 @@ workflows:
       - release-npm:
           name: upload npm
           context:
-            - team-hammerhead-common-deploy-tokens
             - devex_cli_docker_hub
           requires:
             - upload github
@@ -1855,7 +1854,9 @@ jobs:
           version: << pipeline.parameters.aws_version >>
       - run:
           name: Pre-Publishing
-          command: make release-pre
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            make release-pre
       - failed-release-notification
 
   npm-validation:
@@ -1988,7 +1989,9 @@ jobs:
           deployment: stable
       - run:
           name: Publish to npm
-          command: ./release-scripts/upload-artifacts.sh npm
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            ./release-scripts/upload-artifacts.sh npm
       - failed-release-notification
 
   trigger-building-distribution-channels:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,11 @@ parameters:
   windows_bash_env_script:
     type: string
     default: 'snyk-env.sh'
+  # TEMPORARY (CLI-1633): set true to run only the minimal Windows/Linux build workflow.
+  # Revert to false before merging to main.
+  minimal_ci_test:
+    type: boolean
+    default: true
 
 orbs:
   prodsec: snyk/prodsec-orb@1
@@ -551,7 +556,68 @@ commands:
 ####################################################################################################
 
 workflows:
+  # TEMPORARY (CLI-1633): isolated build perf test — prepare-build + linux amd64 + windows x2.
+  # Toggle pipeline parameter minimal_ci_test=false to restore full CI.
+  test_windows_build_perf:
+    when: << pipeline.parameters.minimal_ci_test >>
+    jobs:
+      - prepare-build:
+          context:
+            - devex_cli_docker_hub
+            - go-private-modules
+
+      - build-artifact:
+          name: build linux amd64
+          context:
+            - iac-cli
+            - go-private-modules
+            - devex_cli_docker_hub
+          go_target_os: linux
+          go_os: linux
+          go_arch: amd64
+          static_binary: true
+          go_download_base_url: << pipeline.parameters.go_download_base_url >>
+          executor: docker-amd64-xl
+          requires:
+            - prepare-build
+
+      - build-artifact:
+          name: build windows amd64
+          go_target_os: windows
+          go_os: windows
+          go_arch: amd64
+          go_download_base_url: << pipeline.parameters.fips_go_download_base_url >>
+          make_target: build BUILD_MODE=private
+          install_deps_extension: windows-native-full-signing
+          install_path: 'C:\'
+          executor: win-server2022-amd64
+          context:
+            - snyk-windows-signing
+            - iac-cli
+            - go-private-modules
+          requires:
+            - prepare-build
+
+      - build-artifact:
+          name: build windows fips amd64
+          go_target_os: windows
+          go_os: windows
+          go_arch: amd64
+          go_download_base_url: << pipeline.parameters.fips_go_download_base_url >>
+          make_target: build-fips BUILD_MODE=private
+          install_deps_extension: windows-native-full-signing
+          install_path: 'C:\'
+          executor: win-server2022-amd64
+          context:
+            - snyk-windows-signing
+            - iac-cli
+            - go-private-modules
+          requires:
+            - prepare-build
+
   test_and_release:
+    when:
+      not: << pipeline.parameters.minimal_ci_test >>
     jobs:
       - prodsec/secrets-scan:
           name: secrets-scan
@@ -817,7 +883,24 @@ workflows:
           go_os: windows
           go_arch: amd64
           go_download_base_url: << pipeline.parameters.fips_go_download_base_url >>
-          make_target: build clean-golang build-fips BUILD_MODE=private
+          make_target: build BUILD_MODE=private
+          install_deps_extension: windows-native-full-signing
+          install_path: 'C:\'
+          executor: win-server2022-amd64
+          context:
+            - snyk-windows-signing
+            - iac-cli
+            - go-private-modules
+          requires:
+            - prepare-build
+
+      - build-artifact:
+          name: build windows fips amd64
+          go_target_os: windows
+          go_os: windows
+          go_arch: amd64
+          go_download_base_url: << pipeline.parameters.fips_go_download_base_url >>
+          make_target: build-fips BUILD_MODE=private
           install_deps_extension: windows-native-full-signing
           install_path: 'C:\'
           executor: win-server2022-amd64
@@ -1025,6 +1108,7 @@ workflows:
           context: snyk-windows-signing
           requires:
             - build windows amd64
+            - build windows fips amd64
           go_os: windows
           go_arch: amd64
           make_target: sign sign-fips

--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -216,7 +216,7 @@ require (
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 // indirect
-	github.com/snyk/go-application-framework v0.6.2 // indirect
+	github.com/snyk/go-application-framework v0.6.3 // indirect
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -585,8 +585,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 h1:j2ZPhi78wKIHTiL9EFTNVXMIbsk56FVF2d5Sy1ZwSYk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.6.2 h1:grVccp5mzmctL2hpo9fTnonAEUeMqX+tGczXnECu3j4=
-github.com/snyk/go-application-framework v0.6.2/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
+github.com/snyk/go-application-framework v0.6.3 h1:Po9vOBHGR23LwZy9OKrn4+TFVb+blMu8WhivG6BwTzo=
+github.com/snyk/go-application-framework v0.6.3/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.27.0
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663
-	github.com/snyk/go-application-framework v0.6.2
+	github.com/snyk/go-application-framework v0.6.3
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260626083941-77c2abaeaaaa

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -547,8 +547,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 h1:j2ZPhi78wKIHTiL9EFTNVXMIbsk56FVF2d5Sy1ZwSYk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.6.2 h1:grVccp5mzmctL2hpo9fTnonAEUeMqX+tGczXnECu3j4=
-github.com/snyk/go-application-framework v0.6.2/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
+github.com/snyk/go-application-framework v0.6.3 h1:Po9vOBHGR23LwZy9OKrn4+TFVb+blMu8WhivG6BwTzo=
+github.com/snyk/go-application-framework v0.6.3/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -37,8 +37,8 @@ import (
 	"github.com/snyk/cli/cliv2/internal/cliv2"
 	"github.com/snyk/cli/cliv2/internal/constants"
 
-	cliv2utils "github.com/snyk/cli/cliv2/internal/utils"
 	persona "github.com/snyk/cli/cliv2/internal/persona"
+	cliv2utils "github.com/snyk/cli/cliv2/internal/utils"
 
 	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/config_utils"

--- a/release-scripts/upload-artifacts.sh
+++ b/release-scripts/upload-artifacts.sh
@@ -112,13 +112,11 @@ upload_npm() {
 
   if [ "${DRY_RUN}" == true ]; then
     echo "DRY RUN: uploading to npm..."
-    npm config set '//registry.npmjs.org/:_authToken' "${HAMMERHEAD_NPM_TOKEN}"
     npm publish --dry-run ${npm_tag_arg} ./binary-releases/snyk-fix.tgz
     npm publish --dry-run ${npm_tag_arg} ./binary-releases/snyk-protect.tgz
     npm publish --dry-run ${npm_tag_arg} ./binary-releases/snyk.tgz
   else
     echo "Uploading to npm..."
-    npm config set '//registry.npmjs.org/:_authToken' "${HAMMERHEAD_NPM_TOKEN}"
     npm publish ${npm_tag_arg} ./binary-releases/snyk-fix.tgz
     npm publish ${npm_tag_arg} ./binary-releases/snyk-protect.tgz
     npm publish ${npm_tag_arg} ./binary-releases/snyk.tgz


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Replaces the single Windows build job that ran `build clean-golang build-fips` serially (~14m) with two parallel jobs: `build windows amd64` and `build windows fips amd64`. Updates `sign windows amd64` to require both jobs.

## Where should the reviewer start?

- `.circleci/config.yml` — Windows `build-artifact` workflow jobs and `sign windows amd64` `requires`

## How should this be manually tested?

1. Push branch and run `test_and_release` in CircleCI.
2. Confirm `build windows amd64` and `build windows fips amd64` run in parallel.
3. Compare each job’s `make` step duration to the previous ~14m combined step (~7–8m per job expected).
4. Confirm `sign windows amd64` succeeds on main/release branches after both build jobs complete.

## What's the product update that needs to be communicated to CLI users?

None. CI-only change with no user-facing impact.

<!---
## Risk assessment (Low | Medium | High)?

Low

## Any background context you want to provide?

The Windows build step was ~2× slower than Linux because it compiled both the standard and FIPS binaries in one serial `make` invocation. This mirrors the existing Linux split (`build linux amd64` + `build linux fips amd64`). No cache, signing-context, or Makefile changes in this PR — kept minimal to isolate and measure the split’s impact.

## What are the relevant tickets?

[CLI-1633](https://snyksec.atlassian.net/browse/CLI-1633)

## Screenshots (if appropriate)

N/A
-->

[CLI-1633]: https://snyksec.atlassian.net/browse/CLI-1633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ