### PR TITLE
fix: Exclude passthrough args after -- from scan input directories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1333,7 +1333,6 @@ workflows:
       - release-npm:
           name: upload npm
           context:
-            - team-hammerhead-common-deploy-tokens
             - devex_cli_docker_hub
           requires:
             - upload github
@@ -1865,7 +1864,9 @@ jobs:
           version: << pipeline.parameters.aws_version >>
       - run:
           name: Pre-Publishing
-          command: make release-pre
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            make release-pre
       - failed-release-notification
 
   npm-validation:
@@ -1998,7 +1999,9 @@ jobs:
           deployment: stable
       - run:
           name: Publish to npm
-          command: ./release-scripts/upload-artifacts.sh npm
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            ./release-scripts/upload-artifacts.sh npm
       - failed-release-notification
 
   trigger-building-distribution-channels:

--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -216,7 +216,7 @@ require (
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 // indirect
-	github.com/snyk/go-application-framework v0.6.2 // indirect
+	github.com/snyk/go-application-framework v0.6.3 // indirect
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -585,8 +585,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 h1:j2ZPhi78wKIHTiL9EFTNVXMIbsk56FVF2d5Sy1ZwSYk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.6.2 h1:grVccp5mzmctL2hpo9fTnonAEUeMqX+tGczXnECu3j4=
-github.com/snyk/go-application-framework v0.6.2/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
+github.com/snyk/go-application-framework v0.6.3 h1:Po9vOBHGR23LwZy9OKrn4+TFVb+blMu8WhivG6BwTzo=
+github.com/snyk/go-application-framework v0.6.3/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.27.0
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663
-	github.com/snyk/go-application-framework v0.6.2
+	github.com/snyk/go-application-framework v0.6.3
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260626083941-77c2abaeaaaa

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -547,8 +547,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 h1:j2ZPhi78wKIHTiL9EFTNVXMIbsk56FVF2d5Sy1ZwSYk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.6.2 h1:grVccp5mzmctL2hpo9fTnonAEUeMqX+tGczXnECu3j4=
-github.com/snyk/go-application-framework v0.6.2/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
+github.com/snyk/go-application-framework v0.6.3 h1:Po9vOBHGR23LwZy9OKrn4+TFVb+blMu8WhivG6BwTzo=
+github.com/snyk/go-application-framework v0.6.3/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -37,8 +37,8 @@ import (
 	"github.com/snyk/cli/cliv2/internal/cliv2"
 	"github.com/snyk/cli/cliv2/internal/constants"
 
-	cliv2utils "github.com/snyk/cli/cliv2/internal/utils"
 	persona "github.com/snyk/cli/cliv2/internal/persona"
+	cliv2utils "github.com/snyk/cli/cliv2/internal/utils"
 
 	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/config_utils"

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -162,10 +162,30 @@ func updateConfigFromParameter(config configuration.Configuration, args []string
 	}
 	config.Set(configuration.UNKNOWN_ARGS, doubleDashArgs)
 
-	// only consider the first positional argument as input directory if it is not behind a double dash.
-	if len(args) > 0 && !utils.Contains(doubleDashArgs, args[0]) {
-		config.Set(configuration.INPUT_DIRECTORY, args)
-		config.Set(localworkflows.ConfigurationNewAuthenticationToken, args[0])
+	// Only positional args before "--" are input directories. Everything after "--" is
+	// passthrough (e.g. build-tool flags like `-s settings.xml`) and must not leak into
+	// INPUT_DIRECTORY, otherwise it gets misread as a path/package and force-routes to legacy.
+	// cobra appends the post-"--" tokens as the suffix of args, so trim them off.
+	positionalArgs := args
+	if len(doubleDashArgs) > 0 {
+		if len(args) >= len(doubleDashArgs) {
+			positionalArgs = args[:len(args)-len(doubleDashArgs)]
+		} else {
+			// Unreachable in practice: cobra always appends every post-"--" token to args, so
+			// len(args) >= len(doubleDashArgs) always holds. Guard anyway so we never leak
+			// passthrough args into INPUT_DIRECTORY; fall back to the default (CWD) resolver.
+			globalLogger.Warn().
+				Int("positionalArgCount", len(args)).
+				Int("argsAfterDoubleDashCount", len(doubleDashArgs)).
+				Msg("Unexpected argument layout: more arguments after '--' than positional arguments. " +
+					"Ignoring the provided path arguments and scanning the current working directory instead.")
+			positionalArgs = nil
+		}
+	}
+
+	if len(positionalArgs) > 0 {
+		config.Set(configuration.INPUT_DIRECTORY, positionalArgs)
+		config.Set(localworkflows.ConfigurationNewAuthenticationToken, positionalArgs[0])
 	}
 }
 

--- a/cliv2/pkg/core/main_test.go
+++ b/cliv2/pkg/core/main_test.go
@@ -254,6 +254,87 @@ func Test_runMainWorkflow_unknownargs(t *testing.T) {
 	}
 }
 
+// Test_runMainWorkflow_doubleDashArgsDoNotLeakIntoInputDirectory reproduces CLI-1631.
+//
+// `snyk test <path> -d -- -s /root/.m2/settings.xml` must treat only <path> as an input
+// directory. The passthrough tokens after "--" ("-s", "/root/.m2/settings.xml") must NOT end up
+// in INPUT_DIRECTORY, otherwise the downstream package-vs-path heuristic stats "-s", finds it
+// missing, and force-routes the test to the legacy flow (which silently drops Risk Score).
+//
+// The bug triggers for ANY positional path shape, not just ".", so we cover the current dir,
+// a relative subdirectory, and a fully qualified absolute path.
+func Test_runMainWorkflow_doubleDashArgsDoNotLeakIntoInputDirectory(t *testing.T) {
+	tests := map[string]struct {
+		path string
+	}{
+		"current directory":    {path: "."},
+		"relative path":        {path: "sub/project"},
+		"fully qualified path": {path: "/home/user/project"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			defer cleanup()
+			globalConfiguration = configuration.New()
+			globalConfiguration.Set(configuration.DEBUG, true)
+			globalEngine = workflow.NewWorkFlowEngine(globalConfiguration)
+
+			fn := func(invocation workflow.InvocationContext, input []workflow.Data) ([]workflow.Data, error) {
+				return []workflow.Data{}, nil
+			}
+
+			commandList := []string{"command", localworkflows.WORKFLOWID_OUTPUT_WORKFLOW.Host}
+			for _, v := range commandList {
+				workflowConfig := workflow.ConfigurationOptionsFromFlagset(pflag.NewFlagSet("pla", pflag.ContinueOnError))
+				_, err := globalEngine.Register(workflow.NewWorkflowIdentifier(v), workflowConfig, fn)
+				assert.NoError(t, err)
+			}
+
+			err := localworkflows.InitDataTransformationWorkflow(globalEngine)
+			assert.NoError(t, err)
+			_ = globalEngine.Init()
+			err = localworkflows.InitFilterFindingsWorkflow(globalEngine)
+			assert.NoError(t, err)
+
+			config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
+			cmd := &cobra.Command{Use: "command"}
+
+			// cobra hands us the positional path plus everything after "--".
+			positionalArgs := []string{tc.path, "-s", "/root/.m2/settings.xml"}
+			rawArgs := []string{"snyk", "test", "--project-name=TestProj", tc.path, "-d", "--", "-s", "/root/.m2/settings.xml"}
+
+			err = runMainWorkflow(config, cmd, positionalArgs, rawArgs)
+			assert.Nil(t, err)
+
+			// Only the positional path before "--" is an input directory.
+			inputDirs := config.GetStringSlice(configuration.INPUT_DIRECTORY)
+			assert.Equal(t, []string{tc.path}, inputDirs, "passthrough args after -- must not leak into INPUT_DIRECTORY")
+
+			// Passthrough args are preserved separately.
+			unknownArgs := config.GetStringSlice(configuration.UNKNOWN_ARGS)
+			assert.Equal(t, []string{"-s", "/root/.m2/settings.xml"}, unknownArgs)
+		})
+	}
+}
+
+// Test_updateConfigFromParameter_fallbackWhenArgsShorterThanDoubleDash exercises the defensive
+// else branch. cobra always appends every post-"--" token to args, so len(args) >= len(doubleDashArgs)
+// normally holds and this branch is unreachable in production. We call the function directly with
+// invariant-violating inputs (fewer positional args than post-"--" tokens) to prove that, even
+// then, passthrough args never leak into INPUT_DIRECTORY.
+func Test_updateConfigFromParameter_fallbackWhenArgsShorterThanDoubleDash(t *testing.T) {
+	config := configuration.New()
+
+	// args has 1 element, but rawArgs has 2 tokens after "--" -> len(args) < len(doubleDashArgs).
+	args := []string{"."}
+	rawArgs := []string{"snyk", "test", "--", "-s", "settings.xml"}
+
+	updateConfigFromParameter(config, args, rawArgs)
+
+	assert.Nil(t, config.Get(configuration.INPUT_DIRECTORY), "must not set INPUT_DIRECTORY in the fallback")
+	assert.Equal(t, []string{"-s", "settings.xml"}, config.GetStringSlice(configuration.UNKNOWN_ARGS))
+}
+
 func Test_getErrorFromWorkFlowData(t *testing.T) {
 	engine := workflow.NewWorkFlowEngine(configuration.New())
 	assert.NoError(t, engine.Init())

--- a/release-scripts/upload-artifacts.sh
+++ b/release-scripts/upload-artifacts.sh
@@ -112,13 +112,11 @@ upload_npm() {
 
   if [ "${DRY_RUN}" == true ]; then
     echo "DRY RUN: uploading to npm..."
-    npm config set '//registry.npmjs.org/:_authToken' "${HAMMERHEAD_NPM_TOKEN}"
     npm publish --dry-run ${npm_tag_arg} ./binary-releases/snyk-fix.tgz
     npm publish --dry-run ${npm_tag_arg} ./binary-releases/snyk-protect.tgz
     npm publish --dry-run ${npm_tag_arg} ./binary-releases/snyk.tgz
   else
     echo "Uploading to npm..."
-    npm config set '//registry.npmjs.org/:_authToken' "${HAMMERHEAD_NPM_TOKEN}"
     npm publish ${npm_tag_arg} ./binary-releases/snyk-fix.tgz
     npm publish ${npm_tag_arg} ./binary-releases/snyk-protect.tgz
     npm publish ${npm_tag_arg} ./binary-releases/snyk.tgz


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

When a positional path is passed to a command together with `--` passthrough
args (e.g. `snyk test . -- -s /path/to/settings.xml`), the CLI was storing the
*entire* positional slice — including the tokens after `--` — into
`INPUT_DIRECTORY`. Those passthrough tokens then leak into the scan target list.

For `snyk test` with Risk Score enabled this caused a silent data loss: the
leaked `-s` token was misread as a package name by the downstream flow router,
which force-routed the scan to the legacy engine that never returns Risk Score.
The same leak also affects other slice consumers (SBOM test, monitor, secrets
test).

This fix trims the post-`--` passthrough args before setting `INPUT_DIRECTORY`,
so only real positional paths are treated as scan targets — matching the
existing behavior of `DetermineInputDirectory`.

## Where should the reviewer start?

- `cliv2/pkg/core/main.go` – `updateConfigFromParameter`: only positional args
  before `--` are stored as input directories.
- `cliv2/pkg/core/main_test.go` – `Test_runMainWorkflow_doubleDashArgsDoNotLeakIntoInputDirectory`
  covers `.`, relative, and absolute paths.

## How should this be manually tested?

With an org that has Risk Score enabled
(`useExperimentalRiskScore` + `useExperimentalRiskScoreInCLI`):

1. `snyk test -d` (from a scannable project) → output contains `Risk Score:` lines.
2. `snyk test . -d -- -s <any-settings-file>` → output should now also contain
   `Risk Score:` lines (previously absent), and debug should show
   `Using legacy flow: false`.

## What's the product update that needs to be communicated to CLI users?

Fixes a bug where passing an explicit path together with `--` passthrough
arguments could silently drop Risk Score data from `snyk test` results.

<!---
## Risk assessment (Low | Medium | High)?

Low — narrows what is stored as input directories to positional args before
`--`; covered by regression tests, and mirrors existing `DetermineInputDirectory`
behavior.

## Any background context you want to provide?

Root cause of CLI-1634. The downstream `cli-extension-os-flows` heuristic that
misreads leaked flag tokens as package names is being hardened separately; this
PR removes the leak at the source, which also protects SBOM test, monitor, and
secrets test flows.

## What are the relevant tickets?

[CLI-1634](https://snyksec.atlassian.net/browse/CLI-1634)

## Screenshots (if appropriate)

N/A
--->

[CLI-1634]: https://snyksec.atlassian.net/browse/CLI-1634