### PR TITLE
fix: Exclude passthrough args after -- from scan input directories

### DIFF
--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -162,10 +162,18 @@ func updateConfigFromParameter(config configuration.Configuration, args []string
 	}
 	config.Set(configuration.UNKNOWN_ARGS, doubleDashArgs)
 
-	// only consider the first positional argument as input directory if it is not behind a double dash.
-	if len(args) > 0 && !utils.Contains(doubleDashArgs, args[0]) {
-		config.Set(configuration.INPUT_DIRECTORY, args)
-		config.Set(localworkflows.ConfigurationNewAuthenticationToken, args[0])
+	// Only positional args before "--" are input directories. Everything after "--" is
+	// passthrough (e.g. build-tool flags like `-s settings.xml`) and must not leak into
+	// INPUT_DIRECTORY, otherwise it gets misread as a path/package and force-routes to legacy.
+	// cobra appends the post-"--" tokens as the suffix of args, so trim them off.
+	positionalArgs := args
+	if len(doubleDashArgs) > 0 && len(args) >= len(doubleDashArgs) {
+		positionalArgs = args[:len(args)-len(doubleDashArgs)]
+	}
+
+	if len(positionalArgs) > 0 {
+		config.Set(configuration.INPUT_DIRECTORY, positionalArgs)
+		config.Set(localworkflows.ConfigurationNewAuthenticationToken, positionalArgs[0])
 	}
 }
 

--- a/cliv2/pkg/core/main_test.go
+++ b/cliv2/pkg/core/main_test.go
@@ -185,71 +185,104 @@ func Test_CreateCommandsForWorkflowWithSubcommands(t *testing.T) {
 	assert.True(t, cmd2.Hidden)
 }
 
-func Test_runMainWorkflow_unknownargs(t *testing.T) {
+// setupMainWorkflowTestEnv wires up the global engine/config that runMainWorkflow needs and
+// returns a fresh per-invocation config plus a command. Callers should `defer cleanup()`.
+func setupMainWorkflowTestEnv(t *testing.T) (configuration.Configuration, *cobra.Command) {
+	t.Helper()
+
+	globalConfiguration = configuration.New()
+	globalConfiguration.Set(configuration.DEBUG, true)
+	globalEngine = workflow.NewWorkFlowEngine(globalConfiguration)
+
+	noopWorkflow := func(workflow.InvocationContext, []workflow.Data) ([]workflow.Data, error) {
+		return []workflow.Data{}, nil
+	}
+	for _, name := range []string{"command", localworkflows.WORKFLOWID_OUTPUT_WORKFLOW.Host} {
+		opts := workflow.ConfigurationOptionsFromFlagset(pflag.NewFlagSet("pla", pflag.ContinueOnError))
+		_, err := globalEngine.Register(workflow.NewWorkflowIdentifier(name), opts, noopWorkflow)
+		require.NoError(t, err)
+	}
+	require.NoError(t, localworkflows.InitDataTransformationWorkflow(globalEngine))
+	_ = globalEngine.Init()
+	require.NoError(t, localworkflows.InitFilterFindingsWorkflow(globalEngine))
+
+	return configuration.NewWithOpts(configuration.WithAutomaticEnv()), &cobra.Command{Use: "command"}
+}
+
+// Test_runMainWorkflow_inputDirectoryParsing is the CLI-1631 regression coverage. It asserts how
+// positional paths and "--" passthrough args map onto INPUT_DIRECTORY and UNKNOWN_ARGS. The key
+// invariant: passthrough tokens after "--" must never leak into INPUT_DIRECTORY (which would make
+// the downstream flow router misread them as package names and force the legacy, no-Risk-Score flow),
+// regardless of the path shape. wantInputDirs == nil means INPUT_DIRECTORY must be left unset so it
+// later defaults to the working directory.
+func Test_runMainWorkflow_inputDirectoryParsing(t *testing.T) {
 	tests := map[string]struct {
-		inputDir    string
-		unknownArgs []string
+		positionalArgs  []string
+		rawArgs         []string
+		wantInputDirs   []string
+		wantUnknownArgs []string
 	}{
-		"input dir with unknown arguments":    {inputDir: "a/b/c", unknownArgs: []string{"a", "b", "c"}},
-		"no input dir with unknown arguments": {inputDir: "", unknownArgs: []string{"a", "b", "c"}},
-		"input dir without unknown arguments": {inputDir: "a", unknownArgs: []string{}},
+		"path with -- passthrough, current dir": {
+			positionalArgs:  []string{".", "-s", "settings.xml"},
+			rawArgs:         []string{"snyk", "test", ".", "--", "-s", "settings.xml"},
+			wantInputDirs:   []string{"."},
+			wantUnknownArgs: []string{"-s", "settings.xml"},
+		},
+		"path with -- passthrough, relative": {
+			positionalArgs:  []string{"sub/project", "-s", "settings.xml"},
+			rawArgs:         []string{"snyk", "test", "sub/project", "--", "-s", "settings.xml"},
+			wantInputDirs:   []string{"sub/project"},
+			wantUnknownArgs: []string{"-s", "settings.xml"},
+		},
+		"path with -- passthrough, absolute": {
+			positionalArgs:  []string{"/home/user/project", "-s", "settings.xml"},
+			rawArgs:         []string{"snyk", "test", "/home/user/project", "--", "-s", "settings.xml"},
+			wantInputDirs:   []string{"/home/user/project"},
+			wantUnknownArgs: []string{"-s", "settings.xml"},
+		},
+		"only -- passthrough, no path": {
+			positionalArgs:  []string{"-s", "settings.xml"},
+			rawArgs:         []string{"snyk", "test", "--", "-s", "settings.xml"},
+			wantInputDirs:   nil,
+			wantUnknownArgs: []string{"-s", "settings.xml"},
+		},
+		"no --, single path": {
+			positionalArgs: []string{"."},
+			rawArgs:        []string{"snyk", "test", "."},
+			wantInputDirs:  []string{"."},
+		},
+		"no --, multiple paths": {
+			positionalArgs: []string{"dir1", "dir2"},
+			rawArgs:        []string{"snyk", "test", "dir1", "dir2"},
+			wantInputDirs:  []string{"dir1", "dir2"},
+		},
+		"bare command, no path no --": {
+			positionalArgs: []string{},
+			rawArgs:        []string{"snyk", "test"},
+			wantInputDirs:  nil,
+		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			expectedInputDir := tc.inputDir
-			expectedUnknownArgs := tc.unknownArgs
-
 			defer cleanup()
-			globalConfiguration = configuration.New()
-			globalConfiguration.Set(configuration.DEBUG, true)
-			globalEngine = workflow.NewWorkFlowEngine(globalConfiguration)
+			config, cmd := setupMainWorkflowTestEnv(t)
 
-			fn := func(invocation workflow.InvocationContext, input []workflow.Data) ([]workflow.Data, error) {
-				return []workflow.Data{}, nil
+			require.NoError(t, runMainWorkflow(config, cmd, tc.positionalArgs, tc.rawArgs))
+
+			if tc.wantInputDirs == nil {
+				assert.Nil(t, config.Get(configuration.INPUT_DIRECTORY),
+					"INPUT_DIRECTORY must be left unset so it defaults to the working directory")
+			} else {
+				assert.Equal(t, tc.wantInputDirs, config.GetStringSlice(configuration.INPUT_DIRECTORY),
+					"passthrough args after -- must not leak into INPUT_DIRECTORY")
 			}
 
-			// setup workflow engine to contain a workflow with subcommands
-			commandList := []string{"command", localworkflows.WORKFLOWID_OUTPUT_WORKFLOW.Host}
-			for _, v := range commandList {
-				workflowConfig := workflow.ConfigurationOptionsFromFlagset(pflag.NewFlagSet("pla", pflag.ContinueOnError))
-				workflowId1 := workflow.NewWorkflowIdentifier(v)
-				_, err := globalEngine.Register(workflowId1, workflowConfig, fn)
-				assert.NoError(t, err)
+			if len(tc.wantUnknownArgs) == 0 {
+				assert.Empty(t, config.GetStringSlice(configuration.UNKNOWN_ARGS))
+			} else {
+				assert.Equal(t, tc.wantUnknownArgs, config.GetStringSlice(configuration.UNKNOWN_ARGS))
 			}
-
-			// Register our data transformation workflow
-			err := localworkflows.InitDataTransformationWorkflow(globalEngine)
-			assert.NoError(t, err)
-
-			_ = globalEngine.Init()
-			// Register our data filter workflow
-			err = localworkflows.InitFilterFindingsWorkflow(globalEngine)
-			assert.NoError(t, err)
-
-			config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
-			cmd := &cobra.Command{
-				Use: "command",
-			}
-
-			positionalArgs := []string{expectedInputDir}
-			positionalArgs = append(positionalArgs, expectedUnknownArgs...)
-
-			rawArgs := []string{"app", "command", "--sad", expectedInputDir}
-			if len(expectedUnknownArgs) > 0 {
-				rawArgs = append(rawArgs, "--")
-				rawArgs = append(rawArgs, expectedUnknownArgs...)
-			}
-
-			// call method under test
-			err = runMainWorkflow(config, cmd, positionalArgs, rawArgs)
-			assert.Nil(t, err)
-
-			actualInputDir := config.GetString(configuration.INPUT_DIRECTORY)
-			assert.Equal(t, expectedInputDir, actualInputDir)
-
-			actualUnknownArgs := config.GetStringSlice(configuration.UNKNOWN_ARGS)
-			assert.Equal(t, expectedUnknownArgs, actualUnknownArgs)
 		})
 	}
 }


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

When a positional path is passed to a command together with `--` passthrough
args (e.g. `snyk test . -- -s /path/to/settings.xml`), the CLI was storing the
*entire* positional slice — including the tokens after `--` — into
`INPUT_DIRECTORY`. Those passthrough tokens then leak into the scan target list.

For `snyk test` with Risk Score enabled this caused a silent data loss: the
leaked `-s` token was misread as a package name by the downstream flow router,
which force-routed the scan to the legacy engine that never returns Risk Score.
The same leak also affects other slice consumers (SBOM test, monitor, secrets
test).

This fix trims the post-`--` passthrough args before setting `INPUT_DIRECTORY`,
so only real positional paths are treated as scan targets — matching the
existing behavior of `DetermineInputDirectory`.

## Where should the reviewer start?

- `cliv2/pkg/core/main.go` – `updateConfigFromParameter`: only positional args
  before `--` are stored as input directories.
- `cliv2/pkg/core/main_test.go` – `Test_runMainWorkflow_doubleDashArgsDoNotLeakIntoInputDirectory`
  covers `.`, relative, and absolute paths.

## How should this be manually tested?

With an org that has Risk Score enabled
(`useExperimentalRiskScore` + `useExperimentalRiskScoreInCLI`):

1. `snyk test -d` (from a scannable project) → output contains `Risk Score:` lines.
2. `snyk test . -d -- -s <any-settings-file>` → output should now also contain
   `Risk Score:` lines (previously absent), and debug should show
   `Using legacy flow: false`.

## What's the product update that needs to be communicated to CLI users?

Fixes a bug where passing an explicit path together with `--` passthrough
arguments could silently drop Risk Score data from `snyk test` results.

<!---
## Risk assessment (Low | Medium | High)?

Low — narrows what is stored as input directories to positional args before
`--`; covered by regression tests, and mirrors existing `DetermineInputDirectory`
behavior.

## Any background context you want to provide?

Root cause of CLI-1634. The downstream `cli-extension-os-flows` heuristic that
misreads leaked flag tokens as package names is being hardened separately; this
PR removes the leak at the source, which also protects SBOM test, monitor, and
secrets test flows.

## What are the relevant tickets?

[CLI-1634](https://snyksec.atlassian.net/browse/CLI-1634)

## Screenshots (if appropriate)

N/A
--->

[CLI-1634]: https://snyksec.atlassian.net/browse/CLI-1634