### PR TITLE
chore(language-server): integrate LS

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -220,7 +220,7 @@ require (
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
-	github.com/snyk/snyk-ls v0.0.0-20260626083941-77c2abaeaaaa // indirect
+	github.com/snyk/snyk-ls v0.0.0-20260717113823-6ee379465b93 // indirect
 	github.com/snyk/studio-mcp v1.14.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -595,8 +595,8 @@ github.com/snyk/remy-cli-extension v1.23.1 h1:dZRsQLwFvqABOf5RRw2gTRSQC3nDkbBwGq
 github.com/snyk/remy-cli-extension v1.23.1/go.mod h1:C9xfjNYkSvQUVZSW30AspdwxPn1pPFj/e8OrSutJOxc=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260626083941-77c2abaeaaaa h1:qKLDBzWOoLLn06e69Cw7MLb6TtInLN+Y6IhD+oYVxdw=
-github.com/snyk/snyk-ls v0.0.0-20260626083941-77c2abaeaaaa/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
+github.com/snyk/snyk-ls v0.0.0-20260717113823-6ee379465b93 h1:rg+eZ/ARA95N5G9VNVZVRqIjkV45Gb5iIXvSSwgASIM=
+github.com/snyk/snyk-ls v0.0.0-20260717113823-6ee379465b93/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
 github.com/snyk/studio-mcp v1.14.0 h1:9Z7JPHFNtd5m8fmosBgTzLMFXmjImKvkAtvsjejy4qQ=
 github.com/snyk/studio-mcp v1.14.0/go.mod h1:3ZISZCgorkGg/iLQrryvmP34Db4KkvtfAARi7vMqM/4=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/snyk/go-application-framework v0.7.2
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20260626083941-77c2abaeaaaa
+	github.com/snyk/snyk-ls v0.0.0-20260717113823-6ee379465b93
 	github.com/snyk/studio-mcp v1.14.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -555,8 +555,8 @@ github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhk
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260626083941-77c2abaeaaaa h1:qKLDBzWOoLLn06e69Cw7MLb6TtInLN+Y6IhD+oYVxdw=
-github.com/snyk/snyk-ls v0.0.0-20260626083941-77c2abaeaaaa/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
+github.com/snyk/snyk-ls v0.0.0-20260717113823-6ee379465b93 h1:rg+eZ/ARA95N5G9VNVZVRqIjkV45Gb5iIXvSSwgASIM=
+github.com/snyk/snyk-ls v0.0.0-20260717113823-6ee379465b93/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
 github.com/snyk/studio-mcp v1.14.0 h1:9Z7JPHFNtd5m8fmosBgTzLMFXmjImKvkAtvsjejy4qQ=
 github.com/snyk/studio-mcp v1.14.0/go.mod h1:3ZISZCgorkGg/iLQrryvmP34Db4KkvtfAARi7vMqM/4=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit 6ee379465b93b6b78bd1d735d15ccb14da3be124
Author: Bastian Doetsch <20150761+bastiandoetsch@users.noreply.github.com>
Date:   Fri Jul 17 13:38:23 2026 +0200

    feat: expose stable findingId and RemediationAgentQuickFix kind [IDE-2052] (#1326)
    
    ### **User description**
    ## Summary
    - Add `FindingId` field to `snyk.Issue` and `types.Issue` with stable cross-scan identifier (`Fingerprints.SnykAssetFindingV1`)
    - Add `RemediationAgentQuickFix` LSP code action kind constant (`quickfix.snyk.remediationAgent`)
    - Wire `FindingId` through Code/OSS/Secrets/IaC converters
    - Add `GetFindingId()` accessor to issue interface
    
    ## PR Stack — Merge Order
    ```mermaid
    flowchart LR
        main(["main"])
        PR1["#? PR-1 ← YOU ARE HERE\nfindingId + kind"]
        PR2["#? PR-2\nCA provider"]
        PR3["#? PR-3\nremy initial"]
        PR4["#? PR-4\nworktree impl"]
        PR5["#? PR-5\nunit tests"]
        PR6["#? PR-6\ninteg+smoke tests"]
        main --> PR1 --> PR2 --> PR3 --> PR4 --> PR5 --> PR6
        style PR1 fill:#ffd700,color:#000
    ```
    
    ## Deferred to later PRs
    - Remediation provider implementation (PR-3+)
    - Tests (PR-5, PR-6)
    
    ## Test plan
    - [ ] `make test` passes
    - [ ] Converter tests verify FindingId population for all 4 products
    
    
    ___
    
    ### **PR Type**
    Enhancement, Tests
    
    
    ___
    
    ### **Description**
    - Add stable `FindingId` to `ScanIssue`.
    
    - Introduce `RemediationAgentQuickFix` LSP kind.
    
    - Propagate `FindingId` through converters.
    
    - Add tests for new `FindingId` and `CodeActionKind`.
    
    
    ___
    
    ### Diagram Walkthrough
    
    
    ```mermaid
    flowchart LR
      A[Issue Interface] -- GetFindingId() --> B(ScanIssue);
      C[CodeAction Struct] -- GetKind() --> D(LSP CodeAction);
      B -- FindingId --> E(Client);
      D -- Kind --> F(Client);
      subgraph Domain/Types
        A
        C
      end
      subgraph Domain/Converter
        B
        D
      end
    ```
    
    
    
    <details> <summary><h3> File Walkthrough</h3></summary>
    
    <table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
    <tr>
      <td>
        <details>
          <summary><strong>converter.go</strong><dd><code>Propagate FindingId and handle CodeAction Kind</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
    <hr>
    
    domain/ide/converter/converter.go
    
    <ul><li>Modified <code>ToCodeAction</code> to correctly use the <code>action.GetKind()</code> which can <br>now be <code>RemediationAgentQuickFix</code>.<br> <li> Fallback to <code>types.QuickFix</code> if <code>action.GetKind()</code> is <code>types.Empty</code>.<br> <li> Added <code>FindingId: issue.GetFindingId()</code> to <code>ScanIssue</code> when converting <br>issues for OSS, IaC, Code, and Secrets products.</ul>
    
    
    </details>
    
    
      </td>
      <td><a href="https://github.com/snyk/snyk-ls/pull/1326/changes#diff-906b744a0a633abffa7bc1bfd39886eb37836f675579617c61d13e96c32a4fe9">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>
    
    </tr>
    
    <tr>
      <td>
        <details>
          <summary><strong>codeaction.go</strong><dd><code>Add Kind field to CodeAction struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
    <hr>
    
    domain/snyk/codeaction.go
    
    <ul><li>Added a <code>Kind</code> field of type <code>types.CodeActionKind</code> to the <code>CodeAction</code> <br>struct.<br> <li> Introduced a <code>GetKind()</code> method to access the new <code>Kind</code> field.</ul>
    
    
    </details>
    
    
      </td>
      <td><a href="https://github.com/snyk/snyk-ls/pull/1326/changes#diff-c36818ffaebdf71e9fdc539536a452dbd79bef24c0ba1ee91c479a07bb69a73b">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>
    
    </tr>
    
    <tr>
      <td>
        <details>
          <summary><strong>issues.go</strong><dd><code>Update CodeAction interface with GetKind</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
    <hr>
    
    internal/types/issues.go
    
    <ul><li>Extended the <code>CodeAction</code> interface to include a <code>GetKind()</code> method, <br>enabling access to the code action's kind.</ul>
    
    
    </details>
    
    
      </td>
      <td><a href="https://github.com/snyk/snyk-ls/pull/1326/changes#diff-63ef754c962ab2c2fa558b3f65bf88663612eb2e405b754eb7d5a18b5a5662df">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
    
    </tr>
    
    <tr>
      <td>
        <details>
          <summary><strong>lsp.go</strong><dd><code>Define RemediationAgentQuickFix and document FindingId</code>&nbsp; &nbsp; &nbsp; </dd></summary>
    <hr>
    
    internal/types/lsp.go
    
    <ul><li>Defined a new constant <code>RemediationAgentQuickFix</code> for the LSP <br><code>CodeActionKind</code>.<br> <li> Added a detailed comment to <code>ScanIssue.FindingId</code> explaining its purpose <br>as a stable, cross-scan identifier.</ul>
    
    
    </details>
    
    
      </td>
      <td><a href="https://github.com/snyk/snyk-ls/pull/1326/changes#diff-c16b9b2fc8b4479b07708b28ebdaa473e8f3a73eb62d9402538790b2aed3f978">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>
    
    </tr>
    </table></td></tr><tr><td><strong>Tests</strong></td><td><table>
    <tr>
      <td>
        <details>
          <summary><strong>converter_test.go</strong><dd><code>Test FindingId propagation and CodeAction Kind</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
    <hr>
    
    domain/ide/converter/converter_test.go
    
    <ul><li>Added multiple tests to verify <code>ScanIssue.FindingId</code> population for <br>Code, OSS, Secrets, and IaC issues.<br> <li> Included tests for deterministic conversion of <code>FindingId</code>.<br> <li> Added tests to ensure <code>CodeActionKind</code> is correctly derived, including <br>the new <code>RemediationAgentQuickFix</code> and fallback logic.</ul>
    
    
    </details>
    
    
      </td>
      <td><a href="https://github.com/snyk/snyk-ls/pull/1326/changes#diff-aefddc62a88eee50767d306e120604a7f240ee4a5aaf3382b21cd4aeac5036d9">+172/-0</a>&nbsp; </td>
    
    </tr>
    </table></td></tr></tr></tbody></table>
    
    </details>
    
    ___

M	application/server/precedence_smoke_test.go
M	domain/ide/converter/converter.go
M	domain/ide/converter/converter_test.go
M	internal/types/lsp.go

commit 1ce25706f37c991f564f64ebe39e532ab93d8130
Author: Knut Funkel <knut.funkel@snyk.io>
Date:   Wed Jul 15 14:53:53 2026 +0200

    fix: reset summary panel on stop-scan [IDE-1035] (#1324)
    
    * fix: reset summary panel on stop-scan [IDE-1035]
    
    When the user pressed the stop-scan button (LSP
    window/workDoneProgress/cancel) the summary panel kept showing the
    last scan's counts. The org-change path already had a helper that
    reinitialises the panel to its initial state; this commit wires the
    same reset into the stop-scan handler.
    
    - New resetSummaryPanelOnStopScan helper delegates to the existing
      resetSummaryPanelForOrgChange with the current workspace folders.
    - windowWorkDoneProgressCancelHandler now invokes it after
      progress.Cancel.
    - Unit tests cover the happy path, nil-aggregator safety, and the
      no-folders case.
    
    * fix: correct misspelling cancelled → canceled in test comment [IDE-1035]
    
    Lint catch: golangci-lint misspell wants the American spelling.
    
    * fix(server): gate stop-scan reset to scan tokens; converge after goroutines exit [IDE-1035]
    
    Address PR #1324 review (D, E, F, G):
    
    D) The window/workDoneProgress/cancel handler reset the summary panel for
       every cancel, including CLI install/download trackers, wiping valid
       scan results. Introduce progress.NewScanTracker / IsScanToken so the
       handler can gate the reset on the token being a scan token. Update
       Code, IaC, OSS, and the code-client tracker factory to use the new
       constructor.
    
    E) The reset raced in-flight scan goroutines: progress.Cancel only signals
       over a channel, and a late SetScanDone could land after the synchronous
       Init reset, re-populating the panel. Move the reset into the scan
       lifecycle: DelegatingConcurrentScanner.RegisterCancelCallback stores a
       per-folder reset fn that Scan() consumes (LoadAndDelete) after both
       wait groups return — guaranteeing SetScanDone has already happened.
       New outcome-level test TestScan_CancelCallback_CalledAfterGoroutinesFinish
       asserts SetScanDone appears before the reset (Init) in the call sequence.
    
    F) The cancel handler discarded the `ok` from scanStateAggregatorFromContext,
       silently skipping the reset if the aggregator was missing. Log a Warn
       so wiring failures are observable (panic would be too aggressive for an
       LSP notification handler).
    
    G) resetSummaryPanelForOrgChange is now shared by org-change and stop-scan.
       Rename to resetSummaryPanel (and update callers/comments) so the name
       matches the responsibility.
    
    Tests:
    - TestIsScanToken_{ScanTracker,PlainTracker,Unknown,AfterCancel}_*
    - TestCancelProgress_NonScanToken_DoesNotResetAggregator
    - TestScan_CancelCallback_CalledAfterGoroutinesFinish
    - Renamed TestResetSummaryPanel_* (G)
    
    * style(server,scanner): address golangci-lint feedback [IDE-1035]
    
    - server.go: drop pre-Go-1.22 `fp := fp` (copyloopvar)
    - scanner.go: extract consumeCancelCallback so Scan's cyclomatic complexity
      stays under 15 (gocyclo); checked type assertion instead of `fn.(func())()`
      (forcetypeassert)
    - scanner.go: drop var-decl-with-type (`var a, b int = -1, -1` → `a, b := -1, -1`)
      in the new outcome test (staticcheck QF1011)
    - notification_test.go, scanner_test.go, progress_test.go: cancelled→canceled,
      recognised→recognized (misspell, repo prefers en_US)
    
    * fix(server): defer progress.Cancel so RegisterCancelCallback registers first [IDE-1035]
    
    Defer the cancel call in windowWorkDoneProgressCancelHandler so the
    RegisterCancelCallback loop runs before scan goroutines observe the
    cancel and drain through consumeCancelCallback. Otherwise the reset
    can be silently dropped and a stale callback fires on the folder's
    next scan.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * refactor(server): delete unreferenced resetSummaryPanelOnStopScan wrapper [IDE-1035]
    
    The wrapper had no production callers — only three TestResetSummaryPanel
    OnStopScan_* tests exercised it. The real stop-scan handler in
    windowWorkDoneProgressCancelHandler calls resetSummaryPanel directly,
    so the wrapper plus its dedicated tests gave false coverage of a path
    that never ran in production.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * refactor(scanner,server): lift RegisterCancelCallback to interface, type the registry, cover handler [IDE-1035]
    
    Address the application/server ↔ domain/snyk/scanner layering and
    type-safety feedback from PR review:
    
    - Lift RegisterCancelCallback(folderPath, fn) onto scanner.Scanner so
      the cancel handler calls it through the interface — drops the
      *DelegatingConcurrentScanner downcast and the racy synchronous
      summary-panel reset that used to fire when the type assertion failed.
      TestScanner gets a no-op implementation since it doesn't run the
      cancel-drain cycle.
    
    - Replace the cancelCallbackMap = sync.Map alias with a plain
      map[types.FilePath]func() guarded by a sync.Mutex. Drops the
      defensive v.(func()) assertion in consumeCancelCallback and keeps
      values typed; the access pattern (one register + one consume per
      folder) doesn't need sync.Map's machinery.
    
    - Extract the handler body into handleWindowWorkDoneProgressCancel
      so the new cancel_handler_test.go can drive it without going
      through jrpc2 indirection. Tests cover scan-token register-then-
      cancel ordering, non-scan-token cancel-without-register, and
      the no-scanner skip path (proving the racy sync fallback is gone).
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * refactor(scanner): collapse setupScannerWithResolver into setupScannerWithResolverAndAgg [IDE-1035]
    
    setupScannerWithResolver and setupScannerWithResolverAndAgg duplicated
    the full NewDelegatingScanner construction; the only difference was an
    explicit aggregator parameter. Have the former delegate to the latter
    with NewNoopStateAggregator as the default.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * refactor(progress): collapse scanTokens registry into Tracker.isScan field [IDE-1035]
    
    The parallel scanTokens map (and its mutex) had to be kept in sync with
    the trackers map in three places — deleteTracker, Cancel, and
    CleanupChannels — so any future tracker-removal path that forgot the
    second mutation would leak or stale the scan-token state.
    
    Model "is scan" as an isScan bool field on Tracker. IsScanToken becomes
    a single trackers lookup under trackersMutex.RLock and returns false
    once the tracker entry is gone, so removal logic only has to touch
    trackers.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * style: fix gofmt alignment + misspell in cancel-handler test [IDE-1035]
    
    - gofmt -w internal/progress/progress.go: the new isScan field's
      preceding comment split the Tracker struct's alignment group; reflow
      the pre-comment fields to the gofmt-canonical narrow alignment.
    - recognised → recognized in cancel_handler_test.go to satisfy
      golangci-lint's misspell checker.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
    * fix(lint): remove trailing newline in configuration_test.go (goimports)
    
    * fix(scanner): scope stop-scan summary reset to the canceled folder only [IDE-1035]
    
    The cancel handler reset the summary panel for every open workspace folder,
    so canceling one folder's scan silently wiped another folder's valid,
    already-displayed results on its next completed scan. Tracker now records
    its owning folder at creation and the handler looks that folder up instead
    of iterating every workspace folder.
    
    * fix(server): drop dead conf param from cancel handler [IDE-1035]
    
    handleWindowWorkDoneProgressCancel never read its conf parameter — the
    scan-state aggregator and scanner are both pulled from ctx. Remove it
    from the function and its one caller, and drop the now-unused conf
    plumbing from the three call sites in cancel_handler_test.go.
    
    * fix(progress): avoid NewScanTracker foot-gun for uncancellable code-client token [IDE-1035]
    
    NewScanTracker(true, ..., "") tagged this tracker as isScan=true with an
    empty folder path. FolderForScanToken has no empty-path guard, so a future
    change making this token cancellable would flow an empty folder key into
    resetSummaryPanel. This token is never IDE-cancellable, so it never needs
    scan classification — use NewTracker instead.
    
    ---------
    
    Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    Co-authored-by: Nick Yasnohorodskyi <nikita.yasnohorodskyi@snyk.io>

A	application/server/cancel_handler_test.go
M	application/server/configuration.go
M	application/server/configuration_test.go
M	application/server/notification_test.go
M	application/server/server.go
M	domain/snyk/scanner/scanner.go
M	domain/snyk/scanner/scanner_test.go
M	domain/snyk/scanner/test_scanner.go
M	infrastructure/code/code.go
M	infrastructure/code/code_tracker.go
M	infrastructure/iac/iac.go
M	infrastructure/oss/cli_scanner.go
M	internal/progress/progress.go
M	internal/progress/progress_test.go

commit 2a7a5da7c9a5657acb01276e835db72eb6cc03c0
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Thu Jul 9 16:59:14 2026 +0200

    fix: stabilize Test_E2E_EndpointChangeAfterInitializationClearsToken flaky on windows [IDE-2179] (#1368)
    
    ## Summary
    Fixes flaky `Test_E2E_EndpointChangeAfterInitializationClearsToken` (windows-latest integration-tests, IDE-2179).
    
    Root cause: the OAuth storage-bridge callback (`newOAuthStorageBridgeCallback`) propagated empty-token storage echoes through the serialized `credentialUpdateChan`. On slower runners a stale empty update could be drained by the worker *after* a later synchronous token write, clobbering the just-set token to empty and failing the assertion. The `writingToken` re-entrancy guard cannot catch empty echoes (empty is not a valid in-flight token).
    
    Fix: `newOAuthStorageBridgeCallback` now early-returns on an empty token, keeping non-actionable empty echoes off the serialized channel at the boundary — mirroring the existing `updateCredentials` no-op guard. Credential clears remain correct: `logout` drives `updateCredentials("")` synchronously, independent of the bridge, so logout/clear propagation is unaffected. Real root-cause fix — no sleep/timeout/skip/retry workaround.
    
    ## Tests
    - Two deterministic regression tests added (`auth_configuration_test.go`), confirmed RED before the fix / GREEN after.
    - Stress: `go test ./application/server/ -run '^Test_E2E_EndpointChangeAfterInitializationClearsToken$' -race -count=100` → green.
    - `go build ./...`, `golangci-lint run` (0 issues), and `make test` (unit) all green at HEAD.
    
    ## Known follow-up (non-blocking)
    - Reviewers flagged a now-dead `token_empty` debug log field in `auth_configuration.go` (always false after the early return). Cosmetic only; left for a follow-up to keep this fix minimal.
    
    _This fix was produced by an automated flake-fix loop._

M	.gitignore
M	infrastructure/authentication/auth_configuration.go
M	infrastructure/authentication/auth_configuration_test.go

commit 5bbf698d7cffbd98074624a8846071524457bee5
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Mon Jul 6 18:30:00 2026 +0200

    fix: stabilize OAuth storage bridge last-write-wins under rapid token rotation [IDE-2104] (#1352)
    
    Test_RegisterOAuthStorageBridge_SerializesRapidTokenRotations flaked on
    Windows CI: after three rapid token rotations the stored token was the
    first instead of the last.
    
    Root cause: when credentialUpdateWorker writes a token via conf.Set, the
    persisted OAuth key re-fires the storage-bridge callback, which calls
    QueueCredentialUpdate again and re-enqueues the same token behind newer
    ones. On Windows (15ms clock resolution) all rotation tokens share an
    expiry, so shouldUpdateToken lets the stale re-enqueued copy overwrite
    the final token.
    
    Fix: add an atomic.Pointer[string] guard (writingToken). The worker marks
    the token it is applying (cleared via defer so a panic cannot leave it
    armed) and QueueCredentialUpdate skips the re-entrant enqueue of that same
    token. Add a deterministic regression test using require.Never that is RED
    without the guard and GREEN with it across GOMAXPROCS 1/2/4.
    
    Produced by an automated flake-fix loop.

M	infrastructure/authentication/auth_configuration_test.go
M	infrastructure/authentication/auth_service_impl.go

commit 3a96c5d669f75601c8a27896e2cee46a691a54e5
Author: nick-y-snyk <nikita.yasnohorodskyi@snyk.io>
Date:   Thu Jul 2 16:03:05 2026 +0200

    fix: use configured CLI release channel instead of runtime version [IDE-2133] (#1367)
    
    HTML settings page and CLI download logic both derived the release
    channel from the running binary's version instead of reading the
    user-configured cli_release_channel setting, so changes silently
    reverted after restart. Also makes the download path handle a pinned
    CLI version (not just named channels) by building the URL directly
    instead of running it through the channel-keyed protocol-lookup.

M	infrastructure/cli/install/releases.go
M	infrastructure/cli/install/releases_test.go
M	infrastructure/configuration/config_html.go
M	infrastructure/configuration/config_html_test.go
```

[IDE-2052]: https://snyksec.atlassian.net/browse/IDE-2052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-1035]: https://snyksec.atlassian.net/browse/IDE-1035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ