### PR TITLE
fix: respect Snyk Code exclusions on paths and ignore rules with special characters

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -216,7 +216,7 @@ require (
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 // indirect
-	github.com/snyk/go-application-framework v0.7.1 // indirect
+	github.com/snyk/go-application-framework v0.7.2 // indirect
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -585,8 +585,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 h1:j2ZPhi78wKIHTiL9EFTNVXMIbsk56FVF2d5Sy1ZwSYk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.7.1 h1:xcmb6VnMxBeIupz7yBEHYJPPosb3UeFxhGqIiMUXLEI=
-github.com/snyk/go-application-framework v0.7.1/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
+github.com/snyk/go-application-framework v0.7.2 h1:WzZ7BeFL0pKoB2YdheHtEgEdeB+9nunmwQP8XI+rKcc=
+github.com/snyk/go-application-framework v0.7.2/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.27.0
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663
-	github.com/snyk/go-application-framework v0.7.1
+	github.com/snyk/go-application-framework v0.7.2
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260626083941-77c2abaeaaaa

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -547,8 +547,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 h1:j2ZPhi78wKIHTiL9EFTNVXMIbsk56FVF2d5Sy1ZwSYk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.7.1 h1:xcmb6VnMxBeIupz7yBEHYJPPosb3UeFxhGqIiMUXLEI=
-github.com/snyk/go-application-framework v0.7.1/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
+github.com/snyk/go-application-framework v0.7.2 h1:WzZ7BeFL0pKoB2YdheHtEgEdeB+9nunmwQP8XI+rKcc=
+github.com/snyk/go-application-framework v0.7.2/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps `go-application-framework` to pick up a fix for Snyk Code file exclusions. Exclusions from `.snyk`, `.gitignore`, and `.dcignore` were silently ignored when regex/glob metacharacters — most commonly parentheses — appeared in either:

1. **The project's absolute path**, e.g. `C:\Users\...\OneDrive - Company (Tenant)\...` or `C:\Program Files (x86)\...`; or
2. **The ignore rule itself**, e.g. a rule excluding a folder literally named `build (old)`.

In both cases the exclusions had no effect and directories such as `node_modules` were scanned in full.

Ignore rules are compiled to regular expressions, and these characters were reaching the regex engine unescaped, so they were interpreted as regex syntax (e.g. `(` as a capture group) instead of literal text. The fix escapes the regex metacharacters that gitignore treats as literal — both in the base path prepended to every rule and in the rule patterns themselves — while preserving genuine glob syntax (`*`, `?`, `[`, `]`, `**`).

**Risk: Low.** The change only affects how ignore patterns are escaped before matching; glob/gitignore wildcard semantics are unchanged. Covered by unit and behavioral tests across macOS, Linux, and Windows (including drive-letter, UNC, and extended-length paths).

## Where should the reviewer start?

- https://github.com/snyk/go-application-framework/pull/656
- `cliv2/go.mod` / `cliv2/go.sum` — the `go-application-framework` version bump.
- Upstream change: `pkg/utils/file_filter.go` in go-application-framework:
  - `parseIgnoreRuleToGlobs` — base-path escaping via `regexp.QuoteMeta`.
  - `escapeSpecialGlobChars` / `ruleRegexMetaChars` — rule-pattern escaping.
  - `joinGlob` — preserves UNC (`\\server\share`) prefixes.

## How should this be manually tested?

1. `git clone https://github.com/snyk-labs/nodejs-goof && cd nodejs-goof && npm install`
2. Add a `.snyk` file at the root:
   ```yaml
   exclude:
     global:
       - node_modules