### PR TITLE
fix: bump snyk-mvn-plugin to 4.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "snyk-go-plugin": "2.1.2",
         "snyk-gradle-plugin": "7.0.0",
         "snyk-module": "3.1.0",
-        "snyk-mvn-plugin": "4.8.0",
+        "snyk-mvn-plugin": "4.8.2",
         "snyk-nodejs-lockfile-parser": "2.9.0",
         "snyk-nodejs-plugin": "^2.1.0",
         "snyk-nuget-plugin": "4.2.3",
@@ -20082,9 +20082,9 @@
       "license": "ISC"
     },
     "node_modules/snyk-mvn-plugin": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-4.8.0.tgz",
-      "integrity": "sha512-umRV3maCSpil4eZJzpYOP5ybH+EAss4ipog6caRN+xdrTE4YL2gs9JOCFki8en+3RMrwTi/W0Q8uKBMNfj9vwg==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-4.8.2.tgz",
+      "integrity": "sha512-SsQvbs3+9h9MHPKsilNkTczUgAb6qiqbj0iEKv2T08C48pfDrxUTDy3xmv6qC4LO2AWeRFOInXV4gaJOHtpaQg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@common.js/yocto-queue": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "snyk-go-plugin": "2.1.2",
     "snyk-gradle-plugin": "7.0.0",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "4.8.0",
+    "snyk-mvn-plugin": "4.8.2",
     "snyk-nodejs-lockfile-parser": "2.9.0",
     "snyk-nodejs-plugin": "^2.1.0",
     "snyk-nuget-plugin": "4.2.3",


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps the `snyk-mvn-plugin` dependency from `4.8.0` to `4.8.2` in `package.json` and regenerates `package-lock.json` (`npm install --min-release-age=0`). Picks up snyk/snyk-mvn-plugin#226 and snyk/snyk-mvn-plugin#227.

The underlying changes are:
- A test and `package.json` metadata adjustment
- Adding some additional debug logging

*Example output*:
```
2026-07-10T09:13:53Z legacycli:3 - snyk-mvn-plugin No companion checksum files found for ***/.m2/repository/io/snyk/os-managed/bad-resolution/1.0.0/bad-resolution-1.0.0.jar
2026-07-10T09:13:53Z legacycli:3 - snyk-mvn-plugin No companion checksum files found for ***/.m2/repository/org/jboss/resteasy/resteasy-core/6.2.12.Final/resteasy-core-6.2.12.Final.jar
```

## Where should the reviewer start?

`package.json` / `package-lock.json` diff and the two `snyk-mvn-plugin` PRs referenced above.

## How should this be manually tested?

N/A — trivial dependency bump.

## What's the product update that needs to be communicated to CLI users?

N/A

Risk assessment: Low