### PR TITLE
chore: Reduce Windows CI build time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,6 +270,53 @@ commands:
                   $bashLine = 'export PATH="' + $bashPath + ':$PATH"'
                   [System.IO.File]::AppendAllText($bashEnvScript, $bashLine + "`n", (New-Object System.Text.UTF8Encoding $false))
 
+  # Minimal Windows toolchain for COMPILING the CLI: Node, Python, Make only.
+  # Excludes .NET/Maven/Gradle (needed only by acceptance tests), which keeps
+  # this cache small and fast to restore compared to the full tools cache.
+  install-deps-windows-native-build-min:
+    steps:
+      - run:
+          name: Ensure tools cache directory
+          shell: powershell
+          command: |
+            $cacheDir = '<< pipeline.parameters.windows_cache_dir >>'
+            if (-not (Test-Path $cacheDir)) {
+              New-Item -ItemType Directory -Path $cacheDir | Out-Null
+            }
+      - restore_cache:
+          name: Restoring Windows build tools cache
+          keys:
+            - windows-build-tools-cache-v2-{{ arch }}-{{ checksum ".nvmrc" }}
+      - run:
+          name: Install Node.js (native)
+          shell: powershell
+          command: |
+            .\scripts\windows\install-node.ps1
+      - run:
+          name: Install Python 3.12.8 (native)
+          shell: powershell
+          command: |
+            .\scripts\windows\install-python3.ps1
+      - run:
+          name: Install GNU Make 4.4.1 (native)
+          shell: powershell
+          command: |
+            .\scripts\windows\install-make.ps1
+      - run:
+          name: Ensure Python and uv
+          shell: powershell
+          command: |
+            if (Test-Path '<< pipeline.parameters.windows_cache_dir >>/<< pipeline.parameters.windows_env_script >>') { . '<< pipeline.parameters.windows_cache_dir >>/<< pipeline.parameters.windows_env_script >>' }
+            .\scripts\windows\ensure-python-uv.ps1
+      - save_cache:
+          name: Saving Windows build tools cache
+          key: windows-build-tools-cache-v2-{{ arch }}-{{ checksum ".nvmrc" }}
+          paths:
+            - << pipeline.parameters.windows_cache_dir >>
+            - C:\ProgramData\nvm
+            - C:\tools\make
+            - C:\Program Files\Python312
+
   install-deps-windows-native-build:
     steps:
       - run:
@@ -283,7 +330,7 @@ commands:
       - restore_cache:
           name: Restoring Windows tools cache
           keys:
-            - windows-tools-cache-v5-{{ arch }}-{{ checksum ".nvmrc" }}
+            - windows-tools-cache-v7-{{ arch }}-{{ checksum ".nvmrc" }}
       - run:
           name: Install Node.js (native)
           shell: powershell
@@ -322,10 +369,14 @@ commands:
             .\scripts\windows\ensure-python-uv.ps1
       - save_cache:
           name: Saving Windows tools cache
-          key: windows-tools-cache-v5-{{ arch }}-{{ checksum ".nvmrc" }}
+          key: windows-tools-cache-v7-{{ arch }}-{{ checksum ".nvmrc" }}
           paths:
             - << pipeline.parameters.windows_cache_dir >>
             - C:\ProgramData\nvm
+            - C:\tools\maven
+            - C:\tools\make
+            - C:\Program Files\dotnet
+            - C:\Program Files\Python312
 
   install-deps-windows-native-full-signing:
     steps:
@@ -385,6 +436,19 @@ commands:
       - run:
           name: No dependencies to install
           command: echo all done!
+
+  setup-go-build-cache:
+    description: >-
+      Pin GOMODCACHE and GOCACHE to workspace paths so CircleCI cache
+      restore/save works on Linux, macOS, and Windows executors.
+    steps:
+      - run:
+          name: Configure Go module and build cache paths
+          shell: bash
+          command: |
+            mkdir -p .go-cache/mod .go-cache/build
+            echo "export GOMODCACHE=\"$(pwd)/.go-cache/mod\"" >> "$BASH_ENV"
+            echo "export GOCACHE=\"$(pwd)/.go-cache/build\"" >> "$BASH_ENV"
 
   setup-go-private-modules:
     description: >-
@@ -829,12 +893,11 @@ workflows:
           go_arch: amd64
           go_download_base_url: << pipeline.parameters.fips_go_download_base_url >>
           go_version: << pipeline.parameters.fips_go_version >>
-          make_target: build clean-golang build-fips BUILD_MODE=private
-          install_deps_extension: windows-native-full-signing
+          make_target: build build-fips verify-fips-artifacts BUILD_MODE=private
+          install_deps_extension: windows-native-build-min
           install_path: 'C:\'
           executor: win-server2022-amd64
           context:
-            - snyk-windows-signing
             - iac-cli
             - go-private-modules
           requires:
@@ -1729,8 +1792,12 @@ jobs:
           go_version: << parameters.go_version >>
           extraction_path: << parameters.install_path >>
       - setup-go-private-modules
+      - setup-go-build-cache
       - restore_cache:
-          key: go-build-{{ arch }}-{{ checksum "cliv2/go.sum" }}
+          name: Restoring Go module and build cache
+          keys:
+            - go-build-v2-{{ arch }}-{{ checksum "cliv2/go.sum" }}
+            - go-build-v2-{{ arch }}-
       - make-binary:
           static: << parameters.static_binary >>
           go_arch: << parameters.go_arch >>
@@ -1738,8 +1805,11 @@ jobs:
           make_target: << parameters.make_target >>
           c_compiler: << parameters.c_compiler >>
       - save_cache:
-          key: go-build-{{ arch }}-{{ checksum "cliv2/go.sum" }}
-          paths: [/home/circleci/go/pkg/mod]
+          name: Saving Go module and build cache
+          key: go-build-v2-{{ arch }}-{{ checksum "cliv2/go.sum" }}
+          paths:
+            - .go-cache/mod
+            - .go-cache/build
       - store_artifacts:
           path: binary-releases
       - persist_to_workspace:
@@ -1856,7 +1926,11 @@ jobs:
       - install-deps-<< parameters.install_deps_extension >>
       - run:
           name: Signing << parameters.go_os >> artifact
-          command: make << parameters.make_target >> GOOS=<< parameters.go_os >> GOARCH=<< parameters.go_arch >>
+          shell: bash
+          command: |
+            # Load Windows $Env:Path values of tools necessary for signing (like make).
+            if [ -f "/c/tools-cache/<< pipeline.parameters.windows_bash_env_script >>" ]; then source "/c/tools-cache/<< pipeline.parameters.windows_bash_env_script >>"; fi
+            make << parameters.make_target >> GOOS=<< parameters.go_os >> GOARCH=<< parameters.go_arch >>
       - store_artifacts:
           path: ./binary-releases
       - persist_to_workspace:

--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,14 @@ build-fips: pre-build $(BINARY_OUTPUT_FOLDER)/fips/version
 	@cd $(EXTENSIBLE_CLI_DIR); $(MAKE) fips build-full install bindir=$(WORKING_DIR)/$(BINARY_OUTPUT_FOLDER)/fips USE_LEGACY_EXECUTABLE_NAME=1 BUILD_MODE=$(BUILD_MODE)
 	@$(MAKE) clean-package-files
 
+# Confirms the FIPS binary is genuinely distinct from the normal binary. This is
+# the safety net that lets us build normal + FIPS in one job without clean-golang:
+# if the FIPS build were ever skipped, the two binaries would be identical and
+# this target fails. Requires both `build` and `build-fips` to have run first.
+.PHONY: verify-fips-artifacts
+verify-fips-artifacts:
+	@bash ./scripts/verify-fips-build.sh $(BINARY_OUTPUT_FOLDER) $(BINARY_OUTPUT_FOLDER)/fips
+
 .PHONY: build-experimental
 build-experimental: pre-build $(BINARY_OUTPUT_FOLDER)/experimental/version
 	@cd $(EXTENSIBLE_CLI_DIR); $(MAKE) experimental build-full install bindir=$(WORKING_DIR)/$(BINARY_OUTPUT_FOLDER)/experimental USE_LEGACY_EXECUTABLE_NAME=1 BUILD_MODE=$(BUILD_MODE)

--- a/scripts/verify-fips-build.sh
+++ b/scripts/verify-fips-build.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Verifies that the FIPS build actually produced a FIPS binary that is distinct
+# from the normal build.
+#
+# Why this exists: the normal and FIPS builds compile to the same intermediate
+# output path and are only distinguished by the crypto backend. If a regression
+# (e.g. removing `clean-golang` combined with a stale build output) caused the
+# FIPS build to be skipped, the FIPS binary would just be a copy of the normal
+# one. This script fails loudly in that case.
+#
+# Two independent gates, both must pass:
+#   1. The FIPS binary's embedded Go build info must show a FIPS crypto backend
+#      (GOEXPERIMENT=systemcrypto/cngcrypto/opensslcrypto/boringcrypto).
+#   2. The FIPS binary must be byte-different from the normal binary.
+#
+# The script never exits 0 unless it could actually perform these checks.
+#
+# Usage: verify-fips-build.sh <normal-dir> <fips-dir>
+set -euo pipefail
+
+normal_dir="${1:?normal binary directory required}"
+fips_dir="${2:?fips binary directory required}"
+
+# Best-effort: load the Windows env (PATH for go/sha tools) when running on the
+# Windows executor. The caller (e.g. the make-binary step) normally already
+# sources this and exports PATH, which this child process inherits; this is a
+# fallback for standalone runs. Override the location with SNYK_WIN_ENV_SCRIPT.
+win_env_script="${SNYK_WIN_ENV_SCRIPT:-/c/tools-cache/snyk-env.sh}"
+if [ -f "$win_env_script" ]; then
+  # shellcheck disable=SC1090
+  source "$win_env_script"
+fi
+
+# The verification depends on the Go toolchain to read embedded build info.
+if ! command -v go >/dev/null 2>&1; then
+  echo "[verify-fips] ERROR: 'go' not found on PATH; cannot inspect build info. Failing."
+  exit 1
+fi
+
+find_binary() {
+  local dir="$1"
+  local f
+  shopt -s nullglob
+  for f in "$dir"/snyk-*; do
+    case "$f" in
+      *.sha256 | *.sha256.asc | *.asc) continue ;;
+    esac
+    [ -f "$f" ] || continue
+    echo "$f"
+    return 0
+  done
+  return 1
+}
+
+hash_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    echo "NOHASH"
+  fi
+}
+
+log_build_settings() {
+  local label="$1"
+  local bin="$2"
+  echo "[verify-fips] Build settings ($label): $bin"
+  go version -m "$bin" 2>/dev/null | grep -E '^[[:space:]]*build[[:space:]]' || echo "  (no build info available)"
+}
+
+# True if the binary's Go build info records a FIPS crypto backend. Microsoft's
+# Go toolchain sets this via GOEXPERIMENT; the concrete value is systemcrypto,
+# or the platform backend it resolves to (cngcrypto on Windows, opensslcrypto on
+# Linux). boringcrypto is included for completeness.
+binary_has_fips_backend() {
+  go version -m "$1" 2>/dev/null \
+    | grep -E '^[[:space:]]*build[[:space:]]+GOEXPERIMENT=' \
+    | grep -qiE 'systemcrypto|cngcrypto|opensslcrypto|boringcrypto'
+}
+
+normal_bin="$(find_binary "$normal_dir" || true)"
+fips_bin="$(find_binary "$fips_dir" || true)"
+
+if [ -z "$normal_bin" ] || [ -z "$fips_bin" ]; then
+  echo "[verify-fips] ERROR: could not locate binaries (normal='$normal_bin', fips='$fips_bin')"
+  exit 1
+fi
+
+echo "=================================================================="
+echo "[verify-fips] Normal binary: $normal_bin"
+echo "[verify-fips] FIPS   binary: $fips_bin"
+echo "------------------------------------------------------------------"
+log_build_settings "normal" "$normal_bin"
+log_build_settings "fips" "$fips_bin"
+echo "------------------------------------------------------------------"
+
+failed=0
+
+# Gate 1: the FIPS binary must actually be built with a FIPS crypto backend.
+if binary_has_fips_backend "$fips_bin"; then
+  echo "[verify-fips] Gate 1 PASSED: FIPS binary reports a FIPS crypto backend."
+else
+  echo "[verify-fips] Gate 1 FAILED: FIPS binary does NOT report a FIPS crypto backend (GOEXPERIMENT)."
+  echo "[verify-fips] The build under $fips_dir is not FIPS-enabled."
+  failed=1
+fi
+
+# Sanity: the normal binary should NOT report a FIPS backend. Surface loudly.
+if binary_has_fips_backend "$normal_bin"; then
+  echo "[verify-fips] WARNING: the normal binary unexpectedly reports a FIPS crypto backend."
+fi
+
+# Gate 2: the FIPS and normal binaries must differ. Identical bytes mean the
+# FIPS build did not take effect (e.g. it was skipped). If no hashing tool is
+# available we cannot perform this gate, so we fail rather than pass silently.
+normal_hash="$(hash_file "$normal_bin")"
+fips_hash="$(hash_file "$fips_bin")"
+echo "[verify-fips] normal sha256: $normal_hash"
+echo "[verify-fips] fips   sha256: $fips_hash"
+
+if [ "$normal_hash" = "NOHASH" ] || [ "$fips_hash" = "NOHASH" ]; then
+  echo "[verify-fips] Gate 2 FAILED: no sha256 tool available; cannot verify the binaries differ."
+  failed=1
+elif [ "$normal_hash" = "$fips_hash" ]; then
+  echo "[verify-fips] Gate 2 FAILED: FIPS and normal binaries are IDENTICAL (FIPS build skipped?)."
+  failed=1
+else
+  echo "[verify-fips] Gate 2 PASSED: FIPS binary is distinct from the normal binary."
+fi
+
+echo "=================================================================="
+if [ "$failed" -ne 0 ]; then
+  echo "[verify-fips] FAILED: FIPS verification did not pass."
+  exit 1
+fi
+echo "[verify-fips] PASSED: FIPS binary is genuine and distinct from the normal binary."

--- a/scripts/windows/ensure-python-uv.ps1
+++ b/scripts/windows/ensure-python-uv.ps1
@@ -3,6 +3,11 @@ Param()
 $ErrorActionPreference = 'Stop'
 
 try {
+  if (Get-Command uv -ErrorAction SilentlyContinue) {
+    Write-Host "[uv-cache] HIT: uv already installed; skipping pip install."
+    return
+  }
+
   $python = Get-Command python -ErrorAction SilentlyContinue
   if (-not $python) {
     $python = Get-Command python3 -ErrorAction SilentlyContinue

--- a/scripts/windows/install-dotnet-sdk.ps1
+++ b/scripts/windows/install-dotnet-sdk.ps1
@@ -14,35 +14,53 @@ if (Test-Path $envScript) {
 
 try {
   $dotnetVersion = '8.0.100'
-  $installerPath = Join-Path $cacheDir "dotnet-sdk-$dotnetVersion-win-x64.exe"
-  $expectedSha256 = 'd77a87a78264fcfb1703a7064795ccb10938cdfaea64a03cb0f36b1cda379f82'
+  $dotnetExe = 'C:\Program Files\dotnet\dotnet.exe'
+  $dotnetPath = $null
 
-  if (-not (Test-Path $cacheDir)) {
-    New-Item -ItemType Directory -Path $cacheDir | Out-Null
+  if (Test-Path $dotnetExe) {
+    # `dotnet --version` reports the SDK selected for the current dir (usually the
+    # newest installed), so it can't confirm a specific version. `--list-sdks`
+    # enumerates every installed SDK, which is what we need to detect 8.0.100.
+    $installedSdks = & $dotnetExe --list-sdks 2>&1
+    # `--list-sdks` prints "<version> [<path>]"; require the exact version to be
+    # followed by whitespace or end-of-line so e.g. "8.0.100-preview" is not
+    # treated as "8.0.100", while a bare version line still matches.
+    if ($installedSdks | Where-Object { $_ -match ('^' + [regex]::Escape($dotnetVersion) + '(\s|$)') }) {
+      Write-Host "[dotnet-cache] HIT: .NET SDK $dotnetVersion already installed; skipping installer."
+      $dotnetPath = Split-Path $dotnetExe -Parent
+    }
   }
 
-  if (-not (Test-Path $installerPath)) {
-    Write-Host "Downloading .NET SDK $dotnetVersion installer..."
-    $url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnetVersion/dotnet-sdk-$dotnetVersion-win-x64.exe"
-    curl.exe -L $url -o $installerPath
+  if (-not $dotnetPath) {
+    $installerPath = Join-Path $cacheDir "dotnet-sdk-$dotnetVersion-win-x64.exe"
+    $expectedSha256 = 'd77a87a78264fcfb1703a7064795ccb10938cdfaea64a03cb0f36b1cda379f82'
+
+    if (-not (Test-Path $cacheDir)) {
+      New-Item -ItemType Directory -Path $cacheDir | Out-Null
+    }
+
+    if (-not (Test-Path $installerPath)) {
+      Write-Host "Downloading .NET SDK $dotnetVersion installer..."
+      $url = "https://builds.dotnet.microsoft.com/dotnet/Sdk/$dotnetVersion/dotnet-sdk-$dotnetVersion-win-x64.exe"
+      curl.exe -L $url -o $installerPath
+    }
+
+    Write-Host 'Verifying .NET SDK installer checksum...'
+    $hash = Get-FileHash -Path $installerPath -Algorithm SHA256
+    if ($hash.Hash.ToLower() -ne $expectedSha256.ToLower()) {
+      throw "Checksum verification failed for $installerPath. Expected $expectedSha256 but got $($hash.Hash.ToLower())."
+    }
+
+    Write-Host "Installing .NET SDK $dotnetVersion..."
+    & $installerPath /install /quiet /norestart /log "$cacheDir\dotnet-sdk-install.log"
+
+    # Locate installed dotnet.exe using the known default installation path (%ProgramFiles%\dotnet)
+    if (-not (Test-Path $dotnetExe)) {
+      throw ".NET SDK $dotnetVersion did not install correctly; expected $dotnetExe to exist."
+    }
+
+    $dotnetPath = Split-Path $dotnetExe -Parent
   }
-
-  Write-Host 'Verifying .NET SDK installer checksum...'
-  $hash = Get-FileHash -Path $installerPath -Algorithm SHA256
-  if ($hash.Hash.ToLower() -ne $expectedSha256.ToLower()) {
-    throw "Checksum verification failed for $installerPath. Expected $expectedSha256 but got $($hash.Hash.ToLower())."
-  }
-
-  Write-Host "Installing .NET SDK $dotnetVersion..."
-  & $installerPath /install /quiet /norestart /log "$cacheDir\dotnet-sdk-install.log"
-
-  # Locate installed dotnet.exe using the known default installation path (%ProgramFiles%\dotnet)
-  $dotnetExe = "C:\Program Files\dotnet\dotnet.exe"
-  if (-not (Test-Path $dotnetExe)) {
-    throw ".NET SDK $dotnetVersion did not install correctly; expected $dotnetExe to exist."
-  }
-
-  $dotnetPath = Split-Path $dotnetExe -Parent
 
   Write-Host "Adding $dotnetPath to PATH for current session..."
   $Env:Path = "$dotnetPath;" + $Env:Path

--- a/scripts/windows/install-gradle.ps1
+++ b/scripts/windows/install-gradle.ps1
@@ -34,29 +34,38 @@ try {
     throw "Checksum verification failed for $zipPath. Expected $expectedSha256 but got $($hash.Hash.ToLower())."
   }
 
-  if (Test-Path $installDir) {
-    Write-Host "Cleaning existing Gradle directory at $installDir ..."
-    Remove-Item -Recurse -Force $installDir
+  # Version-specific check: only skip if the pinned version is present, so a
+  # version bump forces a reinstall even when the tools cache is warm.
+  $expectedGradle = Join-Path $installDir "gradle-$gradleVersion\bin\gradle.bat"
+  if (Test-Path $expectedGradle) {
+    Write-Host "[gradle-cache] HIT: Gradle $gradleVersion already extracted; skipping."
+    $binPath = Split-Path $expectedGradle -Parent
   }
+  else {
+    if (Test-Path $installDir) {
+      Write-Host "Cleaning existing Gradle directory at $installDir ..."
+      Remove-Item -Recurse -Force $installDir
+    }
 
-  New-Item -ItemType Directory -Path $installDir | Out-Null
+    New-Item -ItemType Directory -Path $installDir | Out-Null
 
-  Write-Host "Extracting Gradle $gradleVersion..."
-  Add-Type -AssemblyName System.IO.Compression.FileSystem
-  [System.IO.Compression.ZipFile]::ExtractToDirectory($zipPath, $installDir)
+    Write-Host "Extracting Gradle $gradleVersion..."
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipPath, $installDir)
 
-  $gradleRoot = Get-ChildItem -Path $installDir -Directory -Filter "gradle-$gradleVersion" -ErrorAction SilentlyContinue | Select-Object -First 1
-  if (-not $gradleRoot) {
-    $gradleRoot = Get-ChildItem -Path $installDir -Directory -ErrorAction SilentlyContinue | Select-Object -First 1
-  }
+    $gradleRoot = Get-ChildItem -Path $installDir -Directory -Filter "gradle-$gradleVersion" -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $gradleRoot) {
+      $gradleRoot = Get-ChildItem -Path $installDir -Directory -ErrorAction SilentlyContinue | Select-Object -First 1
+    }
 
-  if (-not $gradleRoot) {
-    throw "Failed to locate Gradle root directory under $installDir"
-  }
+    if (-not $gradleRoot) {
+      throw "Failed to locate Gradle root directory under $installDir"
+    }
 
-  $binPath = Join-Path $gradleRoot.FullName 'bin'
-  if (-not (Test-Path (Join-Path $binPath 'gradle.bat'))) {
-    throw "gradle.bat not found in $binPath after extraction"
+    $binPath = Join-Path $gradleRoot.FullName 'bin'
+    if (-not (Test-Path (Join-Path $binPath 'gradle.bat'))) {
+      throw "gradle.bat not found in $binPath after extraction"
+    }
   }
 
   Write-Host "Adding $binPath to PATH for current session..."

--- a/scripts/windows/install-maven.ps1
+++ b/scripts/windows/install-maven.ps1
@@ -34,30 +34,39 @@ try {
     throw "Checksum verification failed for $zipPath. Expected $expectedSha256 but got $($hash.Hash.ToLower())."
   }
 
-  if (Test-Path $installDir) {
-    Write-Host "Cleaning existing Maven directory at $installDir ..."
-    Remove-Item -Recurse -Force $installDir
+  # Version-specific check: only skip if the pinned version is present, so a
+  # version bump forces a reinstall even when the tools cache is warm.
+  $expectedMvn = Join-Path $installDir "apache-maven-$mavenVersion\bin\mvn.cmd"
+  if (Test-Path $expectedMvn) {
+    Write-Host "[maven-cache] HIT: Maven $mavenVersion already extracted; skipping."
+    $binPath = Split-Path $expectedMvn -Parent
   }
+  else {
+    if (Test-Path $installDir) {
+      Write-Host "Cleaning existing Maven directory at $installDir ..."
+      Remove-Item -Recurse -Force $installDir
+    }
 
-  New-Item -ItemType Directory -Path $installDir | Out-Null
+    New-Item -ItemType Directory -Path $installDir | Out-Null
 
-  Write-Host "Extracting Apache Maven $mavenVersion..."
-  Add-Type -AssemblyName System.IO.Compression.FileSystem
-  [System.IO.Compression.ZipFile]::ExtractToDirectory($zipPath, $installDir)
+    Write-Host "Extracting Apache Maven $mavenVersion..."
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipPath, $installDir)
 
-  # Many Maven zips extract to apache-maven-<version>; ensure bin on PATH
-  $mavenRoot = Get-ChildItem -Path $installDir -Directory -Filter "apache-maven-$mavenVersion" -ErrorAction SilentlyContinue | Select-Object -First 1
-  if (-not $mavenRoot) {
-    $mavenRoot = Get-ChildItem -Path $installDir -Directory -ErrorAction SilentlyContinue | Select-Object -First 1
-  }
+    # Many Maven zips extract to apache-maven-<version>; ensure bin on PATH
+    $mavenRoot = Get-ChildItem -Path $installDir -Directory -Filter "apache-maven-$mavenVersion" -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $mavenRoot) {
+      $mavenRoot = Get-ChildItem -Path $installDir -Directory -ErrorAction SilentlyContinue | Select-Object -First 1
+    }
 
-  if (-not $mavenRoot) {
-    throw "Failed to locate Maven root directory under $installDir"
-  }
+    if (-not $mavenRoot) {
+      throw "Failed to locate Maven root directory under $installDir"
+    }
 
-  $binPath = Join-Path $mavenRoot.FullName 'bin'
-  if (-not (Test-Path (Join-Path $binPath 'mvn.cmd'))) {
-    throw "mvn.cmd not found in $binPath after extraction"
+    $binPath = Join-Path $mavenRoot.FullName 'bin'
+    if (-not (Test-Path (Join-Path $binPath 'mvn.cmd'))) {
+      throw "mvn.cmd not found in $binPath after extraction"
+    }
   }
 
   Write-Host "Adding $binPath to PATH for current session..."

--- a/scripts/windows/install-python3.ps1
+++ b/scripts/windows/install-python3.ps1
@@ -14,27 +14,50 @@ if (Test-Path $envScript) {
 
 try {
   $pythonVersion = '3.12.8'
-  $pythonInstaller = Join-Path $cacheDir "python-$pythonVersion-amd64.exe"
-  $expectedSha256 = '71bd44e6b0e91c17558963557e4cdb80b483de9b0a0a9717f06cf896f95ab598'
+  $pythonCandidates = @(
+    'C:\Program Files\Python312\python.exe',
+    'C:\Python312\python.exe',
+    (Join-Path $Env:LOCALAPPDATA 'Programs\Python\Python312\python.exe')
+  )
+  $skipInstall = $false
 
-  if (-not (Test-Path $cacheDir)) {
-    New-Item -ItemType Directory -Path $cacheDir | Out-Null
+  foreach ($candidate in $pythonCandidates) {
+    if (-not (Test-Path $candidate)) {
+      continue
+    }
+    $reportedVersion = (& $candidate --version 2>&1).Trim()
+    # Require the exact version to be followed by whitespace or end-of-string so
+    # a different patch (e.g. 3.12.80) is not treated as 3.12.8.
+    if ($reportedVersion -match '3\.12\.8(\s|$)') {
+      Write-Host "[python-cache] HIT: Python $reportedVersion already installed at $candidate; skipping installer."
+      $skipInstall = $true
+      break
+    }
   }
 
-  if (-not (Test-Path $pythonInstaller)) {
-    Write-Host "Downloading Python $pythonVersion (amd64) installer..."
-    $url = "https://www.python.org/ftp/python/$pythonVersion/python-$pythonVersion-amd64.exe"
-    curl.exe -L $url -o $pythonInstaller
-  }
+  if (-not $skipInstall) {
+    $pythonInstaller = Join-Path $cacheDir "python-$pythonVersion-amd64.exe"
+    $expectedSha256 = '71bd44e6b0e91c17558963557e4cdb80b483de9b0a0a9717f06cf896f95ab598'
 
-  Write-Host 'Verifying Python installer checksum...'
-  $hash = Get-FileHash -Path $pythonInstaller -Algorithm SHA256
-  if ($hash.Hash.ToLower() -ne $expectedSha256.ToLower()) {
-    throw "Checksum verification failed for $pythonInstaller. Expected $expectedSha256 but got $($hash.Hash.ToLower())."
-  }
+    if (-not (Test-Path $cacheDir)) {
+      New-Item -ItemType Directory -Path $cacheDir | Out-Null
+    }
 
-  Write-Host "Installing Python $pythonVersion..."
-  & $pythonInstaller /quiet InstallAllUsers=1 PrependPath=1 Include_test=0
+    if (-not (Test-Path $pythonInstaller)) {
+      Write-Host "Downloading Python $pythonVersion (amd64) installer..."
+      $url = "https://www.python.org/ftp/python/$pythonVersion/python-$pythonVersion-amd64.exe"
+      curl.exe -L $url -o $pythonInstaller
+    }
+
+    Write-Host 'Verifying Python installer checksum...'
+    $hash = Get-FileHash -Path $pythonInstaller -Algorithm SHA256
+    if ($hash.Hash.ToLower() -ne $expectedSha256.ToLower()) {
+      throw "Checksum verification failed for $pythonInstaller. Expected $expectedSha256 but got $($hash.Hash.ToLower())."
+    }
+
+    Write-Host "Installing Python $pythonVersion..."
+    & $pythonInstaller /quiet InstallAllUsers=1 PrependPath=1 Include_test=0
+  }
 
   # Persist a single primary installation location for this Python so it is preferred in subsequent steps.
   # We rely on the checksum for integrity and PATH ordering for preference, instead of failing hard on version mismatches.


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Reduces Windows CI build time. On main, the Windows build job installs the full toolchain (Node, Maven, Gradle, .NET, Python, Make) plus DigiCert signing tools, even though compiling only needs Node/Python/Make — and its Go module cache uses a Linux-only path that never hits on Windows, so modules re-download every run.
This PR:
- Adds a lean `windows-native-build-min` deps bundle (Node, Python, Make) with its own small cache for the build job. .NET/Maven/Gradle stay only on the acceptance-test job that needs them.
- Removes the unused DigiCert signing setup from the build job; signing is unchanged on `sign windows amd64`.
- Fixes the Go module/build cache so it works on Windows (pins GOMODCACHE/GOCACHE to the workspace instead of a Linux-only path).
- Builds the standard and FIPS binaries in one job, drops `clean-golang`, and adds a `verify-fips-artifacts` step that fails if the FIPS build did not take effect.

## Where should the reviewer start?

- `.circleci/config.yml` — `install-deps-windows-native-build-min`, `setup-go-build-cache`, the `build windows amd64` job, and the `build-artifact` Go cache
- `scripts/verify-fips-build.sh` and `Makefile` (`verify-fips-artifacts`) — the FIPS safety net
- `scripts/windows/*.ps1` — skip-if-already-installed logic

## How should this be manually tested?

1. Push branch and run `test_and_release` in CircleCI.
2. Confirm `build windows amd64` restores the small build cache (not the ~3.6 GiB one) and does not install .NET/Maven/Gradle/DigiCert.
3. Confirm the `verify-fips-artifacts` step passes and logs distinct sha256 hashes for the normal vs FIPS binaries.
4. Confirm `acceptance-tests windows amd64` still passes (full tool bundle).
5. On a `main`/`release`/`*e2e*` branch, confirm `sign windows amd64` and the `e2e fips tests (win-server2022-amd64)` still pass.
6. Compare Windows build wall-clock/credits against the previous run.

## What's the product update that needs to be communicated to CLI users?

None. CI-only change with no user-facing impact.

## Risk assessment (Low | Medium | High)?

Low-Medium. CI-only, no user-facing changes. The main correctness concern — removing `clean-golang` while building normal + FIPS in one job — is guarded by `verify-fips-artifacts`, which fails the build if the FIPS binary is not distinct from the normal one. FIPS runtime behaviour is still covered by the existing `e2e fips tests` job.

## Any background context you want to provide?

The Windows build was dominated by cache/dependency overhead rather than compilation: a multi-GB tool cache (mostly .NET/Gradle unused by the build), duplicated DigiCert installs, and a Go module cache that never hit on Windows. These changes remove that overhead from the build path while keeping the tools available where they are actually used (tests/signing).

## What are the relevant tickets?

[CLI-1633](https://snyksec.atlassian.net/browse/CLI-1633)

## Screenshots (if appropriate)

N/A

[CLI-1633]: https://snyksec.atlassian.net/browse/CLI-1633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ