### PR TITLE
chore: propagate cliv2 lint/format failures from make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ release-mgt-create:
 lint:
 	@echo "-- Linting code"
 	@npm run lint
-	@pushd $(EXTENSIBLE_CLI_DIR); export CGO_ENABLED=1; $(MAKE) lint; popd
+	@cd $(EXTENSIBLE_CLI_DIR) && $(MAKE) lint
 	@echo "-- Verifying go.mod files are tidy"
 	@cd $(EXTENSIBLE_CLI_DIR) && $(GOCMD) mod tidy -diff > /dev/null || \
 		(echo "ERROR: cliv2/go.mod is not tidy. Run 'make format' and commit the changes." && exit 1)
@@ -337,7 +337,7 @@ format:
 	@$(MAKE) tidy
 	@echo "-- Formatting code"
 	@npm run format
-	@pushd $(EXTENSIBLE_CLI_DIR); $(MAKE) format; popd
+	@cd $(EXTENSIBLE_CLI_DIR) && $(MAKE) format
 
 .PHONY: tidy
 tidy:

--- a/cliv2/internal/persona/agent/agent.go
+++ b/cliv2/internal/persona/agent/agent.go
@@ -126,10 +126,8 @@ func detectAgent(l lookup) (Agent, bool) {
 // canonicalAgent normalises an explicitly declared AI_AGENT value onto the set
 // of canonical agent names.
 func canonicalAgent(name string) Agent {
-	switch Agent(name) {
-	case "github-copilot-cli":
+	if name == "github-copilot-cli" {
 		return AgentGitHubCopilot
-	default:
-		return Agent(name)
 	}
+	return Agent(name)
 }

--- a/cliv2/internal/persona/interactive/interactive_test.go
+++ b/cliv2/internal/persona/interactive/interactive_test.go
@@ -66,8 +66,8 @@ func Test_InteractiveMode_Has(t *testing.T) {
 func Test_isTerminal_pipeIsNotATerminal(t *testing.T) {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
-	defer r.Close()
-	defer w.Close()
+	defer func() { _ = r.Close() }()
+	defer func() { _ = w.Close() }()
 
 	assert.False(t, isTerminal(r), "read end of a pipe is not a terminal")
 	assert.False(t, isTerminal(w), "write end of a pipe is not a terminal")
@@ -76,7 +76,7 @@ func Test_isTerminal_pipeIsNotATerminal(t *testing.T) {
 func Test_isTerminal_regularFileIsNotATerminal(t *testing.T) {
 	f, err := os.CreateTemp(t.TempDir(), "interactive-test")
 	require.NoError(t, err)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	assert.False(t, isTerminal(f), "a regular file is not a terminal")
 }


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
Changed both recipe lines to `cd $(EXTENSIBLE_CLI_DIR) && ... && $(MAKE) lint / ... && $(MAKE) format`, so a failure anywhere in the chain now correctly fails the Make recipe (and CI). Verified locally that make lint now exits non-zero when cliv2 lint issues are present.

## How should this be manually tested?

On any other branch, introduce a lint issue and verify `make lint` output: errors show up but the command doesn't fail.

## What's the product update that needs to be communicated to CLI users?
None

## What are the relevant tickets?
[CLI-1651](https://snyksec.atlassian.net/browse/CLI-1651
)
<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->


[CLI-1651]: https://snyksec.atlassian.net/browse/CLI-1651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ