### PR TITLE
chore(ci): add safety check that version/build mode match

### DIFF
--- a/cliv2/Makefile
+++ b/cliv2/Makefile
@@ -189,7 +189,7 @@ summary:
 
 # prepare the workspace and cache global parameters
 .PHONY: configure
-configure: _validate-build-mode summary $(CACHE_DIR) $(CACHE_DIR)/variables.mk $(V1_DIRECTORY)/$(V1_EMBEDDED_FILE_OUTPUT) dependencies $(CACHE_DIR)/prepare-3rd-party-licenses
+configure: _validate-build-mode _verify-private-build summary $(CACHE_DIR) $(CACHE_DIR)/variables.mk $(V1_DIRECTORY)/$(V1_EMBEDDED_FILE_OUTPUT) dependencies $(CACHE_DIR)/prepare-3rd-party-licenses
 
 .PHONY: _helpdocs-prepare
 _helpdocs-prepare:
@@ -238,6 +238,15 @@ debug:
 
 .PHONY: build
 build: configure $(BUILD_DIR)/$(V2_EXECUTABLE_NAME)
+
+# Pre-build check: the version file must be consistent with BUILD_MODE.
+# Delegates to next-version.sh --verify so suffix logic lives in one place.
+.PHONY: _verify-private-build
+_verify-private-build:
+	@VERSION_FILE="$(DESTDIR)$(bindir)/version"; \
+	if [ -f "$$VERSION_FILE" ]; then \
+		BUILD_MODE=$(BUILD_MODE) $(V1_WORKING_DIR)/release-scripts/next-version.sh --verify "$$(cat "$$VERSION_FILE")"; \
+	fi
 
 $(WORKING_DIR)/internal/httpauth/generated/httpauth_generated_mock.go:
 	@$(GOCMD) generate ./internal/httpauth/

--- a/release-scripts/next-version.sh
+++ b/release-scripts/next-version.sh
@@ -6,6 +6,31 @@ set -euo pipefail
 # Environment variables:
 #   BUILD_MODE - "public" or "private" (default: "private")
 #                Public builds get an "-oss" suffix appended to the version.
+#
+# Modes:
+#   (default)            Generate the next version and print it to stdout.
+#   --verify <version>   Check that <version> is consistent with BUILD_MODE.
+#                        Exits 0 if consistent, 1 if not. No git/convco needed.
+
+if [ "${1:-}" = "--verify" ]; then
+  VERSION="${2:?Usage: next-version.sh --verify <version> (BUILD_MODE must be set)}"
+  MODE="${BUILD_MODE:-private}"
+  HAS_OSS=false
+  if echo "$VERSION" | grep -qE '[-.]oss$'; then
+    HAS_OSS=true
+  fi
+  if [ "$MODE" = "private" ] && [ "$HAS_OSS" = "true" ]; then
+    echo "ERROR: BUILD_MODE=$MODE but version '$VERSION' contains oss suffix." >&2
+    echo "       Version was generated for a public build." >&2
+    exit 1
+  fi
+  if [ "$MODE" = "public" ] && [ "$HAS_OSS" = "false" ]; then
+    echo "ERROR: BUILD_MODE=$MODE but version '$VERSION' is missing oss suffix." >&2
+    echo "       Version was generated for a private build." >&2
+    exit 1
+  fi
+  exit 0
+fi
 
 NEXT_VERSION="$(convco version --bump)"
 CURRENT_TAG="$(git describe --tags `git rev-list --tags --max-count=1`)"


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
This PR follows https://github.com/snyk/cli/pull/6992 and adds build time validation of the version. This check will detect if a build mixes public and private builds.

## Where should the reviewer start?

## How should this be manually tested?
```
make clean
make build BUILD_MODE=private
make build BUILD_MODE=public
```

the final build will error like this

```
ERROR: BUILD_MODE=public but version '1.1307.0-dev.4f0061fa4f4f0f9668f1012b575d18e660cebd14' is missing oss suffix.
       Version was generated for a private build.
make[1]: *** [_verify-private-build] Error 1
make: *** [build] Error 2
```

## What's the product update that needs to be communicated to CLI users?
N/A

## Risk assessment (Low | Medium | High)?
Low, only ci changes

<!---

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
