### PR TITLE
fix: bump cli-ext-agent-scan version [ADS-685]

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -204,7 +204,7 @@ require (
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.3.2 // indirect
-	github.com/snyk/cli-extension-agent-scan v0.0.0-20260505093105-90d9442ea939 // indirect
+	github.com/snyk/cli-extension-agent-scan v0.0.0-20260715092951-4f8fa1b9886c // indirect
 	github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603 // indirect
 	github.com/snyk/cli-extension-dep-graph/v2 v2.7.1 // indirect
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -561,8 +561,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.3.2 h1:EDL9mgf4NzwMXCTfaxSD/o/a5fxDw/xL9nkU28JjdBg=
 github.com/skeema/knownhosts v1.3.2/go.mod h1:bEg3iQAuw+jyiw+484wwFJoKSLwcfd7fqRy+N0QTiow=
-github.com/snyk/cli-extension-agent-scan v0.0.0-20260505093105-90d9442ea939 h1:GvW35inJZTr2AD1c/sIRkVOajom0kEY8nN30cqes+u0=
-github.com/snyk/cli-extension-agent-scan v0.0.0-20260505093105-90d9442ea939/go.mod h1:+Znlgu2v7sOTNAVjsoldFjDZUIo8tpdKnFlMptZHzz0=
+github.com/snyk/cli-extension-agent-scan v0.0.0-20260715092951-4f8fa1b9886c h1:of6wc3Cq5Ta6BRzdMgSYphJRp0TsRjILV3Dzi6cGjg8=
+github.com/snyk/cli-extension-agent-scan v0.0.0-20260715092951-4f8fa1b9886c/go.mod h1:g1qxNvAl2Qb0V4UJivop+hCqehHVqzB0taEjwTm6VlU=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603 h1:uZyw9OvOGCMFloZy8Fyu6l4K5y77o4k0KdxHuUKAp8M=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603/go.mod h1:RnMP+tFTeKygfXSx7z+heyMZoOps67u5HFytjptHjuk=
 github.com/snyk/cli-extension-dep-graph/v2 v2.7.1 h1:vnDp55PWtYBKYww8nQoCWfJ58huIR9iocax9jxvXe+Q=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.34.0
-	github.com/snyk/cli-extension-agent-scan v0.0.0-20260505093105-90d9442ea939
+	github.com/snyk/cli-extension-agent-scan v0.0.0-20260715092951-4f8fa1b9886c
 	github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603
 	github.com/snyk/cli-extension-dep-graph/v2 v2.7.1
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -523,8 +523,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.3.2 h1:EDL9mgf4NzwMXCTfaxSD/o/a5fxDw/xL9nkU28JjdBg=
 github.com/skeema/knownhosts v1.3.2/go.mod h1:bEg3iQAuw+jyiw+484wwFJoKSLwcfd7fqRy+N0QTiow=
-github.com/snyk/cli-extension-agent-scan v0.0.0-20260505093105-90d9442ea939 h1:GvW35inJZTr2AD1c/sIRkVOajom0kEY8nN30cqes+u0=
-github.com/snyk/cli-extension-agent-scan v0.0.0-20260505093105-90d9442ea939/go.mod h1:+Znlgu2v7sOTNAVjsoldFjDZUIo8tpdKnFlMptZHzz0=
+github.com/snyk/cli-extension-agent-scan v0.0.0-20260715092951-4f8fa1b9886c h1:of6wc3Cq5Ta6BRzdMgSYphJRp0TsRjILV3Dzi6cGjg8=
+github.com/snyk/cli-extension-agent-scan v0.0.0-20260715092951-4f8fa1b9886c/go.mod h1:g1qxNvAl2Qb0V4UJivop+hCqehHVqzB0taEjwTm6VlU=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603 h1:uZyw9OvOGCMFloZy8Fyu6l4K5y77o4k0KdxHuUKAp8M=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603/go.mod h1:RnMP+tFTeKygfXSx7z+heyMZoOps67u5HFytjptHjuk=
 github.com/snyk/cli-extension-dep-graph/v2 v2.7.1 h1:vnDp55PWtYBKYww8nQoCWfJ58huIR9iocax9jxvXe+Q=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
* Bumps the version of `cli-extension-agent-scan` used. This points to `v0.5.14` of `agent-scan` CLI now.
* Extends testing to all supported OS+Arch combinations.
* Some security [fixes](https://github.com/snyk/cli-extension-agent-scan/commit/60bbaa7edee45fc6bc03833c1fabcfdc59101195#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6) in `cli-extension-agent-scan`.

## Where should the reviewer start?

## How should this be manually tested?
snyk agent-scan --experimental

## What's the product update that needs to be communicated to CLI users?
Experimental module agent-scan version bump, so no formal communication required.

## Risk assessment (Low | Medium | High)?
Low

## What are the relevant tickets?
Maintenance bump

JIRA [ticket](https://snyksec.atlassian.net/browse/ADS-685)
