### PR TITLE
fix(ci): add linting to docs-only branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1549,6 +1549,24 @@ jobs:
               fi
             done
             exit 0
+      - restore_cache:
+          name: Restore npm cache
+          keys:
+            - prepare-v1-build-npm-deps-{{ checksum "package-lock.json" }}
+            - prepare-v1-build-npm-deps
+      - run:
+          name: Installing npm dependencies
+          command: npm ci --no-audit --no-progress --cache .npm --prefer-offline
+      - install-go:
+          go_os: linux
+          go_target_os: linux
+          go_arch: amd64
+          base_url: << pipeline.parameters.go_download_base_url >>
+          extraction_path: /tmp
+      - setup-go-private-modules
+      - run:
+          name: Linting project
+          command: make lint
 
   test-node:
     executor: docker-amd64

--- a/help/cli-commands/code-test.md
+++ b/help/cli-commands/code-test.md
@@ -17,7 +17,7 @@ The `snyk code test` command tests source code for any known security issues (St
 Possible exit codes and their meaning:
 
 **0**: success (scan completed), no vulnerabilities found\
-**1**: action\_needed (scan completed), vulnerabilities found\
+**1**: action_needed (scan completed), vulnerabilities found\
 **2**: failure, try to re-run the command. Use `-d` to output the debug logs.\
 **3**: failure, no supported projects detected
 
@@ -127,7 +127,7 @@ Example: `$ snyk code test --sarif`
 
 ### `--sarif-file-output=<OUTPUT_FILE_PATH>`
 
-Save test output in SARIF format directly to the \<OUTPUT\_FILE\_PATH> file, regardless of whether or not you use the `--sarif` option.
+Save test output in SARIF format directly to the \<OUTPUT_FILE_PATH> file, regardless of whether or not you use the `--sarif` option.
 
 Use to display the human-readable test output using stdout and, at the same time, save the SARIF format output to a file.\
 \

--- a/help/cli-commands/container-test.md
+++ b/help/cli-commands/container-test.md
@@ -17,7 +17,7 @@ The `snyk container test` command tests container images for any known vulnerabi
 Possible exit codes and their meaning:
 
 **0**: success (scan completed), no vulnerabilities found\
-**1**: action\_needed (scan completed), vulnerabilities found\
+**1**: action_needed (scan completed), vulnerabilities found\
 **2**: failure, try to re-run command. Use `-d` to output the debug logs.\
 **3**: failure, no supported projects detected
 

--- a/help/cli-commands/iac-test.md
+++ b/help/cli-commands/iac-test.md
@@ -21,7 +21,7 @@ For more information see [Snyk CLI for IaC](https://docs.snyk.io/snyk-cli/scan-a
 Possible exit codes and their meaning:
 
 **0**: success (scan completed), no vulnerabilities found\
-**1**: action\_needed (scan completed), vulnerabilities found\
+**1**: action_needed (scan completed), vulnerabilities found\
 **2**: failure, try to re-run the command. Use `-d` to output the debug logs.\
 **3**: failure, no supported projects detected
 
@@ -89,7 +89,7 @@ Return results in SARIF format.
 
 ### `--sarif-file-output=<OUTPUT_FILE_PATH>`
 
-Save test output in SARIF format directly to the \<OUTPUT\_FILE\_PATH> file, regardless of whether or not you use the `--sarif` option.
+Save test output in SARIF format directly to the \<OUTPUT_FILE_PATH> file, regardless of whether or not you use the `--sarif` option.
 
 This is especially useful if you want to display the human-readable test output using stdout and at the same time save the SARIF format output to a file.
 

--- a/help/cli-commands/ignore.md
+++ b/help/cli-commands/ignore.md
@@ -150,7 +150,7 @@ $ snyk ignore --id='SNYK-JS-PATHPARSE-1077067' --expiry='2021-01-10' --path='nyc
 In this example, `snyk iac test` on Windows returned a Path containing single quotes and a File specification containing back slashes:
 
 Rule: [https://security.snyk.io/rules/cloud/SNYK-CC-TF-118](https://security.snyk.io/rules/cloud/SNYK-CC-TF-118)\
-Path: resource > aws\_iam\_role\[OrganizationAccountAccessRole] > assume\_role\_policy\['Statement']\[0]\
+Path: resource > aws_iam_role\[OrganizationAccountAccessRole] > assume_role_policy\['Statement']\[0]\
 File: terraform\environment\com\iam.tf
 
 The corresponding `snyk ignore` command would be:
@@ -164,7 +164,7 @@ $ snyk ignore --id=SNYK-CC-TF-118 --path="terraform\environment\com\iam.tf > res
 In this example, `snyk iac test` on Linux or Mac OS returned a Path containing single quotes and a File specification containing forward slashes:
 
 Rule: [https://security.snyk.io/rules/cloud/SNYK-CC-TF-118](https://security.snyk.io/rules/cloud/SNYK-CC-TF-118)\
-Path: resource > aws\_iam\_role\[OrganizationAccountAccessRole] > assume\_role\_policy\['Statement']\[0]\
+Path: resource > aws_iam_role\[OrganizationAccountAccessRole] > assume_role_policy\['Statement']\[0]\
 File: terraform/environment/com/iam.tf
 
 The corresponding `snyk ignore` command would be:

--- a/help/cli-commands/log4shell.md
+++ b/help/cli-commands/log4shell.md
@@ -27,7 +27,7 @@ See the Maven options section of the [test command help](test.md); `snyk test --
 Possible exit codes and their meaning:
 
 **0**: success (scan completed), Log4Shell not found\
-**1**: action\_needed (scan completed), Log4Shell found\
+**1**: action_needed (scan completed), Log4Shell found\
 **2**: failure, try to re-run the command. Use `-d` to output the debug logs.
 
 ## Debug

--- a/help/cli-commands/sbom-test.md
+++ b/help/cli-commands/sbom-test.md
@@ -19,7 +19,7 @@ The `snyk sbom test` command checks SBOM files for vulnerabilities in open-sourc
 Possible exit codes and their meaning:
 
 **0**: success (scan completed), no vulnerabilities found\
-**1**: action\_needed (scan completed), vulnerabilities found\
+**1**: action_needed (scan completed), vulnerabilities found\
 **2**: failure, try to re-run the command
 
 ## Configure the Snyk CLI

--- a/help/cli-commands/test.md
+++ b/help/cli-commands/test.md
@@ -19,7 +19,7 @@ The `snyk test` command checks projects for open-source vulnerabilities and lice
 Possible exit codes and their meaning:
 
 **0**: success (scan completed), no vulnerabilities found\
-**1**: action\_needed (scan completed), vulnerabilities found\
+**1**: action_needed (scan completed), vulnerabilities found\
 **2**: failure, try to re-run the command. Use `-d` to output the debug logs.\
 **3**: failure, no supported projects detected
 
@@ -214,7 +214,7 @@ Return results in SARIF format.
 
 ### `--sarif-file-output=<OUTPUT_FILE_PATH>`
 
-Save test output in SARIF format directly to the \<OUTPUT\_FILE\_PATH> file, regardless of whether or not you use the `--sarif` option.
+Save test output in SARIF format directly to the \<OUTPUT_FILE_PATH> file, regardless of whether or not you use the `--sarif` option.
 
 This is especially useful if you want to display the human-readable test output using stdout and at the same time save the SARIF format output to a file.
 


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
Ensure to lint docs-only branches

## Where should the reviewer start?

## How should this be manually tested?

## What's the product update that needs to be communicated to CLI users?

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
