### PR TITLE
fix(deps): upgrade snyk-docker-plugin to 9.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "semver": "^6.0.0",
         "snyk-config": "^5.0.0",
         "snyk-cpp-plugin": "^2.24.3",
-        "snyk-docker-plugin": "^9.11.0",
+        "snyk-docker-plugin": "^9.16.0",
         "snyk-go-plugin": "2.1.2",
         "snyk-gradle-plugin": "7.0.0",
         "snyk-module": "3.1.0",
@@ -19860,9 +19860,9 @@
       "license": "ISC"
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "9.11.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-9.11.0.tgz",
-      "integrity": "sha512-O1u3907oUwoZscxvAazO1EIYxvvnPdy1ppxaDl80s0Z38sd+QDMCY7/sB0rfbzWmqIzDEpn2oUAGdWsq7QVNTA==",
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-9.16.0.tgz",
+      "integrity": "sha512-TAmv5nHRocG0cnbvVJXOve2ss3CwDt/i0O3B4Mytx+8bhGNfkmntqkPANftMU9YQDKYkrMyJo4v40KxTqPL2cQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "semver": "^6.0.0",
     "snyk-config": "^5.0.0",
     "snyk-cpp-plugin": "^2.24.3",
-    "snyk-docker-plugin": "^9.11.0",
+    "snyk-docker-plugin": "^9.16.0",
     "snyk-go-plugin": "2.1.2",
     "snyk-gradle-plugin": "7.0.0",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps `snyk-docker-plugin` from `^9.11.0` to `^9.16.0` and refreshes `package-lock.json`. That is the whole change on the CLI side.

The bump pulls in the CN-1395 APK package ownership series (releases 9.12.0 through 9.16.0). Full diff: https://github.com/snyk/snyk-docker-plugin/compare/v9.11.0...v9.16.0

What each release adds:

- **9.12.0** - parse apk file ownership records ([#869](https://github.com/snyk/snyk-docker-plugin/pull/869)). Reads the file and directory lists apk keeps for each installed package, so the plugin knows which paths on disk belong to which apk package.
- **9.13.0** - capture and merge layer symlinks during extraction ([#870](https://github.com/snyk/snyk-docker-plugin/pull/870)). Records symlinks as layers are extracted and merges them, so a path that reaches an apk-owned file through a symlinked directory still resolves correctly.
- **9.14.0** - add the apk ownership resolution library ([#871](https://github.com/snyk/snyk-docker-plugin/pull/871)). Builds an index of apk-owned files and directories and resolves an evidence path to its owning apk package. It fails closed: an application dependency whose paths are not wholly owned by one apk package keeps its own findings rather than being guessed at.
- **9.15.0** - emit the `apkPackageOwnership` fact for Chainguard images ([#872](https://github.com/snyk/snyk-docker-plugin/pull/872)). Attaches the resolved ownership to app-dependency scan results on Wolfi/Chainguard images as a new scan-result fact.
- **9.16.0** - resolve per-dependency apk ownership for npm global modules ([#879](https://github.com/snyk/snyk-docker-plugin/pull/879)). Extends resolution so individual globally-installed npm modules are matched to their owning apk package, not just whole-result ecosystems like Go binaries and Java jars.

Together these let the backend attribute application dependencies on Chainguard/Wolfi images to the apk package that ships them, so vulnerabilities covered by Chainguard advisory data are handled against the apk package instead of the raw application dependency.

There are no breaking API changes. Every release in the range is a `Features` release, and the new `apkPackageOwnership` fact is additive.

## Where should the reviewer start?

`package.json` and `package-lock.json` are the only files changed.

Worth a look on the CLI side is `src/lib/ecosystems/common.ts` (`filterDockerFacts`). It filters docker facts with a denylist that is gated behind the `CONTAINER_NEW_FACTS_FEATURE_FLAG`. The new `apkPackageOwnership` fact is not on either denylist, so it passes through to the backend by default. If the intent is to gate this fact behind the same flag during rollout, that would be a follow-up decision for the container team. This PR leaves the pass-through behavior as-is.

## How should this be manually tested?

The fact is emitted only for Wolfi/Chainguard images that carry application dependencies (npm global modules, Go binaries, Java jars) whose files are owned by an apk package. On such an image:

```sh
snyk container monitor <chainguard-image-with-app-deps> --json
```

The embedded `scanResult.facts` on an application scan result should include a fact of type `apkPackageOwnership`, with `data.distroId` and a `data.ownedPackages` list mapping evidence paths to their apk package. A plain `chainguard/wolfi-base` image has no application dependencies, so it will not emit the fact.

## What's the product update that needs to be communicated to CLI users?

For Chainguard and Wolfi container images, application dependencies that are shipped by an apk package are now attributed to that apk package in scan results. Vulnerability assessment can then defer to Chainguard's apk-level advisory coverage for those dependencies instead of reporting against the bundled application dependency, which reduces false positives on Chainguard/Wolfi images. As of 9.16.0 this covers individual npm global modules, on top of whole-result ecosystems like Go binaries and Java jars.

The CLI itself gains no new flags and its output text is unchanged. The visible improvement lands once the backend consumes the new `apkPackageOwnership` fact that this version forwards.

## Testing

No CLI integration test is included, and I do not think one is warranted here:

- The CLI change is a version bump with no CLI logic. The ownership behavior lives entirely in the plugin, which carries its own unit and integration coverage for it across the five feature PRs.
- The fact is emitted only for Chainguard/Wolfi images that also carry apk-owned application dependencies. There is no local fixture of that shape, and none of the existing container fixtures qualify. `chainguard/wolfi-base:latest` (already used in the container acceptance suite) is a bare base image with no app dependencies, so it does not trigger the fact.
- A meaningful test would need a bespoke Chainguard image saved as a committed fixture, or a live pull of a mutable `:latest` Chainguard app image. The first is a large binary fixture that duplicates plugin-side coverage; the second is network-dependent and drift-prone, which is the user-journey layer that runs in plugin/extension CI, not CLI acceptance.

The generic docker fact pass-through that this fact rides on is already exercised by existing `container monitor --json` acceptance tests (for example `test/jest/acceptance/snyk-container/layer-attribution.spec.ts`).

## Risk assessment (Low | Medium | High)?

Low. Dependency version bump within the same major, additive plugin features only, no breaking API changes, and no CLI code touched.

## What are the relevant tickets?

[CN-1395](https://snyk.atlassian.net/browse/CN-1395)


[CN-1395]: https://snyksec.atlassian.net/browse/CN-1395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ