### PR TITLE
chore: Ensure Set version uses private build mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1523,9 +1523,9 @@ jobs:
       - run:
           name: Set version
           command: |
-            make binary-releases/version binary-releases/fips/version
+            make binary-releases/version binary-releases/fips/version BUILD_MODE=private
             make release-validate-version
-            make ts-cli-binaries/version BINARY_RELEASES_FOLDER_TS_CLI=ts-cli-binaries
+            make ts-cli-binaries/version BINARY_RELEASES_FOLDER_TS_CLI=ts-cli-binaries BUILD_MODE=private
       - run:
           # required for one unit test (ts-binary-wrapper/test/unit/common.spec.ts:15:30)
           # consider removing this run


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Ensures the `prepare-build` job's **Set version** step always uses private build mode for version generation. Flaky auto-detection of private module access in CI could produce public versions with the `.oss` suffix, inconsistent with the private builds used elsewhere in `test_and_release`.

## Where should the reviewer start?

- `.circleci/config.yml` — `prepare-build` job, **Set version** step

## How should this be manually tested?

1. Confirm the `prepare-build` job passes in CircleCI.
2. In the **Set version** step logs, confirm `Build mode: private` and that the generated version does **not** include an `.oss` suffix.

## What's the product update that needs to be communicated to CLI users?

None. Internal CI change only.

## Risk assessment (Low | Medium | High)?

Low

## Any background context you want to provide?

Similar to #52987e419, which enforced private build mode on build-artifact jobs. Auto-detection via `go mod download` against `cliv2-private` can intermittently fail in CI, causing `next-version.sh` to run in public mode and append `.oss` to dev versions.

## What are the relevant tickets?

[CLI-1686](https://snyksec.atlassian.net/browse/CLI-1686)

## Screenshots (if appropriate)

N/A

[CLI-1686]: https://snyksec.atlassian.net/browse/CLI-1686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ