### PR TITLE
chore(ci): right-size acceptance executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,10 +52,18 @@ executors:
     docker:
       - image: alpine:3.23
     resource_class: xlarge
+  alpine-large:
+    docker:
+      - image: alpine:3.23
+    resource_class: large
   alpine-arm64:
     docker:
       - image: alpine:3.23
     resource_class: arm.xlarge
+  alpine-arm64-large:
+    docker:
+      - image: alpine:3.23
+    resource_class: arm.large
   generic-ubuntu:
     docker:
       - image: ubuntu:latest
@@ -860,7 +868,7 @@ workflows:
           pre_test_cmds: export BROWSER="curl -L"
           requires:
             - build linux static arm64
-          executor: docker-arm64-xl
+          executor: docker-arm64
           test_snyk_command: ./binary-releases/experimental/snyk-linux-arm64
 
       - acceptance-tests:
@@ -883,7 +891,7 @@ workflows:
           pre_test_cmds: export BROWSER="curl -L"
           requires:
             - build linux amd64
-          executor: docker-amd64-xl
+          executor: docker-amd64
           test_snyk_command: ./binary-releases/snyk-linux
 
       - acceptance-tests:
@@ -952,7 +960,7 @@ workflows:
                 - '/release.*/'
           requires:
             - build alpine amd64
-          executor: alpine
+          executor: alpine-large
           test_snyk_command: ./binary-releases/snyk-alpine
           install_deps_extension: alpine-full
           dont_skip_tests: 0
@@ -976,7 +984,7 @@ workflows:
                 - '/release.*/'
           requires:
             - build alpine arm64
-          executor: alpine-arm64
+          executor: alpine-arm64-large
           test_snyk_command: ./binary-releases/snyk-alpine-arm64
           install_deps_extension: alpine-full
           dont_skip_tests: 0


### PR DESCRIPTION
Several acceptance jobs were still using eight-core executors. This PR moves four acceptance jobs from xlarge to large executors:

- Linux x86
- Linux static ARM
- Alpine x86
- Alpine ARM

CircleCI already splits the acceptance files across parallel containers. Inside each container, the acceptance command runs `npx jest --maxWorkers=1`, so each shard executes one Jest worker at a time. The xlarge executors provide eight cores to each shard, but Jest cannot spread that shard's tests across them. Historical usage reflected this, with median CPU around 11% to 12% and median RAM around 4%. Moving these jobs to Large removes idle capacity without reducing the existing shard-level parallelism.

I tested other executor combinations, but they did not improve the result within the agreed runtime threshold. This PR only contains the configuration that met that threshold. The build jobs, shard counts, test selection, and Remote Docker behavior are unchanged.

| Configuration | Pipeline | Runtime | CircleCI credits | Runtime vs baseline | Credits vs baseline |
| --- | --- | ---: | ---: | ---: | ---: |
| Baseline | [38484](https://app.circleci.com/pipelines/gh/snyk/cli/38484) | 47m 57s | 64,899 | - | - |
| Retained configuration, run 1 | [38487](https://app.circleci.com/pipelines/gh/snyk/cli/38487) | 43m 36s | 50,689 | 9.1% faster | 21.9% fewer |
| Retained configuration, run 2 | [38496](https://app.circleci.com/pipelines/gh/snyk/cli/38496) | 46m 03s | 48,831 | 4.0% faster | 24.8% fewer |

The small speed difference is likely normal CI variation. Both retained-configuration runs completed within the baseline runtime, so we did not observe any time degradation while full-workflow credits fell by 21.9% to 24.8%.

Validation also included `make format`, `make lint`, and `make build`.

Tracking: IDP-7
