### PR TITLE
chore: bump cli-extension-dep-graph to v2.7.2

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -206,7 +206,7 @@ require (
 	github.com/skeema/knownhosts v1.3.2 // indirect
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260715092951-4f8fa1b9886c // indirect
 	github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603 // indirect
-	github.com/snyk/cli-extension-dep-graph/v2 v2.7.1 // indirect
+	github.com/snyk/cli-extension-dep-graph/v2 v2.7.2 // indirect
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 // indirect
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e // indirect
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260625140351-2bb6cb470073 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -565,8 +565,8 @@ github.com/snyk/cli-extension-agent-scan v0.0.0-20260715092951-4f8fa1b9886c h1:o
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260715092951-4f8fa1b9886c/go.mod h1:g1qxNvAl2Qb0V4UJivop+hCqehHVqzB0taEjwTm6VlU=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603 h1:uZyw9OvOGCMFloZy8Fyu6l4K5y77o4k0KdxHuUKAp8M=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603/go.mod h1:RnMP+tFTeKygfXSx7z+heyMZoOps67u5HFytjptHjuk=
-github.com/snyk/cli-extension-dep-graph/v2 v2.7.1 h1:vnDp55PWtYBKYww8nQoCWfJ58huIR9iocax9jxvXe+Q=
-github.com/snyk/cli-extension-dep-graph/v2 v2.7.1/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
+github.com/snyk/cli-extension-dep-graph/v2 v2.7.2 h1:+D/r8zDdREbrZs1EZ4DmVzEf7oMHA2rRozhuaVFyg8U=
+github.com/snyk/cli-extension-dep-graph/v2 v2.7.2/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSoQL0zYyFcGQjEPZcQgDkzM5PcgIHlIgzRuhg=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e h1:HE22F5/ivTJ4TlTUnjasZqfkDKVyfmYjf36RaIZqrs4=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260715092951-4f8fa1b9886c
 	github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603
-	github.com/snyk/cli-extension-dep-graph/v2 v2.7.1
+	github.com/snyk/cli-extension-dep-graph/v2 v2.7.2
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260625140351-2bb6cb470073

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -527,8 +527,8 @@ github.com/snyk/cli-extension-agent-scan v0.0.0-20260715092951-4f8fa1b9886c h1:o
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260715092951-4f8fa1b9886c/go.mod h1:g1qxNvAl2Qb0V4UJivop+hCqehHVqzB0taEjwTm6VlU=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603 h1:uZyw9OvOGCMFloZy8Fyu6l4K5y77o4k0KdxHuUKAp8M=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603/go.mod h1:RnMP+tFTeKygfXSx7z+heyMZoOps67u5HFytjptHjuk=
-github.com/snyk/cli-extension-dep-graph/v2 v2.7.1 h1:vnDp55PWtYBKYww8nQoCWfJ58huIR9iocax9jxvXe+Q=
-github.com/snyk/cli-extension-dep-graph/v2 v2.7.1/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
+github.com/snyk/cli-extension-dep-graph/v2 v2.7.2 h1:+D/r8zDdREbrZs1EZ4DmVzEf7oMHA2rRozhuaVFyg8U=
+github.com/snyk/cli-extension-dep-graph/v2 v2.7.2/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSoQL0zYyFcGQjEPZcQgDkzM5PcgIHlIgzRuhg=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e h1:HE22F5/ivTJ4TlTUnjasZqfkDKVyfmYjf36RaIZqrs4=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps `github.com/snyk/cli-extension-dep-graph/v2` from `v2.7.1` to `v2.7.2` in both `cliv2/go.mod` and `cliv2-private/go.mod` (via `go get` + `make tidy`).

This brings in [snyk/cli-extension-dep-graph#224](https://github.com/snyk/cli-extension-dep-graph/pull/224) (`fix(bazel): use query instead of cquery for target discovery`):

- Bazel `cquery` resolves every `select()` in a target pattern's transitive closure during analysis, even for targets unrelated to the one being resolved. A `select()` with no `//conditions:default` branch anywhere under `//...` (e.g. `rules_distroless`'s `dpkg_status`) made target discovery fail outright on any host that satisfied neither branch — this crashed the plugin in production on a client's macOS machine.
- Target discovery (`findTargets`) now uses `bazel query` (loading phase only, never resolves `select()`), via a streamed `--output=streamed_jsonproto` decoder read directly off the process's stdout pipe.
- The deps phase (`buildDepGraph`) still uses `cquery` by design (`query` would flatten selects and over-report platform-specific deps), but gains a `--bazel-platforms` flag forwarded verbatim to bazel's own `--platforms` to pin a branch when needed.

## Where should the reviewer start?

- `cliv2/go.mod` / `cliv2/go.sum` and `cliv2-private/go.mod` / `cliv2-private/go.sum` — the version bump itself.
- Full changes are in [snyk/cli-extension-dep-graph#224](https://github.com/snyk/cli-extension-dep-graph/pull/224).

## How should this be manually tested?

- `make build BUILD_MODE=public` builds successfully.
- `cd cliv2 && make test` — full Go unit suite passes.
- Smoke test `snyk test` / dep-graph generation against a Bazel project affected by the fixed crash (a target pattern whose transitive closure includes a `select()` with no default branch, e.g. involving `rules_distroless`' `dpkg_status`).

## What's the product update that needs to be communicated to CLI users?

N/A

## Risk assessment (Low | Medium | High)?

Low — dependency bump only, confined to the Bazel target-discovery path in `cli-extension-dep-graph`. Full Go build and test suite pass; no other code changes in this repo. Access to Bazel dependency resolution is behind a feature flag.