### PR TITLE
feat: include component metadata for Go modules sboms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "snyk-config": "^5.0.0",
         "snyk-cpp-plugin": "^2.24.3",
         "snyk-docker-plugin": "^9.16.0",
-        "snyk-go-plugin": "2.1.2",
+        "snyk-go-plugin": "2.2.1",
         "snyk-gradle-plugin": "7.0.0",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "4.8.2",
@@ -19972,9 +19972,9 @@
       "license": "0BSD"
     },
     "node_modules/snyk-go-plugin": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-2.1.2.tgz",
-      "integrity": "sha512-UY50eLNowFVDuK8Nr3WCU602/uor0pXZKw73PPSMp/FQlVtuV14HUwAeNeQi6IalEM2zw3YMLYUZt0eFLKMHYA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-2.2.1.tgz",
+      "integrity": "sha512-cP7gNOSYlvhnl80mUvwdmTM3W0mh+a7T1a0w+gImH3JoE9eLWj9klRxL3K1jDkwrWXgkDxbhrmebe7lgG0J0Wg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@snyk/dep-graph": "^2.16.4",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "snyk-config": "^5.0.0",
     "snyk-cpp-plugin": "^2.24.3",
     "snyk-docker-plugin": "^9.16.0",
-    "snyk-go-plugin": "2.1.2",
+    "snyk-go-plugin": "2.2.1",
     "snyk-gradle-plugin": "7.0.0",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "4.8.2",

--- a/test/acceptance/workspaces/go-include-component-metadata/go.mod
+++ b/test/acceptance/workspaces/go-include-component-metadata/go.mod
@@ -1,0 +1,5 @@
+module app
+
+go 1.21
+
+require github.com/gorilla/mux v1.8.1

--- a/test/acceptance/workspaces/go-include-component-metadata/go.sum
+++ b/test/acceptance/workspaces/go-include-component-metadata/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=

--- a/test/acceptance/workspaces/go-include-component-metadata/main.go
+++ b/test/acceptance/workspaces/go-include-component-metadata/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	_ "github.com/gorilla/mux"
+)
+
+func main() {
+	// nothing to see here
+}

--- a/test/jest/acceptance/snyk-test/go-include-component-metadata.spec.ts
+++ b/test/jest/acceptance/snyk-test/go-include-component-metadata.spec.ts
@@ -1,0 +1,135 @@
+import { createProjectFromWorkspace } from '../../util/createProject';
+import { runSnykCLI } from '../../util/runSnykCLI';
+import {
+  fakeServer,
+  getFirstIPv4Address,
+} from '../../../acceptance/fake-server';
+import { getAvailableServerPort } from '../../util/getServerPort';
+
+jest.setTimeout(1000 * 60);
+
+// `--include-component-metadata` makes the go plugin read the `h1:` module
+// hash (via `go list`, falling back to go.sum on older toolchains) and derive
+// a module-proxy distribution URL, surfacing them as `hash:sha-256` and
+// `distribution:url` labels on the dep-graph nodes — matching snyk-mvn-plugin
+// and snyk-nodejs-plugin. Unlike maven there is no separate resolve step: the
+// go plugin's own `go list` invocation resolves the module as needed.
+describe('`snyk test --include-component-metadata` (go modules)', () => {
+  let server;
+  let env: Record<string, string>;
+
+  beforeAll(async () => {
+    const port = await getAvailableServerPort(process);
+    const baseApi = '/api/v1';
+    const fakeServerIp = getFirstIPv4Address();
+    const defaultEnvVars = {
+      SNYK_API: `http://${fakeServerIp}:${port}${baseApi}`,
+      SNYK_HOST: `http://${fakeServerIp}:${port}`,
+      SNYK_TOKEN: '123456789',
+      SNYK_DISABLE_ANALYTICS: '1',
+      SNYK_HTTP_PROTOCOL_UPGRADE: '0',
+    };
+    env = {
+      ...process.env,
+      ...defaultEnvVars,
+    };
+    server = fakeServer(baseApi, env.SNYK_TOKEN);
+    await server.listenPromise(port);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    server.restore();
+  });
+
+  afterAll(
+    () =>
+      new Promise((res) => {
+        server.close(res);
+      }),
+  );
+
+  const parseDepGraph = (printGraphStdout: string) =>
+    JSON.parse(
+      printGraphStdout.split('DepGraph data:')[1].split('DepGraph target:')[0],
+    );
+
+  const labelKeys = (printGraphStdout: string, prefix: string): string[] =>
+    parseDepGraph(printGraphStdout)
+      .graph.nodes.flatMap((node) => Object.keys(node.info?.labels ?? {}))
+      .filter((key) => key.startsWith(prefix));
+
+  const labelValues = (printGraphStdout: string, key: string): string[] =>
+    parseDepGraph(printGraphStdout)
+      .graph.nodes.map((node) => node.info?.labels?.[key])
+      .filter(Boolean);
+
+  it('attaches `hash:sha-256` and `distribution:url` labels with the flag', async () => {
+    const project = await createProjectFromWorkspace(
+      'go-include-component-metadata',
+    );
+
+    const { code, stdout } = await runSnykCLI(
+      'test --include-component-metadata --print-graph',
+      {
+        cwd: project.path(),
+        env,
+      },
+    );
+
+    expect(code).toEqual(0);
+    expect(stdout).toContain('DepGraph data:');
+    expect(labelKeys(stdout, 'hash:').length).toBeGreaterThan(0);
+    expect(labelKeys(stdout, 'distribution:url').length).toBeGreaterThan(0);
+  });
+
+  // Control: without the flag the same project must not produce the labels,
+  // proving they are driven by `--include-component-metadata`.
+  it('does not attach the labels without the flag', async () => {
+    const project = await createProjectFromWorkspace(
+      'go-include-component-metadata',
+    );
+
+    const { code, stdout } = await runSnykCLI('test --print-graph', {
+      cwd: project.path(),
+      env,
+    });
+
+    expect(code).toEqual(0);
+    expect(stdout).toContain('DepGraph data:');
+    expect(labelKeys(stdout, 'hash:')).toHaveLength(0);
+    expect(labelKeys(stdout, 'distribution:url')).toHaveLength(0);
+  });
+
+  // Regression test for a credential leak: a private GOPROXY can carry
+  // basic-auth credentials embedded in the url (e.g. https://user:pass@proxy/).
+  // snyk-go-plugin must strip them before surfacing the proxy url as a
+  // distribution:url label, otherwise they'd be shipped off-host with the
+  // scan results. proxy.golang.org ignores the bogus Authorization header
+  // this produces, so the module still resolves over the real network.
+  // Fixed in snyk-go-plugin#149, released as 2.2.1.
+  it('does not leak GOPROXY credentials into the distribution:url label', async () => {
+    const project = await createProjectFromWorkspace(
+      'go-include-component-metadata',
+    );
+
+    const { code, stdout } = await runSnykCLI(
+      'test --include-component-metadata --print-graph',
+      {
+        cwd: project.path(),
+        env: {
+          ...env,
+          GOPROXY: 'https://foo:bar@proxy.golang.org,direct',
+        },
+      },
+    );
+
+    expect(code).toEqual(0);
+    const urls = labelValues(stdout, 'distribution:url');
+    expect(urls.length).toBeGreaterThan(0);
+    for (const url of urls) {
+      expect(url).not.toContain('foo:bar@');
+      expect(url).not.toMatch(/:\/\/[^/]*@/);
+    }
+  });
+});


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Upgrades `snyk-go-plugin` to `2.2.1`, which adds `includeComponentMetadata` support for Go module (`go.mod`) projects. This brings in: https://github.com/snyk/snyk-go-plugin/pull/148 and https://github.com/snyk/snyk-go-plugin/pull/149

`snyk sbom`, when the  now attaches `hash:sha-256` and `distribution:url` labels to Go dependency graph nodes, matching the existing maven and npm/yarn plugin support, so downstream SBOM generation can populate component hashes and distribution references for Go projects.

## Where should the reviewer start?

- https://github.com/snyk/snyk-go-plugin/pull/148
- `package.json` / `package-lock.json` — `snyk-go-plugin` bump to `2.2.1`
- `test/jest/acceptance/snyk-test/go-include-component-metadata.spec.ts` — new acceptance test, mirroring the existing `maven-include-component-metadata.spec.ts` / `npm-include-component-metadata.spec.ts` / `yarn-include-component-metadata.spec.ts`
- `test/acceptance/workspaces/go-include-component-metadata/` — fixture (single `github.com/gorilla/mux` dependency)

## How should this be manually tested?

It can be tested against pre-prod environments, which have the feature flag fully enabled:
```
❯ ~/code/cli/binary-releases/snyk-macos-arm64 config environment https://api.polaris-pre-prod.snyk.io
❯ snyk sbom --format=cyclonedx1.6+json
{"$schema":"http://cyclonedx.org/schema/bom-1.6.schema.json","bomFormat":"CycloneDX","specVersion":"1.6","serialNumber":"urn:uuid:3a33665f-78ff-47f5-8006-536b188f9be2","version":1,"metadata":{"timestamp":"2026-07-21T10:12:36Z","tools":{"components":[{"type":"application","author":"Snyk","name":"snyk-cli","version":"1.1307.0-dev.4a885b8d3c05bcd288610b5bfd09907de3142ea1"}],"services":[{"provider":{"name":"Snyk"},"name":"SBOM Export API","version":"v1.131.0"}]},"component":{"bom-ref":"1-golang_project_1.24.7@0.0.0","type":"application","name":"golang_project_1.24.7","version":"0.0.0","purl":"pkg:golang/golang_project_1.24.7@0.0.0"}},"components":[{"bom-ref":"2-rsc.io/quote@1.5.2","type":"library","group":"rsc.io","name":"rsc.io/quote","version":"v1.5.2","hashes":[{"alg":"SHA-256","content":"c397dccac8ebc7bcaab43fda3be43046361938a9da33d521d9be34b44953b376"}],"licenses":[{"expression":"BSD-3-Clause"}],"purl":"pkg:golang/rsc.io/quote@v1.5.2","externalReferences":[{"url":"https://proxy.golang.org/rsc.io/quote/@v/v1.5.2.zip","type":"distribution"}]},{"bom-ref":"3-rsc.io/sampler@1.3.0","type":"library","group":"rsc.io","name":"rsc.io/sampler","version":"v1.3.0","hashes":[{"alg":"SHA-256","content":"eee56420599e06a1df7630fe819c2d5d723e44e0c9d967383bb30f121fd0896e"}],"licenses":[{"expression":"BSD-3-Clause"}],"purl":"pkg:golang/rsc.io/sampler@v1.3.0","externalReferences":[{"url":"https://proxy.golang.org/rsc.io/sampler/@v/v1.3.0.zip","type":"distribution"}]},{"bom-ref":"4-std/strings@1.26.4","type":"library","group":"std","name":"std/strings","version":"1.26.4","purl":"pkg:golang/std/strings@1.26.4"},{"bom-ref":"5-std/os@1.26.4","type":"library","group":"std","name":"std/os","version":"1.26.4","purl":"pkg:golang/std/os@1.26.4"},{"bom-ref":"6-golang.org/x/text/language@#14c0d48ead0c","type":"library","group":"golang.org/x","name":"golang.org/x/text/language","version":"v0.0.0-20170915032832-14c0d48ead0c","hashes":[{"alg":"SHA-256","content":"aa0398e9681939a4e4208322563050730f77111044e26df48819b4d2790bd22f"}],"licenses":[{"expression":"BSD-3-Clause"}],"purl":"pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c#language","externalReferences":[{"url":"https://proxy.golang.org/golang.org/x/text/@v/v0.0.0-20170915032832-14c0d48ead0c.zip","type":"distribution"}]},{"bom-ref":"7-std/strconv@1.26.4","type":"library","group":"std","name":"std/strconv","version":"1.26.4","purl":"pkg:golang/std/strconv@1.26.4"},{"bom-ref":"8-std/sort@1.26.4","type":"library","group":"std","name":"std/sort","version":"1.26.4","purl":"pkg:golang/std/sort@1.26.4"},{"bom-ref":"9-golang.org/x/text/internal/tag@#14c0d48ead0c","type":"library","group":"golang.org/x","name":"golang.org/x/text/internal/tag","version":"v0.0.0-20170915032832-14c0d48ead0c","hashes":[{"alg":"SHA-256","content":"aa0398e9681939a4e4208322563050730f77111044e26df48819b4d2790bd22f"}],"licenses":[{"expression":"BSD-3-Clause"}],"purl":"pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c#internal/tag","externalReferences":[{"url":"https://proxy.golang.org/golang.org/x/text/@v/v0.0.0-20170915032832-14c0d48ead0c.zip","type":"distribution"}]},{"bom-ref":"10-std/fmt@1.26.4","type":"library","group":"std","name":"std/fmt","version":"1.26.4","purl":"pkg:golang/std/fmt@1.26.4"},{"bom-ref":"11-std/errors@1.26.4","type":"library","group":"std","name":"std/errors","version":"1.26.4","purl":"pkg:golang/std/errors@1.26.4"},{"bom-ref":"12-std/bytes@1.26.4","type":"library","group":"std","name":"std/bytes","version":"1.26.4","purl":"pkg:golang/std/bytes@1.26.4"},{"bom-ref":"13-std/encoding/hex@1.26.4","type":"library","group":"std/encoding","name":"std/encoding/hex","version":"1.26.4","purl":"pkg:golang/std/encoding/hex@1.26.4"},{"bom-ref":"14-std/crypto/md5@1.26.4","type":"library","group":"std/crypto","name":"std/crypto/md5","version":"1.26.4","purl":"pkg:golang/std/crypto/md5@1.26.4"}],"dependencies":[{"ref":"1-golang_project_1.24.7@0.0.0","dependsOn":["2-rsc.io/quote@1.5.2","10-std/fmt@1.26.4","13-std/encoding/hex@1.26.4","14-std/crypto/md5@1.26.4"]},{"ref":"2-rsc.io/quote@1.5.2","dependsOn":["3-rsc.io/sampler@1.3.0"]},{"ref":"3-rsc.io/sampler@1.3.0","dependsOn":["4-std/strings@1.26.4","5-std/os@1.26.4","6-golang.org/x/text/language@#14c0d48ead0c"]},{"ref":"4-std/strings@1.26.4"},{"ref":"5-std/os@1.26.4"},{"ref":"6-golang.org/x/text/language@#14c0d48ead0c","dependsOn":["4-std/strings@1.26.4","7-std/strconv@1.26.4","8-std/sort@1.26.4","9-golang.org/x/text/internal/tag@#14c0d48ead0c","10-std/fmt@1.26.4","11-std/errors@1.26.4","12-std/bytes@1.26.4"]},{"ref":"7-std/strconv@1.26.4"},{"ref":"8-std/sort@1.26.4"},{"ref":"9-golang.org/x/text/internal/tag@#14c0d48ead0c","dependsOn":["8-std/sort@1.26.4"]},{"ref":"10-std/fmt@1.26.4"},{"ref":"11-std/errors@1.26.4"},{"ref":"12-std/bytes@1.26.4"},{"ref":"13-std/encoding/hex@1.26.4"},{"ref":"14-std/crypto/md5@1.26.4"}]}
```
As you can see, the resulting SBOM contains `components[].hashes[]` and `components[].externalReferences[]` sections:
```
    {
      "bom-ref": "2-rsc.io/quote@1.5.2",
      "type": "library",
      "group": "rsc.io",
      "name": "rsc.io/quote",
      "version": "v1.5.2",
      "hashes": [
        {
          "alg": "SHA-256",
          "content": "c397dccac8ebc7bcaab43fda3be43046361938a9da33d521d9be34b44953b376"
        }
      ],
      "licenses": [
        {
          "expression": "BSD-3-Clause"
        }
      ],
      "purl": "pkg:golang/rsc.io/quote@v1.5.2",
      "externalReferences": [
        {
          "url": "https://proxy.golang.org/rsc.io/quote/@v/v1.5.2.zip",
          "type": "distribution"
        }
      ]
    }
```

## What's the product update that needs to be communicated to CLI users?

N/A

## Risk assessment (Low | Medium | High)?

Low — additive behaviour hidden behind feature flag. No change to default dep-graph output; covered by a new acceptance test plus existing Go acceptance tests.

## Any background context you want to provide?

Companion change to `snyk-mvn-plugin` and `snyk-nodejs-plugin`, which already support `includeComponentMetadata`. `cli`'s plugin dispatch (`get-single-plugin-result.ts`) already forwards the flag generically to every plugin, so no `cli` source changes were needed beyond the dependency bump and test coverage.