### PR TITLE
fix: include distribution:url in mvn component metadata [CMPA-604]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "snyk-go-plugin": "2.2.1",
         "snyk-gradle-plugin": "7.0.0",
         "snyk-module": "3.1.0",
-        "snyk-mvn-plugin": "4.8.2",
+        "snyk-mvn-plugin": "4.9.2",
         "snyk-nodejs-lockfile-parser": "2.10.0",
         "snyk-nodejs-plugin": "^2.2.0",
         "snyk-nuget-plugin": "4.2.3",
@@ -20189,9 +20189,9 @@
       "license": "ISC"
     },
     "node_modules/snyk-mvn-plugin": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-4.8.2.tgz",
-      "integrity": "sha512-SsQvbs3+9h9MHPKsilNkTczUgAb6qiqbj0iEKv2T08C48pfDrxUTDy3xmv6qC4LO2AWeRFOInXV4gaJOHtpaQg==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-4.9.2.tgz",
+      "integrity": "sha512-UKY8+r3hbaIQG5SEp+m49VTJNJTA79rQuMVehPQmPYuQni4BKkbrizOsdpqIzK0iQRFPmhv8vTwDGUXE2AmrbQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@common.js/yocto-queue": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "snyk-go-plugin": "2.2.1",
     "snyk-gradle-plugin": "7.0.0",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "4.8.2",
+    "snyk-mvn-plugin": "4.9.2",
     "snyk-nodejs-lockfile-parser": "2.10.0",
     "snyk-nodejs-plugin": "^2.2.0",
     "snyk-nuget-plugin": "4.2.3",

--- a/test/fixtures/maven-creds-repo/pom.xml
+++ b/test/fixtures/maven-creds-repo/pom.xml
@@ -1,0 +1,38 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.snyk.example</groupId>
+  <artifactId>maven-creds-repo</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>Test project with a credentialed repository URL</name>
+  <description>
+    Declares a repository whose URL carries embedded basic-auth credentials
+    (rather than a settings.xml server block), to prove those credentials
+    never leak into the distribution:url dep-graph label.
+  </description>
+
+  <repositories>
+    <repository>
+      <id>creds-repo</id>
+      <url>https://user:secret@example.invalid/maven2</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+
+    <!-- A single, non-transitive dependency. The test hand-constructs its
+         local .m2 entry (jar + pom + _remote.repositories) rather than
+         resolving it for real, so the dependency itself need not exist on
+         any real repository. -->
+    <dependency>
+      <groupId>io.snyk.example</groupId>
+      <artifactId>creds-dep</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/test/jest/acceptance/snyk-test/maven-include-component-metadata.spec.ts
+++ b/test/jest/acceptance/snyk-test/maven-include-component-metadata.spec.ts
@@ -1,4 +1,7 @@
 import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 
 import { createProjectFromFixture } from '../../util/createProject';
 import { runSnykCLI } from '../../util/runSnykCLI';
@@ -9,10 +12,12 @@ import { isWindowsOperatingSystem } from '../../../utils';
 jest.setTimeout(1000 * 60 * 5);
 
 // `--include-component-metadata` makes the maven plugin read the install-time
-// `.jar.sha1` companion files from the local Maven repository and surface them
-// as `hash:<algorithm>` labels on the dep-graph nodes. The artifacts must
-// therefore be resolved into the local repository first (via `mvn`), otherwise
-// there are no companion files to read.
+// `.jar.sha1` companion files, and the `_remote.repositories` file Maven
+// writes alongside each downloaded artifact, from the local Maven repository.
+// These surface as `hash:<algorithm>` and `distribution:url` labels on the
+// dep-graph nodes. The artifacts must therefore be resolved into the local
+// repository first (via `mvn`), otherwise there are no companion files to
+// read.
 describe('`snyk test --include-component-metadata` (maven)', () => {
   let server;
   let env: Record<string, string>;
@@ -43,21 +48,27 @@ describe('`snyk test --include-component-metadata` (maven)', () => {
       }),
   );
 
-  const hashLabelKeys = (printGraphStdout: string): string[] => {
-    const jsonDG = JSON.parse(
+  const parseDepGraph = (printGraphStdout: string) =>
+    JSON.parse(
       printGraphStdout.split('DepGraph data:')[1].split('DepGraph target:')[0],
     );
-    return jsonDG.graph.nodes
-      .flatMap((node) => Object.keys(node.info?.labels ?? {}))
+
+  const hashLabelKeys = (printGraphStdout: string): string[] =>
+    parseDepGraph(printGraphStdout)
+      .graph.nodes.flatMap((node) => Object.keys(node.info?.labels ?? {}))
       .filter((key) => key.startsWith('hash:'));
-  };
+
+  const distributionUrlLabels = (printGraphStdout: string): string[] =>
+    parseDepGraph(printGraphStdout)
+      .graph.nodes.map((node) => node.info?.labels?.['distribution:url'])
+      .filter(Boolean);
 
   // mvn is required to resolve artifacts into the local repository first.
-  it('attaches `hash:<algorithm>` labels when artifacts are resolved', async () => {
+  it('attaches `hash:<algorithm>` and `distribution:url` labels when artifacts are resolved', async () => {
     const project = await createProjectFromFixture('maven-print-graph');
 
     // Populate the local Maven repository so the `.jar.sha1` companion files
-    // the plugin reads are present.
+    // and `_remote.repositories` records the plugin reads are present.
     execFileSync('mvn', ['dependency:resolve'], {
       cwd: project.path(),
       stdio: 'ignore',
@@ -75,11 +86,21 @@ describe('`snyk test --include-component-metadata` (maven)', () => {
     expect(code).toEqual(0);
     expect(stdout).toContain('DepGraph data:');
     expect(hashLabelKeys(stdout).length).toBeGreaterThan(0);
+
+    // The fixture's axis:axis@1.4 dependency resolves from whichever repository
+    // serves Maven Central (a mirror may be configured to avoid rate limits),
+    // so assert the artifact path suffix rather than a specific repository host.
+    expect(
+      distributionUrlLabels(stdout).some((url) =>
+        url.endsWith('/axis/axis/1.4/axis-1.4.jar'),
+      ),
+    ).toBe(true);
   });
 
-  // Control: without the flag the same project must not produce hash labels,
-  // proving the labels are driven by `--include-component-metadata`.
-  it('does not attach hash labels without the flag', async () => {
+  // Control: without the flag the same project must not produce hash or
+  // distribution:url labels, proving the labels are driven by
+  // `--include-component-metadata`.
+  it('does not attach hash or distribution:url labels without the flag', async () => {
     const project = await createProjectFromFixture('maven-print-graph');
 
     execFileSync('mvn', ['dependency:resolve'], {
@@ -96,5 +117,91 @@ describe('`snyk test --include-component-metadata` (maven)', () => {
     expect(code).toEqual(0);
     expect(stdout).toContain('DepGraph data:');
     expect(hashLabelKeys(stdout)).toHaveLength(0);
+    expect(distributionUrlLabels(stdout)).toHaveLength(0);
+  });
+
+  // Regression test: a repository can be configured with basic-auth
+  // credentials embedded directly in its URL (e.g.
+  // `https://user:secret@example.invalid/maven2`) rather than via a
+  // settings.xml <server> block. `mvn dependency:list-repositories` prints
+  // that URL verbatim, so those credentials must never end up in the
+  // distribution:url label / downstream SBOM externalReferences.
+  //
+  // The `io.snyk.example:creds-dep` dependency doesn't exist on any real
+  // repository, so rather than resolving it for real (which would need a
+  // live server that tolerates arbitrary credentials) we hand-construct its
+  // local .m2 entry — jar, pom, and the `_remote.repositories` record —
+  // exactly what `mvn dependency:resolve` would have written had the
+  // artifact actually come from `creds-repo`. `dependency:tree` and
+  // `dependency:list-repositories` need nothing beyond the project's own
+  // pom.xml and that local cache to succeed, so the whole test runs
+  // hermetically, without ever contacting `example.invalid`.
+  //
+  it('does not leak repository URL credentials into the distribution:url label', async () => {
+    const project = await createProjectFromFixture('maven-creds-repo');
+
+    const repoDir = path.join(
+      os.homedir(),
+      '.m2',
+      'repository',
+      'io',
+      'snyk',
+      'example',
+      'creds-dep',
+      '1.0',
+    );
+    fs.mkdirSync(repoDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(repoDir, 'creds-dep-1.0.pom'),
+      [
+        '<project xmlns="http://maven.apache.org/POM/4.0.0">',
+        '  <modelVersion>4.0.0</modelVersion>',
+        '  <groupId>io.snyk.example</groupId>',
+        '  <artifactId>creds-dep</artifactId>',
+        '  <version>1.0</version>',
+        '  <packaging>jar</packaging>',
+        '</project>',
+        '',
+      ].join('\n'),
+    );
+    fs.writeFileSync(
+      path.join(repoDir, 'creds-dep-1.0.jar'),
+      'fake jar contents',
+    );
+    fs.writeFileSync(
+      path.join(repoDir, '_remote.repositories'),
+      '#NOTE: internal Maven Resolver file\n' +
+        'creds-dep-1.0.pom>creds-repo=\n' +
+        'creds-dep-1.0.jar>creds-repo=\n',
+    );
+
+    try {
+      const { code, stdout } = await runSnykCLI(
+        'test --include-component-metadata --print-graph',
+        {
+          cwd: project.path(),
+          env,
+        },
+      );
+
+      expect(code).toEqual(0);
+      expect(stdout).toContain('DepGraph data:');
+
+      const urls = distributionUrlLabels(stdout);
+      expect(
+        urls.some((url) =>
+          url.endsWith('/io/snyk/example/creds-dep/1.0/creds-dep-1.0.jar'),
+        ),
+      ).toBe(true);
+
+      // The credentialed repo's URL must appear stripped of its userinfo
+      // (`user:secret@`), on every emitted label.
+      for (const url of urls) {
+        expect(url).not.toContain('user:secret');
+        expect(url).not.toMatch(/:\/\/[^/]*@/);
+      }
+    } finally {
+      fs.rmSync(path.dirname(repoDir), { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps `snyk-mvn-plugin` to 4.9.1, pulling in [snyk/snyk-mvn-plugin#224](https://github.com/snyk/snyk-mvn-plugin/pull/224) and [snyk/snyk-mvn-plugin#228](https://github.com/snyk/snyk-mvn-plugin/pull/228). With this bump, dep-graph nodes for Maven projects carry a `distribution:url` label alongside the existing `hash:<algorithm>` labels when `--include-component-metadata` is set.

Extends `test/jest/acceptance/snyk-test/maven-include-component-metadata.spec.ts` to assert the new `distribution:url` label is present when the flag is set and absent otherwise, matching the existing hash-label coverage.

Review on the initial 4.9.0 bump asked for a regression test covering a repository configured with credentials embedded in its URL (e.g. `https://user:secret@example.com/maven2`). Chasing that down surfaced a real leak: `mvn dependency:list-repositories` prints such a URL verbatim, and nothing in `snyk-mvn-plugin` stripped it before building `distribution:url` — those credentials would have flowed straight into the label and downstream SBOM `externalReferences`. Fixed upstream in snyk-mvn-plugin#228 (strips embedded userinfo via the `URL` class, mirroring the same guard `nodejs-lockfile-parser` already applies to npm/yarn resolved URLs) and released as 4.9.1, which this PR now pins. The new regression test hand-constructs a local `.m2` entry for a repository with a credentialed URL and asserts the emitted label contains no userinfo.

## Where should the reviewer start?

`test/jest/acceptance/snyk-test/maven-include-component-metadata.spec.ts` — the first two `it` blocks cover both label kinds (hash and distribution:url) as before; a third covers the credentialed-repository regression. That last test runs hermetically (no live server): the dependency doesn't exist on any real repository, so its `.m2` entry (jar, pom, `_remote.repositories`) is hand-constructed rather than resolved for real, since `dependency:tree`/`dependency:list-repositories` need nothing beyond the project's own pom.xml and that local cache to succeed. The assertion for the original two tests checks the artifact path suffix (`/axis/axis/1.4/axis-1.4.jar`) rather than a specific repository host, since Maven Central rate limiting may require swapping the resolved repository source later.

## How should this be manually tested?

Can be tested against pre-prod environments:
```
mvn dependency:resolve   # in a maven fixture project, to populate ~/.m2
❯ ~/.treehouse/cli-fceb68/1/cli/binary-releases/snyk-macos-arm64 sbom --format=cyclonedx1.6+json
{"$schema":"http://cyclonedx.org/schema/bom-1.6.schema.json","bomFormat":"CycloneDX","specVersion":"1.6","serialNumber":"urn:uuid:fac8f296-1136-4390-889f-0a29ff0da808","version":1,"metadata":{"timestamp":"2026-07-21T15:47:55Z","tools":{"components":[{"type":"application","author":"Snyk","name":"snyk-cli","version":"1.1307.0-dev.255427ed99b9b02a5b297a7ea98927e7b12e6ac7"}],"services":[{"provider":{"name":"Snyk"},"name":"SBOM Export API","version":"v1.131.0"}]},"component":{"bom-ref":"1-io.snyk.os-managed:bad-resolution@1.0.0","type":"application","name":"io.snyk.os-managed:bad-resolution","version":"1.0.0","purl":"pkg:maven/io.snyk.os-managed/bad-resolution@1.0.0","properties":[{"name":"snyk:maven:build_scope","value":"unknown"}]}},"components":[{"bom-ref":"2-org.jboss.resteasy:resteasy-core@6.2.12.Final","type":"library","group":"org.jboss.resteasy","name":"org.jboss.resteasy:resteasy-core","version":"6.2.12.Final","hashes":[{"alg":"SHA-1","content":"45c4596118651373c5c854c69ef1cfa1feaad3cc"}],"licenses":[{"expression":"Apache-2.0"}],"purl":"pkg:maven/org.jboss.resteasy/resteasy-core@6.2.12.Final","externalReferences":[{"url":"https://repo.maven.apache.org/maven2/org/jboss/resteasy/resteasy-core/6.2.12.Final/resteasy-core-6.2.12.Final.jar","type":"distribution"}],"properties":[{"name":"snyk:maven:build_scope","value":"compile"}]}]}
```
(truncated — see original PR description in history for the full sample output)

## What's the product update that needs to be communicated to CLI users?

N/A — not public user-facing.

## Risk assessment (Low | Medium | High)?

Low. Additive label only; existing hash-label behavior and dep-graph shape are unchanged (verified upstream in snyk-mvn-plugin#224). The 4.9.1 patch is itself low-risk and behavior-preserving for any non-credentialed URL (verified: snyk-mvn-plugin's existing functional suite passes unchanged); it only strips userinfo when present.

## What are the relevant tickets?

[CMPA-604](https://snyksec.atlassian.net/browse/CMPA-604)

[CMPA-604]: https://snyksec.atlassian.net/browse/CMPA-604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ