### PR TITLE
test: remove no-op INTERNAL_OAUTH_ALLOWED_HOSTS override

### DIFF
--- a/test/jest/acceptance/auth.spec.ts
+++ b/test/jest/acceptance/auth.spec.ts
@@ -185,8 +185,6 @@ describe('Auth', () => {
           ...env,
           // SNYK_API will actually be used up until the auth workflow
           SNYK_API: 'https://api.this.should.not.be.used.invalid',
-          // override the auth host regex check, else fakeServerHost will be rejected
-          INTERNAL_OAUTH_ALLOWED_HOSTS: '.*',
         },
       });
 
@@ -195,8 +193,6 @@ describe('Auth', () => {
       const configCmd = await runSnykCLI('config get api', {
         env: {
           ...env,
-          // override the auth host regex check, else fakeServerHost will be rejected
-          INTERNAL_OAUTH_ALLOWED_HOSTS: '.*',
         },
       });
       expect(configCmd.code).toEqual(0);
@@ -211,8 +207,6 @@ describe('Auth', () => {
       const authCmd = await runSnykCLI(`auth ${pat} -d`, {
         env: {
           ...envBackup,
-          // override the auth host regex check, else fakeServerHost will be rejected
-          INTERNAL_OAUTH_ALLOWED_HOSTS: '.*',
         },
       });
 
@@ -221,8 +215,6 @@ describe('Auth', () => {
       const configCmd = await runSnykCLI('config get api', {
         env: {
           ...envBackup,
-          // override the auth host regex check, else fakeServerHost will be rejected
-          INTERNAL_OAUTH_ALLOWED_HOSTS: '.*',
         },
       });
       expect(configCmd.code).toEqual(0);

--- a/test/jest/acceptance/pat.spec.ts
+++ b/test/jest/acceptance/pat.spec.ts
@@ -21,8 +21,6 @@ describe('PAT', () => {
       ...process.env,
       SNYK_TOKEN: pat,
       SNYK_DISABLE_ANALYTICS: '1',
-      // override the auth host regex check, else host will be rejected
-      INTERNAL_OAUTH_ALLOWED_HOSTS: '.*',
     };
 
     server = fakeServer(apiPath, env.SNYK_TOKEN);


### PR DESCRIPTION
## What does this PR do?

Removes the no-op `INTERNAL_OAUTH_ALLOWED_HOSTS: '.*'` env override (and its misleading comment) from `test/jest/acceptance/auth.spec.ts` (×4) and `pat.spec.ts` (×1).

Verified no-op: the PAT auth path (`tokenauthenticator.go`) does no allowed-host validation at all; that check only runs in GAF's `modifyTokenUrl` (OAuth instance-redirect), which `snyk auth <pat>` never invokes. Pure test tidy-up, no behavior change.

Related to [IDE-1896](https://snyksec.atlassian.net/browse/IDE-1896) (GAF auth-host validation rework: [go-application-framework#662](https://github.com/snyk/go-application-framework/pull/662)) but **independent of that stack** — no dependency, mergeable any time.

Note: `cli-remy-test-internal` mirrors these same spec files and needs the equivalent deletions as a separate follow-up (tracked in IDE-1896).

## Where should the reviewer start?

`test/jest/acceptance/auth.spec.ts` and `test/jest/acceptance/pat.spec.ts` — diff is deletion-only.

## How should this be manually tested?

N/A — test-only change; existing acceptance suite covers it.

## What's the product update that needs to be communicated to CLI users?

None — internal test cleanup, no user-facing change.

<!---
## Risk assessment (Low | Medium | High)?
Low — deletes a no-op test env var, no production code touched.
--->

[IDE-1896]: https://snyksec.atlassian.net/browse/IDE-1896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ