### PR TITLE
chore: bump snyk-docker-plugin to 9.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "semver": "^6.0.0",
         "snyk-config": "^5.0.0",
         "snyk-cpp-plugin": "^2.24.3",
-        "snyk-docker-plugin": "^9.16.0",
+        "snyk-docker-plugin": "9.18.0",
         "snyk-go-plugin": "2.1.2",
         "snyk-gradle-plugin": "7.0.0",
         "snyk-module": "3.1.0",
@@ -19860,9 +19860,9 @@
       "license": "ISC"
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "9.16.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-9.16.0.tgz",
-      "integrity": "sha512-TAmv5nHRocG0cnbvVJXOve2ss3CwDt/i0O3B4Mytx+8bhGNfkmntqkPANftMU9YQDKYkrMyJo4v40KxTqPL2cQ==",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-9.18.0.tgz",
+      "integrity": "sha512-nc0IzCs82FEFV4y6FIF8aMk8RCbuWvNoqnaBbpZ8qFH3ntZzMsRDzUfsWiT7/pUp9rL/s7GVDJUYfy+0NiFPmg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "semver": "^6.0.0",
     "snyk-config": "^5.0.0",
     "snyk-cpp-plugin": "^2.24.3",
-    "snyk-docker-plugin": "^9.16.0",
+    "snyk-docker-plugin": "9.18.0",
     "snyk-go-plugin": "2.1.2",
     "snyk-gradle-plugin": "7.0.0",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
## What

Bumps `snyk-docker-plugin` from 9.7.0 to **9.18.0**.

## Why

9.18.0 includes provenance-attestation extraction for container images (SLSA/BuildKit provenance → `provenanceMetadata` fact, including base64 Dockerfile contents). Bumping the plugin lets the CLI emit these facts so they flow to Registry → container-monitor-data / assets-api. Gated downstream by the `surface-provenance-attestations` release flag, so no behavior change until the flag is enabled.

Part of [PRIM-100](https://snyksec.atlassian.net/browse/PRIM-100).

## Notes

- Dependency + lockfile bump only; no source changes.
- Exact pin preserved to match existing convention.

[PRIM-100]: https://snyksec.atlassian.net/browse/PRIM-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ