### PR TITLE
Chore/add aibom enrich flag

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -208,7 +208,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.3.2 // indirect
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260715092951-4f8fa1b9886c // indirect
-	github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603 // indirect
+	github.com/snyk/cli-extension-ai-bom v0.0.0-20260721084000-da8dc26c77f2 // indirect
 	github.com/snyk/cli-extension-dep-graph/v2 v2.7.2 // indirect
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 // indirect
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -569,8 +569,8 @@ github.com/snyk/ambient-canary v0.0.0-20260722064253-fba619a134a9 h1:d69mS5cTIs1
 github.com/snyk/ambient-canary v0.0.0-20260722064253-fba619a134a9/go.mod h1:n6GYt41xPhThEEEl/0RZuWpTX68iv6k+6HZ94uGNDGE=
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260715092951-4f8fa1b9886c h1:of6wc3Cq5Ta6BRzdMgSYphJRp0TsRjILV3Dzi6cGjg8=
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260715092951-4f8fa1b9886c/go.mod h1:g1qxNvAl2Qb0V4UJivop+hCqehHVqzB0taEjwTm6VlU=
-github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603 h1:uZyw9OvOGCMFloZy8Fyu6l4K5y77o4k0KdxHuUKAp8M=
-github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603/go.mod h1:RnMP+tFTeKygfXSx7z+heyMZoOps67u5HFytjptHjuk=
+github.com/snyk/cli-extension-ai-bom v0.0.0-20260721084000-da8dc26c77f2 h1:fYTWYiCqw+NqeETMP/0TdVKjCHrHRng8M6+nxvrmluo=
+github.com/snyk/cli-extension-ai-bom v0.0.0-20260721084000-da8dc26c77f2/go.mod h1:axE+HO8U9CIcTjQ7k7BOLgdyZfNGqMn5QvZ0aIkUY4U=
 github.com/snyk/cli-extension-dep-graph/v2 v2.7.2 h1:+D/r8zDdREbrZs1EZ4DmVzEf7oMHA2rRozhuaVFyg8U=
 github.com/snyk/cli-extension-dep-graph/v2 v2.7.2/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSoQL0zYyFcGQjEPZcQgDkzM5PcgIHlIgzRuhg=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.34.0
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260715092951-4f8fa1b9886c
-	github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603
+	github.com/snyk/cli-extension-ai-bom v0.0.0-20260721084000-da8dc26c77f2
 	github.com/snyk/cli-extension-dep-graph/v2 v2.7.2
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -525,8 +525,8 @@ github.com/skeema/knownhosts v1.3.2 h1:EDL9mgf4NzwMXCTfaxSD/o/a5fxDw/xL9nkU28Jjd
 github.com/skeema/knownhosts v1.3.2/go.mod h1:bEg3iQAuw+jyiw+484wwFJoKSLwcfd7fqRy+N0QTiow=
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260715092951-4f8fa1b9886c h1:of6wc3Cq5Ta6BRzdMgSYphJRp0TsRjILV3Dzi6cGjg8=
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260715092951-4f8fa1b9886c/go.mod h1:g1qxNvAl2Qb0V4UJivop+hCqehHVqzB0taEjwTm6VlU=
-github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603 h1:uZyw9OvOGCMFloZy8Fyu6l4K5y77o4k0KdxHuUKAp8M=
-github.com/snyk/cli-extension-ai-bom v0.0.0-20260319140413-ac7392950603/go.mod h1:RnMP+tFTeKygfXSx7z+heyMZoOps67u5HFytjptHjuk=
+github.com/snyk/cli-extension-ai-bom v0.0.0-20260721084000-da8dc26c77f2 h1:fYTWYiCqw+NqeETMP/0TdVKjCHrHRng8M6+nxvrmluo=
+github.com/snyk/cli-extension-ai-bom v0.0.0-20260721084000-da8dc26c77f2/go.mod h1:axE+HO8U9CIcTjQ7k7BOLgdyZfNGqMn5QvZ0aIkUY4U=
 github.com/snyk/cli-extension-dep-graph/v2 v2.7.2 h1:+D/r8zDdREbrZs1EZ4DmVzEf7oMHA2rRozhuaVFyg8U=
 github.com/snyk/cli-extension-dep-graph/v2 v2.7.2/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSoQL0zYyFcGQjEPZcQgDkzM5PcgIHlIgzRuhg=

--- a/test/jest/acceptance/snyk-aibom/aibom.spec.ts
+++ b/test/jest/acceptance/snyk-aibom/aibom.spec.ts
@@ -32,6 +32,16 @@ function aiBomRestEndpointRequests(requests: Request[]): string[] {
   return res;
 }
 
+function getCreateAIBOMRequests(requests: Request[]): Request[] {
+  return requests.filter(
+    (request) =>
+      request.method === 'POST' &&
+      request.url.includes('/ai_boms') &&
+      !request.url.includes('/ai_boms/upload') &&
+      !request.url.includes('cli_policy_test'),
+  );
+}
+
 describe('snyk aibom (mocked servers only)', () => {
   let server: ReturnType<typeof fakeServer>;
   let envWithoutAuth: Record<string, string>;
@@ -136,6 +146,21 @@ describe('snyk aibom (mocked servers only)', () => {
       bomFormat: 'CycloneDX',
     });
     expect(bom.components.length).toBeGreaterThan(1);
+  });
+
+  test('`aibom` passes enriched=true when --enriched flag is set', async () => {
+    expect(server.getRequests().length).toEqual(0);
+    const { code } = await runSnykCLI(
+      `aibom ${pythonChatbotProject} --experimental --enriched`,
+      {
+        env,
+      },
+    );
+    expect(code).toEqual(0);
+
+    const createRequests = getCreateAIBOMRequests(server.getRequests());
+    expect(createRequests.length).toBeGreaterThanOrEqual(2);
+    expect(createRequests[1].url).toContain('enriched=true');
   });
 
   test('`aibom` uses upload endpoint if --upload flag is set', async () => {


### PR DESCRIPTION
## Pull Request Submission Checklist

- [X] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [X] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [X] Includes detailed description of changes
- [X] Contains risk assessment (Low | Medium | High)
- [X] Highlights breaking API changes (if applicable)
- [X] Links to automated tests covering new functionality
- [X] Includes manual testing instructions (if necessary)
- [X] Updates relevant GitBook documentation (PR link: [here](https://github.com/snyk/user-docs/pull/1535))
- [X] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps `cli-extension-ai-bom` to expose the new `--enriched` flag on `snyk aibom` and `snyk aibom test`, wiring it through to the AI-BOM API as `enriched=true`.

Changes:
- Upgrade `github.com/snyk/cli-extension-ai-bom` to `v0.0.0-20260721084000-da8dc26c77f2` in `cliv2/go.mod` and `cliv2-private/go.mod`
- Add an acceptance test asserting `snyk aibom --enriched` sends `enriched=true` on the Create AI-BOM request

## Where should the reviewer start?

1. `test/jest/acceptance/snyk-aibom/aibom.spec.ts` — new test for `--enriched` flag wiring
2. `cliv2/go.mod` — dependency bump (the flag implementation lives in `cli-extension-ai-bom`)

## How should this be manually tested?

```sh
make build
./binary-releases/snyk-linux-amd64 aibom test/fixtures/ai-bom/python-chatbot --experimental --enriched
./binary-releases/snyk-linux-amd64 aibom test test/fixtures/ai-bom/python-chatbot --experimental --enriched
