### PR TITLE
chore: bundle boolean@3.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,8 @@ $(BINARY_WRAPPER_DIR)/src/generated/sha256sums.txt:
 
 .PHONY: build-binary-wrapper
 build-binary-wrapper: pre-build-binary-wrapper $(BINARY_WRAPPER_DIR)/src/generated/version $(BINARY_WRAPPER_DIR)/src/generated/sha256sums.txt
+	@echo "-- Installing Typescript Binary Wrapper dependencies"
+	@cd $(BINARY_WRAPPER_DIR); npm ci --ignore-scripts
 	@echo "-- Building Typescript Binary Wrapper ($(BINARY_WRAPPER_DIR)/dist/)"
 	@cd $(BINARY_WRAPPER_DIR); npm run build
 

--- a/scripts/build-ts-binary-wrapper-locally.go
+++ b/scripts/build-ts-binary-wrapper-locally.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -49,26 +50,26 @@ func getProjectRoot() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	
+
 	// Check if we're in the scripts directory
 	if filepath.Base(scriptDir) == "scripts" {
 		return filepath.Dir(scriptDir), nil
 	}
-	
+
 	// If not, try to find the project root by looking for key files
 	currentDir, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("failed to get current directory: %w", err)
 	}
-	
+
 	// Walk up the directory tree to find the project root
 	for dir := currentDir; dir != filepath.Dir(dir); dir = filepath.Dir(dir) {
-		if fileExists(filepath.Join(dir, "package.json")) && 
-		   fileExists(filepath.Join(dir, "Makefile")) {
+		if fileExists(filepath.Join(dir, "package.json")) &&
+			fileExists(filepath.Join(dir, "Makefile")) {
 			return dir, nil
 		}
 	}
-	
+
 	return "", fmt.Errorf("could not find project root (no package.json and Makefile found)")
 }
 
@@ -82,19 +83,19 @@ func getScriptDir() (string, error) {
 		}
 		return filepath.Dir(filename), nil
 	}
-	
+
 	// If running as compiled binary, use os.Executable
 	executable, err := os.Executable()
 	if err != nil {
 		return "", fmt.Errorf("failed to get executable path: %w", err)
 	}
-	
+
 	// Resolve symlinks to get the actual path
 	resolvedPath, err := filepath.EvalSymlinks(executable)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve symlinks: %w", err)
 	}
-	
+
 	return filepath.Dir(resolvedPath), nil
 }
 
@@ -119,23 +120,27 @@ func dirExists(path string) bool {
 // Function to check if required tools are available
 func checkRequirements(projectRoot string) error {
 	logInfo("Checking requirements...")
-	
+
 	if !isCommandAvailable("npm") {
 		return fmt.Errorf("npm is not installed or not in PATH")
 	}
-	
+
 	if !isCommandAvailable("make") {
 		return fmt.Errorf("make is not installed or not in PATH")
 	}
-	
+
+	if !isCommandAvailable("git") {
+		return fmt.Errorf("git is not installed or not in PATH")
+	}
+
 	if !fileExists(filepath.Join(projectRoot, "package.json")) {
 		return fmt.Errorf("package.json not found in project root")
 	}
-	
+
 	if !fileExists(filepath.Join(projectRoot, "Makefile")) {
 		return fmt.Errorf("Makefile not found in project root")
 	}
-	
+
 	logSuccess("All requirements satisfied")
 	return nil
 }
@@ -143,11 +148,11 @@ func checkRequirements(projectRoot string) error {
 // Function to validate the project structure
 func validateProject(projectRoot string) error {
 	logInfo("Validating project structure...")
-	
+
 	if !dirExists(projectRoot) {
 		return fmt.Errorf("project root directory not found: %s", projectRoot)
 	}
-	
+
 	logSuccess("Project structure validated")
 	return nil
 }
@@ -157,35 +162,156 @@ func runCommand(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	
+
 	logInfo(fmt.Sprintf("Running: %s %s", name, strings.Join(args, " ")))
-	
+
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("command failed: %w", err)
 	}
-	
+
 	return nil
 }
 
 // Write content to a file
 func writeFile(path, content string) error {
 	logInfo(fmt.Sprintf("Creating file: %s", path))
-	
+
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		return fmt.Errorf("failed to write file %s: %w", path, err)
 	}
-	
+
 	return nil
 }
 
 // Create directory if it doesn't exist
 func createDir(path string) error {
 	logInfo(fmt.Sprintf("Creating directory: %s", path))
-	
+
 	if err := os.MkdirAll(path, 0755); err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", path, err)
 	}
-	
+
+	return nil
+}
+
+// Read the "version" field from a package.json / package-lock.json byte slice
+func readManifestVersion(data []byte) (string, error) {
+	var m struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return "", err
+	}
+	return m.Version, nil
+}
+
+// resetWrapperVersion rolls the ts-binary-wrapper version stamp back to the
+// repo's canonical placeholder. `make prepack` runs `npm version <ver>` against
+// the wrapper, and a second build then fails with "Version not changed". Unlike
+// the root manifests, the wrapper package.json may hold in-progress edits, so we
+// must NOT git-checkout it — we only rewrite the single "version" field,
+// preserving everything else.
+//
+// The baseline is the committed *root* version (reliably "1.0.0-monorepo"), not
+// the wrapper's own HEAD: a prior build's stamp can get accidentally committed
+// into the wrapper manifest, in which case the wrapper's own HEAD is already
+// polluted and useless as a reset target.
+func resetWrapperVersion(projectRoot string) error {
+	wrapperDir := filepath.Join(projectRoot, "ts-binary-wrapper")
+	pkgPath := filepath.Join(wrapperDir, "package.json")
+
+	curData, err := os.ReadFile(pkgPath)
+	if err != nil {
+		return err
+	}
+	curVer, err := readManifestVersion(curData)
+	if err != nil {
+		return err
+	}
+
+	baseData, err := exec.Command("git", "-C", projectRoot, "show", "HEAD:package.json").Output()
+	if err != nil {
+		return fmt.Errorf("failed to read committed root version: %w", err)
+	}
+	baseVer, err := readManifestVersion(baseData)
+	if err != nil {
+		return err
+	}
+
+	if curVer == baseVer {
+		return nil // nothing to roll back
+	}
+
+	logInfo(fmt.Sprintf("Resetting ts-binary-wrapper version %s -> %s (preserving other edits)", curVer, baseVer))
+	oldField := fmt.Sprintf("\"version\": %q", curVer)
+	newField := fmt.Sprintf("\"version\": %q", baseVer)
+	for _, f := range []string{pkgPath, filepath.Join(wrapperDir, "package-lock.json")} {
+		b, err := os.ReadFile(f)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return err
+		}
+		if err := os.WriteFile(f, []byte(strings.ReplaceAll(string(b), oldField, newField)), 0644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// resetPrepackResidue makes the build re-runnable by undoing state a previous
+// run may have left behind. Two traps:
+//
+//  1. `make prepack` is NOT idempotent: it stamps the release version into every
+//     manifest and writes a `prepack` marker file, but never rolls back. A second
+//     run hits "npm error Version not changed". We can't use `make clean-prepack`
+//     because it git-checkouts the ts-binary-wrapper manifests too, discarding any
+//     in-progress wrapper edits. So: restore the root + workspace manifests from
+//     git (they are pure prepack targets with no hand edits), reset only the
+//     wrapper's version field, and remove the marker.
+//
+//  2. tsconfig.settings.json sets composite:true (incremental builds). A stale
+//     tsconfig.tsbuildinfo makes tsc skip emitting, shipping an empty wrapper_dist
+//     whose install then fails with "Cannot find module wrapper_dist/bootstrap.js".
+//     Clearing it forces a fresh emit.
+func resetPrepackResidue(projectRoot string) error {
+	markerPath := filepath.Join(projectRoot, "prepack")
+	if fileExists(markerPath) {
+		logInfo("Detected leftover 'make prepack' state; rolling it back...")
+
+		// Root + workspace manifests are pure prepack targets in this workflow
+		// (version stamp + dependency pruning) — restore them from git.
+		rootManifests := []string{
+			"package.json", "package-lock.json",
+			"packages/snyk-fix/package.json", "packages/snyk-fix/package-lock.json",
+			"packages/snyk-protect/package.json", "packages/snyk-protect/package-lock.json",
+		}
+		checkoutArgs := []string{"-C", projectRoot, "checkout", "--"}
+		for _, m := range rootManifests {
+			if fileExists(filepath.Join(projectRoot, m)) {
+				checkoutArgs = append(checkoutArgs, m)
+			}
+		}
+		if err := runCommand("git", checkoutArgs...); err != nil {
+			return fmt.Errorf("failed to restore root manifests: %w", err)
+		}
+
+		if err := resetWrapperVersion(projectRoot); err != nil {
+			return fmt.Errorf("failed to reset wrapper version: %w", err)
+		}
+
+		if err := os.Remove(markerPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove prepack marker: %w", err)
+		}
+	}
+
+	// Always clear the incremental TypeScript build cache so tsc re-emits.
+	tsbuildinfo := filepath.Join(projectRoot, "ts-binary-wrapper", "tsconfig.tsbuildinfo")
+	if err := os.Remove(tsbuildinfo); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to clear tsconfig.tsbuildinfo: %w", err)
+	}
+
 	return nil
 }
 
@@ -193,34 +319,42 @@ func createDir(path string) error {
 func main() {
 	logInfo("Starting build process...")
 	logWarning(fmt.Sprintf("This script assumes %s, please change it if needed!", platform))
-	
+
 	// Get project root
 	projectRoot, err := getProjectRoot()
 	if err != nil {
 		logError(fmt.Sprintf("Failed to get project root: %v", err))
 		os.Exit(1)
 	}
-	
+
 	logInfo(fmt.Sprintf("Project root determined: %s", projectRoot))
-	
+
 	// Validate environment
 	if err := validateProject(projectRoot); err != nil {
 		logError(err.Error())
 		os.Exit(1)
 	}
-	
+
 	if err := checkRequirements(projectRoot); err != nil {
 		logError(err.Error())
 		os.Exit(1)
 	}
-	
+
 	// Change to project root directory
 	logInfo(fmt.Sprintf("Changing to project root: %s", projectRoot))
 	if err := os.Chdir(projectRoot); err != nil {
 		logError(fmt.Sprintf("Failed to change directory: %v", err))
 		os.Exit(1)
 	}
-	
+
+	// Roll back any leftover state from a previous build so this run is
+	// idempotent (prepack version stamps + stale TypeScript build cache).
+	logInfo("Resetting build residue from previous runs...")
+	if err := resetPrepackResidue(projectRoot); err != nil {
+		logError(err.Error())
+		os.Exit(1)
+	}
+
 	// Install dependencies
 	logInfo("Installing npm dependencies...")
 	if err := runCommand("npm", "ci"); err != nil {
@@ -228,21 +362,21 @@ func main() {
 		os.Exit(1)
 	}
 	logSuccess("Dependencies installed successfully")
-	
+
 	// Create binary-releases directory
 	binaryReleasesDir := "binary-releases"
 	if err := createDir(binaryReleasesDir); err != nil {
 		logError(err.Error())
 		os.Exit(1)
 	}
-	
+
 	// Create version file
 	versionFile := filepath.Join(binaryReleasesDir, "version")
 	if err := writeFile(versionFile, version); err != nil {
 		logError(err.Error())
 		os.Exit(1)
 	}
-	
+
 	// Create SHA256 file
 	sha256File := filepath.Join(binaryReleasesDir, platform+".sha256")
 	sha256Content := fmt.Sprintf("%s  %s", sha256Hash, platform)
@@ -250,7 +384,7 @@ func main() {
 		logError(err.Error())
 		os.Exit(1)
 	}
-	
+
 	// Build the binary
 	logInfo("Building binary release...")
 	if err := runCommand("make", "binary-releases/snyk.tgz"); err != nil {
@@ -258,4 +392,4 @@ func main() {
 		os.Exit(1)
 	}
 	logSuccess("Binary build completed successfully")
-} 
+}

--- a/ts-binary-wrapper/package-lock.json
+++ b/ts-binary-wrapper/package-lock.json
@@ -7,6 +7,11 @@
     "": {
       "name": "snyk",
       "version": "1.0.0-monorepo",
+      "bundleDependencies": [
+        "global-agent",
+        "roarr",
+        "boolean"
+      ],
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1314,7 +1319,8 @@
     "node_modules/boolean": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "inBundle": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -1590,6 +1596,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
       "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+      "inBundle": true,
       "dependencies": {
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
@@ -1613,7 +1620,8 @@
     "node_modules/detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "inBundle": true
     },
     "node_modules/diff-sequences": {
       "version": "29.3.1",
@@ -1660,7 +1668,8 @@
     "node_modules/es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "inBundle": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -1804,7 +1813,8 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "inBundle": true
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -1828,6 +1838,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
       "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "inBundle": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -1882,6 +1893,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "inBundle": true,
       "dependencies": {
         "boolean": "^3.0.1",
         "es6-error": "^4.1.1",
@@ -1898,6 +1910,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "inBundle": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -1909,6 +1922,7 @@
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "inBundle": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1922,7 +1936,8 @@
     "node_modules/global-agent/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "inBundle": true
     },
     "node_modules/globals": {
       "version": "11.12.0",
@@ -1937,6 +1952,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
       "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "inBundle": true,
       "dependencies": {
         "define-properties": "^1.1.3"
       },
@@ -1957,6 +1973,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "inBundle": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -1977,6 +1994,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
       "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "inBundle": true,
       "dependencies": {
         "get-intrinsic": "^1.1.1"
       },
@@ -1988,6 +2006,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "inBundle": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2860,7 +2879,8 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "inBundle": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -2964,6 +2984,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
       "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "inBundle": true,
       "dependencies": {
         "escape-string-regexp": "^4.0.0"
       },
@@ -2975,6 +2996,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "inBundle": true,
       "engines": {
         "node": ">=10"
       },
@@ -3070,6 +3092,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "inBundle": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -3359,6 +3382,7 @@
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
       "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "inBundle": true,
       "dependencies": {
         "boolean": "^3.0.1",
         "detect-node": "^2.0.4",
@@ -3374,7 +3398,8 @@
     "node_modules/roarr/node_modules/sprintf-js": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+      "inBundle": true
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -3388,12 +3413,14 @@
     "node_modules/semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "inBundle": true
     },
     "node_modules/serialize-error": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "inBundle": true,
       "dependencies": {
         "type-fest": "^0.13.1"
       },
@@ -3408,6 +3435,7 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "inBundle": true,
       "engines": {
         "node": ">=10"
       },

--- a/ts-binary-wrapper/package.json
+++ b/ts-binary-wrapper/package.json
@@ -52,5 +52,10 @@
   "dependencies": {
     "@sentry/node": "^7.36.0",
     "global-agent": "^3.0.0"
-  }
+  },
+  "bundleDependencies": [
+    "global-agent",
+    "roarr",
+    "boolean"
+  ]
 }


### PR DESCRIPTION
chore: add npm ci to ts-binary-wrapper make process

## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

This PR aims to remove the deprecation warning when installing the CLI from npm.

Bundles boolean, and by extension roarr, and global-agent.

## How should this be manually tested?

```
go run ./scripts/build-ts-binary-wrapper-locally.go
npm npm install -g ./binary-releases/snyk.tgz
```

## What's the product update that needs to be communicated to CLI users?
Nothing.

## What are the relevant tickets?
[CLI-1417](https://snyksec.atlassian.net/browse/CLI-1417)

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?



## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->


[CLI-1417]: https://snyksec.atlassian.net/browse/CLI-1417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ