### PR TITLE
chore(language-server): integrate LS

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -223,7 +223,7 @@ require (
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
-	github.com/snyk/snyk-ls v0.0.0-20260722115044-83ac40a0e148 // indirect
+	github.com/snyk/snyk-ls v0.0.0-20260723155019-176f7433c014 // indirect
 	github.com/snyk/studio-mcp v1.15.1 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -601,8 +601,8 @@ github.com/snyk/remy-cli-extension v1.30.0 h1:F0X8M23uBNFO/azGltrMEJLB7d1/lzqYOR
 github.com/snyk/remy-cli-extension v1.30.0/go.mod h1:ez/NUC+xzLRJB7+H0GTUjv4O1x2U+UWArSLdLVCcY3w=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260722115044-83ac40a0e148 h1:p75XYdOikFlahePjRL+0ZmBagggZaA1ODqpFpoTOVPs=
-github.com/snyk/snyk-ls v0.0.0-20260722115044-83ac40a0e148/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
+github.com/snyk/snyk-ls v0.0.0-20260723155019-176f7433c014 h1:tBVdICJ2LT032FJ2ebSiPygn5O9cK4ghVoIP3CNMs18=
+github.com/snyk/snyk-ls v0.0.0-20260723155019-176f7433c014/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
 github.com/snyk/studio-mcp v1.15.1 h1:g0dw46B+EOQjd7LWa+O1t9SEzgzlcYFxbgo5cp2xaFc=
 github.com/snyk/studio-mcp v1.15.1/go.mod h1:3ZISZCgorkGg/iLQrryvmP34Db4KkvtfAARi7vMqM/4=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/snyk/go-application-framework v0.7.3
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20260722115044-83ac40a0e148
+	github.com/snyk/snyk-ls v0.0.0-20260723155019-176f7433c014
 	github.com/snyk/studio-mcp v1.15.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -555,8 +555,8 @@ github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhk
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260722115044-83ac40a0e148 h1:p75XYdOikFlahePjRL+0ZmBagggZaA1ODqpFpoTOVPs=
-github.com/snyk/snyk-ls v0.0.0-20260722115044-83ac40a0e148/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
+github.com/snyk/snyk-ls v0.0.0-20260723155019-176f7433c014 h1:tBVdICJ2LT032FJ2ebSiPygn5O9cK4ghVoIP3CNMs18=
+github.com/snyk/snyk-ls v0.0.0-20260723155019-176f7433c014/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
 github.com/snyk/studio-mcp v1.15.1 h1:g0dw46B+EOQjd7LWa+O1t9SEzgzlcYFxbgo5cp2xaFc=
 github.com/snyk/studio-mcp v1.15.1/go.mod h1:3ZISZCgorkGg/iLQrryvmP34Db4KkvtfAARi7vMqM/4=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit 176f7433c014b571c7cdd0a682281c1d4117e014
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Thu Jul 23 16:50:19 2026 +0100

    fix: propagate distribute-fallback-html failures and use per-repo default branch [IDE-2298] (#1385)
    
    fix: propagate distribute-fallback-html failures and use per-repo default branch
    
    process_repo() was called as `process_repo ... || FAILED+=(...)`, which
    disables set -e inside the function — a failing git push or gh pr create
    fell through to the final echo and returned 0, so the job reported success
    even when every target repo failed. Explicit `|| return 1` after both calls
    now propagates failures.
    
    --base main was hardcoded, but snyk-intellij-plugin's default branch is
    master, so PR creation there always failed. Base branch is now fetched
    per-repo via `gh repo view --json defaultBranchRef`.
    
    Also trigger the workflow on changes to the script/workflow files
    themselves, not just the html source, so this class of bug surfaces on
    merge instead of silently waiting for the next html change.
    
    IDE-2298
    
    Co-authored-by: Bastian Doetsch <bastian.doetsch@snyk.io>

M	.github/distribute-fallback-html.sh
M	.github/workflows/distribute-fallback-html.yaml

commit dc50fd717e8712a0fac154715b22939ac77424a2
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Thu Jul 23 13:37:11 2026 +0200

    fix: replace fallback-page re-auth control with a Log out action [IDE-2181] (#1371)
    
    ### **User description**
    ## Summary
    The limited settings **fallback** page (shown when the full settings page can't load) had no login control — its Authentication section held only the Insecure/SSL-skip checkbox. A user dropped to the fallback was locked out of re-auth entirely, which is the user-facing half of IDE-2181.
    
    This adds a **"Connect"** control to the fallback page that dispatches `snyk.login` through the IDE command bridge with **no args**, so re-auth reuses the user's existing configured method/endpoint (the limited page must not overwrite them). It is no-op-safe when the bridge is absent, disables while a login is in flight (no double-dispatch), and always recovers — via the bridge callback, a synchronous error, or a safety timeout — so it can never stick on "Connecting…". A generation latch makes a late callback from a superseded attempt inert. Status copy is state-neutral.
    
    ## PR Stack — Merge Order
    ```mermaid
    flowchart LR
        main(["main"])
        PR1["#1370 CP1\nLS dispatch fix"]
        PR2["#1371 CP2 ← YOU ARE HERE\nfallback re-auth control"]
        main --> PR1 --> PR2
        style PR2 fill:#ffd700,color:#000
    ```
    
    **Depends on:** #1370
    
    ## Verified (outside-in TDD)
    `js-tests/settings-fallback.test.mjs` — asserts the control dispatches `snyk.login` (spy, not DOM-only), the disable/re-enable lifecycle, second-click suppression, the safety-timeout recovery, the cross-cycle stale-callback latch, and state-neutral copy. `make test` GREEN (146 JS tests pass).
    
    ## Deferred to later PR (CP3)
    - `snyk-intellij-plugin`: mirror this fallback page (the plugin ships its own byte-identical copy) and prove `snyk.login` dispatches from it.
    
    ## Test plan
    - [ ] Start the IDE with an expired token so the settings page falls back; click **Connect** → the OAuth flow starts and re-auth completes.
    - [ ] Cancel the OAuth tab → the button recovers (not stuck on "Connecting…") and can be retried.
    
    
    ___
    
    ### **PR Type**
    Enhancement, Tests
    
    
    ___
    
    ### **Description**
    - Add 'Log out' button to settings fallback page.
    
    - Dispatch `snyk.logout` command via IDE bridge.
    
    - Implement and test new logout functionality.
    
    
    ___
    
    
    
    <details> <summary><h3> File Walkthrough</h3></summary>
    
    <table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
    <tr>
      <td>
        <details>
          <summary><strong>authentication_flows_e2e_test.go</strong><dd><code>Add E2E test for logout during scanner initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
    <hr>
    
    application/server/authentication_flows_e2e_test.go
    
    <ul><li>Adds a new end-to-end test <br><code>Test_E2E_LogoutDuringScannerInitClearsCredentials</code>.<br> <li> This test verifies that the <code>snyk.logout</code> command correctly clears <br>credentials, even when the language server is in the midst of its <br>initialization phase.</ul>
    
    
    </details>
    
    
      </td>
      <td><a href="https://github.com/snyk/snyk-ls/pull/1371/changes#diff-9deadd440a71de07926bf9936df138c9c5512696795d6b6544d4f40c01d06752">+65/-0</a>&nbsp; &nbsp; </td>
    
    </tr>
    
    <tr>
      <td>
        <details>
          <summary><strong>settings-fallback.test.mjs</strong><dd><code>Unit tests for fallback page logout control</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
    <hr>
    
    js-tests/settings-fallback.test.mjs
    
    <ul><li>Removes unit tests related to the old 'Connect' (re-authentication) <br>button.<br> <li> Adds new unit tests for the 'Log out' button, covering its presence, <br>correct command dispatch (<code>snyk.logout</code>), no-op safety, and status <br>update behavior.</ul>
    
    
    </details>
    
    
      </td>
      <td><a href="https://github.com/snyk/snyk-ls/pull/1371/changes#diff-6da8cfbb056402eea87adbb3081beda3776b81b201de3374c4d20a61b5362931">+78/-0</a>&nbsp; &nbsp; </td>
    
    </tr>
    </table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
    <tr>
      <td>
        <details>
          <summary><strong>settings-fallback.html</strong><dd><code>Update fallback page UI for logout control</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
    <hr>
    
    shared_ide_resources/ui/html/settings-fallback.html
    
    <ul><li>Replaces the previous 'Connect' button for re-authentication with a <br>'Log out' button.<br> <li> Adds new CSS styles for the logout button and status messages.<br> <li> Implements the <code>startLogout</code> JavaScript function to dispatch the <br><code>snyk.logout</code> command and update the UI status.<br> <li> Updates the HTML structure and event listeners to support the new <br>logout functionality.</ul>
    
    
    </details>
    
    
      </td>
      <td><a href="https://github.com/snyk/snyk-ls/pull/1371/changes#diff-3489a54a68d7b46f5b60db397b73c9f4e37526c68f41c78cee2b2e1c7da66eb2">+55/-0</a>&nbsp; &nbsp; </td>
    
    </tr>
    </table></td></tr></tr></tbody></table>
    
    </details>
    
    ___

M	application/server/authentication_flows_e2e_test.go
M	js-tests/settings-fallback.test.mjs
M	shared_ide_resources/ui/html/settings-fallback.html

commit 0d1b16ca35e5733c249daa7a843154bd5a6a3355
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Thu Jul 23 08:23:41 2026 +0200

    fix: keep settings config command serviceable during failing startup auth [IDE-2181] (#1370)
    
    * fix: keep settings config command serviceable during failing startup auth [IDE-2181]
    
    Move the blocking scanner/auth initialization out of the synchronous LSP
    `initialized` handler into a background goroutine so a failing OAuth token
    refresh at startup no longer starves jrpc2 dispatch of the
    snyk.workspace.configuration command that renders the IDE settings page.
    Rendering config HTML requires no authentication, so it must remain
    serviceable while auth is failing.
    
    Freeing dispatch widens the window in which the LSP-initialized flag is
    false, so split the signal into two: an early handshake-acknowledged flag
    (set synchronously before the handler returns) gates the endpoint-switch
    credential clear, so switching endpoint during startup still clears
    old-endpoint credentials (no session leakage); the late scanner-ready
    signal keeps scan-readiness waiters correct. A handler-level safety net
    guarantees the readiness signal still fires if a dependency resolution
    panics before the background goroutine launches. The background init runs
    on a cancellable context that shutdown cancels and awaits before disposing
    shared state, and the goroutine recovers panics so a failing init cannot
    crash the language server.
    
    * test: stabilize init-window races in login and progress listener tests [IDE-2181]
    
    Background scanner init (IDE-2181) made several tests flaky under CI:
    
    - Test_loginCommand_StartsAuthentication: wait for scanner init before clearing
      the startup token so the post-login RefreshConfigFromLdxSync hook always fires.
    - Test_E2E_AuthenticationMethodChangeClearsIncompatibleToken: wait for init
      before config-driven auth changes so hasAuthenticated notifications are not
      blocked behind registerNotifier's WaitForLspInitialized gate.
    - TestCreateProgressListener: require both Callback and Notify before teardown;
      the old shared 'called' flag let Eventually pass after Callback while Notify
      was still pending, which failed under the race detector.
    
    Co-authored-by: Bastian Doetsch <bastian.doetsch@snyk.io>
    
    * docs: clarify scanner-init token comment in login test [IDE-2181]
    
    Co-authored-by: Bastian Doetsch <bastian.doetsch@snyk.io>
    
    * test: wait for scanner init in smoke ensureInitialized helper [IDE-2181]
    
    Background scanner init (IDE-2181) made ensureInitialized return before HandleFolders
    and first-scan setup finished. Smoke tests that call setupRepoAndInitialize or
    ensureInitialized directly assumed the old synchronous initializedHandler semantics.
    
    Wait on WaitForLspInitialized after the initialized RPC so all smoke helpers inherit
    the correct post-init barrier without per-test duplication.
    
    Co-authored-by: Bastian Doetsch <bastian.doetsch@snyk.io>
    
    * test: match folder-config notifications to expected workspace [IDE-2181]
    
    requireLspFolderConfigNotification was accepting the newest notification
    without checking that its folder set matched the validators map. After
    removing a workspace folder, a stale two-folder notification could win
    over the post-removal one-folder payload on macOS, causing
    SmokeOrgSelection to fail with "Not all folder configs were validated".
    
    Skip notifications whose folder count or paths do not exactly match the
    expected validators so Eventually waits for the correct payload.
    
    * test: preserve scan notifications in scan-precedence setup [IDE-2181]
    
    Background scanner init completes workspace scans before
    WaitForLspInitialized returns. setupScanPrecedenceTest was clearing all
    JSON-RPC notifications after init, which discarded the $/snyk.scan success
    payloads that Test_SmokeScanPrecedence_* asserts on immediately afterward.
    
    Clear only $/snyk.configuration notifications so scan-level precedence
    smoke-race tests keep the init scan evidence they expect.
    
    * chore: remove dev-process/AI narration from code comments [IDE-2181]
    
    Strip AI-authoring artefacts from all new test and production files:
    - CP1 / pre-CP1 labels
    - SHOULD-FIX 1/2 markers
    - RED-before / GREEN-after test-state narration
    - invariant D1 inline labels
    - Pre-fix / Post-fix framing
    - IDE-2181 work-item header lines
    
    Comments now describe the behaviour under test and the production code
    rationale without exposing the development process.
    
    * test: pass concurrency arg to startServer at merged-in call site [IDE-2181]
    
    The merge from main reintroduced a startServer(...) call in
    Test_codeActionResolve_RemediationAgent_ReturnsEdit that predates the added
    6th worker-pool-size parameter, breaking compilation of the application/server
    test binary and cascading into every CI job (lint, instance, integration,
    smoke). Pass 0 (production default = number of cores), matching the other
    default-concurrency call sites.
    
    * test: stabilize scanner cancellation flake and enable remediation flag in remy smoke setup [IDE-2181]
    
    Two test failures surfaced once the compile fix let the full suite run:
    
    - Test_ScanStarted_TokenChanged_ScanCancelled raced a fixed time.After(2s)
      against cancellation propagation; under -race ./... load cancellation could
      arrive after the timer, leaving wasCanceled false. The mock now blocks purely
      on ctx.Done() (matching the sibling test), so the outer RequireEventuallyReceive
      bounds the wait and a broken cancellation surfaces as a clear failure.
    
    - The remediation smoke tests never enabled remediation_agent_enabled, so the
      Remy quick-fix action was gated out (codeaction.go) and the action was never
      offered. substituteRemyFlow now sets the flag, covering both remy smoke tests.
    
    ---------
    
    Co-authored-by: Cursor Agent <cursoragent@cursor.com>

M	application/server/authentication_flows_e2e_test.go
A	application/server/background_init_lifecycle_test.go
A	application/server/dispatch_starvation_test.go
M	application/server/execute_command_test.go
A	application/server/initialized_signal_safety_test.go
A	application/server/lsp_folder_config_notif_test.go
M	application/server/notification_test.go
M	application/server/precedence_smoke_test.go
M	application/server/server.go
M	application/server/server_smoke_test.go
M	application/server/server_test.go
M	domain/ide/command/apply_auth_config.go
M	domain/ide/command/apply_auth_config_test.go
M	domain/snyk/scanner/scanner_test.go
M	internal/testsupport/json_rpc_recorder.go
M	internal/types/config_readers.go
M	internal/types/config_readers_test.go
M	internal/types/ldx_sync_config.go

commit ac94584cb6ddc5a4f745ca491e5d89cb49a7c6de
Author: Andrew Robinson Hodges <andrew.robinsonhodges@snyk.io>
Date:   Wed Jul 22 18:37:31 2026 +0100

    fix: cancel login requests when auth method changed, login button pressed, or logout command sent [IDE-2247] (#1380)
    
    * fix: allow login requests to be cancelled, remove deadlock
    
    * chore: comment tidy up
    
    * fix: rre-requesting login should cancel in-flight auth
    
    * lint: whitespace
    
    * fix: wrap timeout error to make it more user friendly
    
    * docs: correct stale deadlock rationale for auth cancel [IDE-2247]
    
    Authenticate releases a.m before the interactive provider call, so
    ConfigureProviders can no longer deadlock behind a blocked login. Reword the
    comments in loginCommand.Execute and ApplyAuthMethodChange to justify the
    pre-reconfigure CancelOngoingAuth by the supersession invariant — canceling the
    auth context makes the ctx.Err() guard discard the now-stale result — rather
    than by deadlock avoidance.
    
    Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
    
    * refactor: fold auth provider snapshot and nil-check under one lock [IDE-2247]
    
    In Authenticate, take a.m once to snapshot the provider, check it for nil, and
    clear the auth cache on the nil path, releasing the lock before the interactive
    provider.Authenticate call. Replaces the previous RLock-snapshot-RUnlock
    followed by a separate Lock for RemoveAll, closing the gap between the two so
    the snapshot and nil-check are atomic. Behavior is unchanged; a.m is still not
    held across the blocking provider call.
    
    Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
    
    * fix: merge error
    
    ---------
    
    Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

M	domain/ide/command/apply_auth_config.go
M	domain/ide/command/apply_auth_config_test.go
M	domain/ide/command/command_service.go
M	domain/ide/command/command_service_test.go
M	domain/ide/command/login.go
M	domain/ide/command/login_test.go
M	infrastructure/authentication/auth_service_impl.go
M	infrastructure/authentication/auth_service_impl_test.go
M	infrastructure/authentication/cli_provider.go
M	infrastructure/authentication/cli_provider_test.go
M	infrastructure/authentication/initializer.go
M	infrastructure/authentication/initializer_test.go
M	infrastructure/authentication/oauth_provider.go
M	infrastructure/authentication/oauth_provider_test.go
M	infrastructure/authentication/provider_fake.go
M	infrastructure/sentry/sentry_error_reporter.go
M	infrastructure/sentry/sentry_error_reporter_test.go
A	internal/util/cancellation.go
A	internal/util/cancellation_test.go
```

[IDE-2298]: https://snyksec.atlassian.net/browse/IDE-2298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-2181]: https://snyksec.atlassian.net/browse/IDE-2181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ