### PR TITLE
feat: adjust private modules context name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -453,7 +453,7 @@ commands:
   setup-go-private-modules:
     description: >-
       Configure git and Go to fetch private snyk modules using the
-      GITHUB_PRIVATE_TOKEN provided by the `go-private-modules` context.
+      GITHUB_PRIVATE_TOKEN provided by the `team-cli-go-private-modules` context.
       Safe to call on Linux, macOS and Windows (uses bash on all executors).
     steps:
       - run:
@@ -466,7 +466,7 @@ commands:
             fi
             if [ -z "${GITHUB_PRIVATE_TOKEN}" ]; then
               echo "GITHUB_PRIVATE_TOKEN is not set; skipping private Snyk modules setup."
-              echo "Add the 'go-private-modules' context to this job if private modules are required."
+              echo "Add the 'team-cli-go-private-modules' context to this job if private modules are required."
               exit 0
             fi
             git config --global url."https://${GITHUB_PRIVATE_TOKEN}:x-oauth-basic@github.com/snyk".insteadOf "https://github.com/snyk"
@@ -632,7 +632,7 @@ workflows:
       - docs-only-check:
           context:
             - devex_cli_docker_hub
-            - go-private-modules
+            - team-cli-go-private-modules
           filters:
             branches:
               only:
@@ -641,7 +641,7 @@ workflows:
       - prepare-build:
           context:
             - devex_cli_docker_hub
-            - go-private-modules
+            - team-cli-go-private-modules
           requires:
             - secrets-scan
           filters:
@@ -657,7 +657,7 @@ workflows:
           context:
             - devex_cli
             - devex_cli_docker_hub
-            - go-private-modules
+            - team-cli-go-private-modules
           requires:
             - prepare-build
           filters:
@@ -687,7 +687,7 @@ workflows:
             - nodejs-install
             - team_hammerhead-cli
             - devex_cli_docker_hub
-            - go-private-modules
+            - team-cli-go-private-modules
           requires:
             - prepare-build
           filters:
@@ -736,7 +736,7 @@ workflows:
           name: build linux amd64
           context:
             - iac-cli
-            - go-private-modules
+            - team-cli-go-private-modules
             - devex_cli_docker_hub
           go_target_os: linux
           go_os: linux
@@ -751,7 +751,7 @@ workflows:
           name: build linux static amd64
           context:
             - iac-cli
-            - go-private-modules
+            - team-cli-go-private-modules
             - devex_cli_docker_hub
           go_target_os: linux
           go_os: linux
@@ -767,7 +767,7 @@ workflows:
           name: build linux fips amd64
           context:
             - iac-cli
-            - go-private-modules
+            - team-cli-go-private-modules
             - devex_cli_docker_hub
           go_target_os: linux
           go_os: linux
@@ -783,7 +783,7 @@ workflows:
           name: build linux arm64
           context:
             - iac-cli
-            - go-private-modules
+            - team-cli-go-private-modules
             - devex_cli_docker_hub
           go_target_os: linux
           go_os: linux
@@ -798,7 +798,7 @@ workflows:
           name: build linux static arm64
           context:
             - iac-cli
-            - go-private-modules
+            - team-cli-go-private-modules
             - devex_cli_docker_hub
           go_target_os: linux
           go_os: linux
@@ -814,7 +814,7 @@ workflows:
           name: build linux fips arm64
           context:
             - iac-cli
-            - go-private-modules
+            - team-cli-go-private-modules
             - devex_cli_docker_hub
           go_target_os: linux
           go_os: linux
@@ -830,7 +830,7 @@ workflows:
           name: build alpine amd64
           context:
             - iac-cli
-            - go-private-modules
+            - team-cli-go-private-modules
             - devex_cli_docker_hub
           go_target_os: alpine
           go_os: linux
@@ -845,7 +845,7 @@ workflows:
           name: build alpine arm64
           context:
             - iac-cli
-            - go-private-modules
+            - team-cli-go-private-modules
             - devex_cli_docker_hub
           go_target_os: alpine
           go_os: linux
@@ -867,7 +867,7 @@ workflows:
           context:
             - snyk-macos-signing
             - iac-cli
-            - go-private-modules
+            - team-cli-go-private-modules
           requires:
             - prepare-build
 
@@ -882,7 +882,7 @@ workflows:
           context:
             - snyk-macos-signing
             - iac-cli
-            - go-private-modules
+            - team-cli-go-private-modules
           requires:
             - prepare-build
 
@@ -899,7 +899,7 @@ workflows:
           executor: win-server2022-amd64
           context:
             - iac-cli
-            - go-private-modules
+            - team-cli-go-private-modules
           requires:
             - prepare-build
 


### PR DESCRIPTION
### **User description**
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Replaces the shared go-private-modules CircleCI context with the restricted, Team CLI-owned team-cli-go-private-modules context for private Go module access. Existing token variable, build behavior, and public builds remain unchanged.

```
› can I just use the initial go-private-modules and have no code changes?


• Yes, technically—but only by changing the existing go-private-modules
  context’s GITHUB_PRIVATE_TOKEN. Repository code would remain unchanged.

  Tradeoff: this is not equivalent to CLI-1535’s dedicated-context design.

  - Every repository using go-private-modules receives Team CLI’s PAT.
  - PAT must include private repositories required by all those consumers, not
    only remy-cli-extension and ambient-canary.

  - Project restriction cannot be narrowed to snyk/cli without breaking other
    consumers.

  - Rotation and ownership remain shared.
  - Requires ProdSec/context-owner approval and a complete consumer audit.

  If you leave the old context and credential unchanged, no code change is
  needed—but CLI-1535 is not completed.

  Recommendation: keep PR #7029. Dedicated context gives actual least-
  privilege isolation; current CI proves it works.
```

## Where should the reviewer start?

## How should this be manually tested?

## What's the product update that needs to be communicated to CLI users?

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->


___

### **PR Type**
Enhancement


___

### **Description**
- Update CircleCI context for private Go modules.

- Utilize `team-cli-go-private-modules` for Git/Go private module access.

- Refine CI configuration for module fetching.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["`go-private-modules` context"] -->|Replaced by| B["`team-cli-go-private-modules` context"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.yml</strong><dd><code>Update private Go module context in CircleCI config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.circleci/config.yml

<ul><li>Replaces the <code>go-private-modules</code> CircleCI context with <br><code>team-cli-go-private-modules</code> across numerous jobs in the <code>workflows</code> <br>section.<br> <li> Updates the <code>setup-go-private-modules</code> command to reference the new, <br>dedicated context for configuring access to private Snyk Go modules.<br> <li> Ensures CI builds correctly fetch private Snyk Go modules using the <br>updated context's <code>GITHUB_PRIVATE_TOKEN</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/cli/pull/7029/changes#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47">+17/-17</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

