### PR TITLE
fix: Restore Windows TS signing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,6 +317,11 @@ commands:
             - C:\tools\make
             - C:\Program Files\Python312
 
+  install-deps-windows-native-build-min-signing:
+    steps:
+      - install-deps-windows-signing
+      - install-deps-windows-native-build-min
+
   install-deps-windows-native-build:
     steps:
       - run:
@@ -426,10 +431,6 @@ commands:
           key: digicert-cache-v3-{{ arch }}-{{ checksum "~/cache_key.txt" }}
           paths:
             - ~\smtools-windows-x64.msi
-
-  install-deps-windows-full-signing:
-    steps:
-      - install-deps-windows-signing
 
   install-deps-noop:
     steps:
@@ -894,10 +895,11 @@ workflows:
           go_download_base_url: << pipeline.parameters.fips_go_download_base_url >>
           go_version: << pipeline.parameters.fips_go_version >>
           make_target: build build-fips verify-fips-artifacts BUILD_MODE=private
-          install_deps_extension: windows-native-build-min
+          install_deps_extension: windows-native-build-min-signing
           install_path: 'C:\'
           executor: win-server2022-amd64
           context:
+            - snyk-windows-signing
             - iac-cli
             - team-cli-go-private-modules
           requires:
@@ -2101,10 +2103,41 @@ jobs:
           environment:
             SNYK_DISABLE_ANALYTICS: 1
           command: |
+            export SNYK_CACHE_PATH="$(pwd)/.snyk-cache"
+            if command -v cygpath >/dev/null 2>&1; then
+              export SNYK_CACHE_PATH="$(cygpath -w "$SNYK_CACHE_PATH")"
+            fi
+            echo "export SNYK_CACHE_PATH=\"$SNYK_CACHE_PATH\"" >> "$BASH_ENV"
             PIP_BREAK_SYSTEM_PACKAGES=1 pip install --user --upgrade requests || PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install --user --upgrade requests
             python scripts/install-snyk.py --base_url=<< parameters.cli_download_base_url >>  $(cat binary-releases/version) || python3 scripts/install-snyk.py --base_url=<< parameters.cli_download_base_url >> $(cat binary-releases/version)
             SNYK_TOKEN=${TEST_SNYK_TOKEN} ./snyk whoami --experimental
             SNYK_TOKEN=${TEST_SNYK_TOKEN} ./snyk woof
+
+      - when:
+          condition:
+            matches:
+              pattern: '^macos.*'
+              value: << parameters.executor >>
+          steps:
+            - run:
+                name: Verify release binaries are signed (macOS)
+                shell: bash
+                command: |
+                  ts_binary=$(./cliv2/scripts/find_ts_binary.sh "$SNYK_CACHE_PATH")
+                  ./cliv2/scripts/issigned_darwin.sh ./snyk "$ts_binary"
+
+      - when:
+          condition:
+            matches:
+              pattern: '^win.*'
+              value: << parameters.executor >>
+          steps:
+            - run:
+                name: Verify release binaries are signed (Windows)
+                shell: bash
+                command: |
+                  ts_binary=$(./cliv2/scripts/find_ts_binary.sh "$SNYK_CACHE_PATH")
+                  powershell ./cliv2/scripts/issigned_windows.ps1 snyk.exe "$ts_binary"
 
   test-release-static:
     parameters:

--- a/cliv2/scripts/find_ts_binary.sh
+++ b/cliv2/scripts/find_ts_binary.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Resolves the single extracted TS binary file under a cache dir (e.g.
+# $SNYK_CACHE_PATH after running a legacy-only command like `snyk woof` to
+# force extraction). Prints the resolved path on success.
+
+LOG_PREFIX="--- $(basename "$0"):"
+
+cache_dir="${1:-}"
+if [[ -z "$cache_dir" ]]; then
+  echo "$LOG_PREFIX ERROR! Usage: $0 <cache-dir>" >&2
+  exit 1
+fi
+
+gnu_find=find
+if command -v cygpath >/dev/null 2>&1; then
+  cache_dir="$(cygpath -u "$cache_dir")"
+  # plain "find" can resolve to Windows' System32\find.exe (a text-search
+  # tool, not GNU find) if it precedes Git's usr/bin on PATH.
+  gnu_find=/usr/bin/find
+fi
+
+if [[ ! -d "$cache_dir" ]]; then
+  echo "$LOG_PREFIX ERROR! Cache dir does not exist: $cache_dir" >&2
+  exit 1
+fi
+
+candidates=()
+while IFS= read -r candidate; do
+  candidates+=("$candidate")
+done < <("$gnu_find" "$cache_dir" -mindepth 2 -maxdepth 2 -type f ! -iname '*.sha256' ! -iname '*.lock')
+
+if [[ ${#candidates[@]} -eq 0 ]]; then
+  echo "$LOG_PREFIX ERROR! Could not find extracted TS binary under $cache_dir" >&2
+  exit 1
+elif [[ ${#candidates[@]} -gt 1 ]]; then
+  echo "$LOG_PREFIX ERROR! Found more than one candidate under $cache_dir: ${candidates[*]}" >&2
+  exit 1
+fi
+
+echo "${candidates[0]}"

--- a/cliv2/scripts/issigned_darwin.sh
+++ b/cliv2/scripts/issigned_darwin.sh
@@ -8,9 +8,19 @@ if [[ "$OSTYPE" != *"darwin"* ]]; then
   exit 1
 fi
 
-if ! codesign --verify --deep --strict "$1"; then
-  echo "$LOG_PREFIX NOT signed!"
+if [[ $# -eq 0 ]]; then
+  echo "$LOG_PREFIX ERROR! Usage: $0 <file> [file...]"
   exit 1
-else
-  echo "$LOG_PREFIX is signed!"
 fi
+
+status=0
+for file in "$@"; do
+  if ! codesign --verify --deep --strict "$file"; then
+    echo "$LOG_PREFIX NOT signed: $file"
+    status=1
+  else
+    echo "$LOG_PREFIX is signed: $file"
+  fi
+done
+
+exit $status

--- a/cliv2/scripts/issigned_windows.ps1
+++ b/cliv2/scripts/issigned_windows.ps1
@@ -1,10 +1,17 @@
 param (
-  [Parameter(Mandatory = $true, Position = 0)]
-  [String]$FilePath
+  [Parameter(Mandatory = $true, ValueFromRemainingArguments = $true)]
+  [String[]]$Paths
 )
 
-# Find the latest version of signtool.exe and use it to sign the executable
+# Find the latest version of signtool.exe and use it to verify the executables
 $SIGNTOOL = Get-ChildItem -Path "C:\Program Files (x86)\Windows Kits\" -Recurse -Include 'signtool.exe' | Where-Object { $_.FullName -like "*x64*" } | Sort-Object LastWriteTime | Select-Object -Last 1 -ExpandProperty FullName
-& $SIGNTOOL verify /pa $FilePath
-exit $LASTEXITCODE
 
+$exitCode = 0
+foreach ($path in $Paths) {
+  & $SIGNTOOL verify /pa $path
+  if ($LASTEXITCODE -ne 0) {
+    $exitCode = $LASTEXITCODE
+  }
+}
+
+exit $exitCode


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Restores signing of the embedded TS binary on the Windows build job. Also fixes and simplifies `test-release`'s signature verification for both the Go binary and the extracted TS binary.

## Where should the reviewer start?

- `.circleci/config.yml` — restored `snyk-windows-signing` context
- `cliv2/scripts/find_ts_binary.sh`, `issigned_darwin.sh`, `issigned_windows.ps1`

## How should this be manually tested?

1. Run CI on a Windows build job, confirm `sign_windows.ps1` reports a successful signature (not "Skipping signing...")
2. Confirm the separate `sign windows amd64` job still signs the release artifact
3. Confirm `test-release` (macOS + Windows) passes and reports both binaries signed in e2e tests

## What's the product update that needs to be communicated to CLI users?

None. Internal CI fix only.

## What are the relevant tickets?

[CLI-1703](https://snyksec.atlassian.net/browse/CLI-1703)
[CLI-1633](https://snyksec.atlassian.net/browse/CLI-1633)

## Screenshots (if appropriate)

N/A

[CLI-1703]: https://snyksec.atlassian.net/browse/CLI-1703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ