### PR TITLE
chore(language-server): integrate LS

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -223,7 +223,7 @@ require (
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
-	github.com/snyk/snyk-ls v0.0.0-20260723155019-176f7433c014 // indirect
+	github.com/snyk/snyk-ls v0.0.0-20260727100503-17c420b24a76 // indirect
 	github.com/snyk/studio-mcp v1.15.1 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -601,8 +601,8 @@ github.com/snyk/remy-cli-extension v1.30.0 h1:F0X8M23uBNFO/azGltrMEJLB7d1/lzqYOR
 github.com/snyk/remy-cli-extension v1.30.0/go.mod h1:ez/NUC+xzLRJB7+H0GTUjv4O1x2U+UWArSLdLVCcY3w=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260723155019-176f7433c014 h1:tBVdICJ2LT032FJ2ebSiPygn5O9cK4ghVoIP3CNMs18=
-github.com/snyk/snyk-ls v0.0.0-20260723155019-176f7433c014/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
+github.com/snyk/snyk-ls v0.0.0-20260727100503-17c420b24a76 h1:dh2ohpboFbX8V7Pf4mtnkzOIkqXPMv2H0xrX7hT4R5M=
+github.com/snyk/snyk-ls v0.0.0-20260727100503-17c420b24a76/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
 github.com/snyk/studio-mcp v1.15.1 h1:g0dw46B+EOQjd7LWa+O1t9SEzgzlcYFxbgo5cp2xaFc=
 github.com/snyk/studio-mcp v1.15.1/go.mod h1:3ZISZCgorkGg/iLQrryvmP34Db4KkvtfAARi7vMqM/4=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/snyk/go-application-framework v0.8.0
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20260723155019-176f7433c014
+	github.com/snyk/snyk-ls v0.0.0-20260727100503-17c420b24a76
 	github.com/snyk/studio-mcp v1.15.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -555,8 +555,8 @@ github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhk
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260723155019-176f7433c014 h1:tBVdICJ2LT032FJ2ebSiPygn5O9cK4ghVoIP3CNMs18=
-github.com/snyk/snyk-ls v0.0.0-20260723155019-176f7433c014/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
+github.com/snyk/snyk-ls v0.0.0-20260727100503-17c420b24a76 h1:dh2ohpboFbX8V7Pf4mtnkzOIkqXPMv2H0xrX7hT4R5M=
+github.com/snyk/snyk-ls v0.0.0-20260727100503-17c420b24a76/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
 github.com/snyk/studio-mcp v1.15.1 h1:g0dw46B+EOQjd7LWa+O1t9SEzgzlcYFxbgo5cp2xaFc=
 github.com/snyk/studio-mcp v1.15.1/go.mod h1:3ZISZCgorkGg/iLQrryvmP34Db4KkvtfAARi7vMqM/4=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit 17c420b24a76c9abdf5d69d0aa14190b04a36654
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Mon Jul 27 12:05:03 2026 +0200

    fix: harden OSS unified converter and fix SetFindingId RLock write race [IDE-2236] (#1387)
    
    * fix: harden OSS unified converter and fix SetFindingId RLock write race [IDE-2236]
    
    Deferred follow-up from the IDE-2207/2208 finding-identity review (parent IDE-2052).
    
    Defect 1 — populateMatchingIssues (infrastructure/oss/unified_converter.go):
    - nil guard: skip findings whose Attributes is nil before dereferencing
      finding.Attributes.Evidence (dormant nil-deref; masked upstream today).
    - omit degenerate entry: continue after a buildOssIssueData error instead of
      appending a zero-value OssIssueData{} to MatchingIssues (defense-in-depth).
    
    Defect 2 — SetFindingId (domain/snyk/issues.go): took RLock/RUnlock around a
    WRITE to i.FindingId; RWMutex permits concurrent RLock holders, so concurrent
    SetFindingId calls raced with no exclusion. Use Lock/Unlock (matches SetIgnored).
    
    Tests: race test for defect 2 (go test -race); unit + integration coverage for
    the nil-attribute skip and degenerate-entry omission in populateMatchingIssues.
    
    * docs: remove IDE-2236 plan mirror from the snyk-ls PR [IDE-2236]
    
    The AC-side plan mirror (docs/plans/IDE-2236-oss-converter-hardening.md) does not
    belong in the snyk-ls repository; drop it from the PR. No code or test change.

M	domain/snyk/issues.go
A	domain/snyk/issues_findingid_race_test.go
M	infrastructure/oss/unified_converter.go
A	infrastructure/oss/unified_converter_populate_matching_test.go

commit 920eb24fdb6677d8767aa86ca6153242ca80f535
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Fri Jul 24 16:13:54 2026 +0100

    chore: fallback settings clear credentials button styling and label (#1386)
    
    * fix(settings): align fallback clear credentials control
    
    Update fallback settings authentication control to match full settings secondary button styling.
    
    - Rename button text to Clear credentials
    - Remove initial helper copy above the button
    - Apply secondary button colors and hover tokens used by full settings page
    - Keep post-action status feedback after snyk.logout completes
    - Add/adjust fallback JS tests for new label and empty pre-action status
    
    Co-authored-by: Ben Durrans <Benjamin.Durrans@snyk.io>
    
    * fix(settings): simplify fallback sign-out status copy
    
    Update fallback post-logout status text to the concise message requested: 'Signed out.'.
    
    Also align the related fallback JS assertion/test name with the new copy.
    
    Co-authored-by: Ben Durrans <Benjamin.Durrans@snyk.io>
    
    * fix(settings): move aria-live to always-visible parent for logout status
    
    aria-live on the display:none <p> at load isn't reliably announced by
    screen readers; the wrapping .form-group stays in the a11y tree, so
    the live region works when the status text is later revealed.
    
    ---------
    
    Co-authored-by: Cursor Agent <cursoragent@cursor.com>
    Co-authored-by: Andrew Robinson Hodges <andrew.robinsonhodges@snyk.io>

M	js-tests/settings-fallback.test.mjs
M	shared_ide_resources/ui/html/settings-fallback.html
```

[IDE-2236]: https://snyksec.atlassian.net/browse/IDE-2236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-2236]: https://snyksec.atlassian.net/browse/IDE-2236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-2236]: https://snyksec.atlassian.net/browse/IDE-2236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ