### PR TITLE
fix: SNYK-JS-SHESCAPE-18319522, CVE-2026-14257

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -881,18 +881,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@ericcornelissen/lregexp": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@ericcornelissen/lregexp/-/lregexp-1.0.7.tgz",
-      "integrity": "sha512-1FFCOKq49eWRCinu3VuTfV1jv0kgeSET89OHDAUDaASzvIpwmh2/nFUayoEXB65mPT3atgECjlu3KVTIQU7jhw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-supported-regexp-flag": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.0 || ^15 || ^16 || ^17 || ^18 || ^19 || ^20 || ^21 || ^22 || ^23 || ^24 || ^25"
-      }
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
@@ -3217,15 +3205,15 @@
       }
     },
     "node_modules/@snyk/code-client/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@snyk/code-client/node_modules/fast-glob": {
@@ -3706,13 +3694,6 @@
       "version": "1.14.1",
       "license": "0BSD"
     },
-    "node_modules/@snyk/snyk-cocoapods-plugin/node_modules/isexe": {
-      "version": "3.1.1",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/@snyk/snyk-cocoapods-plugin/node_modules/lru-cache": {
       "version": "6.0.0",
       "license": "ISC",
@@ -3743,32 +3724,9 @@
         "node": ">=10"
       }
     },
-    "node_modules/@snyk/snyk-cocoapods-plugin/node_modules/shescape": {
-      "version": "2.1.6",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "which": "^3.0.0 || ^4.0.0 || ^5.0.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || ^16.13.0 || ^18 || ^19 || ^20 || ^22 || ^24"
-      }
-    },
     "node_modules/@snyk/snyk-cocoapods-plugin/node_modules/tslib": {
       "version": "2.3.1",
       "license": "0BSD"
-    },
-    "node_modules/@snyk/snyk-cocoapods-plugin/node_modules/which": {
-      "version": "5.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
     },
     "node_modules/@snyk/snyk-cocoapods-plugin/node_modules/yallist": {
       "version": "4.0.0",
@@ -3879,13 +3837,6 @@
       "version": "1.14.1",
       "license": "0BSD"
     },
-    "node_modules/@snyk/snyk-hex-plugin/node_modules/isexe": {
-      "version": "3.1.1",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/@snyk/snyk-hex-plugin/node_modules/lru-cache": {
       "version": "6.0.0",
       "license": "ISC",
@@ -3916,32 +3867,9 @@
         "node": ">=10"
       }
     },
-    "node_modules/@snyk/snyk-hex-plugin/node_modules/shescape": {
-      "version": "2.1.6",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "which": "^3.0.0 || ^4.0.0 || ^5.0.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || ^16.13.0 || ^18 || ^19 || ^20 || ^22 || ^24"
-      }
-    },
     "node_modules/@snyk/snyk-hex-plugin/node_modules/tslib": {
       "version": "2.3.1",
       "license": "0BSD"
-    },
-    "node_modules/@snyk/snyk-hex-plugin/node_modules/which": {
-      "version": "5.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
     },
     "node_modules/@snyk/snyk-hex-plugin/node_modules/yallist": {
       "version": "4.0.0",
@@ -12833,15 +12761,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-supported-regexp-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-2.0.0.tgz",
-      "integrity": "sha512-8i4+OYUjdUaJ88KAs1WojIThDFjIpeYNrSlYy1g/At2p9YjQ7HEmB1yn60un0jRFjM3TQbKPMAluTPEPncZfqA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
     "node_modules/is-symbol": {
       "version": "1.0.4",
       "dev": true,
@@ -19534,16 +19453,23 @@
       "license": "MIT"
     },
     "node_modules/shescape": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/shescape/-/shescape-2.1.11.tgz",
-      "integrity": "sha512-kR+oVEEgfo2TzK6FZAXtZMZ4aaVFuy5WeToxgjh95KPqUOLoFb1M+PYOWrDV7QqfHgdwnBpPBeBbf07sDgyAtA==",
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/shescape/-/shescape-2.1.14.tgz",
+      "integrity": "sha512-BA3/itw2jFZ8MybwHAWN5c78CQDOBn+joA/66ftwwwWr8GbzD6ZchE3hH1trkI8+xEBXnjjkdbzPqTURNojRfQ==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ericcornelissen/lregexp": "^1.0.7",
-        "which": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
+        "which": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       },
       "engines": {
-        "node": "^14.18.0 || ^16.13.0 || ^18 || ^19 || ^20 || ^22 || ^24 || ^25"
+        "node": "^14.18.0 || ^16.13.0 || ^18 || ^19 || ^20 || ^22 || ^24 || ^25 || ^26"
+      },
+      "peerDependencies": {
+        "@ericcornelissen/lregexp": "^1.0.7"
+      },
+      "peerDependenciesMeta": {
+        "@ericcornelissen/lregexp": {
+          "optional": true
+        }
       }
     },
     "node_modules/shescape/node_modules/isexe": {
@@ -20639,13 +20565,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/snyk-python-plugin/node_modules/isexe": {
-      "version": "3.1.1",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/snyk-python-plugin/node_modules/object-hash": {
       "version": "2.2.0",
       "license": "MIT",
@@ -20661,29 +20580,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/snyk-python-plugin/node_modules/shescape": {
-      "version": "2.1.6",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "which": "^3.0.0 || ^4.0.0 || ^5.0.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || ^16.13.0 || ^18 || ^19 || ^20 || ^22 || ^24"
-      }
-    },
-    "node_modules/snyk-python-plugin/node_modules/which": {
-      "version": "5.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/snyk-resolve": {
@@ -20775,39 +20671,9 @@
         "tslib": "^2.8.1"
       }
     },
-    "node_modules/snyk-sbt-plugin/node_modules/isexe": {
-      "version": "3.1.1",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/snyk-sbt-plugin/node_modules/shescape": {
-      "version": "2.1.6",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "which": "^3.0.0 || ^4.0.0 || ^5.0.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || ^16.13.0 || ^18 || ^19 || ^20 || ^22 || ^24"
-      }
-    },
     "node_modules/snyk-sbt-plugin/node_modules/tslib": {
       "version": "2.8.1",
       "license": "0BSD"
-    },
-    "node_modules/snyk-sbt-plugin/node_modules/which": {
-      "version": "5.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
     },
     "node_modules/snyk-swiftpm-plugin": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -206,7 +206,8 @@
     },
     "snyk-nodejs-lockfile-parser@2.10.0": {
       "uuid": "$uuid"
-    }
+    },
+    "shescape@<2.1.14": "2.1.14"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Fixes:
- [SNYK-JS-SHESCAPE-18319522](https://app.snyk.io/org/devex_cli/project/86634988-77b4-48c6-843a-e412de89ee50#issue-SNYK-JS-SHESCAPE-18319518)
- [CVE-2026-14257](https://app.snyk.io/org/devex_cli/project/86634988-77b4-48c6-843a-e412de89ee50#issue-SNYK-JS-BRACEEXPANSION-18313044)

## Where should the reviewer start?

## How should this be manually tested?
Please check if the `package-lock.json` diff is minimal.

## What's the product update that needs to be communicated to CLI users?

Security fixes:
- [SNYK-JS-SHESCAPE-18319522](https://app.snyk.io/org/devex_cli/project/86634988-77b4-48c6-843a-e412de89ee50#issue-SNYK-JS-SHESCAPE-18319518)
- [CVE-2026-14257](https://app.snyk.io/org/devex_cli/project/86634988-77b4-48c6-843a-e412de89ee50#issue-SNYK-JS-BRACEEXPANSION-18313044)

## What are the relevant tickets?
[CLI-1710](https://snyksec.atlassian.net/browse/CLI-1710)

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->


[CLI-1710]: https://snyksec.atlassian.net/browse/CLI-1710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ