### PR TITLE
fix: Bump GAF to gate metacharacter ignore fix behind flag

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -219,7 +219,7 @@ require (
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 // indirect
-	github.com/snyk/go-application-framework v0.8.0 // indirect
+	github.com/snyk/go-application-framework v0.8.1 // indirect
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -591,8 +591,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 h1:j2ZPhi78wKIHTiL9EFTNVXMIbsk56FVF2d5Sy1ZwSYk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.8.0 h1:o3XUcANwsTo1yJDk39kz6cEvgYoxve8lmYUWMGPIWpE=
-github.com/snyk/go-application-framework v0.8.0/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
+github.com/snyk/go-application-framework v0.8.1 h1:oN7Th1QYVbO41fHFuKLSVAFAiDtfrSCHPbq2OqgGTts=
+github.com/snyk/go-application-framework v0.8.1/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.27.0
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663
-	github.com/snyk/go-application-framework v0.8.0
+	github.com/snyk/go-application-framework v0.8.1
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260727100503-17c420b24a76

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -547,8 +547,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 h1:j2ZPhi78wKIHTiL9EFTNVXMIbsk56FVF2d5Sy1ZwSYk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.8.0 h1:o3XUcANwsTo1yJDk39kz6cEvgYoxve8lmYUWMGPIWpE=
-github.com/snyk/go-application-framework v0.8.0/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
+github.com/snyk/go-application-framework v0.8.1 h1:oN7Th1QYVbO41fHFuKLSVAFAiDtfrSCHPbq2OqgGTts=
+github.com/snyk/go-application-framework v0.8.1/go.mod h1:0YC7xCETnFTdz6rq8OQPL0aWekMLOkBQu1FE4/cReMA=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps `go-application-framework` and `code-client-go` to versions where the ignore-rule/path regex-metacharacter fix is opt-in, gated behind `configuration.FF_FILE_FILTER_METACHARACTER_FIX`, instead of always on. No code changes in this repo itself — the flag is read and applied inside `code-client-go`.

## Where should the reviewer start?

- `cliv2/go.mod` / `cliv2/go.sum` – GAF + code-client-go version bump
- `cliv2-private/go.mod` / `cliv2-private/go.sum` – indirect dependency bump
- PR in GAF: https://github.com/snyk/go-application-framework/pull/667

## How should this be manually tested?

1. Run the CLI test suite (`make test` in `cliv2`) and confirm it passes with the bumped dependencies.
2. Scan a directory containing a path or ignore rule with regex metacharacters (e.g. a folder named `build (old)`) and confirm exclusion behavior matches legacy behavior by default.

## What's the product update that needs to be communicated to CLI users?

Introduces **snykFileFilterMetacharacterFix** feature flag capability, but no impact at the moment, because we are preserving the current behavior that is in Preview CLI until we can release all the .gitignore related changes in other repos as well (e.g. code-client-go, etc..) as they need to plug the config to the new constructor so they can make use of it.

<!---
## Risk assessment (Low | Medium | High)?

Low

## Any background context you want to provide?

go-application-framework#656 fixed a bug where ignore rules/paths containing regex metacharacters (e.g. parentheses) were mishandled, but this silently changed which files get scanned/excluded for every existing customer on release. This bump restores the legacy default so the corrected behavior can be rolled out deliberately per-customer via a feature flag instead.

## What are the relevant tickets?

[CLI-1709]: https://snyksec.atlassian.net/browse/CLI-1709

## Screenshots (if appropriate)

N/A
--->