### PR TITLE
docs: add Cursor Cloud environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,3 +310,32 @@ extension/
 - ❌ Domain logic inside the callback — extract into domain packages
 - ❌ Passing `InvocationContext` into domain code — pass concrete values
 - ❌ Deep workflow call chains — keep composition flat
+
+## Cursor Cloud specific instructions
+
+Environment notes for Cursor Cloud agents (dependencies are pre-installed by the
+startup update script; the caveats below are the non-obvious bits).
+
+- **Node/npm:** `/exec-daemon/node` is first on `PATH` but ships **no npm**. Use
+  the nvm-managed Node `22.22.3` (the `.nvmrc` version, set as the nvm default),
+  which provides **npm `11.12.1`** — this repo pins `engine-strict=true` with
+  `npm ^11.12.1`, so the default `/exec-daemon` node fails `npm ci`. Prepend it:
+  `PATH="$HOME/.nvm/versions/node/v22.22.3/bin:$PATH"` before `npm`/`make build`.
+- **Go toolchain is pinned to `go1.26.5`** via `go env -w GOTOOLCHAIN=go1.26.5`
+  (the CLI needs Go 1.26.x and the toolchain auto-download from `go.dev` is
+  blocked; the pin routes it through `proxy.golang.org`).
+- **Build:** use `make build BUILD_MODE=public` — `cliv2-private/` is not
+  accessible here. Output binary: `binary-releases/snyk-linux`.
+- **`convco`** (used by `release-scripts/next-version.sh`) is installed at
+  `/usr/local/bin/convco`; without it `make build` fails at the version step.
+- **3rd-party licenses step:** `make build` runs `prepare-3rd-party-licenses`,
+  which downloads Go's LICENSE from the blocked `go.dev`. A copy of Go's LICENSE
+  is pre-placed at the gitignored
+  `cliv2/internal/embedded/_data/licenses/go.dev/LICENSE`; the script skips the
+  download when that file exists. Keep it in place.
+- **Tests:** standard commands (see [Running Tests](#running-tests)). Go tests
+  `cd cliv2 && go test ./...` pass. Acceptance tests run against the built binary
+  + fake server, e.g.
+  `TEST_SNYK_COMMAND=./binary-releases/snyk-linux npx jest --runInBand test/jest/acceptance/snyk-test/all-projects.spec.ts`.
+  Some acceptance specs reach real package registries and fail under restricted
+  egress — that is an environment limit, not a regression.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting the non-obvious environment setup needed to build/run/test the Snyk CLI in Cursor Cloud.

## Why

Cursor Cloud has restricted egress and a specific pre-provisioned toolchain. The notes record durable caveats future agents need:

- Node/npm: `/exec-daemon/node` is first on PATH but has no npm; use nvm Node `22.22.3` which provides npm `11.12.1` (this repo pins `engine-strict=true` with `npm ^11.12.1`).
- Go toolchain pinned to `go1.26.5` (auto-download from `go.dev` is blocked).
- Build with `make build BUILD_MODE=public` (`cliv2-private/` is inaccessible); output `binary-releases/snyk-linux`.
- `convco` is installed at `/usr/local/bin/convco` (required by `release-scripts/next-version.sh`).
- The `prepare-3rd-party-licenses` build step downloads Go's LICENSE from the blocked `go.dev`; a copy is pre-placed at the gitignored `cliv2/internal/embedded/_data/licenses/go.dev/LICENSE` so the step skips it.
- How to run acceptance tests against the built binary + fake server; some specs need real registries and fail under restricted egress.

Docs-only change.

## Verification

- `npm ci` ✅
- `make build BUILD_MODE=public` ✅ → `binary-releases/snyk-linux --version` works
- `cd cliv2 && go test ./pkg/... ./internal/...` ✅
- `npx jest test/jest/unit/lib/formatters` ✅ (120 tests)
- Acceptance `snyk-test/all-projects.spec.ts` against the built binary ✅ (20/20)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b38072c-8411-4de1-aaa9-f81af521ca2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b38072c-8411-4de1-aaa9-f81af521ca2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

