### PR TITLE
chore(language-server): integrate LS

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -224,7 +224,7 @@ require (
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
-	github.com/snyk/snyk-ls v0.0.0-20260727100503-17c420b24a76 // indirect
+	github.com/snyk/snyk-ls v0.0.0-20260731160838-84952efebbac // indirect
 	github.com/snyk/studio-mcp v1.15.1 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -603,8 +603,8 @@ github.com/snyk/remy-cli-extension v1.36.1 h1:TFiJL7XlqXklGsplIhlnhyRp+nyi4rV7L2
 github.com/snyk/remy-cli-extension v1.36.1/go.mod h1:ez/NUC+xzLRJB7+H0GTUjv4O1x2U+UWArSLdLVCcY3w=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260727100503-17c420b24a76 h1:dh2ohpboFbX8V7Pf4mtnkzOIkqXPMv2H0xrX7hT4R5M=
-github.com/snyk/snyk-ls v0.0.0-20260727100503-17c420b24a76/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
+github.com/snyk/snyk-ls v0.0.0-20260731160838-84952efebbac h1:OlTdwnsq4/vQDxsVZxdPT8R3eSxWjACjQuBCssYYZeg=
+github.com/snyk/snyk-ls v0.0.0-20260731160838-84952efebbac/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
 github.com/snyk/studio-mcp v1.15.1 h1:g0dw46B+EOQjd7LWa+O1t9SEzgzlcYFxbgo5cp2xaFc=
 github.com/snyk/studio-mcp v1.15.1/go.mod h1:3ZISZCgorkGg/iLQrryvmP34Db4KkvtfAARi7vMqM/4=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/snyk/go-application-framework v0.9.0
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20260727100503-17c420b24a76
+	github.com/snyk/snyk-ls v0.0.0-20260731160838-84952efebbac
 	github.com/snyk/studio-mcp v1.15.1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -555,8 +555,8 @@ github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhk
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260727100503-17c420b24a76 h1:dh2ohpboFbX8V7Pf4mtnkzOIkqXPMv2H0xrX7hT4R5M=
-github.com/snyk/snyk-ls v0.0.0-20260727100503-17c420b24a76/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
+github.com/snyk/snyk-ls v0.0.0-20260731160838-84952efebbac h1:OlTdwnsq4/vQDxsVZxdPT8R3eSxWjACjQuBCssYYZeg=
+github.com/snyk/snyk-ls v0.0.0-20260731160838-84952efebbac/go.mod h1:+D/SCNTCa2UUiJTnRmqCHrIrw1QPae/44y8w2LEdmts=
 github.com/snyk/studio-mcp v1.15.1 h1:g0dw46B+EOQjd7LWa+O1t9SEzgzlcYFxbgo5cp2xaFc=
 github.com/snyk/studio-mcp v1.15.1/go.mod h1:3ZISZCgorkGg/iLQrryvmP34Db4KkvtfAARi7vMqM/4=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit 84952efebbacbcc6979392fa841bf05ab64ee7dd
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Fri Jul 31 17:08:38 2026 +0100

    fix: surface logout failure instead of claiming success on settings-fallback page [IDE-2181] (#1388)
    
    startLogout()'s done() callback ignored its result and always showed "Signed
    out.", even when the IDE bridge reports the snyk.logout command never
    reached the language server (e.g. LS not yet initialized). Show the error
    instead of a false-positive success message.
    
    Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>
    Co-authored-by: Bastian Doetsch <bastian.doetsch@snyk.io>

M	js-tests/settings-fallback.test.mjs
M	shared_ide_resources/ui/html/settings-fallback.html

commit 227c16b6e21a762ece3340ebac19a484a2760047
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Fri Jul 31 09:06:36 2026 +0200

    fix: return installed CLI path from download instead of re-discovering it via Find [IDE-2322] (#1390)
    
    ### **User description**
    ## Summary
    
    Fixes the flaky `infrastructure/oss` CI failure where `TestMain` aborted the whole package on a CLI cache-miss run.
    
    `installRelease` discarded the destination the downloader had just written and re-derived the CLI path through `Find()`. `Find()`'s three-tier lookup covers the configured path, the XDG data dir and `$PATH` — but not the CLI cache dir. So on a cache-miss run the binary was downloaded, checksummed, moved and made executable, and the rediscovery still failed with `unable to find snyk-linux in PATH`, aborting the package via `TestMain`'s `log.Fatalf` and silently losing its coverage.
    
    The rediscovery was unreliable because the configured CLI path is read through the config resolver, and that read is not guaranteed to return the same value twice: a value written under a `user:global:` scoped key only round-trips when the resolver carries a scope annotation for it, and it can also be rewritten concurrently.
    
    ## What changed
    
    - The configured CLI path is resolved **exactly once per logical operation** and threaded through, instead of re-read.
    - `Downloader` no longer holds a `ConfigResolverInterface`; `Download` takes the resolved path and returns the destination it actually wrote.
    - `installRelease` returns that path directly. `updateFromRelease` passes its one resolved value to both `Download` and `replaceOutdatedCli`, so the download and rename destinations cannot diverge.
    - An empty configured path is a hard error rather than a silent write to a cwd-relative filename.
    - `Find()` is unchanged and still locates an already-installed CLI.
    - `FakeInstaller.Install` returns the path it wrote instead of an empty string.
    
    ## Correction — a regression this PR introduced, and fixed
    
    The first commit also changed `moveToDestination`'s remove-failure branch, which had returned a nil error (silently skipping the rename). An earlier revision of this description called that "an incidental latent bug fix, not a regression". **That was wrong**, and CI proved it: `smoke (1, windows-latest)` and `smoke (2, windows-latest)` failed with
    
    ```
    couldn't remove old CLI at C:\...\snyk-win.exe ...: Access is denied.
    FAIL    github.com/snyk/snyk-ls/infrastructure/oss
    ```
    
    That swallowed error was load-bearing. Within one `go test ./...` run packages execute in parallel, so `infrastructure/oss`'s `TestMain` and the `application/server` smoke helpers install the CLI into the same cache dir concurrently; when one holds the destination open, the other's `os.Remove` — and equally its `os.Rename` — fails. POSIX unlink-while-open hides this on Linux and macOS entirely, which is why a full local 4-shard smoke run was green and only 2 of 4 Windows shards caught it.
    
    The second commit treats "the requested binary is already there" as success rather than failure: on a remove **or** rename failure, the file already at the destination is compared against the release's expected checksum — match means another installer wrote exactly what we wanted, so its path is returned; mismatch or unreadable returns the original wrapped error. Both call sites share one helper. A genuinely failed operation still reports failure.
    
    ## Verification
    
    | Check | Result |
    |---|---|
    | `go build ./...` / `go vet ./...` | pass |
    | `golangci-lint` | pass, 0 issues |
    | `go test ./infrastructure/cli/install/... -race -count=20` | pass |
    | `go test ./... -race` | pass |
    | `make test` | pass, 0 failures |
    | `make test-smoke-parallel` (4 shards) | pass, 0 failures |
    
    The primary regression test was proven to discriminate: reverting `installRelease` to `return i.Find()` makes `TestInstallRelease_ReturnsInstalledPath_WhenResolverCannotRediscoverIt` fail with the exact CI error. A real cache-miss install was also exercised end-to-end against an empty cache dir with a genuine ~163 MB download.
    
    **No local tier can exercise the Windows failure path** — POSIX semantics hide it. Windows CI is the only real arbiter for that part, which is precisely how the regression above slipped through review.
    
    ## Known gaps
    
    - ~~`TestInstallRelease_ReturnsInstalledPath_WhenCacheDirOutsideDiscovery` does not discriminate against the pre-fix code.~~ **Fixed** in `35cdaa63` — renamed to `TestInstallRelease_ReturnsConfiguredDestination_OnSuccessfulInstall`, which describes what it actually asserts. The genuine regression guard remains `..._WhenResolverCannotRediscoverIt`.
    - Reviewer suggestions accepted but not acted on: the checksum-match fallback does not re-assert the executable bit (moot on Windows; a low-probability compound race on POSIX), and the debug log does not distinguish a checksum mismatch from an unreadable file.
    - Snyk SCA via MCP did not complete (its trust step timed out); it was run via the CLI instead — 9 pre-existing dependency vulnerabilities, none introduced here, no manifests changed. Snyk Code reports 8 pre-existing findings in the unchanged `benchmark/testdata` fixture.
    
    ## Test plan
    
    - [ ] CI green, **including all Windows smoke shards**
    - [ ] Confirm a cache-miss smoke run no longer aborts `infrastructure/oss`
    
    ---
    
    This fix was produced by an automated flake-fix loop.
    
    
    ___
    
    ### **PR Type**
    Bug fix, Enhancement
    
    
    ___
    
    ### **Description**
    - Fixes flaky CI by improving CLI path resolution.
    
    - CLI path resolved once and passed explicitly.
    
    - Enhances handling of concurrent CLI installations.
    
    
    ___
    
    ### Diagram Walkthrough
    
    
    ```mermaid
    flowchart LR
      A[Installer] -->|Get CLI Path| B(Config Resolver)
      A -->|Download CLI| C{Downloader}
      C -->|Uses CLI Path| D[File Operations]
      D -->|Handles Conflicts| E[File System]
      A -->|Returns Installed Path| F[Caller]
      subgraph Refactor
        C -- "Explicit Path" --> D
        D -- "Concurrency Handling" --> E
      end
      B -- "Resolved Once" --> A
    ```
    
    
    
    <details> <summary><h3> File Walkthrough</h3></summary>
    
    <table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
    <tr>
      <td>
        <details>
          <summary><strong>server_smoke_test.go</strong><dd><code>Smoke Test Adjusts Preview CLI Path Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
    <hr>
    
    application/server/server_smoke_test.go
    
    <ul><li>Updates the test to pass the specific <code>previewCLIPath</code> to the <br><code>Downloader.Download</code> method.<br> <li> Aligns the test with the refactored downloader API that expects an <br>explicit path.</ul>
    
    
    </details>
    
    
      </td>
      <td><a href="https://github.com/snyk/snyk-ls/pull/1390/changes#diff-13396c212387ae79a286802e0885b1c86f1bc389f0f6e82de58d49d641e15e08">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>
    
    </tr>
    
    <tr>
      <td>
        <details>
          <summary><strong>downloader_test.go</strong><dd><code>Update Downloader Tests for New API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
    <hr>
    
    infrastructure/cli/install/downloader_test.go
    
    <ul><li>Updates existing tests to accommodate the refactored <br><code>Downloader.Download</code> method signature.<br> <li> Ensures tests correctly pass the destination path and verify the <br>returned installed path.</ul>
    
    
    </details>
    
    
      </td>
      <td><a href="https://github.com/snyk/snyk-ls/pull/1390/changes#diff-bc987779bba3bce6c86614e040335b0da96085c7dc9e7ce403ad6e5a6c4fa13c">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>
    
    </tr>
    
    <tr>
      <td>
        <details>
          <summary><strong>installer_test.go</strong><dd><code>Add Extensive Tests for CLI Install and Download</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
    <hr>
    
    infrastructure/cli/install/installer_test.go
    
    <ul><li>Adds new unit tests to cover various scenarios for CLI installation <br>and download, including:<br>   - Empty CLI path configuration.<br>   - <br>Concurrent installation conflicts and resolutions.<br>   - Correct path <br>resolution and return values.<br>   - <code>FakeInstaller</code>'s behavior.<br> <li> Introduces mocks for <code>ConfigResolverInterface</code> to isolate test cases.</ul>
    
    
    </details>
    
    
      </td>
      <td><a href="https://github.com/snyk/snyk-ls/pull/1390/changes#diff-1708a6a27d97bc0f7269e4994bf6e7c8f82df1cbbd91d93cce862aa579f9ecdb">+361/-0</a>&nbsp; </td>
    
    </tr>
    </table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
    <tr>
      <td>
        <details>
          <summary><strong>downloader.go</strong><dd><code>Refactor Downloader, Improve Concurrency Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
    <hr>
    
    infrastructure/cli/install/downloader.go
    
    <ul><li>Refactors the <code>Downloader</code> to no longer depend on <br><code>ConfigResolverInterface</code>.<br> <li> The <code>Download</code> method now accepts the target <code>cliPath</code> and returns the <br>installed path.<br> <li> Introduces more robust handling for concurrent CLI installations by <br>checking existing files against checksums.<br> <li> Adds dependency injection for <code>os.Remove</code> and <code>os.Rename</code> for improved <br>testability.</ul>
    
    
    </details>
    
    
      </td>
      <td><a href="https://github.com/snyk/snyk-ls/pull/1390/changes#diff-7ba28fb2e4a170e8d1517e55166f1731bf866b6b0ce21759b8cca002b0b7fc06">+69/-36</a>&nbsp; </td>
    
    </tr>
    </table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
    <tr>
      <td>
        <details>
          <summary><strong>installer.go</strong><dd><code>Integrate Refactored Downloader in Installer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
    <hr>
    
    infrastructure/cli/install/installer.go
    
    <ul><li>Integrates the refactored <code>Downloader</code> in <code>installRelease</code> and <br><code>updateFromRelease</code>, passing the resolved CLI path.<br> <li> Ensures the <code>installRelease</code> method now returns the actual installed CLI <br>path.<br> <li> Fixes <code>FakeInstaller.Install</code> to return the path it writes to, aligning <br>with the new contract.<br> <li> Removes redundant CLI path lookups within <code>updateFromRelease</code> and <br><code>replaceOutdatedCli</code>.</ul>
    
    
    </details>
    
    
      </td>
      <td><a href="https://github.com/snyk/snyk-ls/pull/1390/changes#diff-8421d797f924e31a4db10413bf4cdac016fad3dae3f424d1035ac9377c56fbd5">+17/-16</a>&nbsp; </td>
    
    </tr>
    </table></td></tr></tr></tbody></table>
    
    </details>
    
    ___

M	application/server/server_smoke_test.go
M	infrastructure/cli/cli_fake.go
M	infrastructure/cli/install/downloader.go
M	infrastructure/cli/install/downloader_test.go
M	infrastructure/cli/install/installer.go
M	infrastructure/cli/install/installer_test.go
M	infrastructure/oss/oss_test.go

commit c63beaec5c7e56fb656bbad73fbb123601a48b85
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Thu Jul 30 22:08:56 2026 +0200

    fix: stabilize remy git enumeration against stat-cache false-clean (silent fix drop on Windows) [IDE-2289] (#1383)
    
    * fix: stabilize remy git enumeration against stat-cache false-clean (silent fix drop on Windows) [IDE-2289]
    
    remy's change-enumeration (gitChangedFiles on the Remediate path, name-status
    on the FixFolder path) trusted git's stat cache. With core.checkStat=minimal
    and coarse Windows last-write-time granularity, a completed same-byte-size fix
    whose mtime landed in the same clock tick as the worktree checkout matched the
    index entry (mtime+size), so git reported the file clean, git diff returned no
    changes, and the completed fix was silently dropped (Remediate returned edit=nil).
    
    Add refreshStatCache: before enumeration, reset every tracked file's mtime to the
    Unix epoch (git ls-files -z + os.Chtimes). Epoch's integer second (0) differs from
    any modern checkout timestamp, so git marks every file stat-dirty and re-hashes
    content regardless of the stat cache. It returns an error, propagated by both call
    sites, so a failed refresh surfaces instead of silently proceeding on a stale index;
    os.IsNotExist on a runner-deleted tracked file is ignored (git diff detects
    deletions independently of mtime).
    
    Adds deterministic cross-platform regression tests: HARDEN-5 forces the exact
    stat-clean condition on Linux and asserts the change is still detected, plus an
    error-propagation test for refreshStatCache.
    
    Produced by an automated flake-fix loop.
    
    * fix: invalidate git index mtime instead of chtimes-ing every tracked file [IDE-2289]
    
    The stat-cache-clean fix for the Windows silent-fix-drop bug looped
    os.Chtimes over every tracked file returned by git ls-files. That loop
    ignored ctx (no cancellation check), and for FixFolder specifically it
    added an O(tracked files) syscall cost to every folder fix where none
    existed before.
    
    Git's racy-git rule re-hashes any index entry whose cached mtime is >=
    the index file's own mtime. Setting only .git/index's mtime achieves
    the same stat-cache invalidation as one syscall instead of one per
    file, and is naturally bound by ctx since it's a single git subprocess
    call. Verified empirically that the index mtime must be nonzero (1s
    past epoch, not epoch itself) — git's is_racy_timestamp() treats a
    zero index mtime as "no timestamp recorded" and skips the racy check
    entirely, silently reproducing the original bug.
    
    Also closes a coverage gap: FixFolder's collectFileDiffs has its own
    independent stat-cache-invalidation call with no regression test
    proving the fix applies there too, and drops a redundant error-wrap
    left over from the previous mechanism.
    
    ---------
    
    Co-authored-by: Nick Yasnohorodskyi <nikita.yasnohorodskyi@snyk.io>

M	domain/snyk/remediation/export_test.go
M	domain/snyk/remediation/remy.go
M	domain/snyk/remediation/remy_fix_folder_test.go
M	domain/snyk/remediation/remy_remediate_harden_test.go
M	domain/snyk/remediation/remy_test.go

commit 36b979fb8d7f9a5793e21e60b9de5631c29b9d0e
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Wed Jul 29 17:27:29 2026 +0200

    feat: add file/issue search to the tree view [IDE-2362] (#1393)
    
    feat: add tree search [IDE-2362]

M	docs/tree-view.md
M	domain/ide/treeview/template/styles.css
M	domain/ide/treeview/template/tree.html
M	domain/ide/treeview/template/tree.js
M	domain/ide/treeview/tree_html_test.go
M	js-tests/tree-runtime.test.mjs

commit f70aac3025df404876b7df055aa1447e58821cce
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Wed Jul 29 14:20:16 2026 +0200

    fix(code): serialize AUTHENTICATION_ADDITIONAL_URLS writes to fix data race [IDE-2169] (#1364)
    
    * fix(code): serialize AUTHENTICATION_ADDITIONAL_URLS writes to fix data race [IDE-2169]
    
    CodeConfig.SnykCodeApi and updateCodeApiLocalEngine both performed an
    unsynchronized read-modify-write (GetStringSlice -> append -> Set) on the
    shared engine configuration key AUTHENTICATION_ADDITIONAL_URLS. Each
    workspace-folder scan creates its own *CodeConfig but they share one
    workflow.Engine configuration, so concurrent scans raced on the slice and
    the -race detector aborted Test_SmokeIssueCaching.
    
    Remove the useless per-instance mutex (it could never guard cross-instance
    access) and introduce a single package-level authURLsMu sync.Mutex that is
    the one exclusion domain for every writer of the key in this package. Guard
    both write paths with it and add a slices.Contains idempotency check so
    repeated scans of the same URL no longer append duplicates.
    
    Tests: three concurrent -race tests reproduce the failure (same-instance,
    cross-instance, and SnykCodeApi-vs-updateCodeApiLocalEngine). They fire the
    data race without the fix (RED) and pass with it (GREEN).
    
    * test: eliminate keep-alive reuse race in OAuth refresher reachability test [IDE-2169]
    
    Test_IsAuthenticated_DoesNotUseOAuth2ProviderCustomRefresherFunc flaked in CI:
    the token-refresh request and the immediately-following whoami request could
    land on the same pooled connection to the test's httptest server, racing its
    teardown of that idle connection. The resulting io.EOF/net.OpError trips
    shouldCauseLogout's transient-network fallback before the request's real
    (status: 401) outcome is ever considered, so the stale token is left
    uncleared and the test's final assertion fails.
    
    Disable keep-alives on the test server so each request opens a fresh
    connection, removing the race. Production logic is untouched - the
    transient-network fallback is correct in general.
    
    ---------
    
    Co-authored-by: nick-y-snyk <nikita.yasnohorodskyi@snyk.io>

M	infrastructure/authentication/oauth_refresher_reachability_test.go
M	infrastructure/code/codeconfig.go
A	infrastructure/code/codeconfig_test.go
M	infrastructure/code/sast_local_engine.go

commit 8bfcd291fbe77fe334cb0c1005bf1545e596675b
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Wed Jul 29 12:28:56 2026 +0200

    fix: stabilize Test_SmokeTreeView/toggleTreeFilter flaky notification race [IDE-2087] (#1379)
    
    The "toggleTreeFilter disables low severity" subtest used a count-only
    require.Eventually predicate, then asserted on the last $/snyk.treeView
    notification's HTML. A stale async scan-render notification could increment
    the count before the filter-applied one arrived, so the content assert ran
    against the wrong notification and failed immediately (~0.01s) on
    windows-latest smoke runs.
    
    Fold the filter-content check into the require.Eventually predicate, scanning
    notifications[countBefore:] for the filter-applied marker so interleaved stale
    notifications no longer satisfy the wait early. No sleep/retry/skip/timeout
    workaround; the assertion content is unchanged.
    
    Produced by an automated flake-fix loop.
    
    Co-authored-by: nick-y-snyk <nikita.yasnohorodskyi@snyk.io>

M	application/server/server_smoke_treeview_test.go

commit 0c65b0b84b7cdd200014526c73dd21c25388d6b8
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Wed Jul 29 11:45:48 2026 +0200

    fix: isolate smoke test config home to stop cross-test interference [IDE-2108] (#1354)
    
    ## Summary
    - Fixes the flaky smoke test `Test_SmokeScanPrecedence_OSSEnabled_CodeDisabled` (Ubuntu CI), where the OSS scan never completed (28s timeout) with config-file errors from a parallel test in the logs.
    - Root cause: the smoke-test setup helpers mutated the **process-global** `xdg.ConfigHome` (read by `storage.NewStorageWithCallbacks` via `xdg.ConfigFile`) and restored it in `t.Cleanup`. When two smoke tests ran concurrently, each writing its own `t.TempDir()` to that global, one test's storage/folder-config resolved into another test's directory — the folder config file was missing and the scan stalled.
    - Fix: drop the `xdg.ConfigHome` mutation and instead set an explicit per-test `SettingConfigFile` on the engine configuration. `folderconfig.ConfigFileFromConfig` returns that explicit path before ever consulting the `xdg` global, so each test is fully isolated without touching shared process state. Applied at all four setup sites (`precedence_smoke_test.go` x3, `ldx_sync_smoke_test.go`).
    - Adds isolation-invariant regression tests proving `ConfigFileFromConfig` returns the explicit path for the primary, legacy, and user-global keys and never falls back to `xdg.ConfigHome`.
    
    ## Test plan
    - [x] `go build ./...`, `go vet`, `golangci-lint ./internal/folderconfig/...` clean (0 issues)
    - [x] `go test ./internal/folderconfig/... -race` race-clean over repeated runs; the kept isolation test proven RED if `SettingConfigFile` resolution regresses
    - [x] No `xdg.ConfigHome` assignment remains anywhere in the repo
    - [x] `make test` (full unit suite) green at this commit
    - [ ] CI smoke shards (run on PR; live OSS scan needs network/token not available locally)
    
    ---
    This fix was produced by an automated flake-fix loop.

M	application/server/ldx_sync_smoke_test.go
M	application/server/precedence_smoke_test.go
A	internal/folderconfig/xdg_isolation_test.go

commit cd20b367246d0e8c88751e46e1d90e7f5a9069aa
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Wed Jul 29 10:12:58 2026 +0100

    fix: sign commits made by distribute-fallback-html [IDE-2321] (#1389)
    
    fix(ci): sign commits made by distribute-fallback-html [IDE-2321]
    
    Target repos require signed commits to merge, so the sync PRs this
    workflow opens could never be merged as-is. Copies the SSH-signing
    setup already used by create-cli-pr (ssh-agent + gpg.format ssh +
    commit.gpgsign + user.signingkey).

M	.github/distribute-fallback-html.sh
M	.github/workflows/distribute-fallback-html.yaml

commit 46b2bf4f1f5a5d1cb0ae518c0065541dd6737ca1
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Tue Jul 28 14:36:52 2026 +0200

    fix: stabilize scan-dedup cancellation race in Test_SeveralScansOnSameFolder_DoNotRunAtOnce [IDE-2099] (#1382)
    
    ## Summary
    Fixes the flaky `Test_SeveralScansOnSameFolder_DoNotRunAtOnce` (IDE-2099), observed failing on `smoke (1, windows-latest)` with 2 finished scans instead of 1.
    
    Root cause: OSS/IaC scan deduplication cancelled a superseded scan by sending on an **unbuffered** `cancel` channel that had to be received by a `go Listen(...)` goroutine. If that goroutine had not yet been scheduled when the next scan called `CancelScan()`, the send blocked up to the 5s safety timeout — long enough for the superseded scan's execution to finish, so the dedup count was 2.
    
    Fix: register the context `CancelFunc` on `ScanProgress` via `SetCancelFunc` (before `go Listen(...)` and before inserting into `runningScans`, under the scanner mutex), and have `CancelScan` invoke it **directly** while guarded by the `ScanProgress` mutex — removing the goroutine-readiness dependency entirely. The legacy unbuffered-channel path is preserved for any caller that does not set a cancel func. Applied at both call sites (`infrastructure/oss/cli_scanner.go`, `infrastructure/iac/iac.go`).
    
    ## Changes
    - `internal/scans/scan_progress.go`: add `cancelFunc` field + `SetCancelFunc` (mutex-guarded); `CancelScan` calls it directly when set.
    - `infrastructure/oss/cli_scanner.go`, `infrastructure/iac/iac.go`: call `SetCancelFunc(cancel)` before starting `Listen`.
    - `internal/scans/scan_progress_test.go`: regression test (immediate cancel without a running listener) + concurrency race test for `SetCancelFunc`/`CancelScan` under `-race`.
    
    ## Test plan
    - [x] `go test ./internal/scans/... ./infrastructure/oss/... ./infrastructure/iac/... -race` — green
    - [x] New regression test fails without the fix (5s block), passes with it
    - [x] `make test` full unit suite — 203 ok, 0 failures; `go build ./... && go vet ./...` clean; golangci-lint 0 issues
    - [ ] CI smoke on windows-latest
    
    _Produced by an automated flake-fix loop._

M	infrastructure/iac/iac.go
M	infrastructure/oss/cli_scanner.go
M	internal/scans/scan_progress.go
M	internal/scans/scan_progress_test.go
```

[IDE-2181]: https://snyksec.atlassian.net/browse/IDE-2181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-2322]: https://snyksec.atlassian.net/browse/IDE-2322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ