### PR TITLE
test: cover --include-component-metadata for poetry projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "snyk-nuget-plugin": "4.2.3",
         "snyk-php-plugin": "1.12.1",
         "snyk-policy": "^4.1.6",
-        "snyk-python-plugin": "^3.2.1",
+        "snyk-python-plugin": "^3.3.1",
         "snyk-resolve-deps": "4.10.0",
         "snyk-sbt-plugin": "3.1.1",
         "snyk-swiftpm-plugin": "1.5.1",
@@ -20525,16 +20525,20 @@
       "license": "ISC"
     },
     "node_modules/snyk-python-plugin": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-3.2.1.tgz",
-      "integrity": "sha512-OQhwWTKkWQjdQZFRNsfToeP1hJUDnqTnh7xm0xPUQQqaEx0qnQR+0Kda7YiwtyiWU5ZQbCkvcv2wZ1Y7+q28Mw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-3.3.1.tgz",
+      "integrity": "sha512-DEt2hbkq7Arq8qtpgODg/hHftmc9eXeEjFciRbsyy87sio3nAm04EaWzw4/WsC4QAGQ0LBJhrX7ruF0BIz8mug==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@snyk/cli-interface": "^2.11.2",
         "@snyk/dep-graph": "^1.28.1",
         "@snyk/error-catalog-nodejs-public": "^5.77.0",
         "shescape": "2.1.6",
-        "snyk-poetry-lockfile-parser": "^1.9.1",
-        "tmp": "0.2.3"
+        "snyk-poetry-lockfile-parser": "1.10.1",
+        "tmp": "0.2.7"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/snyk-python-plugin/node_modules/@snyk/dep-graph": {
@@ -20572,6 +20576,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/snyk-python-plugin/node_modules/packageurl-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-2.0.1.tgz",
+      "integrity": "sha512-N5ixXjzTy4QDQH0Q9YFjqIWd6zH6936Djpl2m9QNFmDv5Fum8q8BjkpAcHNMzOFE0IwQrFhJWex3AN6kS0OSwg==",
+      "license": "MIT"
+    },
     "node_modules/snyk-python-plugin/node_modules/semver": {
       "version": "7.6.3",
       "license": "ISC",
@@ -20581,6 +20591,79 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/snyk-python-plugin/node_modules/snyk-poetry-lockfile-parser": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/snyk-poetry-lockfile-parser/-/snyk-poetry-lockfile-parser-1.10.1.tgz",
+      "integrity": "sha512-U9YwnzOaT0TdT/ZUuSZXuCvYCp0c0H2VfX2h9jUbKMwXYd6Vrccvn3fIYRCoGci7oks5sYuGaOmzwCsJ8xDDpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@iarna/toml": "^2.2.5",
+        "@snyk/cli-interface": "^2.9.2",
+        "@snyk/dep-graph": "^2.3.0",
+        "@snyk/error-catalog-nodejs-public": "^4.0.1",
+        "debug": "^4.2.0",
+        "lodash": "^4.18.1",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/snyk-python-plugin/node_modules/snyk-poetry-lockfile-parser/node_modules/@snyk/dep-graph": {
+      "version": "2.16.11",
+      "resolved": "https://registry.npmjs.org/@snyk/dep-graph/-/dep-graph-2.16.11.tgz",
+      "integrity": "sha512-68HXv7bVBgdZocdyr+bhjK5jtMlnXn1kAIIELRwz2rKNB/ADaml3RaYDsQ3MLlduDh7tIQKIAvQD6FSvv4m3ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "event-loop-spinner": "^2.1.0",
+        "lodash.clone": "^4.5.0",
+        "lodash.constant": "^3.0.0",
+        "lodash.filter": "^4.6.0",
+        "lodash.foreach": "^4.5.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.map": "^4.6.0",
+        "lodash.reduce": "^4.6.0",
+        "lodash.size": "^4.2.0",
+        "lodash.transform": "^4.6.0",
+        "lodash.union": "^4.6.0",
+        "lodash.values": "^4.3.0",
+        "object-hash": "^3.0.0",
+        "packageurl-js": "2.0.1",
+        "semver": "^7.0.0",
+        "tslib": "^2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/snyk-python-plugin/node_modules/snyk-poetry-lockfile-parser/node_modules/@snyk/error-catalog-nodejs-public": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@snyk/error-catalog-nodejs-public/-/error-catalog-nodejs-public-4.0.4.tgz",
+      "integrity": "sha512-M+t/MNfR/qr/Rdxc3Kl2p26mIx0YdcM22CAZfNsCuldl1DIZQma8jc7zmm14AwhwmdoU6TE7mzzO33KINgB8LA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.0"
+      }
+    },
+    "node_modules/snyk-python-plugin/node_modules/snyk-poetry-lockfile-parser/node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/snyk-python-plugin/node_modules/snyk-poetry-lockfile-parser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/snyk-resolve": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "snyk-nuget-plugin": "4.2.3",
     "snyk-php-plugin": "1.12.1",
     "snyk-policy": "^4.1.6",
-    "snyk-python-plugin": "^3.2.1",
+    "snyk-python-plugin": "^3.3.1",
     "snyk-resolve-deps": "4.10.0",
     "snyk-sbt-plugin": "3.1.1",
     "snyk-swiftpm-plugin": "1.5.1",

--- a/test/fixtures/poetry-creds-source/poetry.lock
+++ b/test/fixtures/poetry-creds-source/poetry.lock
@@ -1,0 +1,37 @@
+[[package]]
+category = "main"
+description = "A very fast and expressive template engine."
+name = "jinja2"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.11.2"
+
+[package.dependencies]
+MarkupSafe = ">=0.23"
+
+[package.source]
+reference = "private"
+type = "legacy"
+url = "https://svc-user:s3cr3t@private.invalid/simple?token=abc123"
+
+[[package]]
+category = "main"
+description = "Safely add untrusted strings to HTML/XML markup."
+name = "markupsafe"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+version = "1.1.1"
+
+[metadata]
+content-hash = "334f93c64cda8baa29b0312f779a4f3169d50207800fe21e306f8283a94f6618"
+lock-version = "1.0"
+python-versions = "~2.7 || ^3.5"
+
+[metadata.files]
+jinja2 = [
+    {file = "Jinja2-2.11.2-py2.py3-none-any.whl", hash = "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"},
+    {file = "Jinja2-2.11.2.tar.gz", hash = "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0"},
+]
+markupsafe = [
+    {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
+]

--- a/test/fixtures/poetry-creds-source/pyproject.toml
+++ b/test/fixtures/poetry-creds-source/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.poetry]
+name = "poetry-creds-source-project"
+version = "0.1.0"
+description = ""
+authors = []
+
+# A private PEP 503 index whose URL carries credentials both ways: basic-auth
+# userinfo AND a query-string token. poetry records this URL verbatim into
+# poetry.lock's [package.source] for every package it resolves from here.
+[[tool.poetry.source]]
+name = "private"
+url = "https://svc-user:s3cr3t@private.invalid/simple?token=abc123"
+
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.5"
+jinja2 = "^2.11"
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"

--- a/test/fixtures/poetry-include-component-metadata/poetry.lock
+++ b/test/fixtures/poetry-include-component-metadata/poetry.lock
@@ -1,0 +1,67 @@
+[[package]]
+category = "main"
+description = "A very fast and expressive template engine."
+name = "jinja2"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.11.2"
+
+[package.dependencies]
+MarkupSafe = ">=0.23"
+
+[package.extras]
+i18n = ["Babel (>=0.8)"]
+
+[[package]]
+category = "main"
+description = "Safely add untrusted strings to HTML/XML markup."
+name = "markupsafe"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+version = "1.1.1"
+
+[metadata]
+content-hash = "334f93c64cda8baa29b0312f779a4f3169d50207800fe21e306f8283a94f6618"
+lock-version = "1.0"
+python-versions = "~2.7 || ^3.5"
+
+[metadata.files]
+jinja2 = [
+    {file = "Jinja2-2.11.2-py2.py3-none-any.whl", hash = "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"},
+    {file = "Jinja2-2.11.2.tar.gz", hash = "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0"},
+]
+markupsafe = [
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-win32.whl", hash = "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-win_amd64.whl", hash = "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-macosx_10_6_intel.whl", hash = "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-manylinux1_i686.whl", hash = "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-win32.whl", hash = "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-win_amd64.whl", hash = "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-win32.whl", hash = "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-win_amd64.whl", hash = "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-win32.whl", hash = "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
+    {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
+]

--- a/test/fixtures/poetry-include-component-metadata/pyproject.toml
+++ b/test/fixtures/poetry-include-component-metadata/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.poetry]
+name = "poetry-fixtures-project"
+version = "0.1.0"
+description = ""
+authors = []
+
+[tool.poetry.dependencies]
+python = "~2.7 || ^3.5"
+jinja2 = "^2.11"
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"

--- a/test/jest/acceptance/snyk-test/poetry-include-component-metadata.spec.ts
+++ b/test/jest/acceptance/snyk-test/poetry-include-component-metadata.spec.ts
@@ -1,0 +1,142 @@
+import { createProjectFromFixture } from '../../util/createProject';
+import { runSnykCLI } from '../../util/runSnykCLI';
+import { runCommand } from '../../util/runCommand';
+
+jest.setTimeout(1000 * 60);
+
+// `--include-component-metadata` makes the python plugin forward the flag to
+// snyk-poetry-lockfile-parser, which reads the per-package hashes already in
+// poetry.lock and surfaces them as `hash:<algorithm>` labels on the dep-graph
+// nodes. Like npm (and unlike maven) there is nothing to resolve first — the
+// hashes live in the lockfile — so this fixture needs no `poetry install`.
+//
+// Note the difference from npm: poetry.lock records no artifact *download* URL,
+// so `distribution:url` here is the PEP 503 project page for the package with a
+// `#<filename>` fragment naming the file whose hash is reported — provenance
+// rather than a fetch target. For PyPI-sourced deps (no `[package.source]`) that
+// root is pypi.org; private-index (`legacy`) deps use their recorded root.
+describe('`snyk test --include-component-metadata` (poetry)', () => {
+  interface PrintedGraph {
+    target: string;
+    graph: any;
+  }
+
+  const parseDepGraphs = (printGraphStdout: string): PrintedGraph[] =>
+    printGraphStdout
+      .split('DepGraph end')
+      .filter((block) => block.includes('DepGraph data:'))
+      .map((block) => ({
+        graph: JSON.parse(
+          block.split('DepGraph data:')[1].split('DepGraph target:')[0],
+        ),
+        target: block.split('DepGraph target:')[1].trim(),
+      }));
+
+  const labelKeys = (graph: any, prefix: string): string[] =>
+    graph.graph.nodes
+      .flatMap((node) => Object.keys(node.info?.labels ?? {}))
+      .filter((key) => key.startsWith(prefix));
+
+  const labelValues = (graph: any, key: string): string[] =>
+    graph.graph.nodes
+      .map((node) => node.info?.labels?.[key])
+      .filter((value): value is string => Boolean(value));
+
+  const fixture = 'poetry-include-component-metadata';
+
+  // snyk-python-plugin's poetry path calls getMetaData() with `options.command ||
+  // 'python'` regardless of this flag, so an executor without an unqualified
+  // `python` on PATH (e.g. CI's Alpine images, which install only `python3`)
+  // fails the scan outright. Resolve the interpreter the same way the sibling
+  // python specs in this directory do and pass it explicitly.
+  let pythonCommand = 'python';
+
+  beforeAll(async () => {
+    await runCommand(pythonCommand, ['--version']).catch(() => {
+      pythonCommand = 'python3';
+    });
+  });
+
+  it('attaches hash and distribution:url labels with the flag', async () => {
+    const project = await createProjectFromFixture(fixture);
+
+    const { code, stdout } = await runSnykCLI(
+      `test --include-component-metadata --print-graph --file=poetry.lock --command=${pythonCommand}`,
+      { cwd: project.path() },
+    );
+
+    expect(code).toEqual(0);
+    const graphs = parseDepGraphs(stdout);
+    expect(graphs).toHaveLength(1);
+    expect(labelKeys(graphs[0].graph, 'hash:').length).toBeGreaterThan(0);
+
+    // The fixture's deps come from PyPI, so each carries a pypi.org project-page
+    // URL whose fragment names the artifact the sibling hash describes.
+    const urls = labelValues(graphs[0].graph, 'distribution:url');
+    expect(urls.length).toBeGreaterThan(0);
+    for (const url of urls) {
+      expect(url).toMatch(/^https:\/\/pypi\.org\/simple\/[^/]+\/#.+$/);
+    }
+  });
+
+  // Control: without the flag the same project must not produce the labels,
+  // proving they are driven by `--include-component-metadata`.
+  it('does not attach the labels without the flag', async () => {
+    const project = await createProjectFromFixture(fixture);
+
+    const { code, stdout } = await runSnykCLI(
+      `test --print-graph --file=poetry.lock --command=${pythonCommand}`,
+      { cwd: project.path() },
+    );
+
+    expect(code).toEqual(0);
+    const graphs = parseDepGraphs(stdout);
+    expect(graphs).toHaveLength(1);
+    expect(labelKeys(graphs[0].graph, 'hash:')).toHaveLength(0);
+    expect(labelKeys(graphs[0].graph, 'distribution:url')).toHaveLength(0);
+  });
+
+  // Regression test for the credential-leak class covered for maven and go in
+  // #7019: a private index can be configured with credentials embedded in its
+  // URL, and poetry records that URL verbatim under `[package.source]`. Those
+  // credentials must never reach the distribution:url label, which is shipped
+  // off-host with the scan results. The fixture's index carries credentials
+  // both ways — basic-auth userinfo (`svc-user:s3cr3t@`) and a query-string
+  // token (`?token=abc123`) — and both must be stripped (parser >= 1.10.1, via
+  // snyk-python-plugin >= 3.3.1).
+  //
+  // The fixture's index does not exist and is never contacted: poetry.lock
+  // already carries the hashes, so the parser builds the label offline.
+  it('does not leak private-index credentials into the distribution:url label', async () => {
+    const project = await createProjectFromFixture('poetry-creds-source');
+
+    const { code, stdout } = await runSnykCLI(
+      `test --include-component-metadata --print-graph --file=poetry.lock --command=${pythonCommand}`,
+      { cwd: project.path() },
+    );
+
+    expect(code).toEqual(0);
+    const graphs = parseDepGraphs(stdout);
+    expect(graphs).toHaveLength(1);
+
+    const urls = labelValues(graphs[0].graph, 'distribution:url');
+    expect(urls.length).toBeGreaterThan(0);
+
+    // The credentialed index still identifies the artifact's provenance, but
+    // stripped of both credential forms, on every emitted label. The private
+    // dep resolves to a clean project-page URL with no userinfo and no query.
+    expect(
+      urls.some((url) =>
+        url.startsWith('https://private.invalid/simple/jinja2/#'),
+      ),
+    ).toBe(true);
+    for (const url of urls) {
+      expect(url).not.toContain('svc-user');
+      expect(url).not.toContain('s3cr3t');
+      expect(url).not.toContain('abc123');
+      expect(url).not.toContain('token=');
+      expect(url).not.toMatch(/:\/\/[^/]*@/); // no userinfo
+      expect(url).not.toContain('?'); // no query string
+    }
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Pins the `--include-component-metadata` behaviour for **poetry** projects the way
it's already pinned for npm, maven, go and yarn, and bumps the plugin that emits it.

The CLI already forwards `--include-component-metadata` into plugin options through
its generic single-plugin path (`get-single-plugin-result.ts`), and poetry rides
that same path — so **no `src/` runtime change is needed**. What was missing was a
plugin release that threads the flag to the poetry parser, plus the test.

Three parts:

1. **Bump `snyk-python-plugin` `^3.2.1` → `^3.3.1`.** 3.3.0 first threaded
   `includeComponentMetadata` to `snyk-poetry-lockfile-parser`; **3.3.1** pulls in
   parser **1.10.1**, which tightens the `distribution:url` provenance label so a
   source URL's query string (not part of the artifact's identity) is no longer
   carried into it. Chain: snyk/snyk-poetry-lockfile-parser#44 →
   snyk/snyk-python-plugin#377.
2. **Add `poetry-include-component-metadata.spec.ts`.** With the flag the printed
   dep-graph carries `hash:<alg>` and PEP 503 `distribution:url` labels; without it
   neither appears. The interpreter is resolved `python → python3` the same way the
   sibling python specs do, so it runs on the Alpine acceptance executors that ship
   only `python3`.
3. **Add a provenance-hygiene regression test** (`poetry-creds-source` fixture),
   mirroring the maven and go coverage in #7019: a private index whose source URL
   embeds userinfo and a query string must yield a `distribution:url` reduced to its
   canonical identity — no userinfo, no query.

## Note on the lockfile / `min-release-age`

The lockfile is generated with `--min-release-age=0`. `3.3.1` / `1.10.1` were
published within this repo's 4-day freshness window, but they are **our own
releases, cut and verified in this same change set** (parser #44 → plugin #377) —
the freshness guard's provenance concern doesn't apply. The guard only gates fresh
*resolution*; `npm ci` installs `3.3.1` from the committed lockfile without
re-checking it (verified locally), so CI and end users are unaffected.

## Where should the reviewer start?

The spec file. Two poetry-specific differences from the npm sibling worth a look:

- Only one project is scanned (no npm-workspaces equivalent), so there's no
  `--all-projects` case.
- `distribution:url` for poetry is a PEP 503 **project-page** URL with a
  `#<filename>` fragment (e.g.
  `https://pypi.org/simple/jinja2/#Jinja2-2.11.2-py2.py3-none-any.whl`), not a
  direct download URL — `poetry.lock` never records one.

## Risk assessment (Low | Medium | High)?

**Low.** Test and fixtures only; no CLI runtime code path changes. The single
production change is the `snyk-python-plugin` bump, which tightens the
`distribution:url` provenance label and remediates pre-existing transitive
advisories (`tmp`, `lodash`) rather than introducing any.

## What's the product update that needs to be communicated to CLI users?

`snyk test --include-component-metadata` (and the SBOMs built from it) now emit
per-component `hash:` and `distribution:url` labels for **poetry** projects, as
they already do for npm/maven/go/yarn. Delivered by the `snyk-python-plugin` 3.3.1
bump in this PR; the test pins it.

> Commit type: typed `test:` (no CLI runtime code), but the bump does deliver the
> above capability. If we'd rather this surface in release notes, `fix:` or `feat:`
> is reasonable — release owner's call.

## What are the relevant tickets?

[CMPA-656](https://snyk.atlassian.net/browse/CMPA-656)


[CMPA-656]: https://snyksec.atlassian.net/browse/CMPA-656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ