### PR TITLE
chore: bump secrets extensions to allow exclusions [PS-715]

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -215,7 +215,7 @@ require (
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e // indirect
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091 // indirect
 	github.com/snyk/cli-extension-sbom v0.0.0-20260722102401-3c3af28e7b93 // indirect
-	github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3 // indirect
+	github.com/snyk/cli-extension-secrets v0.0.0-20260728151749-3c88a5e044f3 // indirect
 	github.com/snyk/code-client-go v1.31.3 // indirect
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -583,8 +583,8 @@ github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091 h1:MDR
 github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091/go.mod h1:qNOr9aDWYUa3Tl74k+04hOCEgKcgpBLVcvs26L4ooN0=
 github.com/snyk/cli-extension-sbom v0.0.0-20260722102401-3c3af28e7b93 h1:iCHSAW2OkvObczF5zNmEwnGeavQri4/rO1w1efaAfT4=
 github.com/snyk/cli-extension-sbom v0.0.0-20260722102401-3c3af28e7b93/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
-github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3 h1:wBYQm4YP65FTZ4rZ0iunhsIUYBindUEnfRWRi+Rugag=
-github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3/go.mod h1:D/Bk0EH8np/d6c1tG7wazpHI6iU9m8KzxytFcIQkEvQ=
+github.com/snyk/cli-extension-secrets v0.0.0-20260728151749-3c88a5e044f3 h1:YD4ethi1r6zo6r+W7kbbs++8t52YUwY72KzbyT5izg8=
+github.com/snyk/cli-extension-secrets v0.0.0-20260728151749-3c88a5e044f3/go.mod h1:Xh4JxbL09lqqF5CO64YE8ytthbRr1lhM6sgu0izMz4k=
 github.com/snyk/code-client-go v1.31.3 h1:X1vzubbdGXWpxwnjBkC3HchH1rWjDdqdn0cCz2to0TA=
 github.com/snyk/code-client-go v1.31.3/go.mod h1:Yl1x9g7Y6JOcEWoaxyrKFvrj76JkaeRFUpEkXVjRhS8=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea h1:/v48hCMPiZVjplylgE2FX1ib8Qd8LN/vf8ZIKfA+wkI=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091
 	github.com/snyk/cli-extension-sbom v0.0.0-20260722102401-3c3af28e7b93
-	github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3
+	github.com/snyk/cli-extension-secrets v0.0.0-20260728151749-3c88a5e044f3
 	github.com/snyk/code-client-go v1.31.3
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -537,8 +537,8 @@ github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091 h1:MDR
 github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091/go.mod h1:qNOr9aDWYUa3Tl74k+04hOCEgKcgpBLVcvs26L4ooN0=
 github.com/snyk/cli-extension-sbom v0.0.0-20260722102401-3c3af28e7b93 h1:iCHSAW2OkvObczF5zNmEwnGeavQri4/rO1w1efaAfT4=
 github.com/snyk/cli-extension-sbom v0.0.0-20260722102401-3c3af28e7b93/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
-github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3 h1:wBYQm4YP65FTZ4rZ0iunhsIUYBindUEnfRWRi+Rugag=
-github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3/go.mod h1:D/Bk0EH8np/d6c1tG7wazpHI6iU9m8KzxytFcIQkEvQ=
+github.com/snyk/cli-extension-secrets v0.0.0-20260728151749-3c88a5e044f3 h1:YD4ethi1r6zo6r+W7kbbs++8t52YUwY72KzbyT5izg8=
+github.com/snyk/cli-extension-secrets v0.0.0-20260728151749-3c88a5e044f3/go.mod h1:Xh4JxbL09lqqF5CO64YE8ytthbRr1lhM6sgu0izMz4k=
 github.com/snyk/code-client-go v1.31.3 h1:X1vzubbdGXWpxwnjBkC3HchH1rWjDdqdn0cCz2to0TA=
 github.com/snyk/code-client-go v1.31.3/go.mod h1:Yl1x9g7Y6JOcEWoaxyrKFvrj76JkaeRFUpEkXVjRhS8=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea h1:/v48hCMPiZVjplylgE2FX1ib8Qd8LN/vf8ZIKfA+wkI=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [x] Updates relevant GitBook documentation (PR link: https://github.com/snyk/user-docs/pull/1610)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Updates the secrets extension to a new version which supports setting .snyk exclusions for secrets

## Where should the reviewer start?

## How should this be manually tested?

run `snyk secrets test ` in a folder with a .snyk file that contains a `secrets` section  under `exclude` in the .snyk file 

## What's the product update that needs to be communicated to CLI users?

Users are able to exclude files from secrets scanning by adding them to a new "excludes.secrets" section in the .snyk file 

<!---
## Risk assessment (Low | Medium | High)?

Low

## Any background context you want to provide?


## What are the relevant tickets?

[Secrets-Extension - Support .snyk exclusions](https://snyksec.atlassian.net/browse/PS-715)

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
