### PR TITLE
feat: add snyk cos commands for continuous offensive security

### DIFF
--- a/cliv2-private/cmd/cliv2/main.go
+++ b/cliv2-private/cmd/cliv2/main.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/snyk/ambient-canary/pkg/daemon"
+	"github.com/snyk/cli-extension-cos/pkg/cos"
 	"github.com/snyk/remy-cli-extension/pkg/remy"
 
 	"github.com/snyk/cli/cliv2/pkg/core"
@@ -12,6 +13,7 @@ import (
 func main() {
 	os.Exit(core.Run(
 		core.WithAdditionalExtensions(remy.Init),
+		core.WithAdditionalExtensions(cos.Init),
 		core.WithAdditionalExtensions(daemon.Init),
 	))
 }

--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -4,6 +4,7 @@ go 1.26.5
 
 require (
 	github.com/snyk/ambient-canary v0.0.0-20260722064253-fba619a134a9
+	github.com/snyk/cli-extension-cos v0.0.0-20260730085209-d326e44b9140
 	github.com/snyk/cli/cliv2 v0.0.0
 	github.com/snyk/remy-cli-extension v1.33.0
 )
@@ -319,5 +320,7 @@ replace github.com/snyk/cli/cliv2 => ../cliv2
 // replace github.com/snyk/cli-extension-sbom => ../../cli-extension-sbom
 
 // replace github.com/snyk/cli-extension-secrets => ../../cli-extension-secrets
+
+// replace github.com/snyk/cli-extension-cos => ../../cli-extension-cos
 
 // replace github.com/snyk/ambient-canary => ../../ambient-canary

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -571,6 +571,8 @@ github.com/snyk/cli-extension-agent-scan v0.0.0-20260715092951-4f8fa1b9886c h1:o
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260715092951-4f8fa1b9886c/go.mod h1:g1qxNvAl2Qb0V4UJivop+hCqehHVqzB0taEjwTm6VlU=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260721084000-da8dc26c77f2 h1:fYTWYiCqw+NqeETMP/0TdVKjCHrHRng8M6+nxvrmluo=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260721084000-da8dc26c77f2/go.mod h1:axE+HO8U9CIcTjQ7k7BOLgdyZfNGqMn5QvZ0aIkUY4U=
+github.com/snyk/cli-extension-cos v0.0.0-20260730085209-d326e44b9140 h1:7yYsL4egJlFruDMgsng/nXTe5MFx8Ciys0+ADH61yOw=
+github.com/snyk/cli-extension-cos v0.0.0-20260730085209-d326e44b9140/go.mod h1:YpcOdcMBJOzwtla/OOoBOArx27Bc2v42Vcwd/FeGl9M=
 github.com/snyk/cli-extension-dep-graph/v2 v2.7.2 h1:+D/r8zDdREbrZs1EZ4DmVzEf7oMHA2rRozhuaVFyg8U=
 github.com/snyk/cli-extension-dep-graph/v2 v2.7.2/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSoQL0zYyFcGQjEPZcQgDkzM5PcgIHlIgzRuhg=
@@ -733,8 +735,8 @@ go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjce
 go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.uber.org/mock v0.5.2 h1:LbtPTcP8A5k9WPXj54PPPbjcI4Y6lhyOZXn+VS7wNko=
-go.uber.org/mock v0.5.2/go.mod h1:wLlUxC2vVTPTaE3UD51E0BGOAElKrILxhVSDYQLld5o=
+go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
+go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.yaml.in/yaml/v4 v4.0.0-rc.2 h1:/FrI8D64VSr4HtGIlUtlFMGsm7H7pWTbj6vOLVZcA6s=

--- a/test/fixtures/cos/cos.yaml
+++ b/test/fixtures/cos/cos.yaml
@@ -1,0 +1,3 @@
+target:
+  name: Demo App
+  url: https://demo-app.com

--- a/test/fixtures/cos/cos_invalid.yaml
+++ b/test/fixtures/cos/cos_invalid.yaml
@@ -1,0 +1,3 @@
+target:
+  name: Demo App
+  # missing url

--- a/test/jest/acceptance/snyk-cos/cos.spec.ts
+++ b/test/jest/acceptance/snyk-cos/cos.spec.ts
@@ -1,0 +1,770 @@
+import { runSnykCLI } from '../../util/runSnykCLI';
+import {
+  fakeServer,
+  getFirstIPv4Address,
+} from '../../../acceptance/fake-server';
+import { resolve, join } from 'path';
+import { readFileSync, mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { getAvailableServerPort } from '../../util/getServerPort';
+
+jest.setTimeout(1000 * 60);
+
+// The cos (Continuous Offensive Security / AI pen test) extension talks to the
+// hidden API, grouped by resource under the /cos namespace:
+//   POST   /hidden/tenants/:tenantId/cos/scans             (scan start)
+//   GET    /hidden/tenants/:tenantId/cos/scans             (scan list)
+//   GET    /hidden/tenants/:tenantId/cos/scans/:id         (scan status)
+//   POST   /hidden/tenants/:tenantId/cos/scans/:id/cancel  (scan cancel)
+//   GET    /hidden/tenants/:tenantId/cos/scans/:id/report  (scan report)
+//   POST   /hidden/tenants/:tenantId/cos/targets           (target create)
+//   GET    /hidden/tenants/:tenantId/cos/targets           (target list)
+//   GET    /hidden/tenants/:tenantId/cos/targets/:id       (target get, dump, lookup)
+//   PATCH  /hidden/tenants/:tenantId/cos/targets/:id       (target update)
+//   DELETE /hidden/tenants/:tenantId/cos/targets/:id       (target delete)
+//   GET    /hidden/tenants/:tenantId/cos/findings          (finding list)
+//   GET    /hidden/tenants/:tenantId/cos/findings/:id      (finding get)
+//
+// Requests are JSON:API (application/vnd.api+json). Passing --tenant-id skips
+// the tenant auto-discovery call, so only the resource endpoint is hit.
+
+const tenantId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const scanId = '11111111-2222-3333-4444-555555555555';
+const targetId = '66666666-7777-8888-9999-aaaaaaaaaaaa';
+const findingId = 'bbbbbbbb-cccc-dddd-eeee-ffffffffffff';
+
+const scansPath = `/api/hidden/tenants/${tenantId}/cos/scans`;
+const scanPath = `${scansPath}/${scanId}`;
+const targetsPath = `/api/hidden/tenants/${tenantId}/cos/targets`;
+const targetPath = `${targetsPath}/${targetId}`;
+const findingsPath = `/api/hidden/tenants/${tenantId}/cos/findings`;
+const findingPath = `${findingsPath}/${findingId}`;
+
+function scanResource(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'scan',
+    id: scanId,
+    attributes: {
+      tenant_id: tenantId,
+      target_id: targetId,
+      target_url: 'https://demo-app.com',
+      status: 'running',
+      created_at: '2024-10-15T10:00:00Z',
+      updated_at: '2024-10-15T10:05:00Z',
+      ...overrides,
+    },
+  };
+}
+
+function targetResource(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'target',
+    id: targetId,
+    attributes: {
+      tenant_id: tenantId,
+      name: 'Demo App',
+      url: 'https://demo-app.com',
+      created_at: '2024-10-15T10:00:00Z',
+      updated_at: '2024-10-15T10:00:00Z',
+      ...overrides,
+    },
+  };
+}
+
+function findingResource(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'finding',
+    id: findingId,
+    attributes: {
+      tenant_id: tenantId,
+      target_id: targetId,
+      title: 'SQL Injection',
+      category: 'injection',
+      severity: 'high',
+      endpoint: '/login',
+      state: 'open',
+      ...overrides,
+    },
+  };
+}
+
+describe('snyk cos (mocked servers only)', () => {
+  let server: ReturnType<typeof fakeServer>;
+  let env: Record<string, string>;
+  let envWithoutAuth: Record<string, string>;
+  let tmpDir: string | undefined;
+  let configHome: string | undefined;
+
+  const projectRoot = resolve(__dirname, '../../../..');
+  const configFile = resolve(projectRoot, 'test/fixtures/cos/cos.yaml');
+  const invalidConfigFile = resolve(
+    projectRoot,
+    'test/fixtures/cos/cos_invalid.yaml',
+  );
+
+  beforeAll(async () => {
+    const baseApi = '/api/v1';
+    const ipAddr = getFirstIPv4Address();
+    const port = await getAvailableServerPort(process);
+    const serverBase = `http://${ipAddr}:${port}`;
+
+    server = fakeServer(baseApi, '123456789');
+    await server.listenPromise(port);
+
+    env = {
+      ...process.env,
+      SNYK_API: `${serverBase}${baseApi}`,
+      SNYK_HOST: serverBase,
+      SNYK_TOKEN: '123456789',
+      SNYK_DISABLE_ANALYTICS: '1',
+      SNYK_CFG_ORG: tenantId,
+      SNYK_HTTP_PROTOCOL_UPGRADE: '0',
+    };
+    // Trigger "unauthenticated" regardless of how the extension detects auth:
+    // clear the organization scope AND every credential source (token / OAuth),
+    // and point at an isolated config dir so persisted credentials can't leak in.
+    configHome = mkdtempSync(join(tmpdir(), 'snyk-cos-config-'));
+    envWithoutAuth = {
+      ...env,
+      SNYK_TOKEN: '',
+      SNYK_OAUTH_TOKEN: '',
+      INTERNAL_OAUTH_TOKEN_STORAGE: '',
+      SNYK_CFG_ORG: '',
+      SNYK_ORG: '',
+      TEST_SNYK_TOKEN: 'UNSET',
+      XDG_CONFIG_HOME: configHome,
+    };
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    server.restore();
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  afterAll(() => {
+    if (configHome) {
+      rmSync(configHome, { recursive: true, force: true });
+      configHome = undefined;
+    }
+    return new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  // Only matches the hidden /cos endpoints, keeping assertions resilient to the
+  // auth/analytics/config requests the CLI makes around them.
+  function cosRequests(): { method: string; path: string }[] {
+    return server
+      .getRequests()
+      .filter((req) => req.url?.includes('/hidden/tenants/'))
+      .map((req) => ({
+        method: req.method as string,
+        path: (req.url as string).split('?')[0],
+      }));
+  }
+
+  describe('experimental gate', () => {
+    test('`scan list` requires --experimental', async () => {
+      const { code, stdout } = await runSnykCLI(
+        `cos scan list --tenant-id=${tenantId}`,
+        { env },
+      );
+      expect(code).toEqual(2);
+      expect(stdout).toContain('experimental');
+      // No API call should be made before the gate.
+      expect(cosRequests()).toEqual([]);
+    });
+  });
+
+  describe('cos scan list', () => {
+    test('lists scans in a table', async () => {
+      server.setEndpointResponse(scansPath, {
+        data: [scanResource()],
+        links: { self: scansPath },
+      });
+
+      const { code, stdout } = await runSnykCLI(
+        `cos scan list --experimental --tenant-id=${tenantId}`,
+        { env },
+      );
+      expect(code).toEqual(0);
+      expect(stdout).toContain('ID');
+      expect(stdout).toContain('STATUS');
+      expect(stdout).toContain(scanId);
+      expect(stdout).toContain('running');
+
+      expect(cosRequests()).toEqual([{ method: 'GET', path: scansPath }]);
+    });
+
+    test('renders JSON with -o json', async () => {
+      server.setEndpointResponse(scansPath, {
+        data: [scanResource()],
+        links: { self: scansPath },
+      });
+
+      const { code, stdout } = await runSnykCLI(
+        `cos scan list --experimental --tenant-id=${tenantId} -o json`,
+        { env },
+      );
+      expect(code).toEqual(0);
+
+      const parsed = JSON.parse(stdout);
+      expect(parsed.scans).toHaveLength(1);
+      expect(parsed.scans[0]).toMatchObject({
+        id: scanId,
+        status: 'running',
+      });
+    });
+
+    test('handles an empty result', async () => {
+      server.setEndpointResponse(scansPath, {
+        data: [],
+        links: { self: scansPath },
+      });
+
+      const { code, stdout } = await runSnykCLI(
+        `cos scan list --experimental --tenant-id=${tenantId}`,
+        { env },
+      );
+      expect(code).toEqual(0);
+      expect(stdout).toContain('No scans found.');
+    });
+
+    test('surfaces a server error', async () => {
+      server.setEndpointResponse(scansPath, {
+        errors: [{ status: '500', title: 'Internal Server Error' }],
+      });
+      server.setEndpointStatusCode(scansPath, 500);
+
+      // --max-attempts=1 disables network retries so the 500 fails fast.
+      const { code } = await runSnykCLI(
+        `cos scan list --experimental --tenant-id=${tenantId} --max-attempts=1`,
+        { env },
+      );
+      expect(code).toEqual(2);
+    });
+  });
+
+  describe('cos scan start', () => {
+    test('creates a scan for a target', async () => {
+      server.setEndpointResponse(scansPath, {
+        data: scanResource({ status: 'queued' }),
+        links: { self: scanPath },
+      });
+
+      const { code, stdout } = await runSnykCLI(
+        `cos scan start --target-id=${targetId} --experimental --tenant-id=${tenantId}`,
+        { env },
+      );
+      expect(code).toEqual(0);
+      expect(stdout).toContain('Scan started');
+      expect(stdout).toContain(scanId);
+
+      expect(cosRequests()).toEqual([{ method: 'POST', path: scansPath }]);
+    });
+
+    test('fails without --target-id', async () => {
+      const { code, stdout } = await runSnykCLI(
+        `cos scan start --experimental --tenant-id=${tenantId}`,
+        { env },
+      );
+      expect(code).toEqual(2);
+      expect(stdout).toContain('--target-id');
+      // Validation happens before any API call.
+      expect(cosRequests()).toEqual([]);
+    });
+  });
+
+  describe('cos scan status', () => {
+    test('reports the status of a scan', async () => {
+      server.setEndpointResponse(scanPath, {
+        data: scanResource({ status: 'completed' }),
+        links: { self: scanPath },
+      });
+
+      const { code, stdout } = await runSnykCLI(
+        `cos scan status --experimental --tenant-id=${tenantId} --scan-id=${scanId}`,
+        { env },
+      );
+      expect(code).toEqual(0);
+      expect(stdout).toContain('Scan');
+      expect(stdout).toContain(scanId);
+      expect(stdout).toContain('completed');
+
+      expect(cosRequests()).toEqual([{ method: 'GET', path: scanPath }]);
+    });
+
+    test('renders JSON with --json', async () => {
+      server.setEndpointResponse(scanPath, {
+        data: scanResource({ status: 'completed' }),
+        links: { self: scanPath },
+      });
+
+      const { code, stdout } = await runSnykCLI(
+        `cos scan status --experimental --tenant-id=${tenantId} --scan-id=${scanId} --json`,
+        { env },
+      );
+      expect(code).toEqual(0);
+
+      const parsed = JSON.parse(stdout);
+      expect(parsed).toMatchObject({
+        id: scanId,
+        status: 'completed',
+      });
+    });
+
+    test('fails without --scan-id', async () => {
+      const { code, stdout } = await runSnykCLI(
+        `cos scan status --experimental --tenant-id=${tenantId}`,
+        { env },
+      );
+      expect(code).toEqual(2);
+      expect(stdout).toContain('--scan-id');
+      expect(cosRequests()).toEqual([]);
+    });
+  });
+
+  describe('cos scan cancel', () => {
+    test('cancels a scan', async () => {
+      const cancelPath = `${scanPath}/cancel`;
+      server.setEndpointResponse(cancelPath, {
+        data: scanResource({ status: 'canceled' }),
+        links: { self: scanPath },
+      });
+
+      const { code, stdout } = await runSnykCLI(
+        `cos scan cancel --experimental --tenant-id=${tenantId} --scan-id=${scanId}`,
+        { env },
+      );
+      expect(code).toEqual(0);
+      expect(stdout).toContain('canceled');
+      expect(stdout).toContain(scanId);
+
+      expect(cosRequests()).toEqual([{ method: 'POST', path: cancelPath }]);
+    });
+
+    test('fails without --scan-id', async () => {
+      const { code, stdout } = await runSnykCLI(
+        `cos scan cancel --experimental --tenant-id=${tenantId}`,
+        { env },
+      );
+      expect(code).toEqual(2);
+      expect(stdout).toContain('--scan-id');
+      expect(cosRequests()).toEqual([]);
+    });
+  });
+
+  describe('cos scan report', () => {
+    test('prints the report JSON', async () => {
+      const reportPath = `${scanPath}/report`;
+      server.setEndpointResponse(reportPath, {
+        data: {
+          type: 'scan_report',
+          id: scanId,
+          attributes: { summary: { issues: 2 }, findings: ['a', 'b'] },
+        },
+      });
+
+      const { code, stdout } = await runSnykCLI(
+        `cos scan report --experimental --tenant-id=${tenantId} --scan-id=${scanId}`,
+        { env },
+      );
+      expect(code).toEqual(0);
+
+      const parsed = JSON.parse(stdout);
+      expect(parsed).toMatchObject({
+        summary: { issues: 2 },
+        findings: ['a', 'b'],
+      });
+
+      expect(cosRequests()).toEqual([{ method: 'GET', path: reportPath }]);
+    });
+
+    test('writes the report to --output-file', async () => {
+      const reportPath = `${scanPath}/report`;
+      server.setEndpointResponse(reportPath, {
+        data: {
+          type: 'scan_report',
+          id: scanId,
+          attributes: { summary: { issues: 0 } },
+        },
+      });
+
+      tmpDir = mkdtempSync(join(tmpdir(), 'snyk-cos-'));
+      const outFile = join(tmpDir, 'report.json');
+
+      const { code } = await runSnykCLI(
+        `cos scan report --experimental --tenant-id=${tenantId} --scan-id=${scanId} --output-file=${outFile}`,
+        { env },
+      );
+      expect(code).toEqual(0);
+
+      const written = JSON.parse(readFileSync(outFile, 'utf-8'));
+      expect(written).toMatchObject({ summary: { issues: 0 } });
+    });
+
+    test('fails without --scan-id', async () => {
+      const { code, stdout } = await runSnykCLI(
+        `cos scan report --experimental --tenant-id=${tenantId}`,
+        { env },
+      );
+      expect(code).toEqual(2);
+      expect(stdout).toContain('--scan-id');
+      expect(cosRequests()).toEqual([]);
+    });
+  });
+
+  describe('cos target create', () => {
+    test('creates a target from a config file', async () => {
+      server.setEndpointResponse(targetsPath, {
+        data: targetResource(),
+        links: { self: `${targetsPath}/${targetId}` },
+      });
+
+      const { code, stdout } = await runSnykCLI(
+        `cos target create --experimental --tenant-id=${tenantId} --config=${configFile}`,
+        { env },
+      );
+      expect(code).toEqual(0);
+      expect(stdout).toContain('Target created');
+      expect(stdout).toContain(targetId);
+
+      expect(cosRequests()).toEqual([{ method: 'POST', path: targetsPath }]);
+    });
+
+    test('fails when the config is missing target.url', async () => {
+      const { code } = await runSnykCLI(
+        `cos target create --experimental --tenant-id=${tenantId} --config=${invalidConfigFile}`,
+        { env },
+      );
+      expect(code).toEqual(2);
+      // Validation happens before any API call.
+      expect(cosRequests()).toEqual([]);
+    });
+  });
+
+  describe('cos target list', () => {
+    test('lists targets in a table', async () => {
+      server.setEndpointResponse(targetsPath, {
+        data: [targetResource()],
+        links: { self: targetsPath },
+      });
+
+      const { code, stdout } = await runSnykCLI(
+        `cos target list --experimental --tenant-id=${tenantId}`,
+        { env },
+      );
+      expect(code).toEqual(0);
+      expect(stdout).toContain('ID');
+      expect(stdout).toContain('NAME');
+      expect(stdout).toContain(targetId);
+      expect(stdout).toContain('Demo App');
+
+      expect(cosRequests()).toEqual([{ method: 'GET', path: targetsPath }]);
+    });
+
+    test('handles an empty result', async () => {
+      server.setEndpointResponse(targetsPath, {
+        data: [],
+        links: { self: targetsPath },
+      });
+
+      const { code, stdout } = await runSnykCLI(
+        `cos target list --experimental --tenant-id=${tenantId}`,
+        { env },
+      );
+      expect(code).toEqual(0);
+      expect(stdout).toContain('No targets found.');
+    });
+  });
+
+  describe('cos target get', () => {
+    test('shows a target', async () => {
+      server.setEndpointResponse(targetPath, {
+        data: targetResource(),
+        links: { self: targetPath },
+      });
+
+      const { code, stdout } = await runSnykCLI(
+        `cos target get --experimental --tenant-id=${tenantId} --target-id=${targetId}`,
+        { env },
+      );
+      expect(code).toEqual(0);
+      expect(stdout).toContain(targetId);
+      expect(stdout).toContain('Demo App');
+      expect(stdout).toContain('https://demo-app.com');
+
+      expect(cosRequests()).toEqual([{ method: 'GET', path: targetPath }]);
+    });
+
+    test('renders JSON with -o json', async () => {
+      server.setEndpointResponse(targetPath, {
+        data: targetResource(),
+        links: { self: targetPath },
+      });
+
+      const { code, stdout } = await runSnykCLI(
+        `cos target get --experimental --tenant-id=${tenantId} --target-id=${targetId} -o json`,
+        { env },
+      );
+      expect(code).toEqual(0);
+
+      const parsed = JSON.parse(stdout);
+      expect(parsed).toMatchObject({
+        id: targetId,
+        name: 'Demo App',
+        url: 'https://demo-app.com',
+      });
+    });
+
+    test('fails without --target-id', async () => {
+      const { code, stdout } = await runSnykCLI(
+        `cos target get --experimental --tenant-id=${tenantId}`,
+        { env },
+      );
+      expect(code).toEqual(2);
+      expect(stdout).toContain('--target-id');
+      expect(cosRequests()).toEqual([]);
+    });
+  });
+
+  describe('cos target update', () => {
+    test('updates a target from a config file', async () => {
+      // One registration answers both requests: the endpoint config is keyed by
+      // path, not by method.
+      server.setEndpointResponse(targetPath, {
+        data: targetResource(),
+        links: { self: targetPath },
+      });
+
+      const { code, stdout } = await runSnykCLI(
+        `cos target update --experimental --tenant-id=${tenantId} --target-id=${targetId} --config=${configFile}`,
+        { env },
+      );
+      expect(code).toEqual(0);
+      expect(stdout).toContain('Target updated');
+      expect(stdout).toContain(targetId);
+
+      expect(cosRequests()).toEqual([
+        { method: 'GET', path: targetPath },
+        { method: 'PATCH', path: targetPath },
+      ]);
+    });
+
+    test('fails without --config', async () => {
+      const { code, stdout } = await runSnykCLI(
+        `cos target update --experimental --tenant-id=${tenantId} --target-id=${targetId}`,
+        { env },
+      );
+      expect(code).toEqual(2);
+      expect(stdout).toContain('--config');
+      expect(cosRequests()).toEqual([]);
+    });
+  });
+
+  describe('cos target delete', () => {
+    test('deletes a target with --yes', async () => {
+      server.setEndpointResponse(targetPath, {
+        data: targetResource(),
+        links: { self: targetPath },
+      });
+
+      const { code, stdout } = await runSnykCLI(
+        `cos target delete --experimental --tenant-id=${tenantId} --target-id=${targetId} --yes`,
+        { env },
+      );
+      expect(code).toEqual(0);
+      expect(stdout).toContain(targetId);
+      expect(stdout).toContain('deleted');
+
+      expect(cosRequests()).toEqual([
+        { method: 'GET', path: targetPath },
+        { method: 'DELETE', path: targetPath },
+      ]);
+    });
+  });
+
+  describe('cos target dump', () => {
+    test('prints the target configuration as YAML', async () => {
+      server.setEndpointResponse(targetPath, {
+        data: targetResource(),
+        links: { self: targetPath },
+      });
+
+      const { code, stdout } = await runSnykCLI(
+        `cos target dump --experimental --tenant-id=${tenantId} --target-id=${targetId}`,
+        { env },
+      );
+      expect(code).toEqual(0);
+      expect(stdout).toContain('target:');
+      expect(stdout).toContain('name: Demo App');
+      expect(stdout).toContain('url: https://demo-app.com');
+
+      expect(cosRequests()).toEqual([{ method: 'GET', path: targetPath }]);
+    });
+
+    test('writes the YAML to --output-file', async () => {
+      server.setEndpointResponse(targetPath, {
+        data: targetResource(),
+        links: { self: targetPath },
+      });
+
+      tmpDir = mkdtempSync(join(tmpdir(), 'snyk-cos-'));
+      const outFile = join(tmpDir, 'cos.yaml');
+
+      const { code } = await runSnykCLI(
+        `cos target dump --experimental --tenant-id=${tenantId} --target-id=${targetId} --output-file=${outFile}`,
+        { env },
+      );
+      expect(code).toEqual(0);
+
+      const written = readFileSync(outFile, 'utf-8');
+      expect(written).toContain('name: Demo App');
+      expect(written).toContain('url: https://demo-app.com');
+    });
+  });
+
+  describe('cos finding list', () => {
+    test('lists findings in a table', async () => {
+      // The command resolves --target-id before listing, so the target lookup
+      // has to answer as well.
+      server.setEndpointResponse(targetPath, {
+        data: targetResource(),
+        links: { self: targetPath },
+      });
+      server.setEndpointResponse(findingsPath, {
+        data: [findingResource()],
+        links: { self: findingsPath },
+      });
+
+      const { code, stdout } = await runSnykCLI(
+        `cos finding list --experimental --tenant-id=${tenantId} --target-id=${targetId}`,
+        { env },
+      );
+      expect(code).toEqual(0);
+      expect(stdout).toContain('ID');
+      expect(stdout).toContain('SEVERITY');
+      expect(stdout).toContain(findingId);
+      expect(stdout).toContain('high');
+
+      expect(cosRequests()).toEqual([
+        { method: 'GET', path: targetPath },
+        { method: 'GET', path: findingsPath },
+      ]);
+    });
+
+    test('renders JSON with -o json', async () => {
+      server.setEndpointResponse(targetPath, {
+        data: targetResource(),
+        links: { self: targetPath },
+      });
+      server.setEndpointResponse(findingsPath, {
+        data: [findingResource()],
+        links: { self: findingsPath },
+      });
+
+      const { code, stdout } = await runSnykCLI(
+        `cos finding list --experimental --tenant-id=${tenantId} --target-id=${targetId} -o json`,
+        { env },
+      );
+      expect(code).toEqual(0);
+
+      const parsed = JSON.parse(stdout);
+      expect(parsed.findings).toHaveLength(1);
+      expect(parsed.findings[0]).toMatchObject({
+        id: findingId,
+        severity: 'high',
+      });
+    });
+
+    test('fails without --target-id', async () => {
+      const { code, stdout } = await runSnykCLI(
+        `cos finding list --experimental --tenant-id=${tenantId}`,
+        { env },
+      );
+      expect(code).toEqual(2);
+      expect(stdout).toContain('--target-id');
+      expect(cosRequests()).toEqual([]);
+    });
+  });
+
+  describe('cos finding get', () => {
+    test('shows the finding detail', async () => {
+      server.setEndpointResponse(findingPath, {
+        data: findingResource({
+          description: 'The login form concatenates input into a SQL query.',
+        }),
+        links: { self: findingPath },
+      });
+
+      const { code, stdout } = await runSnykCLI(
+        `cos finding get --experimental --tenant-id=${tenantId} --finding-id=${findingId}`,
+        { env },
+      );
+      expect(code).toEqual(0);
+      expect(stdout).toContain(findingId);
+      expect(stdout).toContain('SQL Injection');
+      expect(stdout).toContain('high');
+      expect(stdout).toContain('/login');
+      // Detail fields are rendered under their own headings.
+      expect(stdout).toContain('Description');
+      expect(stdout).toContain('concatenates input into a SQL query');
+
+      expect(cosRequests()).toEqual([{ method: 'GET', path: findingPath }]);
+    });
+
+    test('renders JSON with --json', async () => {
+      server.setEndpointResponse(findingPath, {
+        data: findingResource(),
+        links: { self: findingPath },
+      });
+
+      const { code, stdout } = await runSnykCLI(
+        `cos finding get --experimental --tenant-id=${tenantId} --finding-id=${findingId} --json`,
+        { env },
+      );
+      expect(code).toEqual(0);
+
+      const parsed = JSON.parse(stdout);
+      expect(parsed).toMatchObject({
+        id: findingId,
+        severity: 'high',
+        title: 'SQL Injection',
+      });
+    });
+
+    test('fails without --finding-id', async () => {
+      const { code, stdout } = await runSnykCLI(
+        `cos finding get --experimental --tenant-id=${tenantId}`,
+        { env },
+      );
+      expect(code).toEqual(2);
+      expect(stdout).toContain('--finding-id');
+      expect(cosRequests()).toEqual([]);
+    });
+  });
+
+  describe('error handling', () => {
+    test('handles unauthenticated requests', async () => {
+      const { code, stdout } = await runSnykCLI(
+        `cos scan list --experimental --tenant-id=${tenantId}`,
+        { env: envWithoutAuth },
+      );
+      expect(code).toEqual(2);
+      expect(stdout).toContain('Authentication error (SNYK-0005)');
+    });
+
+    test('rejects the --org flag', async () => {
+      const { code, stdout } = await runSnykCLI(
+        `cos scan list --experimental --org=my-org`,
+        { env },
+      );
+      expect(code).toEqual(2);
+      expect(stdout).toContain('--org');
+    });
+  });
+});


### PR DESCRIPTION
Adds the `snyk cos` command group to the private CLI build — targets, scans and
findings for Snyk's AI penetration testing service. Every command is gated behind
`--experimental`. The public build is unchanged.

- `snyk cos target create|list|get|update|delete|dump`
- `snyk cos scan start|list|status|cancel|report`
- `snyk cos finding list|get`

Tests: `test/jest/acceptance/snyk-cos/cos.spec.ts` — 35 acceptance cases covering
all 13 commands against the fake server.

Risk: low. Additive, private build only; no existing command or output path changes.