### PR TITLE
chore(ci): enable the agentic Open Source fix [AG-387]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1524,6 +1524,7 @@ jobs:
           open-source-scan-reachability: true
           open-source-scan: high
           open-source-block-ignore-sla: true
+          open-source-agentic-fix-enabled: true
 
   docs-only-check:
     executor: docker-amd64


### PR DESCRIPTION
## What this does

Enables the agentic Open Source fix in the ProdSec orb for the `code-analysis` job. One parameter:

```yaml
open-source-agentic-fix-enabled: true
```

When the Enhanced Gate blocks an Open Source scan, `snyk fix --agentic` runs against the blocking vulnerabilities, commits the result to `<branch>+remy_fix`, and opens a pull request against the branch that failed — so the next action is reviewing a diff rather than reading a CVE.

Released in [prodsec-orb v1.2.29](https://github.com/snyk/prodsec-orb/pull/166), so no version bump is needed: `@1` already resolves to it. `main` already attaches the `prodsec-orb-runtime` context that supplies the credentials, which is why this is a single line.

Nothing else changes. `open-source-scan` stays at `high`, so what blocks this repository is exactly what blocks it today.

## Why it's low risk

- **The fix only runs after the gate has already failed the build.** It cannot change that verdict — every path through the step exits 0, so it can neither mask a failure nor turn a passing build red.
- **It never pushes to this branch.** Work goes to a separate `+remy_fix` branch and arrives as a pull request for review.
- It refuses to act on anything unexpected: no fix branch if the tree is already dirty, no commit of build output, lockfile-only staging, and hard caps on the size of a change it will push.
- Disabling it is deleting the line.

One caveat worth knowing rather than discovering: enabling the feature adds a `github-cli/install` step that runs on **every** build of this repository, not only blocked ones, because a CircleCI step cannot be made conditional on a runtime value. If that install fails it fails the job — the one new way a green build could go red.

Also note `snyk fix` runs this repository's dependency lifecycle scripts in the same job that holds the context secrets. See the orb's [Agentic Fix](https://github.com/snyk/prodsec-orb/blob/main/docs/agentic-fix.md) docs for the full security discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
