### PR TITLE
chore: bump remy-cli-extension to v1.33.0

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 require (
 	github.com/snyk/ambient-canary v0.0.0-20260722064253-fba619a134a9
 	github.com/snyk/cli/cliv2 v0.0.0
-	github.com/snyk/remy-cli-extension v1.32.0
+	github.com/snyk/remy-cli-extension v1.33.0
 )
 
 require (

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -597,8 +597,8 @@ github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyR
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
-github.com/snyk/remy-cli-extension v1.32.0 h1:bBI89uDmmMFzxsKqIN2w7oAV7xAMsSwPnq+sUxOMbgI=
-github.com/snyk/remy-cli-extension v1.32.0/go.mod h1:ez/NUC+xzLRJB7+H0GTUjv4O1x2U+UWArSLdLVCcY3w=
+github.com/snyk/remy-cli-extension v1.33.0 h1:G4/MK0zUkcQ2GOm09453uGGPdyo36+rEzQMahF+Ab1g=
+github.com/snyk/remy-cli-extension v1.33.0/go.mod h1:ez/NUC+xzLRJB7+H0GTUjv4O1x2U+UWArSLdLVCcY3w=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
 github.com/snyk/snyk-ls v0.0.0-20260727100503-17c420b24a76 h1:dh2ohpboFbX8V7Pf4mtnkzOIkqXPMv2H0xrX7hT4R5M=


### PR DESCRIPTION
## What does this PR do?

Bumps `github.com/snyk/remy-cli-extension` **v1.32.0 → v1.33.0** in `cliv2-private` (dependency-only; no CLI source changes).

Picks up in `snyk fix --agentic`:
- **`--additional-params`** (#149) — pass extra arguments through to the Snyk Open Source scan (e.g. `--exclude=vendor`, `--detection-depth=3`). Defaults that conflict are dropped automatically (e.g. `--all-projects` when `--file` is supplied).
- **`--agent-max-iterations`** (#137) — cap how many iterations the fix agent runs per fix (0 = built-in default).

## Where should the reviewer start?

`cliv2-private/go.mod` / `go.sum` — the version bump only.

## Risk assessment (Low | Medium | High)?

**Low** — dependency bump behind the experimental `--agentic` flow; no transitive dep changes beyond the extension itself.

## What's the product update that needs to be communicated to CLI users?

`snyk fix --agentic` gains `--additional-params` (forward extra flags to the Open Source scan) and `--agent-max-iterations` (bound agent work per fix).
