### PR TITLE
test: make drift output test independent of colour detection

### DIFF
--- a/test/jest/unit/lib/iac/drift/drift.spec.ts
+++ b/test/jest/unit/lib/iac/drift/drift.spec.ts
@@ -1,4 +1,5 @@
 import * as mockFs from 'mock-fs';
+import chalk from 'chalk';
 
 import {
   driftignoreFromPolicy,
@@ -395,6 +396,22 @@ describe('Test describe output', () => {
     const filePath = path.join(__dirname, 'fixtures', name);
     return fs.readFileSync(filePath, 'utf-8');
   };
+
+  // The .console fixtures contain ANSI colour codes, so the output has to be
+  // generated with colour on. Chalk otherwise decides that from the ambient
+  // environment and emits plain text whenever stdout is not a TTY.
+  const originalLevel = chalk.level;
+  const originalEnabled = chalk.enabled;
+
+  beforeAll(() => {
+    chalk.level = 1;
+    chalk.enabled = true;
+  });
+
+  afterAll(() => {
+    chalk.level = originalLevel;
+    chalk.enabled = originalEnabled;
+  });
 
   it('test output for known analysis', () => {
     const analysis = JSON.parse(loadFile('all.json'));


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are release-note ready
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low)
- [x] Highlights breaking API changes (if applicable) — none
- [x] Links to automated tests covering new functionality — the change *is* the test
- [x] Includes manual testing instructions
- [ ] Updates relevant GitBook documentation — n/a
- [ ] Includes product update to be announced in the next stable release notes — n/a, test-only

## What does this PR do?

Makes `test/jest/unit/lib/iac/drift/drift.spec.ts` → `Test describe output › test output for known analysis` pass regardless of the terminal it runs in.

That test compares `getHumanReadableAnalysis` output against the `fixtures/all.console` golden file, which contains hard-coded ANSI escapes (`\e[1m…\e[22m`, `\e[34m…\e[39m`). Whether those escapes are emitted at all is decided by chalk from the ambient environment, so today the test passes only when chalk happens to think colour is supported.

Concretely: chalk 2.4.2 depends on supports-color 5.5.0, which returns level `0` for a non-TTY stream *before* it gets as far as checking CI vendor variables. CircleCI runs steps under a pty, so the test passes in CI. Anywhere jest output is piped — a plain local run, an editor-integrated runner, a container, a sandboxed agent — chalk emits plain text and the test fails with a large and fairly baffling whitespace-looking diff:

```
-   Managed Resources: [1m8[22m
+   Managed Resources: 8
```

This wasn't hypothetical: it's reproducible on a normal dev machine with full network access and valid credentials, and it was originally reported as an environment problem because the failure looks nothing like a colour issue.

The fix pins chalk's colour level for that `describe` block and restores the previous value afterwards, so the assertion covers the formatting logic rather than the terminal it happens to run in.

## Where should the reviewer start?

The whole diff is ~16 lines in `drift.spec.ts`. Worth confirming you agree with the direction: this keeps the golden file asserting on colours (rather than stripping ANSI from both sides, which would silently stop testing them).

## How should this be manually tested?

```sh
npx jest --runInBand test/jest/unit/lib/iac/drift/drift.spec.ts                 # passes (fails on main)
FORCE_COLOR=1 npx jest --runInBand test/jest/unit/lib/iac/drift/drift.spec.ts   # passes
FORCE_COLOR=0 npx jest --runInBand test/jest/unit/lib/iac/drift/drift.spec.ts   # passes (fails on main)
```

On `main` the first and third fail. Full `npm run test:unit` was also run: this suite passes and nothing else changed behaviour.

## What's the product update that needs to be communicated to CLI users?

None — test-only change, no shipped code touched.

## Risk assessment: Low

Test-only. The chalk level is scoped to one `describe` block and restored in `afterAll`, and jest gives each test file its own module registry, so no other suite is affected.

Made with [Cursor](https://cursor.com)