### PR TITLE
chore: bump remy-cli-extension to v1.34.0

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/snyk/ambient-canary v0.0.0-20260722064253-fba619a134a9
 	github.com/snyk/cli-extension-cos v0.0.0-20260730085209-d326e44b9140
 	github.com/snyk/cli/cliv2 v0.0.0
-	github.com/snyk/remy-cli-extension v1.33.0
+	github.com/snyk/remy-cli-extension v1.34.0
 )
 
 require (

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -599,8 +599,8 @@ github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyR
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
-github.com/snyk/remy-cli-extension v1.33.0 h1:G4/MK0zUkcQ2GOm09453uGGPdyo36+rEzQMahF+Ab1g=
-github.com/snyk/remy-cli-extension v1.33.0/go.mod h1:ez/NUC+xzLRJB7+H0GTUjv4O1x2U+UWArSLdLVCcY3w=
+github.com/snyk/remy-cli-extension v1.34.0 h1:VewsgqqA3Yahm8RtuR2RsjZ3UspHzGrzRjvM3zSgsb0=
+github.com/snyk/remy-cli-extension v1.34.0/go.mod h1:ez/NUC+xzLRJB7+H0GTUjv4O1x2U+UWArSLdLVCcY3w=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
 github.com/snyk/snyk-ls v0.0.0-20260727100503-17c420b24a76 h1:dh2ohpboFbX8V7Pf4mtnkzOIkqXPMv2H0xrX7hT4R5M=


### PR DESCRIPTION
## What

Bumps `github.com/snyk/remy-cli-extension` in `cliv2-private` to **v1.34.0**, which adds two `snyk fix --agentic` params:

- **`--fix-report=<path>`** — writes a structured JSON report partitioning the scanned vulns into `fixed[]` / `notFixed[]`, each with `product`, `id`, `title`, `severity`, `fixable`, `filePaths`, and (SCA only) a `breakability` object (`risk`, `confidence`, `summary`). Intended for CI to consume and open a PR.
- **`--skip-sandbox`** — disables the command/path sandbox validation for trusted/ephemeral checkouts (logs a warning when used).

Dependency-only change: `cliv2-private/go.mod` + `go.sum`, only the `remy-cli-extension` line.

Picks up snyk/remy-cli-extension#152 (released as v1.34.0). `go mod tidy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)