### PR TITLE
docs: document that unit tests require TEST_SNYK_TOKEN

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,8 +177,8 @@ The CLI follows a layered testing pyramid. Each layer has a different goal, syst
 ## Running Tests
 
 ```sh
-# TypeScript unit tests
-npm run test:unit
+# TypeScript unit tests (some suites validate credentials, so a token is required)
+TEST_SNYK_TOKEN=<token> npm run test:unit
 
 # TypeScript acceptance/user journey tests (requires a built binary)
 TEST_SNYK_COMMAND=./binary-releases/snyk-macos-arm64 npm run test:acceptance
@@ -190,6 +190,8 @@ cd cliv2 && make test
 # A single TS test file
 npx jest --runInBand test/jest/unit/path/to/test.spec.ts
 ```
+
+`SNYK_TOKEN` is **not** an alternative to `TEST_SNYK_TOKEN` — `test/setup.js` removes `SNYK_TOKEN` (and `SNYK_API_KEY`) from the environment when either is set, and writes `TEST_SNYK_TOKEN` into the CLI user config so tests run against a known configuration.
 
 ## Running the CLI Locally
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,13 @@ Avoid using mocks as these can go out of sync and be challenging to maintain; pr
 If you are mostly testing functions calling other functions, consider writing an acceptance test instead. Otherwise,
 your tests will likely mirror the implementation and rely heavily on mocks; making future changes difficult.
 
+Despite the above, `npm run test:unit` currently needs `TEST_SNYK_TOKEN` set to a
+[valid API token](https://docs.snyk.io/snyk-api/authentication-for-api). A handful of suites drive command entry points
+that validate credentials before doing anything else, so without it they fail with `MissingApiTokenError`. Note that
+setting `SNYK_TOKEN` does not work: [`test/setup.js`](./test/setup.js) removes `SNYK_TOKEN` (and `SNYK_API_KEY`) from the
+environment when either is set, and separately writes `TEST_SNYK_TOKEN` into the CLI user config so tests run against a
+known configuration rather than whatever the developer happens to be authenticated as.
+
 ### Acceptance tests
 
 Acceptance tests enforce the correctness of our distribution and are written from the perspective of a user.


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are release-note ready
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low)
- [x] Highlights breaking API changes (if applicable) — none
- [ ] Links to automated tests covering new functionality — n/a, docs only
- [x] Includes manual testing instructions
- [ ] Updates relevant GitBook documentation — n/a, contributor docs
- [ ] Includes product update to be announced in the next stable release notes — n/a

## What does this PR do?

Documents that `npm run test:unit` requires `TEST_SNYK_TOKEN`.

Without it, four suites fail with `MissingApiTokenError`, because they drive command entry points that call `validateCredentials` before doing anything else:

- `test/jest/unit/lib/commands/fix/fix.spec.ts`
- `test/jest/unit/python/snyk-test-pyproject.spec.ts`
- `test/jest/unit/pnpm/snyk-test-pnpm-project.spec.ts`
- `test/jest/unit/snyk-code/snyk-code-test-report.spec.ts`

This wasn't written down anywhere. `CONTRIBUTING.md` mentions `TEST_SNYK_TOKEN` only under **acceptance** tests, and `AGENTS.md` showed a bare `npm run test:unit`.

The part worth documenting explicitly is that reaching for `SNYK_TOKEN` — the obvious variable, and the one the CLI itself uses — has no effect. `test/setup.js` deletes `SNYK_TOKEN` and `SNYK_API_KEY`, then writes `TEST_SNYK_TOKEN` into the CLI user config. That's sensible (tests run against a known configuration rather than whatever the developer is authenticated as), but from the outside it looks like the token is being ignored and the tests are simply broken.

This came out of an agent reporting these suites as failures during environment setup, having concluded from the error that `SNYK_TOKEN` was needed. It isn't, and setting it changes nothing.

No behaviour is changed here — this only documents what already happens. Whether these suites *should* need a token is a separate question: `CONTRIBUTING.md` states unit tests "should not test services outside the code itself", so arguably they belong at the acceptance layer. Happy to raise that separately if the team agrees.

## Where should the reviewer start?

`CONTRIBUTING.md` -> "Unit tests". The `AGENTS.md` change mirrors it.

## How should this be manually tested?

```sh
npm run test:unit                            # 4 suites fail with MissingApiTokenError
TEST_SNYK_TOKEN=<token> npm run test:unit    # those 4 suites pass (22 tests)
SNYK_TOKEN=<token> npm run test:unit         # unchanged - still fails
```

## What's the product update that needs to be communicated to CLI users?

None — contributor documentation only.

## Risk assessment: Low

Documentation only.

Made with [Cursor](https://cursor.com)