### PR TITLE
fix: add user journey tests for FUA code path + bump code-client-go

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -216,7 +216,7 @@ require (
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091 // indirect
 	github.com/snyk/cli-extension-sbom v0.0.0-20260722102401-3c3af28e7b93 // indirect
 	github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3 // indirect
-	github.com/snyk/code-client-go v1.31.0 // indirect
+	github.com/snyk/code-client-go v1.31.1 // indirect
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -585,8 +585,8 @@ github.com/snyk/cli-extension-sbom v0.0.0-20260722102401-3c3af28e7b93 h1:iCHSAW2
 github.com/snyk/cli-extension-sbom v0.0.0-20260722102401-3c3af28e7b93/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3 h1:wBYQm4YP65FTZ4rZ0iunhsIUYBindUEnfRWRi+Rugag=
 github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3/go.mod h1:D/Bk0EH8np/d6c1tG7wazpHI6iU9m8KzxytFcIQkEvQ=
-github.com/snyk/code-client-go v1.31.0 h1:6/pMoZpjBhosUhOKn7z565kARdiQulRIe5Iv83WuiME=
-github.com/snyk/code-client-go v1.31.0/go.mod h1:sAl5uS+Bc+3Owy1HS0UjrFihuWdq5CkIF4jzEZT2meY=
+github.com/snyk/code-client-go v1.31.1 h1:fJHx9kZwcYikKGvIIXDxMxpSNbj5gxChEsV8xrYDRnw=
+github.com/snyk/code-client-go v1.31.1/go.mod h1:sAl5uS+Bc+3Owy1HS0UjrFihuWdq5CkIF4jzEZT2meY=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea h1:/v48hCMPiZVjplylgE2FX1ib8Qd8LN/vf8ZIKfA+wkI=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea/go.mod h1:P5yW8+jkwhYBsj5l2jtHeWujyX+SAtvkC8+LELKdlWI=
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3YKLR5LJbqL8WJmUYgDSbFKREIY79g0=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091
 	github.com/snyk/cli-extension-sbom v0.0.0-20260722102401-3c3af28e7b93
 	github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3
-	github.com/snyk/code-client-go v1.31.0
+	github.com/snyk/code-client-go v1.31.1
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663
 	github.com/snyk/go-application-framework v0.9.0

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -539,8 +539,8 @@ github.com/snyk/cli-extension-sbom v0.0.0-20260722102401-3c3af28e7b93 h1:iCHSAW2
 github.com/snyk/cli-extension-sbom v0.0.0-20260722102401-3c3af28e7b93/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3 h1:wBYQm4YP65FTZ4rZ0iunhsIUYBindUEnfRWRi+Rugag=
 github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3/go.mod h1:D/Bk0EH8np/d6c1tG7wazpHI6iU9m8KzxytFcIQkEvQ=
-github.com/snyk/code-client-go v1.31.0 h1:6/pMoZpjBhosUhOKn7z565kARdiQulRIe5Iv83WuiME=
-github.com/snyk/code-client-go v1.31.0/go.mod h1:sAl5uS+Bc+3Owy1HS0UjrFihuWdq5CkIF4jzEZT2meY=
+github.com/snyk/code-client-go v1.31.1 h1:fJHx9kZwcYikKGvIIXDxMxpSNbj5gxChEsV8xrYDRnw=
+github.com/snyk/code-client-go v1.31.1/go.mod h1:sAl5uS+Bc+3Owy1HS0UjrFihuWdq5CkIF4jzEZT2meY=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea h1:/v48hCMPiZVjplylgE2FX1ib8Qd8LN/vf8ZIKfA+wkI=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea/go.mod h1:P5yW8+jkwhYBsj5l2jtHeWujyX+SAtvkC8+LELKdlWI=
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3YKLR5LJbqL8WJmUYgDSbFKREIY79g0=

--- a/test/jest/acceptance/snyk-code/snyk-code-user-journey.spec.ts
+++ b/test/jest/acceptance/snyk-code/snyk-code-user-journey.spec.ts
@@ -16,6 +16,10 @@ import {
   createFilepaths,
   deleteFilepaths,
 } from '../../../jest/util/fileIgnoreRulesFixture';
+import * as sarifSchema from '../../../schemas/sarif-schema-2.1.0.json';
+
+const readJson = (filePath: string): any =>
+  JSON.parse(readFileSync(filePath, 'utf8'));
 
 expect.extend(matchers);
 jest.setTimeout(1000 * 300);
@@ -41,7 +45,6 @@ interface ValidProjectTest {
 }
 
 const projectRoot = resolve(__dirname, '../../../..');
-const sarifSchema = require('../../../schemas/sarif-schema-2.1.0.json');
 const EXIT_CODE_SUCCESS = 0;
 const EXIT_CODE_ACTION_NEEDED = 1;
 const EXIT_CODE_FAIL_WITH_ERROR = 2;
@@ -404,7 +407,7 @@ describe('snyk code test', () => {
             expect(code).toBe(EXIT_CODE_ACTION_NEEDED);
 
             expect(existsSync(filePath)).toBe(true);
-            expect(require(filePath)).toMatchSchema(sarifSchema);
+            expect(readJson(filePath)).toMatchSchema(sarifSchema);
 
             // execute snyk-to-html for a basic compatibility check
             const s2h = await runCommand('npx', [
@@ -445,7 +448,7 @@ describe('snyk code test', () => {
           expect(code).toBe(EXIT_CODE_ACTION_NEEDED);
 
           expect(existsSync(filePath)).toBe(true);
-          expect(require(filePath)).toMatchSchema(sarifSchema);
+          expect(readJson(filePath)).toMatchSchema(sarifSchema);
 
           // cleanup file
           try {
@@ -475,10 +478,10 @@ describe('snyk code test', () => {
           expect(code).toBe(EXIT_CODE_ACTION_NEEDED);
 
           expect(existsSync(sarifFilePath)).toBe(true);
-          expect(require(sarifFilePath)).toMatchSchema(sarifSchema);
+          expect(readJson(sarifFilePath)).toMatchSchema(sarifSchema);
 
           expect(existsSync(jsonFilePath)).toBe(true);
-          expect(require(jsonFilePath)).toMatchSchema(sarifSchema);
+          expect(readJson(jsonFilePath)).toMatchSchema(sarifSchema);
 
           // cleanup file
           try {
@@ -509,7 +512,7 @@ describe('snyk code test', () => {
           expect(code).toBe(EXIT_CODE_SUCCESS);
 
           expect(existsSync(sarifFilePath)).toBe(true);
-          expect(require(sarifFilePath)).toMatchSchema(sarifSchema);
+          expect(readJson(sarifFilePath)).toMatchSchema(sarifSchema);
 
           expect(existsSync(jsonFilePath)).toBe(false);
 
@@ -582,7 +585,7 @@ describe('snyk code test', () => {
 
           // Verify SARIF file
           expect(existsSync(sarifFilePath)).toBe(true);
-          const sarifOutput = require(sarifFilePath);
+          const sarifOutput = readJson(sarifFilePath);
           expect(sarifOutput.runs[0].results.length).toBeGreaterThan(0);
           // Verify no suppressions exist in the results
           expect(
@@ -672,6 +675,80 @@ describe('snyk code test', () => {
           expect(stderr).toBe('');
           expect([EXIT_CODE_SUCCESS, EXIT_CODE_ACTION_NEEDED]).toContain(code);
         });
+
+        // File-upload-api is only supported on the golang/native implementation
+        if (type === 'golang/native') {
+          describe('file upload api', () => {
+            const fuaEnv = {
+              ...process.env,
+              ...integrationEnv,
+              // force use of file-upload-api instead of files-bundle-store
+              INTERNAL_UPLOAD_TO_FUA: 'true',
+            };
+
+            it('Stateless code test', async () => {
+              const path = await ensureUniqueBundleIsUsed(
+                projectWithCodeIssues,
+              );
+
+              const { stdout, stderr, code } = await runSnykCLI(
+                `code test ${path} --json`,
+                { env: fuaEnv },
+              );
+
+              expect(stderr).toBe('');
+              expect(code).toBe(EXIT_CODE_ACTION_NEEDED);
+              expect(
+                JSON.parse(stdout)?.runs[0]?.results?.length,
+              ).toBeGreaterThan(0);
+            });
+
+            it('Stateful local code test --report', async () => {
+              const sarifFileName = 'sarifReportOutputFua.json';
+              const sarifFilePath = `${projectRoot}/${sarifFileName}`;
+
+              const args = [
+                'code',
+                'test',
+                '--report',
+                '--project-name=cicd-user-journey-test-fua',
+                `--sarif-file-output=${sarifFilePath}`,
+                await ensureUniqueBundleIsUsed(projectWithCodeIssues),
+              ];
+              const { stdout, stderr, code } = await runSnykCLIWithArray(args, {
+                env: fuaEnv,
+              });
+
+              expect(stderr).toBe('');
+              expect([EXIT_CODE_SUCCESS, EXIT_CODE_ACTION_NEEDED]).toContain(
+                code,
+              );
+
+              const sarifOutput = JSON.parse(
+                readFileSync(sarifFilePath, 'utf8'),
+              );
+
+              // ensure that uploadResult metadata exists
+              const uploadResult = sarifOutput.runs[0].properties.uploadResult;
+              expect(uploadResult.projectId).toBeDefined();
+              expect(uploadResult.projectId).not.toBe('');
+              expect(uploadResult.snapshotId).toBeDefined();
+              expect(uploadResult.snapshotId).not.toBe('');
+              expect(uploadResult.reportUrl).toBeDefined();
+              expect(uploadResult.reportUrl).not.toBe('');
+
+              // ensure that the same report url is displayed in the stdout and in the sarif file
+              expect(stdout).toContain(uploadResult.reportUrl);
+
+              // cleanup file
+              try {
+                unlinkSync(sarifFilePath);
+              } catch (error) {
+                console.error('failed to remove file.', error);
+              }
+            });
+          });
+        }
 
         const validProjectTestList: ValidProjectTest[] = [
           {


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
* Add tests for Code CLI upload path
* Remove deprecated calls to `request`
* Bump code-client-go to pull in an observability fix https://github.com/snyk/code-client-go/pull/170


## Risk assessment (Low | Medium | High)?
Low 