### PR TITLE
chore: bump remy-cli-extension to v1.36.1

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/snyk/ambient-canary v0.0.0-20260722064253-fba619a134a9
 	github.com/snyk/cli-extension-cos v0.0.0-20260730085209-d326e44b9140
 	github.com/snyk/cli/cliv2 v0.0.0
-	github.com/snyk/remy-cli-extension v1.34.0
+	github.com/snyk/remy-cli-extension v1.36.1
 )
 
 require (

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -599,8 +599,8 @@ github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyR
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
-github.com/snyk/remy-cli-extension v1.34.0 h1:VewsgqqA3Yahm8RtuR2RsjZ3UspHzGrzRjvM3zSgsb0=
-github.com/snyk/remy-cli-extension v1.34.0/go.mod h1:ez/NUC+xzLRJB7+H0GTUjv4O1x2U+UWArSLdLVCcY3w=
+github.com/snyk/remy-cli-extension v1.36.1 h1:TFiJL7XlqXklGsplIhlnhyRp+nyi4rV7L2Nze4ggR9Q=
+github.com/snyk/remy-cli-extension v1.36.1/go.mod h1:ez/NUC+xzLRJB7+H0GTUjv4O1x2U+UWArSLdLVCcY3w=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
 github.com/snyk/snyk-ls v0.0.0-20260727100503-17c420b24a76 h1:dh2ohpboFbX8V7Pf4mtnkzOIkqXPMv2H0xrX7hT4R5M=


### PR DESCRIPTION
## What

Dependency-only bump of `github.com/snyk/remy-cli-extension` **v1.34.0 → v1.36.1** in `cliv2-private`. Only `cliv2-private/go.mod` + `go.sum` change — no CLI source edits. `go mod tidy -diff` is clean in both `cliv2` and `cliv2-private` (no transitive drift).

## New CLI arguments this bump exposes (v1.34.0..v1.36.1)

New flags on `snyk fix --agentic`:

- `--cos` — opt into the Snyk Continuous Offensive Security (COS) agentic fix flow. Requires `--cos-report-dir`.
- `--cos-report-dir <path>` — path to the COS report directory (must contain `vulnerabilities.csv`). Required with `--cos`.
- `--max-validation-attempts <n>` — cap validation retry attempts per fix; after this many failed `run_tests` attempts the fix is skipped and the batch continues. `0` uses the built-in default (1 for SCA, 3 for COS).

(All other flags — `--fix-report`, `--skip-sandbox`, `--agent-max-iterations`, `--auto-approve`, etc. — already existed in v1.34.0.)

## Extension changes this picks up (v1.34.0..v1.36.1)

- snyk/remy-cli-extension#155 — feat: apply every fix under `--auto-approve` regardless of breakability
- snyk/remy-cli-extension#158 — fix(sca): forward-only, per-line SCA fixes — no downgrades, no dropped lines
- snyk/remy-cli-extension#153 — feat: [AG-370] COS v1
- snyk/remy-cli-extension#150 — docs: document the CLI bump/release procedure in AGENTS.md
- snyk/remy-cli-extension#159 — fix(agent): raise default agent iteration cap to 50

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AG-370]: https://snyksec.atlassian.net/browse/AG-370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ