### PR TITLE
chore: bump cli-extension-ai-bom

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -209,7 +209,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.3.2 // indirect
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af // indirect
-	github.com/snyk/cli-extension-ai-bom v0.0.0-20260721084000-da8dc26c77f2 // indirect
+	github.com/snyk/cli-extension-ai-bom v0.0.0-20260804095026-fdfc28cd38b8 // indirect
 	github.com/snyk/cli-extension-dep-graph/v2 v2.7.2 // indirect
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 // indirect
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -569,8 +569,8 @@ github.com/snyk/ambient-canary v0.0.0-20260722064253-fba619a134a9 h1:d69mS5cTIs1
 github.com/snyk/ambient-canary v0.0.0-20260722064253-fba619a134a9/go.mod h1:n6GYt41xPhThEEEl/0RZuWpTX68iv6k+6HZ94uGNDGE=
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af h1:AgYHuCfs6oNkd/QFwsuEtvswclfBujhBfwbZUB4xEU4=
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af/go.mod h1:u4d7qoWWVx3II+ZnpLQGjAegaJLmgPefXKXJD/jp/wM=
-github.com/snyk/cli-extension-ai-bom v0.0.0-20260721084000-da8dc26c77f2 h1:fYTWYiCqw+NqeETMP/0TdVKjCHrHRng8M6+nxvrmluo=
-github.com/snyk/cli-extension-ai-bom v0.0.0-20260721084000-da8dc26c77f2/go.mod h1:axE+HO8U9CIcTjQ7k7BOLgdyZfNGqMn5QvZ0aIkUY4U=
+github.com/snyk/cli-extension-ai-bom v0.0.0-20260804095026-fdfc28cd38b8 h1:OiY6RfgGICJ1QCRW1WxWk9cm9G9Hd8aStIz5EASltw0=
+github.com/snyk/cli-extension-ai-bom v0.0.0-20260804095026-fdfc28cd38b8/go.mod h1:axE+HO8U9CIcTjQ7k7BOLgdyZfNGqMn5QvZ0aIkUY4U=
 github.com/snyk/cli-extension-cos v0.0.0-20260730085209-d326e44b9140 h1:7yYsL4egJlFruDMgsng/nXTe5MFx8Ciys0+ADH61yOw=
 github.com/snyk/cli-extension-cos v0.0.0-20260730085209-d326e44b9140/go.mod h1:YpcOdcMBJOzwtla/OOoBOArx27Bc2v42Vcwd/FeGl9M=
 github.com/snyk/cli-extension-dep-graph/v2 v2.7.2 h1:+D/r8zDdREbrZs1EZ4DmVzEf7oMHA2rRozhuaVFyg8U=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.34.0
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af
-	github.com/snyk/cli-extension-ai-bom v0.0.0-20260721084000-da8dc26c77f2
+	github.com/snyk/cli-extension-ai-bom v0.0.0-20260804095026-fdfc28cd38b8
 	github.com/snyk/cli-extension-dep-graph/v2 v2.7.2
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -525,8 +525,8 @@ github.com/skeema/knownhosts v1.3.2 h1:EDL9mgf4NzwMXCTfaxSD/o/a5fxDw/xL9nkU28Jjd
 github.com/skeema/knownhosts v1.3.2/go.mod h1:bEg3iQAuw+jyiw+484wwFJoKSLwcfd7fqRy+N0QTiow=
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af h1:AgYHuCfs6oNkd/QFwsuEtvswclfBujhBfwbZUB4xEU4=
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af/go.mod h1:u4d7qoWWVx3II+ZnpLQGjAegaJLmgPefXKXJD/jp/wM=
-github.com/snyk/cli-extension-ai-bom v0.0.0-20260721084000-da8dc26c77f2 h1:fYTWYiCqw+NqeETMP/0TdVKjCHrHRng8M6+nxvrmluo=
-github.com/snyk/cli-extension-ai-bom v0.0.0-20260721084000-da8dc26c77f2/go.mod h1:axE+HO8U9CIcTjQ7k7BOLgdyZfNGqMn5QvZ0aIkUY4U=
+github.com/snyk/cli-extension-ai-bom v0.0.0-20260804095026-fdfc28cd38b8 h1:OiY6RfgGICJ1QCRW1WxWk9cm9G9Hd8aStIz5EASltw0=
+github.com/snyk/cli-extension-ai-bom v0.0.0-20260804095026-fdfc28cd38b8/go.mod h1:axE+HO8U9CIcTjQ7k7BOLgdyZfNGqMn5QvZ0aIkUY4U=
 github.com/snyk/cli-extension-dep-graph/v2 v2.7.2 h1:+D/r8zDdREbrZs1EZ4DmVzEf7oMHA2rRozhuaVFyg8U=
 github.com/snyk/cli-extension-dep-graph/v2 v2.7.2/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSoQL0zYyFcGQjEPZcQgDkzM5PcgIHlIgzRuhg=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] (no breaking change) Highlights breaking API changes (if applicable)
- [x] (not applicable) Links to automated tests covering new functionality, https://snyksec.atlassian.net/browse/AIBOM-978 will add additional tests covering the html output.
- [x] Includes manual testing instructions (if necessary)
- [x] (not required) Updates relevant GitBook documentation (PR link: ___)
- [x] (not required)  Includes product update to be announced in the next stable release notes

## What does this PR do?
Bumps the version of cli-extension-ai-bom to bring in a fix related to an unpineed third party javascript library used in an html file generated by the cli extension.

## Where should the reviewer start?
https://github.com/snyk/cli-extension-ai-bom/pull/64

## How should this be manually tested?
`snyk aibom --html` was previously producing an html file that failed to load a dependency.

## What's the product update that needs to be communicated to CLI users?
None.

## Risk assessment (Low | Medium | High)?
Low. Fixing an unpinned dependency for a local html page generated with aibom --html.

## Any background context you want to provide?
The issue was reported [here](https://snyk.slack.com/archives/C09P17DD6JU/p1785789905458239).

## What are the relevant tickets?
No ticket was created.