### PR TITLE
fix: preserve uv lockfile line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/fixtures/**/uv.lock text eol=lf


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Commit messages are release-note ready
- [x] Includes detailed description of changes
- [x] Contains risk assessment
- [x] Links to automated tests covering the fix
- [x] No breaking API changes
- [x] No manual testing required
- [x] No GitBook update required
- [x] No product update required

## What does this PR do?

Forces tracked UV lockfile fixtures to retain LF line endings on Windows checkouts. This prevents UV from rejecting the fixtures as non-canonical when Git has core.autocrlf enabled.

Strict UV test assertions remain unchanged.

## Where should the reviewer start?

.gitattributes

## How should this be manually tested?

No manual testing required. CircleCI pipeline 38837 passed, including all eight Windows acceptance-test shards: https://app.circleci.com/pipelines/gh/snyk/cli/38837/details

## Risk assessment

Low. The rule only affects test/fixtures/**/uv.lock checkout line endings.

## Relevant ticket

CLI-1711: https://snyksec.atlassian.net/browse/CLI-1711