### PR TITLE
chore: Bump code-client-go - get the file filter from the invocation context

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -216,7 +216,7 @@ require (
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091 // indirect
 	github.com/snyk/cli-extension-sbom v0.0.0-20260722102401-3c3af28e7b93 // indirect
 	github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3 // indirect
-	github.com/snyk/code-client-go v1.31.1 // indirect
+	github.com/snyk/code-client-go v1.31.3 // indirect
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -585,8 +585,8 @@ github.com/snyk/cli-extension-sbom v0.0.0-20260722102401-3c3af28e7b93 h1:iCHSAW2
 github.com/snyk/cli-extension-sbom v0.0.0-20260722102401-3c3af28e7b93/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3 h1:wBYQm4YP65FTZ4rZ0iunhsIUYBindUEnfRWRi+Rugag=
 github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3/go.mod h1:D/Bk0EH8np/d6c1tG7wazpHI6iU9m8KzxytFcIQkEvQ=
-github.com/snyk/code-client-go v1.31.1 h1:fJHx9kZwcYikKGvIIXDxMxpSNbj5gxChEsV8xrYDRnw=
-github.com/snyk/code-client-go v1.31.1/go.mod h1:sAl5uS+Bc+3Owy1HS0UjrFihuWdq5CkIF4jzEZT2meY=
+github.com/snyk/code-client-go v1.31.3 h1:X1vzubbdGXWpxwnjBkC3HchH1rWjDdqdn0cCz2to0TA=
+github.com/snyk/code-client-go v1.31.3/go.mod h1:Yl1x9g7Y6JOcEWoaxyrKFvrj76JkaeRFUpEkXVjRhS8=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea h1:/v48hCMPiZVjplylgE2FX1ib8Qd8LN/vf8ZIKfA+wkI=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea/go.mod h1:P5yW8+jkwhYBsj5l2jtHeWujyX+SAtvkC8+LELKdlWI=
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3YKLR5LJbqL8WJmUYgDSbFKREIY79g0=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091
 	github.com/snyk/cli-extension-sbom v0.0.0-20260722102401-3c3af28e7b93
 	github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3
-	github.com/snyk/code-client-go v1.31.1
+	github.com/snyk/code-client-go v1.31.3
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663
 	github.com/snyk/go-application-framework v0.11.0

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -539,8 +539,8 @@ github.com/snyk/cli-extension-sbom v0.0.0-20260722102401-3c3af28e7b93 h1:iCHSAW2
 github.com/snyk/cli-extension-sbom v0.0.0-20260722102401-3c3af28e7b93/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3 h1:wBYQm4YP65FTZ4rZ0iunhsIUYBindUEnfRWRi+Rugag=
 github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3/go.mod h1:D/Bk0EH8np/d6c1tG7wazpHI6iU9m8KzxytFcIQkEvQ=
-github.com/snyk/code-client-go v1.31.1 h1:fJHx9kZwcYikKGvIIXDxMxpSNbj5gxChEsV8xrYDRnw=
-github.com/snyk/code-client-go v1.31.1/go.mod h1:sAl5uS+Bc+3Owy1HS0UjrFihuWdq5CkIF4jzEZT2meY=
+github.com/snyk/code-client-go v1.31.3 h1:X1vzubbdGXWpxwnjBkC3HchH1rWjDdqdn0cCz2to0TA=
+github.com/snyk/code-client-go v1.31.3/go.mod h1:Yl1x9g7Y6JOcEWoaxyrKFvrj76JkaeRFUpEkXVjRhS8=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea h1:/v48hCMPiZVjplylgE2FX1ib8Qd8LN/vf8ZIKfA+wkI=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea/go.mod h1:P5yW8+jkwhYBsj5l2jtHeWujyX+SAtvkC8+LELKdlWI=
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3YKLR5LJbqL8WJmUYgDSbFKREIY79g0=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps `code-client-go` from v1.31.1 to v1.31.3.

In v1.31.3, `snyk code test`'s file listing obtains its file filter from the invocation context (`invocationCtx.GetFileFilter(...)`) instead of constructing one locally. The filter therefore arrives already wired to the invocation's configuration, which means filtering behaviour the framework gates on configuration now takes effect for Snyk Code.

No CLI code changes are needed; this is the `go.mod`/`go.sum` bump only.

## Where should the reviewer start?

- `cliv2/go.mod` and `cliv2-private/go.mod` — the version bump, identical in both runtimes
- `cliv2/go.sum`, `cliv2-private/go.sum` — corresponding checksums

## How should this be manually tested?

Use a repository whose **absolute path contains regex metacharacters**, containing:

- `.gitignore` with `*.log` and `node_modules`
- `node_modules/lib/index.js` (untracked, matched by the `node_modules` rule)
- `src/app.js` (not matched by any rule)

Then run, from a build of this branch:

INTERNAL_SNYK_FILE_FILTER_METACHARACTER_FIX_ENABLED=false snyk code test "$PWD" -d
INTERNAL_SNYK_FILE_FILTER_METACHARACTER_FIX_ENABLED=true  snyk code test "$PWD" -d

Expected, from the `Snyk Code file filtering` and `Coverage report` lines:

| metacharacter fix | files into filter | scanned | `.js` files |
|---|---|---|---|
| false | 4 | 2 | 2 — `node_modules/lib/index.js` is not excluded |
| true | 3 | 1 | 1 — only `src/app.js` |

## What's the product update that needs to be communicated to CLI users?

None for this bump on its own. The filtering fixes it enables are feature-flagged and announced with their own rollouts.

## What are the relevant tickets?

[CLI-1717](https://snyksec.atlassian.net/browse/CLI-1717)

<!---
## Risk assessment (Low | Medium | High)?

Low. Dependency bump only, no CLI code changes. Filtering behaviour changes are gated behind feature flags (`FF_FILE_FILTER_METACHARACTER_FIX`, `FF_GITIGNORE_RESPECT_TRACKED_FILES`), so default behaviour is unchanged where those are off.

Note that preview builds force both flags on unless the value is explicitly set (`cliv2/pkg/core/workflows.go`, marked `TODO: remove once CLI-1733 is solved`), so preview users get the new filtering behaviour by default.

## Any background context you want to provide?

Verified manually against a locally built binary (`BUILD_MODE=public make build`) with `go.mod` replace directives pointing at local `code-client-go` and `go-application-framework`, using the table above. Both flags were also checked in isolation by driving the framework's FileFilter directly, confirming they compose: with both on, `node_modules` stays excluded while a tracked-but-ignored file is preserved.

## Screenshots (if appropriate)

N/A
--->

[CLI-1717]: https://snyksec.atlassian.net/browse/CLI-1717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ