### PR TITLE
feat: file filter doesn't exclude tracked files though .gitignore rules

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -222,7 +222,7 @@ require (
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 // indirect
-	github.com/snyk/go-application-framework v0.13.0 // indirect
+	github.com/snyk/go-application-framework v0.14.0 // indirect
 	github.com/snyk/go-httpauth v0.0.0-20260803174134-2de16f8df223 // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -592,8 +592,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.13.0 h1:/5Fu4ZfsGVQQGoAW2isEiQLQJOzLpRzomvWQDKlXOco=
-github.com/snyk/go-application-framework v0.13.0/go.mod h1:vAxNYf7eXOMlb+mK5U7Gt2bYvKUblXi5SfjcTm3b1hs=
+github.com/snyk/go-application-framework v0.14.0 h1:GMDeUNwJeAYUqkjM/MYseFOWasrII27JCBQO3K/dd+E=
+github.com/snyk/go-application-framework v0.14.0/go.mod h1:vAxNYf7eXOMlb+mK5U7Gt2bYvKUblXi5SfjcTm3b1hs=
 github.com/snyk/go-httpauth v0.0.0-20260803174134-2de16f8df223 h1:4DysAKzfdy+EZzoZnPiifRRW+8XgwbdM9GAk+AL3rP0=
 github.com/snyk/go-httpauth v0.0.0-20260803174134-2de16f8df223/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.31.3
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663
-	github.com/snyk/go-application-framework v0.13.0
+	github.com/snyk/go-application-framework v0.14.0
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260804092303-865b318b1c8f

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -547,8 +547,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663 h1:j2ZPhi78wKIHTiL9EFTNVXMIbsk56FVF2d5Sy1ZwSYk=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260505112649-a5103d411663/go.mod h1:Ytttq7Pw4vOCu9NtRQaOeDU2dhBYUyNBe6kX4+nIIQ4=
-github.com/snyk/go-application-framework v0.13.0 h1:/5Fu4ZfsGVQQGoAW2isEiQLQJOzLpRzomvWQDKlXOco=
-github.com/snyk/go-application-framework v0.13.0/go.mod h1:vAxNYf7eXOMlb+mK5U7Gt2bYvKUblXi5SfjcTm3b1hs=
+github.com/snyk/go-application-framework v0.14.0 h1:GMDeUNwJeAYUqkjM/MYseFOWasrII27JCBQO3K/dd+E=
+github.com/snyk/go-application-framework v0.14.0/go.mod h1:vAxNYf7eXOMlb+mK5U7Gt2bYvKUblXi5SfjcTm3b1hs=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65 h1:CEQuYv0Go6MEyRCD3YjLYM2u3Oxkx8GpCpFBd4rUTUk=
 github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65/go.mod h1:88KbbvGYlmLgee4OcQ19yr0bNpXpOr2kciOthaSzCAg=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -501,9 +501,13 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
 
   // Feature flag batch evaluation used by the Go binary's GAF layer
   // (config_utils.AddFeatureFlagToConfig → featureflaggateway.EvaluateFlags).
-  // Request: POST /hidden/orgs/:orgId/feature_flags/evaluation
   // Body: { data: { attributes: { flags: ["flag-name", ...] } } }
-  app.post('/hidden/orgs/:orgId/feature_flags/evaluation', (req, res) => {
+  // GAF derives the URL from the API URL, so the /api prefix may or may not be present.
+  const flagEvaluationPaths = [
+    '/hidden/orgs/:orgId/feature_flags/evaluation',
+    '/api/hidden/orgs/:orgId/feature_flags/evaluation',
+  ];
+  app.post(flagEvaluationPaths, (req, res) => {
     const flags: string[] = req.body?.data?.attributes?.flags ?? [];
     // Maps batch evaluation API flag names to their GAF config keys.
     // The batch endpoint receives short API names; tests call setFeatureFlag

--- a/test/jest/acceptance/snyk-code/gitignore-flag-wiring.spec.ts
+++ b/test/jest/acceptance/snyk-code/gitignore-flag-wiring.spec.ts
@@ -1,0 +1,199 @@
+// The fake server answers the batch flag evaluation endpoint, so the remote flag path is
+// testable without real backend access.
+import { runSnykCLI } from '../../util/runSnykCLI';
+import { runCommand } from '../../util/runCommand';
+import { fakeServer } from '../../../acceptance/fake-server';
+import { fakeDeepCodeServer } from '../../../acceptance/deepcode-fake-server';
+import { getServerPort } from '../../util/getServerPort';
+import * as fs from 'fs';
+import * as os from 'os';
+import { join } from 'path';
+
+jest.setTimeout(1000 * 120);
+
+const REMOTE_FLAG_NAME = 'clientFileFilterGitignore_TrackedFilesRollout';
+const FLAG_ENV = 'INTERNAL_SNYK_GITIGNORE_RESPECT_TRACKED_FILES_ENABLED';
+const PREVIEW_ENV = 'INTERNAL_PREVIEW_FEATURES_ENABLED';
+const EVALUATION_PATH = '/feature_flags/evaluation';
+
+describe('snyk code test — tracked-file feature flag wiring', () => {
+  let server: ReturnType<typeof fakeServer>;
+  let deepCodeServer: ReturnType<typeof fakeDeepCodeServer>;
+  let baseEnv: Record<string, string>;
+  const port = getServerPort(process);
+  const baseApi = '/api/v1';
+
+  beforeAll(async () => {
+    deepCodeServer = fakeDeepCodeServer();
+    await new Promise<void>((resolve) =>
+      deepCodeServer.listen(() => resolve()),
+    );
+    server = fakeServer(baseApi, 'snykToken');
+    await new Promise<void>((resolve) => server.listen(port, () => resolve()));
+
+    baseEnv = {
+      ...process.env,
+      SNYK_API: `http://localhost:${port}${baseApi}`,
+      SNYK_HOST: `http://localhost:${port}`,
+      SNYK_TOKEN: '123456789',
+      SNYK_CFG_ORG: '11111111-2222-3333-4444-555555555555',
+      INTERNAL_SNYK_CODE_NATIVE_IMPLEMENTATION: 'true',
+      // Preview/dev builds force the flag on (cliv2/pkg/core/workflows.go), bypassing
+      // the remote flag. Without this, every assertion below is vacuous.
+      [PREVIEW_ENV]: 'false',
+    } as Record<string, string>;
+    // The local override must be absent, otherwise the remote flag is never consulted.
+    delete baseEnv[FLAG_ENV];
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => deepCodeServer.close(() => resolve()));
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  function configureServers(remoteFlagValue: boolean | undefined) {
+    server.restore();
+    deepCodeServer.restore();
+    server.setOrgSetting('sast', true);
+    server.setLocalCodeEngineConfiguration({
+      enabled: true,
+      allowCloudUpload: true,
+      url: `http://localhost:${deepCodeServer.getPort()}`,
+    });
+    deepCodeServer.setFiltersResponse({ configFiles: [], extensions: ['.js'] });
+    deepCodeServer.setSarifResponse({
+      $schema: 'https://json.schemastore.org/sarif-2.1.0.json',
+      version: '2.1.0',
+      runs: [],
+    });
+    // Preview builds force this on too; enable it here so rule parsing matches
+    // production rather than falling back to the legacy parser.
+    server.setFeatureFlag('clientFileFilterGitignore_MetaCharFix', true);
+    if (remoteFlagValue !== undefined) {
+      server.setFeatureFlag(REMOTE_FLAG_NAME, remoteFlagValue);
+    }
+  }
+
+  /** A repo where tracked.js is both git-tracked and matched by .gitignore. */
+  async function buildFixture(): Promise<string> {
+    const root = fs.mkdtempSync(join(os.tmpdir(), 'snyk-ff-'));
+    fs.writeFileSync(join(root, 'control.js'), 'const c = 0;\n');
+    fs.writeFileSync(join(root, 'tracked.js'), 'const a = 1;\n');
+    fs.writeFileSync(join(root, '.gitignore'), 'tracked.js\n');
+    await runCommand('git', ['init'], { cwd: root });
+    await runCommand('git', ['add', '-f', 'tracked.js'], { cwd: root });
+    return root;
+  }
+
+  function uploadedFiles(): string[] {
+    const bundleRequest = deepCodeServer
+      .getRequests()
+      .find(
+        (r) => r.method === 'POST' && (r.url as string).includes('/bundle'),
+      );
+    if (!bundleRequest) return [];
+    const raw = Buffer.isBuffer(bundleRequest.body)
+      ? Buffer.from(bundleRequest.body.toString('utf8'), 'base64').toString(
+          'utf8',
+        )
+      : JSON.stringify(bundleRequest.body);
+    return Object.keys(JSON.parse(raw)).sort();
+  }
+
+  /** The flags the CLI asked the backend to evaluate. */
+  function evaluatedFlags(): string[] {
+    return server
+      .getRequests()
+      .filter((r) => (r.url as string).includes(EVALUATION_PATH))
+      .flatMap((r) => r.body?.data?.attributes?.flags ?? []);
+  }
+
+  async function scan(opts: {
+    remoteFlag?: boolean;
+    envOverride?: boolean;
+    previewFeatures?: boolean;
+  }): Promise<{ files: string[]; flags: string[]; code: number }> {
+    configureServers(opts.remoteFlag);
+    const root = await buildFixture();
+    const env = { ...baseEnv };
+    if (opts.envOverride !== undefined) {
+      env[FLAG_ENV] = String(opts.envOverride);
+    }
+    if (opts.previewFeatures) {
+      env[PREVIEW_ENV] = 'true';
+    }
+    const { code } = await runSnykCLI(`code test ${root}`, { env });
+    return { files: uploadedFiles(), flags: evaluatedFlags(), code };
+  }
+
+  it('asks the backend to evaluate the tracked-files flag by its remote name', async () => {
+    const { flags } = await scan({ remoteFlag: true });
+
+    // A wrong mapping here would leave a dead rollout switch that no behaviour test
+    // would catch.
+    expect(flags).toContain(REMOTE_FLAG_NAME);
+  });
+
+  it('scans a tracked, gitignored file when the backend enables the flag', async () => {
+    const { files } = await scan({ remoteFlag: true });
+
+    expect(files).toEqual(['control.js', 'tracked.js']);
+  });
+
+  it('excludes a tracked, gitignored file when the backend disables the flag', async () => {
+    const { files } = await scan({ remoteFlag: false });
+
+    expect(files).toEqual(['control.js']);
+  });
+
+  it('defaults to the legacy behaviour when the backend does not know the flag', async () => {
+    const { files } = await scan({});
+
+    expect(files).toEqual(['control.js']);
+  });
+
+  it('a local override wins over the backend value', async () => {
+    // Backend says on, local config says off.
+    const off = await scan({ remoteFlag: true, envOverride: false });
+    expect(off.files).toEqual(['control.js']);
+
+    // Backend says off, local config says on.
+    const on = await scan({ remoteFlag: false, envOverride: true });
+    expect(on.files).toEqual(['control.js', 'tracked.js']);
+  });
+
+  describe('preview builds deliberately force the flag on', () => {
+    // Intended behaviour. The consequence worth pinning: a preview binary cannot
+    // validate the backend rollout switch.
+    it('activates the feature even when the backend disables it', async () => {
+      const { files } = await scan({
+        remoteFlag: false,
+        previewFeatures: true,
+      });
+
+      expect(files).toEqual(['control.js', 'tracked.js']);
+    });
+
+    it('does not even ask the backend to evaluate the flag', async () => {
+      const { flags } = await scan({
+        remoteFlag: false,
+        previewFeatures: true,
+      });
+
+      expect(flags).not.toContain(REMOTE_FLAG_NAME);
+    });
+
+    it('still lets a local override turn the feature off', async () => {
+      const { files, flags } = await scan({
+        remoteFlag: true,
+        previewFeatures: true,
+        envOverride: false,
+      });
+
+      expect(files).toEqual(['control.js']);
+      // An override short-circuits the default-value function, so setting the key by
+      // hand cannot be used to test the remote flag either.
+      expect(flags).not.toContain(REMOTE_FLAG_NAME);
+    });
+  });
+});

--- a/test/jest/acceptance/snyk-code/gitignore-tracked-files.spec.ts
+++ b/test/jest/acceptance/snyk-code/gitignore-tracked-files.spec.ts
@@ -1,0 +1,444 @@
+// The SCLE setting routes code-client-go at a fake deeproxy server, so the `POST /bundle`
+// body is the exact set of files that survived the filter.
+import { runSnykCLI } from '../../util/runSnykCLI';
+import { runCommand } from '../../util/runCommand';
+import { fakeServer } from '../../../acceptance/fake-server';
+import { fakeDeepCodeServer } from '../../../acceptance/deepcode-fake-server';
+import { getServerPort } from '../../util/getServerPort';
+import * as fs from 'fs';
+import * as os from 'os';
+import { dirname, join } from 'path';
+
+jest.setTimeout(1000 * 120);
+
+// GAF binds config keys to upper-cased env vars, bypassing the remote flag.
+const TRACKED_FILES_FLAG_ENV =
+  'INTERNAL_SNYK_GITIGNORE_RESPECT_TRACKED_FILES_ENABLED';
+
+const EXIT_CODE_SUCCESS = 0;
+const EXIT_CODE_NO_SUPPORTED_FILES = 3;
+
+type Files = Record<string, string>;
+
+interface FilterCase {
+  name: string;
+  files: Files;
+  /** Staged with `git add -f`, so gitignored paths are tracked too. */
+  tracked?: string[];
+  /** `git rm --cached` after staging, i.e. tracked then untracked again. */
+  untrack?: string[];
+  /** Deleted from disk after staging, so they remain in the index only. */
+  deleteFromWorktree?: string[];
+  noGitRepo?: boolean;
+  scanSubdir?: string;
+  expectedOff: string[];
+  expectedOn: string[];
+}
+
+// Never ignored, never tracked: proves the scan reached the upload step.
+const CONTROL_FILE = 'control.js';
+
+const cases: FilterCase[] = [
+  // --- baselines ---
+  {
+    name: 'no ignore files: everything is scanned',
+    files: {
+      [CONTROL_FILE]: 'const c = 0;\n',
+      'tracked.js': 'const a = 1;\n',
+      'untracked.js': 'const b = 2;\n',
+    },
+    tracked: ['tracked.js'],
+    expectedOff: [CONTROL_FILE, 'tracked.js', 'untracked.js'],
+    expectedOn: [CONTROL_FILE, 'tracked.js', 'untracked.js'],
+  },
+  {
+    name: 'an untracked file matching .gitignore is excluded in both flag states',
+    files: {
+      [CONTROL_FILE]: 'const c = 0;\n',
+      '.gitignore': 'untracked.js\n',
+      'untracked.js': 'const b = 2;\n',
+    },
+    expectedOff: [CONTROL_FILE],
+    expectedOn: [CONTROL_FILE],
+  },
+  {
+    name: 'a .gitignore rule matching nothing changes nothing',
+    files: {
+      [CONTROL_FILE]: 'const c = 0;\n',
+      '.gitignore': 'nothing-matches-this\n',
+      'tracked.js': 'const a = 1;\n',
+    },
+    tracked: ['tracked.js'],
+    expectedOff: [CONTROL_FILE, 'tracked.js'],
+    expectedOn: [CONTROL_FILE, 'tracked.js'],
+  },
+  {
+    name: 'a .gitignore with only comments and blank lines changes nothing',
+    files: {
+      [CONTROL_FILE]: 'const c = 0;\n',
+      '.gitignore': '# a comment\n\n   \n',
+      'tracked.js': 'const a = 1;\n',
+    },
+    tracked: ['tracked.js'],
+    expectedOff: [CONTROL_FILE, 'tracked.js'],
+    expectedOn: [CONTROL_FILE, 'tracked.js'],
+  },
+
+  // --- the core behaviour ---
+  {
+    name: 'CORE: a tracked file matching .gitignore is scanned only with the flag on',
+    files: {
+      [CONTROL_FILE]: 'const c = 0;\n',
+      '.gitignore': '*.log.js\n',
+      'secret.log.js': 'const a = 1;\n',
+      'other.log.js': 'const b = 2;\n',
+    },
+    tracked: ['secret.log.js'],
+    expectedOff: [CONTROL_FILE],
+    expectedOn: [CONTROL_FILE, 'secret.log.js'],
+  },
+  {
+    name: 'CORE: a tracked file inside a .gitignore-excluded directory is scanned with the flag on',
+    files: {
+      [CONTROL_FILE]: 'const c = 0;\n',
+      '.gitignore': 'build/\n',
+      'build/tracked.js': 'const a = 1;\n',
+      'build/untracked.js': 'const b = 2;\n',
+    },
+    tracked: ['build/tracked.js'],
+    expectedOff: [CONTROL_FILE],
+    expectedOn: [CONTROL_FILE, 'build/tracked.js'],
+  },
+  {
+    name: 'CORE: a tracked file deep in a subdirectory is scanned with the flag on',
+    files: {
+      [CONTROL_FILE]: 'const c = 0;\n',
+      '.gitignore': '*.gen.js\n',
+      'src/nested/deep/a.gen.js': 'const a = 1;\n',
+      'src/nested/deep/b.gen.js': 'const b = 2;\n',
+    },
+    tracked: ['src/nested/deep/a.gen.js'],
+    expectedOff: [CONTROL_FILE],
+    expectedOn: [CONTROL_FILE, 'src/nested/deep/a.gen.js'],
+  },
+  {
+    name: 'CORE: a rule from a nested .gitignore also honours tracked files',
+    files: {
+      [CONTROL_FILE]: 'const c = 0;\n',
+      'src/.gitignore': 'generated.js\n',
+      'src/generated.js': 'const a = 1;\n',
+      'src/other.js': 'const b = 2;\n',
+    },
+    tracked: ['src/generated.js'],
+    expectedOff: [CONTROL_FILE, 'src/other.js'],
+    expectedOn: [CONTROL_FILE, 'src/generated.js', 'src/other.js'],
+  },
+  {
+    name: 'CORE: a file staged but never committed counts as tracked',
+    files: {
+      [CONTROL_FILE]: 'const c = 0;\n',
+      '.gitignore': 'staged.js\n',
+      'staged.js': 'const a = 1;\n',
+    },
+    tracked: ['staged.js'],
+    expectedOff: [CONTROL_FILE],
+    expectedOn: [CONTROL_FILE, 'staged.js'],
+  },
+
+  // --- user-provided Snyk exclusions must win ---
+  {
+    name: 'USER RULES: a .snyk exclusion still applies to a tracked, gitignored file',
+    files: {
+      [CONTROL_FILE]: 'const c = 0;\n',
+      '.gitignore': 'secret.js\n',
+      '.snyk': 'exclude:\n  global:\n    - secret.js\n',
+      'secret.js': 'const a = 1;\n',
+    },
+    tracked: ['secret.js'],
+    expectedOff: [CONTROL_FILE],
+    expectedOn: [CONTROL_FILE],
+  },
+  {
+    name: 'USER RULES: a .snyk exclusion still applies to a tracked file no .gitignore rule matches',
+    files: {
+      [CONTROL_FILE]: 'const c = 0;\n',
+      '.snyk': 'exclude:\n  global:\n    - secret.js\n',
+      'secret.js': 'const a = 1;\n',
+    },
+    tracked: ['secret.js'],
+    expectedOff: [CONTROL_FILE],
+    expectedOn: [CONTROL_FILE],
+  },
+  {
+    name: 'USER RULES: a .dcignore rule still applies to a tracked file — only git un-ignores tracked files',
+    files: {
+      [CONTROL_FILE]: 'const c = 0;\n',
+      '.dcignore': 'vendored.js\n',
+      'vendored.js': 'const a = 1;\n',
+    },
+    tracked: ['vendored.js'],
+    expectedOff: [CONTROL_FILE],
+    expectedOn: [CONTROL_FILE],
+  },
+  {
+    name: 'USER RULES: a .dcignore rule wins over .gitignore tracking for the same file',
+    files: {
+      [CONTROL_FILE]: 'const c = 0;\n',
+      '.gitignore': 'vendored.js\n',
+      '.dcignore': 'vendored.js\n',
+      'vendored.js': 'const a = 1;\n',
+    },
+    tracked: ['vendored.js'],
+    expectedOff: [CONTROL_FILE],
+    expectedOn: [CONTROL_FILE],
+  },
+
+  // --- negation semantics ---
+  {
+    name: 'NEGATION: a negation inside .gitignore is honoured regardless of tracking',
+    files: {
+      [CONTROL_FILE]: 'const c = 0;\n',
+      '.gitignore': 'gen/*.js\n!gen/keep.js\n',
+      'gen/keep.js': 'const a = 1;\n',
+      'gen/drop.js': 'const b = 2;\n',
+    },
+    expectedOff: [CONTROL_FILE, 'gen/keep.js'],
+    expectedOn: [CONTROL_FILE, 'gen/keep.js'],
+  },
+  {
+    name: 'NEGATION: the flag must not change the outcome for an untracked file negated across ignore sources',
+    files: {
+      [CONTROL_FILE]: 'const c = 0;\n',
+      '.dcignore': 'gen/*.js\n',
+      '.gitignore': '!gen/keep.js\n',
+      'gen/keep.js': 'const a = 1;\n',
+      'gen/drop.js': 'const b = 2;\n',
+    },
+    // Nothing is tracked, so the flag must not change this.
+    expectedOff: [CONTROL_FILE, 'gen/keep.js'],
+    expectedOn: [CONTROL_FILE, 'gen/keep.js'],
+  },
+
+  // --- git edge cases ---
+  {
+    name: 'GIT: outside a git repository the legacy behaviour is kept',
+    files: {
+      [CONTROL_FILE]: 'const c = 0;\n',
+      '.gitignore': 'ignored.js\n',
+      'ignored.js': 'const a = 1;\n',
+    },
+    noGitRepo: true,
+    expectedOff: [CONTROL_FILE],
+    expectedOn: [CONTROL_FILE],
+  },
+  {
+    name: 'GIT: a file removed from the index is untracked again and stays excluded',
+    files: {
+      [CONTROL_FILE]: 'const c = 0;\n',
+      '.gitignore': 'removed.js\n',
+      'removed.js': 'const a = 1;\n',
+    },
+    tracked: ['removed.js'],
+    untrack: ['removed.js'],
+    expectedOff: [CONTROL_FILE],
+    expectedOn: [CONTROL_FILE],
+  },
+  {
+    name: 'GIT: a tracked file missing from the working tree does not break the scan',
+    files: {
+      [CONTROL_FILE]: 'const c = 0;\n',
+      '.gitignore': 'gone.js\n',
+      'gone.js': 'const a = 1;\n',
+    },
+    tracked: ['gone.js'],
+    deleteFromWorktree: ['gone.js'],
+    expectedOff: [CONTROL_FILE],
+    expectedOn: [CONTROL_FILE],
+  },
+  {
+    name: 'GIT: scanning a subdirectory resolves tracked files relative to that subdirectory',
+    // GetAllFiles only walks the scan root, so the .gitignore must live inside src/.
+    files: {
+      [CONTROL_FILE]: 'const c = 0;\n',
+      'src/.gitignore': '*.gen.js\n',
+      'src/inside.gen.js': 'const a = 1;\n',
+      'src/control.js': 'const d = 3;\n',
+      'src/other.gen.js': 'const e = 4;\n',
+      'outside.gen.js': 'const b = 2;\n',
+    },
+    tracked: ['src/inside.gen.js', 'outside.gen.js'],
+    scanSubdir: 'src',
+    expectedOff: ['control.js'],
+    expectedOn: ['control.js', 'inside.gen.js'],
+  },
+  {
+    // Pins a pre-existing leak, unaffected by the flag: `!.git/**` negates the built-in
+    // `**/.git/**` default, so repository internals are scanned. Tracked separately.
+    name: 'GIT: a .gitignore negation of .git/** leaks repository internals',
+    files: {
+      [CONTROL_FILE]: 'const c = 0;\n',
+      '.gitignore': '!.git/**\n',
+    },
+    expectedOff: [CONTROL_FILE, '.git/planted.js'],
+    expectedOn: [CONTROL_FILE, '.git/planted.js'],
+  },
+];
+
+describe('snyk code test — gitignore / tracked-file filtering', () => {
+  let server: ReturnType<typeof fakeServer>;
+  let deepCodeServer: ReturnType<typeof fakeDeepCodeServer>;
+  let baseEnv: Record<string, string>;
+  const port = getServerPort(process);
+  const baseApi = '/api/v1';
+
+  beforeAll(async () => {
+    deepCodeServer = fakeDeepCodeServer();
+    await new Promise<void>((resolve) =>
+      deepCodeServer.listen(() => resolve()),
+    );
+    server = fakeServer(baseApi, 'snykToken');
+    await new Promise<void>((resolve) => server.listen(port, () => resolve()));
+
+    baseEnv = {
+      ...process.env,
+      SNYK_API: `http://localhost:${port}${baseApi}`,
+      SNYK_HOST: `http://localhost:${port}`,
+      SNYK_TOKEN: '123456789',
+      // code-client-go panics without an org UUID
+      SNYK_CFG_ORG: '11111111-2222-3333-4444-555555555555',
+      INTERNAL_SNYK_CODE_NATIVE_IMPLEMENTATION: 'true',
+    } as Record<string, string>;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => deepCodeServer.close(() => resolve()));
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  // Called before every scan, not every test, so a test that scans twice sees only its
+  // own requests.
+  function configureServers() {
+    server.restore();
+    deepCodeServer.restore();
+    server.setOrgSetting('sast', true);
+    server.setLocalCodeEngineConfiguration({
+      enabled: true,
+      allowCloudUpload: true,
+      url: `http://localhost:${deepCodeServer.getPort()}`,
+    });
+    deepCodeServer.setFiltersResponse({
+      configFiles: [],
+      extensions: ['.js'],
+    });
+    deepCodeServer.setSarifResponse({
+      $schema: 'https://json.schemastore.org/sarif-2.1.0.json',
+      version: '2.1.0',
+      runs: [],
+    });
+  }
+
+  beforeEach(configureServers);
+
+  async function buildFixture(testCase: FilterCase): Promise<string> {
+    const root = fs.mkdtempSync(join(os.tmpdir(), 'snyk-gitignore-'));
+
+    for (const [relPath, content] of Object.entries(testCase.files)) {
+      const absPath = join(root, relPath);
+      fs.mkdirSync(dirname(absPath), { recursive: true });
+      fs.writeFileSync(absPath, content);
+    }
+
+    if (!testCase.noGitRepo) {
+      await runCommand('git', ['init'], { cwd: root });
+
+      // Proves the built-in .git exclusion holds.
+      fs.writeFileSync(join(root, '.git', 'planted.js'), 'const g = 9;\n');
+
+      if (testCase.tracked?.length) {
+        // -f: plain `git add` refuses gitignored paths.
+        await runCommand('git', ['add', '-f', ...testCase.tracked], {
+          cwd: root,
+        });
+      }
+      if (testCase.untrack?.length) {
+        await runCommand('git', ['rm', '--cached', '-q', ...testCase.untrack], {
+          cwd: root,
+        });
+      }
+    }
+
+    for (const relPath of testCase.deleteFromWorktree ?? []) {
+      fs.rmSync(join(root, relPath));
+    }
+
+    return testCase.scanSubdir ? join(root, testCase.scanSubdir) : root;
+  }
+
+  /** The files code-client-go uploaded, i.e. what survived the filter. */
+  function uploadedFiles(): string[] {
+    const bundleRequest = deepCodeServer
+      .getRequests()
+      .find(
+        (r) => r.method === 'POST' && (r.url as string).includes('/bundle'),
+      );
+
+    if (!bundleRequest) return [];
+
+    // Base64-encoded JSON map of { relativePath: fileHash }.
+    const raw = Buffer.isBuffer(bundleRequest.body)
+      ? Buffer.from(bundleRequest.body.toString('utf8'), 'base64').toString(
+          'utf8',
+        )
+      : JSON.stringify(bundleRequest.body);
+
+    return Object.keys(JSON.parse(raw)).sort();
+  }
+
+  async function scan(
+    testCase: FilterCase,
+    flagEnabled: boolean,
+  ): Promise<{ files: string[]; code: number; stdout: string }> {
+    configureServers();
+    const scanPath = await buildFixture(testCase);
+    const { code, stdout } = await runSnykCLI(`code test ${scanPath}`, {
+      env: {
+        ...baseEnv,
+        [TRACKED_FILES_FLAG_ENV]: String(flagEnabled),
+      },
+    });
+    return { files: uploadedFiles(), code, stdout };
+  }
+
+  describe.each([
+    { label: 'flag off', flagEnabled: false },
+    { label: 'flag on', flagEnabled: true },
+  ])('$label', ({ flagEnabled }) => {
+    it.each(cases)('$name', async (testCase) => {
+      const expected = (
+        flagEnabled ? testCase.expectedOn : testCase.expectedOff
+      ).slice();
+
+      const { files, code, stdout } = await scan(testCase, flagEnabled);
+
+      // Catch a broken fixture masquerading as a filtering result.
+      expect([EXIT_CODE_SUCCESS, EXIT_CODE_NO_SUPPORTED_FILES]).toContain(code);
+      expect(stdout).not.toContain('SNYK-CODE-0006');
+
+      expect(files).toEqual(expected.sort());
+    });
+  });
+
+  // The feature is strictly additive: it may only ever un-ignore tracked files.
+  describe('the flag is a no-op when nothing relevant is tracked', () => {
+    const noOpCases = cases.filter(
+      (c) => !c.tracked?.length || c.untrack?.length,
+    );
+
+    it.each(noOpCases)('$name', async (testCase) => {
+      const off = await scan(testCase, false);
+      const on = await scan(testCase, true);
+
+      expect(on.files).toEqual(off.files);
+    });
+  });
+});


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?


Updates GAF to v0.14.0 so `.gitignore` rules no longer exclude files already tracked by Git. The behavior is feature-flagged through `clientFileFilterGitignore_TrackedFilesRollout`. Explicit `.snyk` and `.dcignore` exclusions continue to apply regardless of Git tracking.

## Where should the reviewer start?

- [GAF PR](https://github.com/snyk/go-application-framework/pull/693)
- Added spec files

## How should this be manually tested?

- Acceptance test should expose a few cases in which the filtered files used by the CLI to scan would be different depending on wether the FF is ON/OFF.

## What's the product update that needs to be communicated to CLI users?

N/A

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
