### PR TITLE
fix: bump snyk-nodejs-plugin to 2.2.1 for pnpm 11 lockfile support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "4.9.2",
         "snyk-nodejs-lockfile-parser": "2.10.0",
-        "snyk-nodejs-plugin": "^2.2.0",
+        "snyk-nodejs-plugin": "^2.2.1",
         "snyk-nuget-plugin": "^4.5.1",
         "snyk-php-plugin": "1.12.1",
         "snyk-policy": "^4.1.6",
@@ -3430,13 +3430,16 @@
       }
     },
     "node_modules/@snyk/error-catalog-nodejs-public": {
-      "version": "5.79.0",
-      "resolved": "https://registry.npmjs.org/@snyk/error-catalog-nodejs-public/-/error-catalog-nodejs-public-5.79.0.tgz",
-      "integrity": "sha512-kBmouDmOgwgGsTnicVdBShVuN7QaWoauzZ0HEHUKP82X5XUWpbir2rSM3T/ta+3PO98a5nKpMTB3zU2OumagFw==",
+      "version": "5.82.1",
+      "resolved": "https://registry.npmjs.org/@snyk/error-catalog-nodejs-public/-/error-catalog-nodejs-public-5.82.1.tgz",
+      "integrity": "sha512-fchNDV+LtJGEJVqtiPyOG3kaUT/LALohZygf32Uzly3UTaxbJvT7wJn5PZiDtP6A8+YJT8klyiYiH3lvdIRCgQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.1",
         "uuid": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@snyk/error-catalog-nodejs-public/node_modules/tslib": {
@@ -20200,9 +20203,9 @@
       }
     },
     "node_modules/snyk-nodejs-plugin": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-plugin/-/snyk-nodejs-plugin-2.2.0.tgz",
-      "integrity": "sha512-wvjzQsvqwH2HTMqfk2wx0RvQ1Lqtv9FhJCAtanp11umM4qMGbWc0CkW/inpAWumzgZXTsoRHVrEhDK1fpe9eAA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-plugin/-/snyk-nodejs-plugin-2.2.1.tgz",
+      "integrity": "sha512-pbTCsUipKd/l9z40mIk017bUVhkiCgzD+X4OkdpowBXI2d4lvBwainneBybdW5rlAQC3+gVUq4zIwLrgQmqYyA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@snyk/cli-interface": "^2.13.0",
@@ -20213,11 +20216,34 @@
         "lodash.isempty": "^4.4.0",
         "lodash.sortby": "^4.7.0",
         "micromatch": "4.0.8",
-        "snyk-nodejs-lockfile-parser": "2.10.0",
+        "snyk-nodejs-lockfile-parser": "2.10.4",
         "snyk-resolve-deps": "4.8.0"
       },
       "engines": {
         "node": "^20.18.1 || ^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/snyk-nodejs-plugin/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/snyk-nodejs-plugin/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/snyk-nodejs-plugin/node_modules/hosted-git-info": {
@@ -20250,6 +20276,28 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
     },
+    "node_modules/snyk-nodejs-plugin/node_modules/js-yaml": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
     "node_modules/snyk-nodejs-plugin/node_modules/lru-cache": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -20259,6 +20307,12 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "node_modules/snyk-nodejs-plugin/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/snyk-nodejs-plugin/node_modules/semver": {
       "version": "5.7.2",
@@ -20277,6 +20331,51 @@
       "dependencies": {
         "debug": "^4.1.1",
         "hosted-git-info": "^4.0.2"
+      }
+    },
+    "node_modules/snyk-nodejs-plugin/node_modules/snyk-nodejs-lockfile-parser": {
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-2.10.4.tgz",
+      "integrity": "sha512-rVwroHPZcnH1xPYUwwkw89epxToW3bm2Qwo6EtcSjGQ17MD9mnLAoGvN1PcKbJSLDwNeMGcG26SdvFsOEbfIFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@snyk/dep-graph": "^2.12.0",
+        "@snyk/error-catalog-nodejs-public": "^5.82.1",
+        "@snyk/graphlib": "2.1.9-patch.3",
+        "@yarnpkg/lockfile": "^1.1.0",
+        "debug": "^4.4.3",
+        "dependency-path": "^9.2.8",
+        "event-loop-spinner": "^2.0.0",
+        "js-yaml": "^5.2.2",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.flatmap": "^4.5.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.topairs": "^4.3.0",
+        "micromatch": "^4.0.8",
+        "p-map": "^4.0.0",
+        "semver": "^7.6.0",
+        "snyk-config": "^5.2.0",
+        "tslib": "^1.9.3",
+        "uuid": "^11.1.1"
+      },
+      "bin": {
+        "parse-nodejs-lockfile": "bin/index.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0",
+        "npm": ">=10"
+      }
+    },
+    "node_modules/snyk-nodejs-plugin/node_modules/snyk-nodejs-lockfile-parser/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/snyk-nodejs-plugin/node_modules/snyk-resolve-deps": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "4.9.2",
     "snyk-nodejs-lockfile-parser": "2.10.0",
-    "snyk-nodejs-plugin": "^2.2.0",
+    "snyk-nodejs-plugin": "^2.2.1",
     "snyk-nuget-plugin": "^4.5.1",
     "snyk-php-plugin": "1.12.1",
     "snyk-policy": "^4.1.6",

--- a/test/fixtures/pnpm-app-multidoc/package.json
+++ b/test/fixtures/pnpm-app-multidoc/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "pnpm11-devengines",
+  "version": "1.0.0",
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "^11.0.0",
+      "onFail": "download"
+    }
+  },
+  "dependencies": {
+    "is-odd": "^3.0.1"
+  }
+}

--- a/test/fixtures/pnpm-app-multidoc/pnpm-lock.yaml
+++ b/test/fixtures/pnpm-app-multidoc/pnpm-lock.yaml
@@ -1,0 +1,230 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 11.20.0
+        version: 11.20.0
+      pnpm:
+        specifier: 11.20.0
+        version: 11.20.0
+
+packages:
+
+  '@pnpm/exe@11.20.0':
+    resolution: {integrity: sha512-6ZiImENLhgpKifw3CltPmwSMhFLgSeEsNjJQvxFs5uu0mjqH6Rq6f7FDA1J7lBPOerxctUstMu3n+KA2qrWRlA==}
+    hasBin: true
+
+  '@pnpm/linux-arm64@11.20.0':
+    resolution: {integrity: sha512-yrly8s9sGVKaHyO1soLP1z12YmOKOM0wNnVsKAEfeOoPsFkuf+3116kb4ysDlY8PZ5xJ9KDv+UXgDNOew7c7RA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pnpm/linux-x64@11.20.0':
+    resolution: {integrity: sha512-B97xRRGMktHsPzIpEgK1BuCUtO3mwUTMpVW9fV+BoY/giCCoJvgTvZTqyY8gTKSNmiPrp7Twwn5Em0r04k2fAw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@pnpm/linuxstatic-arm64@11.20.0':
+    resolution: {integrity: sha512-pdgQdxExyVLPNedhXH6RFHYCabXzfA4gU21JFWa+aXVSKI49QA817FzfjLed+hlHL+JMH7HQZvooqw3VdvLTzQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/linuxstatic-x64@11.20.0':
+    resolution: {integrity: sha512-n1pyBbXenYQJFi8nQ5Z0h4eUd9CTzbVFfnhODqYl27xqRxu8yODx5NzpCBfCczczcedCUU9NPq9McH0KtK7gyA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/macos-arm64@11.20.0':
+    resolution: {integrity: sha512-tGuwiSQWvNxKEnABtAWWLhoL3ACE6DKZstYRNjMIFouNZqHy8PsQGFnBMoKiSqtGEx7EQ7sLa+bpJsb7y6bXoA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/win-arm64@11.20.0':
+    resolution: {integrity: sha512-F4GacJqJaRDxgkpUsfefRcMC6jgrjYUnhDc/mfPPUvWUe3ioLm5LSdjyvtTbbIs8d/nojMQyV9H1PS1w7pFshg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/win-x64@11.20.0':
+    resolution: {integrity: sha512-0Db1+7D7TtvYT0ecBRhkaD8YSMcVyiArOtWqvm0UrIu8l7wWx9FgP/8NKbpg9qKHi00UxsLd03AVPl9hx2BzSw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink@0.1.19':
+    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
+    engines: {node: '>= 10'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  pnpm@11.20.0:
+    resolution: {integrity: sha512-mm8zCpW2ZEbqCI+vFSFAWooB8H/ecSTMmVjf7VLUu0NnN+ZbCPhfN7Rvy6N1CSVYrFEmK4FoRLIvY0Bu0Wa/7g==}
+    engines: {node: '>=22.13'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe@11.20.0':
+    dependencies:
+      '@reflink/reflink': 0.1.19
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@pnpm/linux-arm64': 11.20.0
+      '@pnpm/linux-x64': 11.20.0
+      '@pnpm/linuxstatic-arm64': 11.20.0
+      '@pnpm/linuxstatic-x64': 11.20.0
+      '@pnpm/macos-arm64': 11.20.0
+      '@pnpm/win-arm64': 11.20.0
+      '@pnpm/win-x64': 11.20.0
+
+  '@pnpm/linux-arm64@11.20.0':
+    optional: true
+
+  '@pnpm/linux-x64@11.20.0':
+    optional: true
+
+  '@pnpm/linuxstatic-arm64@11.20.0':
+    optional: true
+
+  '@pnpm/linuxstatic-x64@11.20.0':
+    optional: true
+
+  '@pnpm/macos-arm64@11.20.0':
+    optional: true
+
+  '@pnpm/win-arm64@11.20.0':
+    optional: true
+
+  '@pnpm/win-x64@11.20.0':
+    optional: true
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink@0.1.19':
+    optionalDependencies:
+      '@reflink/reflink-darwin-arm64': 0.1.19
+      '@reflink/reflink-darwin-x64': 0.1.19
+      '@reflink/reflink-linux-arm64-gnu': 0.1.19
+      '@reflink/reflink-linux-arm64-musl': 0.1.19
+      '@reflink/reflink-linux-x64-gnu': 0.1.19
+      '@reflink/reflink-linux-x64-musl': 0.1.19
+      '@reflink/reflink-win32-arm64-msvc': 0.1.19
+      '@reflink/reflink-win32-x64-msvc': 0.1.19
+
+  detect-libc@2.1.2: {}
+
+  pnpm@11.20.0: {}
+
+---
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      is-odd:
+        specifier: ^3.0.1
+        version: 3.0.1
+
+packages:
+
+  is-number@6.0.0:
+    resolution: {integrity: sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg==}
+    engines: {node: '>=0.10.0'}
+
+  is-odd@3.0.1:
+    resolution: {integrity: sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==}
+    engines: {node: '>=4'}
+
+snapshots:
+
+  is-number@6.0.0: {}
+
+  is-odd@3.0.1:
+    dependencies:
+      is-number: 6.0.0

--- a/test/jest/acceptance/snyk-test/basic-test-all-languages.spec.ts
+++ b/test/jest/acceptance/snyk-test/basic-test-all-languages.spec.ts
@@ -805,6 +805,25 @@ describe.each(userJourneyWorkflows)(
           expect(code).toEqual(0);
         });
 
+        test('run `snyk test` on a pnpm project with a multi-document lockfile (pnpm 11)', async () => {
+          const project = await createProjectFromFixture('pnpm-app-multidoc');
+
+          const { code, stdout } = await runSnykCLI('test --print-deps -d', {
+            cwd: project.path(),
+            env,
+          });
+
+          expect(stdout).toMatch('Target file:       pnpm-lock.yaml');
+          expect(stdout).toMatch('Package manager:   pnpm');
+          // The project dependencies live only in the second YAML document of
+          // the multi-document pnpm-lock.yaml. Resolving them proves the
+          // multi-document lockfile is parsed (snyk-nodejs-plugin#56).
+          expect(stdout).toMatch('is-odd @ 3.0.1');
+          expect(stdout).toMatch('is-number @ 6.0.0');
+
+          expect(code).toEqual(0);
+        });
+
         test('run `snyk test` on an out of sync pnpm project with --strict-out-of-sync=false', async () => {
           const project = await createProjectFromWorkspace(
             'pnpm-app-out-of-sync',


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable) — none
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___) — n/a
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps `snyk-nodejs-plugin` from `^2.2.0` (locked `2.2.0`) to `^2.2.1`.

`2.2.1` delivers snyk/snyk-nodejs-plugin#56 — **support for pnpm 11 multi-document `pnpm-lock.yaml` files**. When a project uses pnpm 11's `devEngines.packageManager` with `onFail: download`, pnpm writes a multi-document YAML lockfile (the pnpm binary is tracked in a first document, the project's dependencies in a second). Previously `snyk test` failed to resolve dependencies from such lockfiles; now they parse correctly.

The lockfile also picks up the plugin's own transitive updates: a nested `snyk-nodejs-lockfile-parser@2.10.4`, and a hoisted bump of `@snyk/error-catalog-nodejs-public` `5.79.0` → `5.82.1` (required by the new lockfile-parser).

## Where should the reviewer start?

- `package.json` / `package-lock.json` — the dependency bump.
- `test/fixtures/pnpm-app-multidoc/` — a real pnpm 11 multi-document lockfile fixture (mirrors the one added in snyk/snyk-nodejs-plugin#56).
- `test/jest/acceptance/snyk-test/basic-test-all-languages.spec.ts` — new acceptance test asserting the project dependencies (which live only in the second YAML document) are resolved.

## How should this be manually tested?

```sh
make build
./binary-releases/snyk-<platform> test --print-deps ./test/fixtures/pnpm-app-multidoc
```

The dependency tree should resolve the project dependencies from the second YAML document:

```
pnpm11-devengines @ 1.0.0
   └─ is-odd @ 3.0.1
      └─ is-number @ 6.0.0
```

## What's the product update that needs to be communicated to CLI users?

`snyk test` now supports pnpm 11 multi-document `pnpm-lock.yaml` files.

<!---
## Risk assessment (Low | Medium | High)?

Low. Dependency version bump of a first-party plugin delivering a bug fix; no CLI code changes. Covered by a new acceptance test plus the existing pnpm suite.

## Any background context you want to provide?

`snyk-nodejs-plugin@2.2.1` was published 2026-08-06. CI installs via `npm ci`, which honours the committed lockfile (exact version + integrity) and does not re-apply the repo's `min-release-age=4` npm cooldown.

## What are the relevant tickets?

Delivers snyk/snyk-nodejs-plugin#56.
--->
