### PR TITLE
chore(language-server): integrate LS

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -226,7 +226,7 @@ require (
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
-	github.com/snyk/snyk-ls v0.0.0-20260804092303-865b318b1c8f // indirect
+	github.com/snyk/snyk-ls v0.0.0-20260814112015-c5325e836868 // indirect
 	github.com/snyk/studio-mcp v1.15.3 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -604,8 +604,8 @@ github.com/snyk/rift-cli-extension v1.1.1 h1:WeBeO8tUP/SWX/lqe9tTltOdeJDKNOQdOrF
 github.com/snyk/rift-cli-extension v1.1.1/go.mod h1:uZuSGZS6n/pBGTEoxtvVsfiNAPCXcTitpnQV9a3RgDI=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260804092303-865b318b1c8f h1:egNW6/d4pz/yXxq7RKRXgD/JkqQRr1LEeiTWJE9iv6s=
-github.com/snyk/snyk-ls v0.0.0-20260804092303-865b318b1c8f/go.mod h1:zd9hsXBqnftPgvmqrUzQlb+qGg/IXMa9/HQTl5ScLWw=
+github.com/snyk/snyk-ls v0.0.0-20260814112015-c5325e836868 h1:hBuzcAYbQ9XkOWp8L31p3PcQZQksDJtq6yAtPf76USQ=
+github.com/snyk/snyk-ls v0.0.0-20260814112015-c5325e836868/go.mod h1:s4gqDKMyXZ4Z5GthWyM3D079/dT0woNbQyJ8UrHW6nE=
 github.com/snyk/studio-mcp v1.15.3 h1:t+vBRKGMWS6FLY1BAMzP2Vp+z8k8hK7kYKuAYlKEBHU=
 github.com/snyk/studio-mcp v1.15.3/go.mod h1:3ZISZCgorkGg/iLQrryvmP34Db4KkvtfAARi7vMqM/4=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/snyk/go-application-framework v0.14.2-0.20260811083722-b9443a56d4b1
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20260804092303-865b318b1c8f
+	github.com/snyk/snyk-ls v0.0.0-20260814112015-c5325e836868
 	github.com/snyk/studio-mcp v1.15.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -550,8 +550,8 @@ github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhk
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260804092303-865b318b1c8f h1:egNW6/d4pz/yXxq7RKRXgD/JkqQRr1LEeiTWJE9iv6s=
-github.com/snyk/snyk-ls v0.0.0-20260804092303-865b318b1c8f/go.mod h1:zd9hsXBqnftPgvmqrUzQlb+qGg/IXMa9/HQTl5ScLWw=
+github.com/snyk/snyk-ls v0.0.0-20260814112015-c5325e836868 h1:hBuzcAYbQ9XkOWp8L31p3PcQZQksDJtq6yAtPf76USQ=
+github.com/snyk/snyk-ls v0.0.0-20260814112015-c5325e836868/go.mod h1:s4gqDKMyXZ4Z5GthWyM3D079/dT0woNbQyJ8UrHW6nE=
 github.com/snyk/studio-mcp v1.15.3 h1:t+vBRKGMWS6FLY1BAMzP2Vp+z8k8hK7kYKuAYlKEBHU=
 github.com/snyk/studio-mcp v1.15.3/go.mod h1:3ZISZCgorkGg/iLQrryvmP34Db4KkvtfAARi7vMqM/4=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit c5325e83686805ae647bf9f9dbf9d35f9b77c9d5
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Fri Aug 14 12:20:15 2026 +0100

    refactor: read consistent ignores from the folder config the scan holds (#1408)
    
    The scan resolved this flag by folder path while already holding that folder's
    config, so it built a second one: a go-git enrichment and a storage write, for a
    value the config in hand already answers. Scan cannot reach this point without a
    folder config — ResolveFolderAndScanType fails first, and the folder path comes
    from that same config — so the two read the same key on the same configuration.
    
    Test_Scan listed the expected upload path per case and never asserted it, so
    forcing the flag either way left the suite green. The fake code scanner now
    records which of the two upload paths ran, and the cases assert it, which is what
    pins the flag to the folder config it is staged on.

M	infrastructure/code/code.go
M	infrastructure/code/code_test.go
M	infrastructure/code/fake_code_client_scanner.go

commit cfcd02b29f06919f4040d578627d1d5445085991
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Thu Aug 13 09:58:07 2026 +0100

    fix(config): restore VS Code Snyk Studio UI [IDE-2452] (#1406)
    
    * fix(config): restore VS Code secure at inception UI [IDE-2452]
    
    Expose Secure At Inception controls only for VS Code-family integrations.
    Preserve existing native-setting and MCP behavior while covering rendering,
    serialization, reset semantics, generated fixtures, and non-VS exclusions.
    
    Co-authored-by: benjamin.durrans <benjamin.durrans@snyk.io>
    
    * test(config): generate VS Code settings fixture [IDE-2452]
    
    Use the no-projects generated page for the VS Code integration so the
    tracked fixture visibly covers the gated Secure At Inception controls.
    
    Co-authored-by: benjamin.durrans <benjamin.durrans@snyk.io>
    
    * fix(config): align Studio UI review feedback [IDE-2452]
    
    Use Snyk Studio in user-facing copy, centralize the VS Code integration
    name, share HTML test helpers, and remove redundant snapshot assertions.
    
    Co-authored-by: benjamin.durrans <benjamin.durrans@snyk.io>
    
    * fix(config): correct Studio section naming [IDE-2452]
    
    Restore the Secure At Inception section heading while retaining Snyk Studio
    for user-facing product copy, and centralize all renderer integration names.
    
    Co-authored-by: benjamin.durrans <benjamin.durrans@snyk.io>
    
    * test(config): remove Secrets independence case [IDE-2452]
    
    Drop the unnecessary coupling regression test from the configuration HTML
    renderer suite as requested during review.
    
    Co-authored-by: benjamin.durrans <benjamin.durrans@snyk.io>
    
    * fix(config): restore inception rules tooltip [IDE-2452]
    
    Use Secure At Inception for the execution-frequency rules copy while
    retaining Snyk Studio for the product configuration control.
    
    Co-authored-by: benjamin.durrans <benjamin.durrans@snyk.io>
    
    * fix(config): restore inception configuration copy [IDE-2452]
    
    Use Secure At Inception for the configuration tooltips and documentation,
    while retaining Snyk Studio only for the renamed auto-configuration control.
    
    Co-authored-by: benjamin.durrans <benjamin.durrans@snyk.io>
    
    ---------
    
    Co-authored-by: Cursor Agent <cursoragent@cursor.com>

M	Makefile
M	application/server/configuration_smoke_test.go
M	docs/configuration-dialog.md
M	docs/configuration.md
M	domain/ide/command/configuration_command.go
M	domain/ide/command/configuration_command_settings_test.go
M	infrastructure/configuration/config_html.go
M	infrastructure/configuration/config_html_test.go
M	infrastructure/configuration/template/config.html
M	infrastructure/configuration/template/js/ui/reset-handler.js
M	internal/constants/constants.go
A	internal/testutil/html.go
M	js-tests/folder-reset.test.mjs
M	js-tests/form-handler.test.mjs
M	js-tests/global-reset.test.mjs
M	js-tests/snapshots/form-payload.json
M	js-tests/tabs.test.mjs
M	scripts/config-dialog/config_output_multi_project.html
M	scripts/config-dialog/config_output_no_projects.html
M	scripts/config-dialog/config_output_single_solution.html
M	scripts/config-dialog/main.go

commit 68dc3ee1a1d3cc31820daa762475292675464799
Author: Bastian Doetsch <20150761+bastiandoetsch@users.noreply.github.com>
Date:   Tue Aug 11 19:36:38 2026 +0200

    refactor(di): remove process-global singletons to enable t.Parallel() [IDE-2036] (#1319)
    
    * refactor(di): remove process-global singletons to enable t.Parallel() [IDE-2036]
    
    - TestInit no longer writes package-level vars; each call returns an
      independent Dependencies struct so concurrent calls are race-free
    - Add Installer to di.Dependencies for test access without globals
    - Replace global progressStopChan with a per-server channel threaded
      through initHandlers → initializeHandler / shutdownHandler
    - cleanupChannels(deps) uses deps.HoverService instead of di.HoverService()
    - All test files updated to use deps.* instead of di.Xxx() global accessors
    - setupRepoAndInitialize/InDir accept optional deps for scan-state cleanup
    - Add t.Parallel() to all smoke tests except Test_SmokeRealScanMonorepoFixture
      (which is excluded because pprof.StartCPUProfile is process-global)
    
    * fix: address verification findings in IDE-2036 parallelization refactor
    
    - shutdownHandler: non-blocking send on progressStopChan (capacity 1)
      prevents deadlock when shutdown is called twice without a prior
      initialize (e.g. test body + t.Cleanup both calling shutdown)
    - test_init.go: replace comment claiming no globals are written with
      accurate documentation of remaining global side-effects
      (command.SetService, DefaultOpenBrowserFunc)
    - DefaultOpenBrowserFunc: protect the write with sync.Once so
      concurrent TestInit calls do not race under go test -race
    - cleanupChannels: add comment explaining why progress.CleanupChannels
      is intentionally absent (cancelling all trackers breaks parallel tests)
    - sendFileSavedMessage: change variadic deps to a required parameter,
      removing the nil-interface dead-code path
    - setupRepoAndInitializeInDir: document the scan-disabled contract
      for callers that omit deps
    - configuration_test.go: remove _ = testDeps2746 dead code
    
    * fix: replace sync.Once with init() for DefaultOpenBrowserFunc in test_init
    
    sync.Once implies potential future re-use and adds conceptual overhead; a
    package-level init() is cleaner and conveys the single-assignment semantics
    directly. Both achieve the same effect: the no-op is set once at process
    startup before any TestInit call, so no concurrent writes can race.
    
    * fix: move browser no-op init() to test-only file and fix stale comment
    
    test_init.go is compiled into the production binary (no build constraint,
    non-_test.go suffix), so the init() added in the previous commit silenced
    DefaultOpenBrowserFunc — including OAuth login and snyk.openBrowser — in
    production. Move the assignment to browser_noop_test.go (package di,
    _test.go suffix), which Go only compiles into test binaries.
    
    Also fix stale comment in fflags/features.go: cachedErr → errOnce (the
    variable was renamed in IDE-2103 but the comment was not updated).
    
    * fix: restore browser no-op for server tests and clean up lint issues
    
    - Add browser_noop_test.go to application/server/ so server package
      test binaries also silence DefaultOpenBrowserFunc (di's init only
      fires when testing application/di, not application/server)
    - Remove orphaned stale comment line from test_init.go (leftover from
      the deleted init() function that now lives in browser_noop_test.go)
    - Remove unused //nolint:gocyclo on TestInit (now a 4-line wrapper)
    - Fix spelling: cancelling → canceling in cleanupChannels comment
    - Fix dogsled lint: reduce triple blank identifier in precedence smoke test
    - Add t.Parallel() to subtests in Test_SmokeWorkspaceScan,
      Test_SmokePreScanCommand, Test_SmokeIssueCaching, Test_SmokeOrgSelection
    - Add //nolint:tparallel to Test_SmokeTreeView (subtests share server state)
    - Fix stale comment: cachedErr → errOnce in fflags/features.go
    
    * fix: add browser_noop_test.go to codelens and oss test packages
    
    domain/ide/codelens and infrastructure/oss both import application/di
    in their test code. The _test.go init() in application/di/browser_noop_test.go
    does not execute when those packages' test binaries run — each package's
    test binary compiles independently. Add the same no-op guard to prevent
    any future test in those packages from accidentally opening a real browser.
    
    * fix: move endpoint env setup before t.Parallel() in smoke tests
    
    t.Setenv (and t.Parallel after t.Setenv) both panic when a test is
    already parallel in Go 1.22+. Replace t.Setenv("SNYK_API", ...) with
    a local endpoint variable in Test_SmokeInstanceTest and
    Test_SmokeWorkspaceScan; t.Parallel() can then be called immediately
    after. runSmokeTest's t.Setenv path is only reached when a non-empty
    non-/v1 endpoint is passed, which always comes from a sequential
    context (non-parallel caller).
    
    * fix: use os.Setenv for SNYK_API in parallel smoke tests
    
    t.Setenv and t.Parallel are mutually exclusive in Go 1.21+: calling
    either after the other panics. For parallel smoke tests that need a
    default SNYK_API, use os.Setenv before t.Parallel() (no cleanup needed
    — all smoke tests target the same endpoint URL for the lifetime of the
    process). runSmokeTest also switches to os.Setenv since it is called
    from parallel test contexts.
    
    * fix: use TestInit deps struct in Test_GetCodeLensForPath [IDE-2036]
    
    Global di.*() accessors return nil after the DI refactor (50cbbef4)
    because TestInit no longer writes globals. Capture the returned
    Dependencies struct and use its fields directly.
    
    * fix: replace t.Setenv with os.Setenv+Cleanup in parallel smoke tests [IDE-2036]
    
    t.Setenv panics when called from t.Parallel() contexts (Go 1.21+).
    Replace with os.Setenv + t.Cleanup to preserve the automatic restoration
    semantics for SNYK_TOKEN and SNYK_LOG_LEVEL.
    
    * fix: replace t.Setenv with os.Setenv+Cleanup in Test_Concurrent_CLI_Runs [IDE-2036]
    
    t.Setenv panics after t.Parallel() (Go 1.21+). Apply the same
    os.Setenv + t.Cleanup restoration pattern used elsewhere in the
    smoke test suite.
    
    * style: fix nolint comment alignment in parallelization_test.go [IDE-2036]
    
    * refactor(di): thread CommandService through withContext injection [IDE-2036]
    
    Remove command.SetService/command.Service() process-global singleton.
    Add CommandService to di.Dependencies, inject via withContext deps-map
    (same pattern as other mandatory deps). Update execute_command.go and
    notification.go to read the service from context/parameter instead of
    the global. Update all test call sites to inject via deps.
    
    Fixes the Singleton Race identified in PR review: concurrent TestInit
    calls no longer race on command.SetService.
    
    * refactor(server): reduce validateMandatoryDeps cyclomatic complexity [IDE-2036]
    
    Switch statement (16 cases) exceeds gocyclo limit of 15. Replace with
    slice-of-structs loop (complexity 2). Logic is identical: early return
    on first nil dependency with the same error message format.
    
    * fix(di): eliminate env race + add per-server ProgressChannel [IDE-2036]
    
    Fix 2 — env var race: guard SNYK_API and SNYK_LOG_LEVEL with sync.Once
    in parallel smoke tests; de-parallelize the SNYK_TOKEN-mutating subtest.
    
    Fix 3 — progress channel: add ProgressChannel to di.Dependencies,
    introduce NewTrackerWithChannel for tests that need per-server isolation.
    Production and default-TestInit paths continue to use the global
    progress.ToServerProgressChannel so existing scanner→LSP routing is
    preserved. Tests can override via overrideDeps.ProgressChannel.
    
    * style: fix nolint comment placement in smoke test helpers [IDE-2036]
    
    * style: add explanation to gochecknoglobals nolint directives [IDE-2036]
    
    * fix: eliminate xdg.ConfigHome race in parallel precedence smoke tests [IDE-2036]
    
    Replace global xdg.ConfigHome mutation with per-test config injection via
    engine.GetConfiguration().Set(UserGlobalKey(SettingConfigFile)). Extract
    shared setupTestConfigIsolation helper (with INTEGRATION_ENVIRONMENT guard)
    to eliminate duplication across precedence/ldx-sync/scan-precedence setups.
    All 22 t.Parallel() calls restored — the config injection is the correct fix;
    removing parallelism would have been a workaround.
    
    * fix: replace t.Setenv with os.Setenv in unauthenticated OrgSelection subtest [IDE-2036]
    
    t.Setenv panics in subtests whose parent called t.Parallel() (Go 1.21+).
    The unauthenticated subtest of Test_SmokeOrgSelection is not itself
    parallel, but its parent is — triggering the panic in CI and aborting
    the entire test binary. Replace with os.Setenv; the t.Cleanup restore
    already in place handles restoration.
    
    * fix: remove INTEGRATION_ENVIRONMENT dependency from setupTestConfigIsolation [IDE-2036]
    
    The guard (t.Fatalf if INTEGRATION_ENVIRONMENT unset) broke all precedence
    smoke tests in SMOKE_SHARD_3 CI: that env var is not set for that shard.
    It was irrelevant — config isolation only needs a path inside t.TempDir();
    ConfigFileFromConfig reads SettingConfigFile first, bypassing xdg.ConfigHome.
    
    * fix: create parent dir in setupTestConfigIsolation before setting SettingConfigFile [IDE-2036]
    
    Raw filepath injection does not auto-create parent directories unlike
    xdg.ConfigFile, causing folderconfig to fail with 'no such file or
    directory'. Add os.MkdirAll to create the snyk/ parent before use.
    
    * fix: remove t.Parallel from Test_Concurrent_CLI_Runs — incompatible with WithRealDI [IDE-2036]
    
    WithRealDI() calls di.Init() which modifies process-global package variables
    (HTTP clients, scanners, notifiers). Parallel execution causes context
    cancellation in shared HTTP clients, failing Code API requests in sibling
    tests. Documented with inline comment.
    
    * refactor(di): add RealDependencies for parallel-safe test DI [IDE-2036]
    
    di.Init() writes to 30+ package-level globals, making parallel smoke
    tests unsafe. RealDependencies() provides the same real-implementation
    bootstrap using only local variables — no globals written — so parallel
    test servers each get isolated service instances.
    
    - Add di.RealDependencies(engine, tokenService) that mirrors
      initInfrastructure + initDomain + initApplication but uses local
      vars throughout, never writing package-level globals
    - Update setupServer (WithRealDI path) to call di.RealDependencies
      instead of di.Init, eliminating shared-global races across parallel
      test servers
    - Re-enable t.Parallel() on Test_Concurrent_CLI_Runs; passes -race in
      50s locally after the global-state race is eliminated
    - Add TestRealDependencies_ParallelSafe: 3 concurrent goroutines each
      call RealDependencies with independent engines, assert Notifier and
      other instances are all distinct (no shared pointers)
    - Correct ProgressChannel comment: it uses process-global
      progress.ToServerProgressChannel intentionally (scanners write to it
      via NewTracker); per-server isolation deferred to follow-up
    
    * fix(test): use os.Setenv save-and-restore in Test_SmokeSecretsScan [IDE-2036]
    
    t.Setenv panics when called after t.Parallel() (Go 1.21+). Replace with
    the codebase-approved save-and-restore pattern: capture previous value
    via os.Getenv, set the new value, restore in t.Cleanup. Consistent with
    commit 4aadc51d which applied the same pattern to other smoke tests.
    
    * fix(test): limit concurrent Code API calls + serialize unmanaged scan [IDE-2036]
    
    Running all shard smoke tests in parallel overwhelms the Snyk Code API:
    6+ concurrent scans trigger throttling, manifesting as context canceled
    (fast failure) or indefinite hangs (15-min timeout).
    
    - Add codeAPISem (buffered channel, capacity 3) limiting concurrent
      Code API calls within a shard to 3. Acquired via acquireCodeAPISlot(t)
      before each Code-scanning test; released in t.Cleanup.
    - Apply acquireCodeAPISlot to: runSmokeTest helper (covers WorkspaceScan,
      InstanceTest), IssueCaching subtests, SmokeSnykCodeFileScan, 4 Code
      delta tests, and SmokeUncFilePath.
    - Remove t.Parallel() from Test_SmokeScanUnmanaged: the --unmanaged CLI
      scan is CPU/IO-intensive and consistently times out at maxIntegTestDuration
      when competing with parallel shard-1 tests for CLI and API resources.
    
    * fix(test): reduce Code API semaphore to 1, extend to SHARD_3 [IDE-2036]
    
    codeAPISem capacity reduced from 3 to 1: only 1 Code scan runs per shard
    at a time. With 4 shards on separate CI machines this yields 4 concurrent
    Code API calls total — within the API's throttling tolerance.
    
    Add acquireCodeAPISlot(t) to 5 SHARD_3 precedence scan tests that enable
    the Code product but were missing the semaphore acquisition:
    - Test_SmokeScanPrecedence_CodeEnabled_OSSDisabled
    - Test_SmokeScanPrecedence_UserOverrideEnablesProduct
    - Test_SmokeScanPrecedence_UserOverrideDisablesProduct
    - Test_SmokeScanPrecedence_SeverityFilter_DiagnosticsRespectFilter
    - Test_SmokeScanPrecedence_EnableAllProducts_AllScansRun
    
    Without the slot these tests ran concurrently, overloading the Code API
    and causing context canceled failures in shard-3 CI jobs.
    
    * fix(test): cap=2 semaphore + use SNYK_TOKEN for Code scan precedence tests [IDE-2036]
    
    Two fixes for remaining CI failures:
    
    1. codeAPISem capacity 1→2: cap=1 caused test starvation on Windows
       shard-2 — Test_SmokeUncFilePath waited 15+ minutes for the semaphore
       while Test_SmokeInstanceTest held the single slot. Cap=2 allows 2
       concurrent Code scans per shard (8 total across 4 shards), within
       the API's tolerance while eliminating starvation.
    
    2. setupScanPrecedenceTest and Test_SmokeScanPrecedence_SeverityFilter_*
       now use "" (default SNYK_TOKEN) instead of SNYK_TOKEN_CONSISTENT_IGNORES.
       The 3 Code-enabled precedence tests consistently failed context canceled
       using the consistent ignores token. SNYK_TOKEN provides the same Code
       API access without the issue. The non-Code setupPrecedenceTest retains
       SNYK_TOKEN_CONSISTENT_IGNORES for its original test coverage.
    
    * fix(test): serialize SHARD_3 Code scans + cap=1 + fix starvation [IDE-2036]
    
    Three targeted fixes for remaining CI failures:
    
    1. cap=1 (was 2): cap=2 reintroduced API overload in shard-1 and shard-3.
       With cap=1, only 1 Code scan runs per shard at a time, preventing
       concurrent API throttling while still allowing 4 parallel shards total.
    
    2. Test_SmokeInstanceTest loses t.Parallel(): this test can hold the
       Code API semaphore slot for up to maxIntegTestDuration (15 min),
       starving Test_SmokeUncFilePath on Windows. Removing t.Parallel()
       prevents the starvation without affecting test correctness.
    
    3. SHARD_3 Code-scanning tests lose t.Parallel(): SHARD_3 runs 22+
       parallel non-Code precedence tests concurrently. Under this load,
       Code scan contexts are pre-canceled immediately (4-8s failures).
       Affected tests: CodeEnabled_OSSDisabled, UserOverrideEnablesProduct,
       UserOverrideDisablesProduct, SeverityFilter_DiagnosticsRespectFilter,
       EnableAllProducts_AllScansRun, and NoNewIssuesFound_JavaGoof.
       These removals are due to external concurrent load, not global state.
    
    Token for setupScanPrecedenceTest restored to SNYK_TOKEN_CONSISTENT_IGNORES
    (the default SNYK_TOKEN caused even faster failures, 4s vs 28s, indicating
    the Code scanner aborts before making any API call with that token/org).
    
    * refactor(context): fix Clone whitelist bug — use context.WithoutCancel [IDE-2036]
    
    ctx2.Clone had a whitelist-based implementation that silently dropped any
    context key not explicitly enumerated (deps map, workdir, logger, scan type,
    scan source). This caused cross-test Code scan cancellation: the reference
    scan context lost DepProgressChannel, fell back to the global progress
    channel, and received spurious cancel signals from other parallel tests.
    
    Fix: replace the 17-line whitelist with context.WithoutCancel(ctx) which
    preserves ALL context values automatically and severs cancellation from the
    parent — exactly the semantic needed for background scans that must outlive
    their originating handler but carry its full dependency set.
    
    The newCtx parameter is retained for backward compatibility (all existing
    callers pass context.Background(), so the break is safe) but is now a no-op.
    Two new tests verify the fix: PreservesUnknownKeys and CancellationSevered.
    
    Also update all code.New() call sites in test files to pass the required
    progressChannel parameter (infrastructure/code/code_test.go,
    code_integration_test.go, domain/ide/command/code_fix_diffs_test.go).
    
    * refactor(di,code,context): isolate Code scanner progress channel + delete dead Clone [IDE-2036]
    
    - Add progressChannel field to code.Scanner; internalScan now routes
      progress events through an injected channel instead of the global
      progress.ToServerProgressChannel, enabling per-server LSP isolation
    - Delete ctx2.Clone (zero callers after previous commit); callers use
      context.WithoutCancel directly
    - Delete Clone tests; add TestGenerateTrackerRoutesToGlobalChannel to
      regression-gate the known gap where TrackerFactory still routes to
      the global channel (documented with TODO(IDE-2036))
    - Move localProgressChannel init block before code.New in test_init.go
      to satisfy the new constructor parameter ordering
    
    * fix(code): thread progressChannel into TrackerFactory for full isolation [IDE-2036]
    
    GenerateTracker() now calls NewTrackerWithChannel(t.progressChannel, ...)
    instead of NewTracker() (global channel), completing per-server progress
    event isolation for the Snyk Code scanner. Eliminates cross-server context
    cancellations in parallel smoke tests caused by upload-phase events bleeding
    across servers via the global channel.
    
    * refactor(di): eliminate RealDependencies duplication via buildDependencies [IDE-2036]
    
    Extract buildDependencies() as the single construction path. Init() and
    RealDependencies() both call it; Init() additionally writes results into
    the package-level globals that back the legacy accessor functions.
    
    Deletes initInfrastructure, initDomain, initApplication, currentDependencies
    and the intermediate-only globals (snykApiClient, snykCodeScanner, snykCli,
    instrumentor, codeInstrumentor, codeErrorReporter, scanStateChangeEmitter,
    etc.) that were never accessed outside those four functions.
    
    * chore(lint): enable gochecknoglobals linter + whitelist existing globals [IDE-2036]
    
    Enable gochecknoglobals in .golangci.yaml to prevent new unreviewed
    package-level variables. Exclude _test.go and fake_*/mock_* files where
    test-fixture globals are expected.
    
    Add //nolint:gochecknoglobals // <reason> to every existing production
    global with a precise rationale:
    - "effectively a package-level constant": env var strings, context keys,
      compiled regexes, read-only maps — immutable after process init
    - "legacy process-global DI state; targeted for elimination (IDE-2036)":
      the globals in application/di/init.go that buildDependencies now
      encapsulates but that the legacy accessor functions still reference
    - "process-global progress channel; per-session isolation is a follow-up
      (IDE-2036)": progress.ToServerProgressChannel and trackers registry
    - "required guard for mutable package state": all sync.Mutex/RWMutex fields
    - "process-global cancel / concurrency limiter / analytics mutex": remaining
      stateful singletons that are genuinely process-wide
    
    Removes the now-redundant nolint directives from env_once_helpers_test.go
    (covered by the new _test.go exclusion rule). Zero linter violations.
    
    * fix(test,di): eliminate config.Version race + per-server progress channel isolation [IDE-2036]
    
    Fix 1 — DATA RACE: ensureInitialized() wrote config.Version (process-global)
    concurrently from parallel test goroutines while analytics read it. Delete
    the write — commitHash is already set locally on initParams.ClientInfo.Version
    and IntegrationOptions.IntegrationVersion. Default "SNAPSHOT" is correct for
    CI analytics.
    
    Fix 2 — context canceled in Code Delta smoke tests: RealDependencies()
    was sharing progress.ToServerProgressChannel across parallel test servers.
    When one server's createProgressListener stopped (via progressStopChan),
    other tests' Code scanners were still writing upload-phase events to the
    same global channel, causing cross-server context cancellations.
    
    Thread progressCh through buildDependencies(): RealDependencies() creates
    make(chan types.ProgressParams, 1000) per call; Init() continues to pass
    progress.ToServerProgressChannel (correct for single-server production).
    
    * fix(test): replace CleanupChannels with non-blocking drain to fix parallel test cancellation [IDE-2036]
    
    progress.CleanupChannels() cancels ALL global trackers by calling
    Cancel(token) for each entry in the trackers map. Under t.Parallel(),
    this fires during one test's cleanup while another test's Code scan is
    mid-flight — the cancel signal propagates through CancelOrDone() →
    onCancel() → the Code scan's cancel func → context.canceled in
    retrieveTestURL, causing consistent Code Delta test failures.
    
    Replace all three cleanup-path calls with a safe non-blocking labeled
    drain that removes buffered progress messages without touching any
    tracker:
    
        drain: for {
            select {
            case <-progress.ToServerProgressChannel:
            default:
                break drain
            }
        }
    
    Updated:
    - internal/testutil/test_setup.go (UnitTestWithEngine + prepareTestHelper)
    - domain/ide/codelens/codelens_test.go (dummyProgressListeners)
    
    CleanupChannels() definition is preserved (used in serial tests via
    progress_test.go) but is now unreachable from any parallel test cleanup.
    
    * fix(server): cancel server-lifetime scan context on shutdown to prevent Windows file handle leaks [IDE-2036]
    
    Background scan goroutines started by initializedHandler used
    context.Background() — they ran indefinitely and held file handles in
    t.TempDir(). On Windows, this caused TempDir RemoveAll cleanup to fail
    with "The process cannot access the file because it is being used by
    another process."
    
    Add scanCtx/scanCancel to initHandlers, thread scanCtx to
    initializedHandler so ScanWorkspace uses it, and call scanCancel() in
    shutdownHandler. When the LSP shutdown is received (or test cleanup runs
    it), all scan goroutines derived from scanCtx exit and release handles
    before the temp-dir cleanup fires.
    
    ChangeWorkspaceFolders-triggered scans keep context.Background() — they
    are one-off operations not tied to the server lifetime.
    
    Added TestScanContextCanceledOnShutdown that intercepts the context
    passed to ScanWorkspace and asserts it is canceled after shutdown.
    
    * fix(scanner,iac,oss): fix detached reference scan context + complete progress channel isolation [IDE-2036]
    
    Fixes two issues flagged by the PR review bot:
    
    1. Detached reference scan context: reference branch scans used
       context.WithoutCancel(ctx) — a permanently non-cancelable context that
       ignored the server-lifetime scanCtx canceled in shutdownHandler. On
       server shutdown (or test cleanup), reference scans kept running and held
       file handles in t.TempDir(), causing Windows 'access denied' cleanup
       failures. Fix: save serverCtx := ctx before per-scan context.WithCancel
       wrapping; reference scans now use serverCtx and are canceled at shutdown.
    
    2. Partial progress isolation: IaC and OSS scanners used
       progress.NewTracker() (global channel) while Code already used
       NewTrackerWithChannel. Thread progressCh through iac.New() and
       oss.NewCLIScanner() constructors; buildDependencies passes the per-server
       channel; TestInit passes the per-test channel. All three scanners now
       have full per-server progress event isolation.
    
    * refactor(progress,di,server): eliminate process-global progress channel + complete scanCtx threading [IDE-2036]
    
    Replaces the process-global progress.ToServerProgressChannel and global tracker
    registry with a per-server progress.Tracker (owner: channel + token->Task registry,
    Cancel/IsCanceled) and progress.Task (per-operation handle, implements ui.ProgressBar);
    token cancellation resolves per-server via the context-injected Tracker. Migrates the
    downloader and the GAF extension entrypoint off the global ctor and all scanner/test
    callsites onto per-server (drained) Trackers. Threads the server-lifetime scanCtx into
    HandleFolders (initialized) and the workspace/folder/clear-cache scan commands so every
    background scan respects shutdown cancellation. Also: thread scanCtx into the didSave +
    didChangeWorkspaceFolders handlers; share one process-global CLI concurrency semaphore
    across executors; replace the order-dependent sync.Once SNYK_API env with a per-server
    WithAPIEndpoint config option.
    
    * fix(test,lint): Windows scanCtx test path + reflect.Pointer + golangci 2.12.2 [IDE-2036]
    
    - scan_context_test.go: build the didSave intercept path via filepath.Join and
      store interceptPath as uri.PathFromUri(uri.PathToUri(fakePath)) so it matches
      the handler's computed path on Windows (was a forward-slash literal + exact
      string match, failing integration/smoke on windows-latest).
    - internal/util/values.go: reflect.Ptr -> reflect.Pointer (deprecated since Go 1.18).
    - .golangci.yaml: targeted exclusion for the govet 'inline' analyzer false-positive
      on generic stdlib calls (slices.Contains/ContainsFunc) — "type parameter inference
      is not yet supported", no fix available; real inline findings stay enforced.
    - Makefile: bump pinned golangci-lint v2.10.1 -> v2.12.2 so CI's make lint matches
      the analyzer set; make lint reports 0 issues whole-repo.
    
    * test(smoke): remove process-global env mutation from parallel smoke tests [IDE-2036]
    
    Three smoke tests mutated process-global environment variables while their
    siblings ran in parallel, which is a genuine data race rather than a lint
    annoyance.
    
    Test_SmokeOrgSelection's "unauthenticated - re-adding folder" subtest set
    SNYK_TOKEN to the empty string. Its siblings share SMOKE_SHARD_3 and read the
    variable lazily at test-body time via prepareTestHelper ->
    testsupport.GetEnvironmentToken(""), so a sibling could observe the blanked
    value and configure its engine with an empty token. The t.Cleanup restore only
    fires after the subtest ends and therefore never covered the overlap window.
    The empty token is now set on the test's own engine configuration via
    tokenService.SetToken, mirroring the WithAPIEndpoint pattern already used
    elsewhere in this PR, and t.Parallel() is restored.
    
    secrets_smoke_test.go set and restored SNYK_LOG_LEVEL. Dropping the variable
    outright was preferable to dropping t.Parallel(): config.SetLogLevel was not a
    viable swap because ensureInitialized resets the level to info when the
    environment is empty, and zerolog's level is process-global regardless.
    
    unified_test_api_smoke_test.go still used os.Getenv plus t.Setenv for SNYK_API.
    It now uses WithAPIEndpoint, with "/v1" mapping to the empty string as a no-op.
    This removes the last t.Setenv("SNYK_API") in the server tests.
    
    Addresses review comments #3636779260, #3426849216 and #3637303342.
    
    * test: tighten progress and scan-context assertions, drop dead test scaffolding [IDE-2036]
    
    Review found several tests in this PR that asserted less than their names
    claimed, plus leftover scaffolding.
    
    The two "progress channel isolation" tests were tautologies. Both iac_test.go
    and cli_scanner_test.go created the sibling channel after the scan had already
    run and never wired it to a scanner, so asserting it was empty proved nothing.
    Both now build two channels and two scanners up front, scan with the first, and
    assert events landed on that channel and not the other. The OSS test previously
    only compared a struct field and never scanned at all; it now runs a real scan
    through cli.NewTestExecutor. That required the in-file folderConfigWithFlags
    helper, because a bare types.FolderConfig nil-panics in findNewFeature ->
    GetFeatureFlag.
    
    progress_channel_test.go built a full DI graph whose result was discarded via
    _ = locA and never initialized, so the createProgressListener routing it
    claimed to cover was never exercised; those setupServer calls are removed along
    with an unused ctx/cancel pair. It now asserts require.Same between the
    injected Tracker and deps.ProgressTracker, which is what actually verifies
    TestInit honored the injection.
    
    code_tracker_test.go had two for/select loops that unconditionally broke on the
    first iteration; since Eventually already supplies the retry, they are plain
    non-blocking selects and the nolint directives are gone.
    
    Remaining changes are assertion tightening: re-checking engine A's endpoint
    after engine B is configured, asserting context.Canceled as the scanCtx error
    reason, requiring delivery on the cancel channel rather than draining and
    discarding it, and failing immediately instead of waiting on a timeout for a
    synchronous cancel.
    
    Two deviations from the literal review requests are worth noting. In
    execute_command_test.go the suggested "not using the global" assertion was not
    expressible, because di exposes no setter for that global; the test now pins
    di.CommandService() as nil, which is what makes a handler reading the global
    observable. In configuration_test.go the flagged line number referred to a
    variable named testDeps2746 rather than a comment; no line number is correct
    there, so the name is simply testDeps.
    
    Also drops a conf.Set("snyk.trustedFolders", true) that had no effect, since
    HandleUntrustedFolders reads GetFolderTrust and the test workspace returns the
    folder as untrusted unconditionally, and removes leftover TDD narration and
    AI-generated commentary.
    
    Addresses review comments #3632018446, #3632024121, #3637374527, #3421668378,
    #3421615305, #3632149307, #3421776687, #3631756625, #3420291147, #3636679568,
    #3637433078, #3426690339, #3421385742, #3426751908, #3420229265, #3420101099,
    #3420105078, #3426737222, #3632152061, #3632150884 and #3632151506.
    
    * docs: correct test-interference rationale and warn about ownerless tasks [IDE-2036]
    
    precedence_smoke_test.go justified five test-serialisation workarounds as a
    "context initialization" race. That explanation is wrong. snyk-ls hands
    code-client-go a 12h analysis budget by default (config.go:154 and :163,
    applied at :425), internalScan adds no deadline of its own (code.go:262 uses
    WithCancel), and the CLI timeout is 90m (cli.go:72). SNYK_CODE_TIMEOUT is never
    exported by CI, so the default stands. The only deadlines CPU contention can
    realistically breach are the suite's own 15m maxIntegTestDuration
    (server_test.go:70) and the shard's go test -timeout=25m (build.yaml:216
    and :335), interacting with this PR's new shutdown-cancels-scanCtx behaviour.
    All five comments now describe it as the CPU-contention and test-timeout-budget
    workaround it actually is.
    
    NewTaskWithChannel gains a GoDoc warning that the tasks it produces have no
    owner, so IsCanceled always reports false and client cancellation requests are
    dropped. This is documentation only; a follow-up commit removes the constructor
    entirely in favour of Tracker.New, which registers the task.
    
    Addresses review comments #3421827975 and #3427173917.
    
    * fix(progress): hand scanners the tracker so cancel resolves [IDE-2036]
    
    The Code, OSS and IaC scanners received the per-server progress channel and
    minted their progress tasks with progress.NewTaskWithChannel, which produces an
    ownerless, unregistered task. Tracker.Cancel(token) from the
    window/workDoneProgress/cancel handler could never resolve those tokens, so the
    IDE's cancel button on a scan's progress bar did nothing, and Tracker.IsCanceled
    reported the same live scans as already cancelled.
    
    Pass the *progress.Tracker itself to the three scanner constructors and mint
    tasks with tracker.New(true), which registers them. NewTaskWithChannel is
    deleted so no caller can reintroduce an ownerless task; NewTestTask stays, and
    tests that need to inspect a raw channel wrap it with NewTrackerWithChannel.
    
    The code-client-go upload tracker keeps taking the owner's channel rather than a
    registered task: it mints its own token and code-client-go exposes no cancel
    hook for the upload phase, so a registry entry there would never be resolved nor
    released. Its unread cancelChannel field goes with the change.
    
    Task.begin now takes the task mutex around its lastReport / lastMessage writes.
    Cancellation arriving immediately after Begin makes CancelOrDone read
    lastMessage concurrently with that write, which the race detector flags.
    
    testutil.NewTestProgressTracker passes a nop logger instead of nil, since tasks
    are now minted from it and Task.begin dereferences the logger.
    
    * refactor(oss): drop dead cancellation check in scheduled refresh [IDE-2036]
    
    scheduleRefreshScan decouples the refresh from the session with
    context.WithoutCancel, so the newCtx.Err() check after the timer fires can never
    be true. The live check beside it, case <-ctx.Done(), is the one that aborts a
    scheduled scan and is unchanged.
    
    * refactor(di): delete caller-free DI accessors and their globals [IDE-2036]
    
    An audit of the accessors in application/di found twelve with zero callers
    anywhere in the tree: Notifier, ErrorReporter, HoverService, ScanPersister,
    ScanStateAggregator, ScanNotifier, Scanner, Installer, CodeActionService,
    FileWatcher, FeatureFlagService (+ its setter) and LdxSyncService (+ its
    setter). Every consumer now reads the Dependencies struct that Init and
    TestInit return, so the accessors and the package-level variables backing
    them are dead weight.
    
    Deleting them shrinks the process-global var block from nineteen entries to
    six and removes twelve gochecknoglobals suppressions with it.
    
    The remaining accessors still have live call sites and are migrated
    separately, so this commit reads as a pure deletion.
    
    * refactor(di): drop last DI process-globals; server owns tree-emitter disposal [IDE-2036]
    
    The application/di var block is now empty and every gochecknoglobals
    suppression in it is gone with it, which makes the PR title literally true for
    the dependency-injection layer.
    
    Tree-emitter disposal was the one load-bearing global and the one real design
    choice here. The concrete *treeview.TreeScanStateEmitter now rides on
    Dependencies rather than command.TreeEmitter growing a Dispose method:
    disposal is a server-lifecycle concern, and command.TreeEmitter exists to
    describe what the command layer consumes, which is emission and nothing else.
    Widening a consumer interface to serve the owner's lifecycle would have put a
    method on it that no command ever calls.
    
    Typing the field concretely also removes a typed-nil hazard: assigning a nil
    *TreeScanStateEmitter to an interface field produced a non-nil interface, so
    `deps.TreeEmitter != nil` passed when emitter construction had failed and a nil
    pointer was published into the handler context map.
    
    Dispose now tolerates a nil receiver. Construction is allowed to fail, so every
    owner holds an optional emitter; one guard in the shared method replaces a nil
    check at each of the four call sites. The dead treeview.Disposable interface
    (one implementation, no consumers) goes too.
    
    With no globals left to write, Init and RealDependencies had identical bodies,
    so they collapse into Init, and buildDependencies folds in with them. Callers
    own the graph they get, including disposing TreeEmitter.
    
    Remaining accessor readers move to the Dependencies struct that Init and
    TestInit already return:
    
    - The OSS integration test reads deps fields and uses the downloadCLI helper
      already present in its package, which drops the last di.Initializer() caller.
      Initializer therefore never joins Dependencies: the struct carries what
      handlers read, and no handler reads it — it is consumed once at startup by
      NewDelegatingScanner. The Dependencies comment now states that rule instead
      of asserting the exclusion is permanent.
    - Three di.SetConfigResolver calls in configuration_test.go were dead: the same
      resolver is already passed to validateLockedFields explicitly.
    - The di.CommandService() nil-assertion in execute_command_test.go existed only
      to prove TestInit does not write that global. With the global deleted the
      assertion has no premise left.
    
    Comments across seven files still named the deleted accessors; they now
    describe what the code actually does. One test's globalSentinel was never a
    global at all — it was the pre-override base deps value — so it is renamed to
    match.
    
    * fix(di): cancel scan contexts in test cleanups; collapse duplicate emitter local [IDE-2036]
    
    Init's doc comment says the caller owns the returned graph, including
    Dependencies.ScanCancel, but the three test callers only disposed the tree
    emitter. Init roots its scan context at context.Background(), so each of those
    contexts outlived its test. Cancel them alongside the emitter.
    
    localTreeEmitterInstance existed only so the old Init could assign the
    treeEmitterInstance global without a runtime type assertion. That global is
    gone, and NewTreeScanStateEmitter already returns nil on error, so the variable
    was a copy of localTreeEmitter in both branches.
    
    Also drop the Initializer rationale duplicated from the Dependencies struct
    comment into init_test.go, and correct the Dispose comment: injectHandlerDeps
    still needs its own nil check because it boxes the emitter into an any-valued
    map, so a nil-tolerant Dispose spares the owner, not every caller.
    
    * fix(progress): route the GAF progress bar to the drained tracker [IDE-2036]
    
    The language-server extension entry point installed a progress user
    interface on the process-scoped engine, backed by a tracker it created on
    the spot. Nothing drained that tracker's channel, so framework progress was
    invisible in the IDE and the cap-1000 buffer filled monotonically; once
    full, the next report blocks forever and wedges the reporting workflow.
    
    Move the installation into server.Start, immediately after di.Init, where
    the server's own tracker exists — the one createProgressListener drains.
    
    Bars are now minted per NewProgressBar() call rather than stored once. A
    Task is spent after Clear (finished, deregistered), and GAF calls
    NewProgressBar per workflow invocation with a deferred Clear, so a single
    shared bar would leave every operation after the first invisible and risk
    the "end progress twice" panic. This also retires the previous bar's
    never-ended, whole-server-lifetime registration.
    
    The bar no longer advertises itself as cancellable: nothing handles
    cancellation for it, so the claim was dishonest.
    
    Behaviour change: the standalone language-server binary (main.go) installs
    no user interface today and gains the progress bar with this move.
    
    * fix(cli): thread the per-server progress tracker into CLI downloads [IDE-2036]
    
    The downloader constructor the installer called fabricated its own tracker whose
    channel nothing drained, so a download running past the buffer depth blocked in
    io.Copy forever, and download progress never reached the IDE.
    
    Delete that constructor rather than keeping both: NewDownloader now takes the
    owner, and the installer receives the per-server tracker from DI and passes it to
    every downloader it builds.
    
    Per the reviewer's advice the buffer-fill hang is not reproduced in a test —
    filling it needs minutes of active download. The wiring is asserted instead.
    
    NewTestProgressTracker now drains continuously via NewDrainedProgressTracker,
    which also works from TestMain, where there is no *testing.T.
    
    * refactor(command): delete process-global command service holder [IDE-2036]
    
    The command package held the service in a package-level `instance` behind
    `SetService`/`Service`. Nothing outside tests ever called the setter, so
    `command.Service()` returned nil in a running language server. Production
    resolves the service from the request context via
    `mustCommandServiceFromContext`, fed from `deps.CommandService`.
    
    `folder_handler_test.go` saved and restored the global around a mock; nothing
    read it, confirmed by running the test without the ritual.
    
    `execute_command_test.go` dropped the hand-rolled `myTestCommandService`
    sentinel, whose `called` field was written and never read, in favour of the
    existing `types.NewCommandServiceMock()` that `di.TestInit` already injects.
    Its `NotSame` assertion went with the global it probed for: `di.TestInit`
    returns `Dependencies` by value and always allocates a fresh mock, so the
    comparison could no longer fail. The test also no longer claims to exercise
    `executeCommandHandler`, which it never called, and is named for the
    `withContext` injection it does verify.
    
    * test: honest names, honest comments, drop no-op helper, parallelise scan-context tests [IDE-2036]
    
    Five independent test-only cleanups raised in review.
    
    Misnamed forwarding test: TestHandleFoldersForwardsCtxToHandleUntrustedFolders
    asserted that a context the test itself cancelled was still cancelled after the
    call. That assertion holds even if HandleFolders ignores the context entirely,
    and the doc comment admitted as much at length. Dropped the assertion and its
    defence, renamed to TestHandleFoldersDoesNotPanicOnCanceledContext, and pointed
    at TestHandleFoldersScanCtxCanceledOnShutdown, which carries the real coverage.
    
    No-op helper: CreateDummyProgressListener became empty when the process-global
    progress channel was removed. Deleted it and its eleven call sites.
    
    Browser suppression comment: the gochecknoglobals rationale on
    DefaultOpenBrowserFunc claimed the value is immutable after init. Four test
    packages reassign it in init() so tests never launch a real browser, which is
    the only reason it is a variable. Replaced the rationale with that, and noted
    that injecting it through the five production call sites is out of scope.
    
    Test identifiers: four occurrences wrote the branch marker as a parenthesised
    suffix (UNIT-110 (IDE-2036)) while the rest use it as a prefix
    (IDE-2036-UNIT-110). Normalised those four so a search by the expected pattern
    finds them.
    
    Parallelisation: seven scan-context tests were held sequential by a comment
    claiming the injected workspace is engine-global state. It is not — the
    workspace lives on the engine's own configuration and the engine is built fresh
    per test. Added t.Parallel() and settled it by running: two full iterations of
    all seven under -race reported zero data races and zero failures, so the
    comments are gone and the tests stay parallel. The tests are slow under -race
    (~440s each on an unloaded machine, ~33s without it), but that cost is
    pre-existing and unrelated to parallelism — running them parallel makes five of
    them cost the wall-clock of one.
    
    * refactor(server): scope background-init lifecycle to the server [IDE-2036]
    
    The background scanner-init cancel func, its done channel and the cache-check
    cancel func were process-global, so two servers in one process would overwrite
    each other's handles and shutdown could cancel the wrong server's goroutines.
    
    They now live in a per-server backgroundInit value created in initHandlers and
    handed to the initialized and shutdown handlers, guarded by its own mutex
    because the two handlers run at different points in the LSP lifecycle.
    
    * fix(progress): close the task-registry lifecycle holes [IDE-2036]
    
    Ending a task left its registry entry behind: only Clear and CancelOrDone
    released one. Callers that end without clearing — the CLI downloader, the
    framework progress-bar factory installed at startup — therefore grew the
    per-server registry for as long as the server ran. End and Clear now share one
    finish() that sends the end event and releases the entry.
    
    EndWithMessage also read and wrote the finished flag outside the task mutex
    while Clear did so inside, so a concurrent end and clear was a data race.
    finish() takes the mutex for both.
    
    NewScan registered the task first and marked it as a scan second, under a
    separate lock acquisition. A cancel arriving in that window resolved a token
    that was not yet flagged as a scan and skipped the summary-panel reset — the
    IDE-1035 symptom the flag exists to prevent. The scan fields are now set
    before the task becomes visible in the registry.
    
    * fix(server): reject nil pointer-typed mandatory dependencies [IDE-2036]
    
    The mandatory-dependency check stored each dependency as an `any` and compared
    that to nil. Interface-typed dependencies survive the boxing; the two held as
    concrete pointers do not — a nil pointer in an interface is a non-nil interface
    value, so a server wired with a nil FileWatcher or CodeActionService started
    anyway and panicked later somewhere unrelated.
    
    Nil-ness is now evaluated at the call site on the statically typed field and
    the table carries a bool, so a pointer-typed dependency added later cannot
    silently reopen the hole.
    
    * fix(server): cancel in-flight scans before stopping the progress listener [IDE-2036]
    
    Shutdown signalled the progress listener to exit and only then cancelled the
    scan context. Between those two statements the scanners were still live and
    still sending, and the send is an unguarded channel write with no select and no
    done case — once the buffer filled, the scan would block forever with no reader
    left. The writers are now cancelled first.
    
    The handler body moved into shutdown() so the ordering is reachable from a test
    without standing up a full jrpc2 server.
    
    * chore: state the tree-emitter nil contract and the CLI semaphore scope [IDE-2036]
    
    Dependencies.TreeEmitter documents nil on construction failure but the graph
    passed through whatever the constructor returned; assign nil explicitly so the
    code says what the doc says.
    
    The CLI concurrency semaphore is deliberately process-scoped: concurrencyLimit
    derives from host CPU count, so a per-executor bound would let N servers in one
    process spawn N×limit CLI subprocesses. Recorded in a comment.
    
    * chore: surface test failures while the run is still going
    
    go test buffers a package's output until the package exits, so a long run
    reports nothing for its whole duration and a failure that happened in minute
    two is only visible in minute forty.
    
    scripts/test-live.sh wraps go test -json, prints each failure with its output
    the moment it arrives, and tees the full stream to $TEST_LIVE_LOG so the run
    stays write-once, grep-many. make test-live is the entry point.
    
    * refactor(progress): finish the tracker rename and drop its scaffolding [IDE-2036]
    
    The per-server progress type landed as Tracker, but the vocabulary around it
    still said owner: parameters, struct fields, method receivers, two file names
    and a test name. Anyone grepping for one name found half the call sites.
    
    Rename everything to tracker, and remove four pieces of scaffolding the
    half-finished rename left behind:
    
    - The downloader's one-line progress accessor and the progressReporter
      interface with a single implementation. Tests inject the task through the
      struct literal, so the field is enough.
    - The drained-tracker test helper that took a *testing.T and used it only to
      mark itself a helper. All ~90 call sites now use the handle-free version.
    - The split between TestInit and buildTestDependencies, which existed only to
      relocate a gocyclo directive. The directive moves back onto TestInit.
    - progress.go, whose remaining content was one test-only constructor and a
      package comment for a package that had moved elsewhere. NewTestTask lives in
      task.go, next to the type it builds.
    
    Docs: drop the superseded progress.Bus decision entry, which described a type
    that was never committed, and repoint the surviving snippets and package
    summary at the names actually in the tree.
    
    Also drops an assign-then-discard in the environment-helper test.
    
    No behaviour change.
    
    * fix(server): reject a nil ProgressTracker or ScanCancel by name [IDE-2036]
    
    Both were absent from the mandatory-dependency list, which predates the fix
    that made the check evaluate nil-ness on the statically typed field. Neither is
    optional: the progress listener reads the tracker's channel, and shutdown calls
    ScanCancel to stop in-flight scans.
    
    A nil tracker used to panic before the check could report it, because
    initHandlers dereferenced deps.ProgressTracker.Channel() while registering the
    handlers. The initialize handler now reads the channel from the request context
    like every other dependency, so validateMandatoryDeps runs first and the client
    gets a named error.
    
    With ScanCancel mandatory, the nil guard in the shutdown path is dead; drop it.
    
    This turns a startup panic into an early named error, so it is a behaviour
    change and lands on its own.
    
    * chore: bump Go toolchain to 1.26.5 to fix SNYK-GOLANG-STDOS-17905377 [IDE-2036]
    
    The Snyk Open Source gate in CircleCI blocks on std/os@1.26.4 (Symlink
    Attack, HIGH) now that the finding is past its 30-day remediation SLA.
    1.26.5 is the first fix version on the 1.26 line.
    
    * test: raise go test -parallel above GOMAXPROCS for the I/O-bound suites [IDE-2036]
    
    t.Parallel() concurrency defaults to GOMAXPROCS, which is 3-4 on the CI
    runners. The integration and smoke suites spend their time waiting on the
    Snyk API and on CLI subprocesses, so that default leaves the newly
    parallelised tests serialised behind the core count rather than behind the
    work they actually contend for.
    
    * Revert "test: raise go test -parallel above GOMAXPROCS for the I/O-bound suites [IDE-2036]"
    
    This reverts commit 626b079d08c7eefa2d02934188ef03ea4c8bbecb.
    
    * refactor(server): read the integration name and version from configuration [IDE-2036]
    
    setClientInformation fell back to os.Getenv, which forced three tests to write
    process environment and therefore kept them serial. The configuration already
    resolves the same variables: configuration.INTEGRATION_NAME is
    snyk_integration_name, and viper's AutomaticEnv uppercases that to find
    SNYK_INTEGRATION_NAME. Reading through the per-engine configuration lets those
    tests seed state locally and run in parallel.
    
    Test_integrationConfigKeys_matchTheirEnvVarNames keeps the environment contract
    covered, so the key and its variable name cannot drift apart unnoticed.
    
    * test(server): stop the CLI dir and smoke harness tests writing process env [IDE-2036]
    
    resolveCliDir read SNYK_LS_CLI_CACHE_DIR itself, so its three tests had to write
    process environment to exercise it. It now takes the directory as a parameter and
    TestMain passes the variable in, leaving the CI cache contract unchanged while the
    tests pass plain strings and run in parallel.
    
    The monorepo real-scan harness sets its API endpoint through WithAPIEndpoint on the
    per-server configuration instead of SNYK_API, and still lets a CI-provided SNYK_API
    win. The shell env guard keeps using os.Setenv, matching testutil: its value has to
    outlive the test, because restoring it would re-enable the login shell spawn the
    guard exists to prevent.
    
    * test(remediation): cancel the caller ctx explicitly instead of racing a 500ms timeout [IDE-2036]
    
    TestRemediate_EnumCtx_SurvivesCallerDeadline gave the provider a 500ms budget
    that had to cover resolveGitRoot, MkdirTemp, git worktree add and the tracked
    file snapshot before the runner even started. On a loaded Windows CI agent
    git worktree add exceeded that budget, so the context killed git mid-checkout
    and Remediate failed with "git worktree add: exit status 1" and no fatal line
    in the captured output.
    
    The runner now cancels the caller context after writing the fix, which expires
    the provider's derived context deterministically, and the provider timeout is
    raised to 30s. The assertion is unchanged: buildWorkspaceEdits must still
    return edits with a dead caller context. The test no longer depends on machine
    speed and finishes in ~0.25s instead of waiting out the timeout.
    
    ---------
    
    Co-authored-by: Bastian Doetsch <bastian.doetsch@snyk.io>
    Co-authored-by: Nick Yasnohorodskyi <nikita.yasnohorodskyi@snyk.io>

M	.circleci/config.yml
M	.gitignore
M	.golangci.yaml
M	Makefile
M	application/config/config.go
A	application/di/browser_noop_test.go
M	application/di/init.go
M	application/di/init_fix_folder_test.go
M	application/di/init_test.go
M	application/di/test_init.go
M	application/server/authentication_flows_e2e_test.go
A	application/server/browser_noop_test.go
M	application/server/cancel_handler_test.go
M	application/server/configuration.go
M	application/server/configuration_oauth_endpoint_test.go
M	application/server/configuration_smoke_test.go
M	application/server/configuration_test.go
M	application/server/di_context_injection_test.go
A	application/server/env_once_helpers_test.go
A	application/server/env_race_test.go
M	application/server/execute_command.go
M	application/server/execute_command_test.go
M	application/server/initialized_signal_safety_test.go
M	application/server/ldx_sync_smoke_test.go
M	application/server/lsp_init_perf_test.go
M	application/server/notification.go
M	application/server/notification_test.go
M	application/server/parallelization_test.go
M	application/server/precedence_smoke_test.go
A	application/server/progress_channel_test.go
A	application/server/progress_tracker_test.go
A	application/server/scan_context_command_test.go
A	application/server/scan_context_test.go
M	application/server/secrets_smoke_test.go
M	application/server/server.go
M	application/server/server_diagnostic_test.go
M	application/server/server_multiroot_test.go
M	application/server/server_smoke_test.go
M	application/server/server_smoke_treeview_test.go
M	application/server/server_test.go
A	application/server/shutdown_order_test.go
M	application/server/smoke_main_helpers_test.go
M	application/server/smoke_main_test.go
M	application/server/unified_test_api_smoke_test.go
M	docs/requirements/architecture.md
A	domain/ide/codelens/browser_noop_test.go
M	domain/ide/codelens/codelens_test.go
M	domain/ide/command/clear_cache.go
M	domain/ide/command/code_fix_diffs_test.go
M	domain/ide/command/command_factory.go
M	domain/ide/command/command_factory_test.go
M	domain/ide/command/command_service.go
M	domain/ide/command/command_service_test.go
M	domain/ide/command/folder_handler_test.go
M	domain/ide/command/remediation_fix_folder_test.go
M	domain/ide/command/toggle_tree_filter.go
M	domain/ide/command/update_folder_config.go
M	domain/ide/command/workspace_scan.go
M	domain/ide/treeview/expand_state.go
M	domain/ide/treeview/tree_scan_emitter.go
M	domain/ide/treeview/tree_scan_emitter_test.go
M	domain/snyk/persistence/git_persistence_provider.go
M	domain/snyk/remediation/remy_remediate_harden_test.go
M	domain/snyk/scanner/scanner.go
M	domain/snyk/scanner/scanner_test.go
M	go.mod
M	infrastructure/analytics/analytics.go
M	infrastructure/cli/cli.go
M	infrastructure/cli/cli_test.go
M	infrastructure/cli/environment.go
M	infrastructure/cli/initializer_test.go
M	infrastructure/cli/install/downloader.go
M	infrastructure/cli/install/downloader_test.go
A	infrastructure/cli/install/downloader_tracker_test.go
M	infrastructure/cli/install/installer.go
M	infrastructure/cli/install/installer_test.go
M	infrastructure/code/code.go
M	infrastructure/code/code_html.go
M	infrastructure/code/code_integration_test.go
M	infrastructure/code/code_test.go
M	infrastructure/code/code_tracker.go
M	infrastructure/code/code_tracker_test.go
M	infrastructure/code/codeconfig.go
M	infrastructure/code/snyk_code_http_client.go
M	infrastructure/diagnostics/directory_check/formatter.go
M	infrastructure/featureflag/featureflag.go
M	infrastructure/iac/errors.go
M	infrastructure/iac/iac.go
M	infrastructure/iac/iac_test.go
M	infrastructure/learn/service.go
A	infrastructure/oss/browser_noop_test.go
M	infrastructure/oss/cli_scanner.go
M	infrastructure/oss/cli_scanner_test.go
M	infrastructure/oss/issue.go
M	infrastructure/oss/main_test.go
M	infrastructure/oss/oss_integration_test.go
M	infrastructure/oss/oss_test.go
M	infrastructure/oss/ostest_scan.go
M	infrastructure/oss/types.go
M	infrastructure/oss/url_parse_cache.go
M	infrastructure/oss/vulnerability_count_test.go
M	infrastructure/secrets/errors.go
M	infrastructure/sentry/init.go
M	infrastructure/utils/error_messages.go
M	internal/context/context.go
M	internal/context/context_test.go
M	internal/delta/fuzzy_matcher.go
M	internal/fflags/features.go
M	internal/fileicon/pm.go
A	internal/progress/lifecycle_test.go
D	internal/progress/progress.go
M	internal/progress/progress_test.go
A	internal/progress/task.go
A	internal/progress/tracker.go
A	internal/progress/tracker_test.go
M	internal/testutil/test_setup.go
M	internal/types/command.go
M	internal/types/config_resolver.go
M	internal/types/config_writers.go
M	internal/types/issues.go
M	internal/types/ldx_sync_adapter.go
M	internal/uri/uri_util.go
M	internal/user_interface/user_interface.go
M	internal/user_interface/user_interface_test.go
M	internal/util/values.go
M	internal/vcs/git_utils.go
M	ls_extension/directory_check_workflow.go
M	ls_extension/language_server_workflow.go
A	scripts/test-live.sh

commit 1cf40fcabd330a1fe4e8eb9493b15a99a392e17f
Author: Andrew Robinson Hodges <andrew.robinsonhodges@snyk.io>
Date:   Fri Aug 7 13:19:02 2026 +0100

    fix: only dedupe secrets issues [IDE-2140] (#1384)
    
    * fix: only collapse secrets issues by fingerprint
    
    * test: add extra tests around fingerprint calculation

M	domain/ide/treeview/tree_builder.go
M	domain/ide/treeview/tree_builder_test.go
M	domain/scanstates/summary_html.go
M	domain/scanstates/summary_html_test.go
M	domain/snyk/persistence/git_persistence_provider_test.go
M	infrastructure/code/conversion_test.go
A	infrastructure/code/convert_num1_dedup_test.go
M	internal/product/product.go
M	internal/product/product_test.go
A	internal/testutil/fingerprint.go
M	internal/testutil/issue.go
M	internal/types/issues.go
```

[IDE-2452]: https://snyksec.atlassian.net/browse/IDE-2452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ