### PR TITLE
fix: reachability fails due to .git traversing error

### DIFF
--- a/src/lib/find-files.ts
+++ b/src/lib/find-files.ts
@@ -49,7 +49,8 @@ interface FindFilesRes {
   allFilesFound: string[];
 }
 
-const ignoreFolders = ['node_modules', '.build'];
+// ensure we ignore find against node_modules path, .build folder for swift, and .git
+const ignoreFolders = ['node_modules', '.build', '.git'];
 
 interface FindFilesConfig {
   path: string;
@@ -91,8 +92,8 @@ export async function find(findConfig: FindFilesConfig): Promise<FindFilesRes> {
   const found: string[] = [];
   const foundAll: string[] = [];
 
-  // ensure we ignore find against node_modules path and .build folder for swift.
-  if (config.path.endsWith('node_modules') || config.path.endsWith('/.build')) {
+  // ensure we never scan the ignored folders, even when one is the scan root
+  if (ignoreFolders.includes(pathLib.basename(config.path))) {
     return { files: found, allFilesFound: foundAll };
   }
 

--- a/test/jest/unit/lib/find-files.spec.ts
+++ b/test/jest/unit/lib/find-files.spec.ts
@@ -1,0 +1,92 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as pathLib from 'path';
+
+import { find } from '../../../../src/lib/find-files';
+
+describe('find() ignored folders', () => {
+  let workspace: string;
+
+  // A `.git` directory can't be committed as a fixture (git tracks a nested
+  // `.git` as a gitlink), so the tree is built on disk for these tests.
+  beforeAll(() => {
+    workspace = fs.mkdtempSync(pathLib.join(os.tmpdir(), 'find-files-'));
+
+    fs.writeFileSync(pathLib.join(workspace, 'package.json'), '{}');
+
+    for (const folder of ['.git', 'node_modules', '.build']) {
+      fs.mkdirSync(pathLib.join(workspace, folder));
+      fs.writeFileSync(pathLib.join(workspace, folder, 'package.json'), '{}');
+    }
+
+    // Mirrors the loose-object fan-out that made a real repo's `.git` the most
+    // expensive and most race-prone subtree to walk. See CLI-1737.
+    fs.mkdirSync(pathLib.join(workspace, '.git', 'objects', 'ab'), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      pathLib.join(workspace, '.git', 'objects', 'ab', 'cdef'),
+      '',
+    );
+
+    // A directory whose name merely *ends* in an ignored folder name must still
+    // be scanned.
+    fs.mkdirSync(pathLib.join(workspace, 'my_node_modules'));
+    fs.writeFileSync(
+      pathLib.join(workspace, 'my_node_modules', 'package.json'),
+      '{}',
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  });
+
+  it('does not traverse ignored folders', async () => {
+    const { allFilesFound } = await find({ path: workspace, levelsDeep: 6 });
+
+    expect(allFilesFound).toContain(pathLib.join(workspace, 'package.json'));
+    expect(
+      allFilesFound.filter((file) =>
+        ['.git', 'node_modules', '.build'].some((folder) =>
+          file.split(pathLib.sep).includes(folder),
+        ),
+      ),
+    ).toEqual([]);
+  });
+
+  it.each(['.git', 'node_modules', '.build'])(
+    'returns nothing when the scan root itself is %s',
+    async (folder) => {
+      const { files, allFilesFound } = await find({
+        path: pathLib.join(workspace, folder),
+        levelsDeep: 6,
+      });
+
+      expect(files).toEqual([]);
+      expect(allFilesFound).toEqual([]);
+    },
+  );
+
+  it('returns nothing when the scan root is an ignored folder with a trailing separator', async () => {
+    const { allFilesFound } = await find({
+      path: pathLib.join(workspace, '.build') + pathLib.sep,
+      levelsDeep: 6,
+    });
+
+    expect(allFilesFound).toEqual([]);
+  });
+
+  it('scans a directory whose name only ends in an ignored folder name', async () => {
+    const expected = pathLib.join(workspace, 'my_node_modules', 'package.json');
+
+    const asScanRoot = await find({
+      path: pathLib.join(workspace, 'my_node_modules'),
+      levelsDeep: 6,
+    });
+    expect(asScanRoot.files).toEqual([expected]);
+
+    const asSubdirectory = await find({ path: workspace, levelsDeep: 6 });
+    expect(asSubdirectory.allFilesFound).toContain(expected);
+  });
+});


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Ignores `.git` in legacy CLI TS `src/lib/find-files.ts`.

## How should this be manually tested?

Before applying the commit & after:
Create a churn process that creates and removes `./.git/objects` processes and run `snyk test`.

## What's the product update that needs to be communicated to CLI users?

None. Read bellow.

## Risk assessment (Low | Medium | High)?

Low: The risk associated with this change depends on whether `src/lib/find-files.ts` is utilized by other extensions, and the slight possibility that skipping this folder could alter the scanner's findings. However, since it appears to be used solely by cli-extension-os-flows, this outcome is unlikely, and the change should instead offer a modest improvement in scan performance.

## What are the relevant tickets?
[CLI-1737](https://snyksec.atlassian.net/browse/CLI-1737)

<!---
## Any background context you want to provide?



## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->


[CLI-1737]: https://snyksec.atlassian.net/browse/CLI-1737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ