### PR TITLE
feat: [AG-414] add studio extension to CLI

### DIFF
--- a/cliv2-private/cmd/cliv2/main.go
+++ b/cliv2-private/cmd/cliv2/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/snyk/cli-extension-axi/pkg/agent"
 	"github.com/snyk/cli-extension-cos/pkg/cos"
+	"github.com/snyk/cli-extension-studio/pkg/studio"
 	"github.com/snyk/remy-cli-extension/pkg/remy"
 	"github.com/snyk/rift-cli-extension/pkg/rift"
 
@@ -17,5 +18,6 @@ func main() {
 		core.WithAdditionalExtensions(remy.Init),
 		core.WithAdditionalExtensions(cos.Init),
 		core.WithAdditionalExtensions(rift.Init),
+		core.WithAdditionalExtensions(studio.Init),
 	))
 }

--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -216,6 +216,7 @@ require (
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091 // indirect
 	github.com/snyk/cli-extension-sbom v0.0.0-20260722102401-3c3af28e7b93 // indirect
 	github.com/snyk/cli-extension-secrets v0.0.0-20260619070019-764c5c87eda3 // indirect
+	github.com/snyk/cli-extension-studio v0.0.0-00010101000000-000000000000 // indirect
 	github.com/snyk/code-client-go v1.31.1 // indirect
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
@@ -298,6 +299,8 @@ require (
 
 // For local development, point to the sibling public module:
 replace github.com/snyk/cli/cliv2 => ../cliv2
+
+replace github.com/snyk/cli-extension-studio => ../../cli-extension-studio
 
 // replace github.com/snyk/remy-cli-extension => ../../remy-cli-extension
 

--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -5,6 +5,7 @@ go 1.26.6
 require (
 	github.com/snyk/cli-extension-axi v0.0.0-20260901142946-cb915113acb7
 	github.com/snyk/cli-extension-cos v0.0.0-20260818151318-d63bb9db9484
+	github.com/snyk/cli-extension-studio v1.0.1
 	github.com/snyk/cli/cliv2 v0.0.0
 	github.com/snyk/remy-cli-extension v1.42.0
 	github.com/snyk/rift-cli-extension v1.2.2
@@ -301,6 +302,8 @@ require (
 
 // For local development, point to the sibling public module:
 replace github.com/snyk/cli/cliv2 => ../cliv2
+
+// replace github.com/snyk/cli-extension-studio => ../../cli-extension-studio
 
 // replace github.com/snyk/remy-cli-extension => ../../remy-cli-extension
 

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -595,6 +595,8 @@ github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9 h1:Kz/UCPa
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd h1:sSVkD1CuL8v49boItrt2CnQ4DJIH+sjGwFGheGCVAxo=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd/go.mod h1:PrKXTT4fwEJPIzphT4n1tH5mwt2D1/qadP5HNCvub9Y=
+github.com/snyk/cli-extension-studio v1.0.1 h1:42YpcPY89cEJnCRqe1TIwWnrBXKoOlkyl6SEjfto/HA=
+github.com/snyk/cli-extension-studio v1.0.1/go.mod h1:9QjZA7PPhnbcoxFMOnVwOyUXQQCl3F+PYqhNmFh16YQ=
 github.com/snyk/code-client-go v1.31.8 h1:3o9vJKsgXiKkwiOPplJejw41nqTPylDzXqQmq5Daor8=
 github.com/snyk/code-client-go v1.31.8/go.mod h1:pHrCXCt5BJmG2L99KO5d8Qm4xdSOpbE9HEs61WsoHSo=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea h1:/v48hCMPiZVjplylgE2FX1ib8Qd8LN/vf8ZIKfA+wkI=

--- a/cliv2/pkg/core/workflows.go
+++ b/cliv2/pkg/core/workflows.go
@@ -9,6 +9,7 @@ import (
 	"github.com/snyk/cli-extension-os-flows/pkg/osflows"
 	"github.com/snyk/cli-extension-sbom/pkg/sbom"
 	"github.com/snyk/cli-extension-secrets/pkg/secrets"
+	"github.com/snyk/cli-extension-studio/pkg/studio"
 	"github.com/snyk/code-client-go/pkg/code"
 	"github.com/snyk/container-cli/pkg/container"
 	"github.com/snyk/go-application-framework/pkg/configuration"
@@ -40,6 +41,7 @@ func initExtensions(engine workflow.Engine, config configuration.Configuration, 
 	engine.AddExtensionInitializer(ignore_workflow.InitIgnoreWorkflows)
 	engine.AddExtensionInitializer(agentscan.Init)
 	engine.AddExtensionInitializer(secrets.Init)
+	engine.AddExtensionInitializer(studio.Init)
 
 	// Register additional extensions injected via Run(WithAdditionalExtensions(...))
 	for _, ext := range additionalExts {


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Adding a new CLI extension for Snyk Studio.  This new extension takes the existing hooks and installer that we have in snyk/studio-recipes and embeds them into the CLI, so that you can both install and run your Snyk Studio scripts directly by running CLI commands, as opposed to running random python scripts.

## Where should the reviewer start?

Just some package changes adding our new cli-extension

## How should this be manually tested?

you should be able to run `snyk studio install` and install the new hooks.  We've added a bunch of comparison tests in our studio-internal repo to confirm working solutions.

Added tests to Studio Internal to test the CLI's extension:
https://github.com/snyk/studio-internal/pull/256
https://github.com/snyk/studio-internal/pull/255
https://github.com/snyk/studio-internal/pull/290

## What's the product update that needs to be communicated to CLI users?

This is going in as `experimental` and not yet GA.

## Risk assessment (Low | Medium | High)?

Low - should be isolated to just the new extension.  No changes to existing functionality

## What are the relevant tickets?

[AG-411](https://snyksec.atlassian.net/browse/AG-411)




[AG-411]: https://snyksec.atlassian.net/browse/AG-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive extension registration only; no changes to existing CLI behavior beyond loading the new module.
> 
> **Overview**
> Wires the **Snyk Studio** CLI extension into the private `cliv2` binary so Studio commands (e.g. `snyk studio install`) are available alongside existing extensions.
> 
> The change adds `github.com/snyk/cli-extension-studio` **v1.0.1** to `go.mod`/`go.sum`, registers `studio.Init` via `core.WithAdditionalExtensions` in `main.go`, and includes a commented local `replace` for developing against a sibling `cli-extension-studio` repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa6ea0a08f5ac3347441d8c4dcf3978ddb6b76a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->