### PR TITLE
chore: CLI-1758 trigger Endpoint Explorer refresh after releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1333,6 +1333,33 @@ workflows:
                 - main
                 - '/release.*/'
 
+      # Best-effort terminal jobs: no release job depends on these dispatches.
+      - trigger-endpoint-explorer-refresh:
+          name: Trigger Endpoint Explorer refresh (preview)
+          channel: preview
+          context:
+            - team-hammerhead-common-deploy-tokens
+          requires:
+            - upload preview
+          filters:
+            branches:
+              only:
+                - main
+                - '/release.*/'
+
+      - trigger-endpoint-explorer-refresh:
+          name: Trigger Endpoint Explorer refresh (stable)
+          channel: stable
+          context:
+            - team-hammerhead-common-deploy-tokens
+          requires:
+            - upload latest/stable
+          filters:
+            branches:
+              only:
+                - main
+                - '/release.*/'
+
       - release-github:
           name: upload github
           context:
@@ -2095,6 +2122,19 @@ jobs:
           name: Create Jira Release
           command: ./release-scripts/create-jira-release.sh
       - failed-release-notification
+
+  trigger-endpoint-explorer-refresh:
+    parameters:
+      channel:
+        type: string
+    executor: docker-amd64
+    steps:
+      - checkout
+      - shall-deploy:
+          deployment: << parameters.channel >>
+      - run:
+          name: Request Endpoint Explorer refresh
+          command: ./release-scripts/trigger-endpoint-explorer-refresh.sh << parameters.channel >>
 
   release-npm:
     parameters:

--- a/release-scripts/trigger-endpoint-explorer-refresh.sh
+++ b/release-scripts/trigger-endpoint-explorer-refresh.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# This trigger is deliberately best-effort. The CLI release must not wait for
+# the Explorer refresh or fail when the Explorer or GitHub API is unavailable.
+set -u
+
+CHANNEL="${1:-}"
+
+case "$CHANNEL" in
+  stable|preview)
+    ;;
+  *)
+    echo "WARNING: Endpoint Explorer refresh skipped for unsupported channel '$CHANNEL'."
+    exit 0
+    ;;
+esac
+
+if [ -z "${HAMMERHEAD_GITHUB_PAT:-}" ]; then
+  echo "WARNING: HAMMERHEAD_GITHUB_PAT is unavailable; Endpoint Explorer $CHANNEL refresh was not requested."
+  exit 0
+fi
+
+HTTP_STATUS=$(curl \
+  --location \
+  --request POST \
+  --connect-timeout 2 \
+  --max-time 5 \
+  --header "Accept: application/vnd.github+json" \
+  --header "Authorization: Bearer $HAMMERHEAD_GITHUB_PAT" \
+  --header "X-GitHub-Api-Version: 2022-11-28" \
+  --data "{\"ref\":\"main\",\"inputs\":{\"channel\":\"$CHANNEL\"}}" \
+  --write-out "%{http_code}" \
+  --silent \
+  --show-error \
+  --output /dev/null \
+  "https://api.github.com/repos/snyk/endpoint-binary-explorer/actions/workflows/refresh-cli-data.yml/dispatches")
+CURL_STATUS=$?
+
+if [ "$CURL_STATUS" -ne 0 ]; then
+  echo "WARNING: Endpoint Explorer $CHANNEL refresh dispatch failed (curl exit $CURL_STATUS); continuing the CLI release."
+elif [ "$HTTP_STATUS" != "204" ]; then
+  echo "WARNING: Endpoint Explorer $CHANNEL refresh was not requested (HTTP $HTTP_STATUS); continuing the CLI release."
+else
+  echo "Endpoint Explorer $CHANNEL refresh requested."
+fi
+
+exit 0

--- a/release-scripts/trigger-endpoint-explorer-refresh_test.go
+++ b/release-scripts/trigger-endpoint-explorer-refresh_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTriggerEndpointExplorerRefreshAcceptsDispatch(t *testing.T) {
+	result := runEndpointExplorerTrigger(t, "preview", map[string]string{
+		"MOCK_CURL_HTTP_STATUS": "204",
+	})
+
+	if result.err != nil {
+		t.Fatalf("expected a successful exit, got %v\n%s", result.err, result.output)
+	}
+	if !strings.Contains(result.output, "Endpoint Explorer preview refresh requested") {
+		t.Fatalf("expected accepted-dispatch message, got:\n%s", result.output)
+	}
+	if !strings.Contains(result.curlArguments, "refresh-cli-data.yml/dispatches") {
+		t.Fatalf("expected the Explorer workflow dispatch endpoint, got:\n%s", result.curlArguments)
+	}
+	if !strings.Contains(result.curlArguments, `"channel":"preview"`) {
+		t.Fatalf("expected preview workflow input, got:\n%s", result.curlArguments)
+	}
+}
+
+func TestTriggerEndpointExplorerRefreshIgnoresHTTPFailure(t *testing.T) {
+	result := runEndpointExplorerTrigger(t, "stable", map[string]string{
+		"MOCK_CURL_HTTP_STATUS": "503",
+	})
+
+	if result.err != nil {
+		t.Fatalf("expected the fire-and-forget trigger to exit successfully, got %v\n%s", result.err, result.output)
+	}
+	if !strings.Contains(result.output, "WARNING: Endpoint Explorer stable refresh was not requested") {
+		t.Fatalf("expected a warning, got:\n%s", result.output)
+	}
+}
+
+func TestTriggerEndpointExplorerRefreshIgnoresTransportFailure(t *testing.T) {
+	result := runEndpointExplorerTrigger(t, "stable", map[string]string{
+		"MOCK_CURL_EXIT_STATUS": "28",
+	})
+
+	if result.err != nil {
+		t.Fatalf("expected the fire-and-forget trigger to exit successfully, got %v\n%s", result.err, result.output)
+	}
+	if !strings.Contains(result.output, "WARNING: Endpoint Explorer stable refresh dispatch failed") {
+		t.Fatalf("expected a warning, got:\n%s", result.output)
+	}
+}
+
+func TestTriggerEndpointExplorerRefreshIgnoresMissingToken(t *testing.T) {
+	result := runEndpointExplorerTrigger(t, "preview", map[string]string{
+		"HAMMERHEAD_GITHUB_PAT": "",
+	})
+
+	if result.err != nil {
+		t.Fatalf("expected the fire-and-forget trigger to exit successfully, got %v\n%s", result.err, result.output)
+	}
+	if !strings.Contains(result.output, "WARNING: HAMMERHEAD_GITHUB_PAT is unavailable") {
+		t.Fatalf("expected a missing-token warning, got:\n%s", result.output)
+	}
+	if result.curlArguments != "" {
+		t.Fatalf("expected curl not to run without a token, got:\n%s", result.curlArguments)
+	}
+}
+
+type endpointExplorerTriggerResult struct {
+	output        string
+	curlArguments string
+	err           error
+}
+
+func runEndpointExplorerTrigger(t *testing.T, channel string, overrides map[string]string) endpointExplorerTriggerResult {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	curlLog := filepath.Join(tempDir, "curl-arguments")
+	mockCurl := filepath.Join(tempDir, "curl")
+	mock := []byte(`#!/usr/bin/env bash
+printf '%s\n' "$@" > "$MOCK_CURL_LOG"
+printf '%s' "${MOCK_CURL_HTTP_STATUS:-204}"
+exit "${MOCK_CURL_EXIT_STATUS:-0}"
+`)
+	if err := os.WriteFile(mockCurl, mock, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	environment := map[string]string{
+		"HAMMERHEAD_GITHUB_PAT": "test-token",
+		"MOCK_CURL_EXIT_STATUS": "0",
+		"MOCK_CURL_HTTP_STATUS": "204",
+		"MOCK_CURL_LOG":         curlLog,
+		"PATH":                  tempDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+	for key, value := range overrides {
+		environment[key] = value
+	}
+
+	command := exec.Command("bash", "./trigger-endpoint-explorer-refresh.sh", channel)
+	command.Env = environmentWithOverrides(os.Environ(), environment)
+	output, err := command.CombinedOutput()
+	curlArguments, readErr := os.ReadFile(curlLog)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		t.Fatal(readErr)
+	}
+
+	return endpointExplorerTriggerResult{
+		output:        string(output),
+		curlArguments: string(curlArguments),
+		err:           err,
+	}
+}
+
+func environmentWithOverrides(current []string, overrides map[string]string) []string {
+	result := make([]string, 0, len(current)+len(overrides))
+	for _, entry := range current {
+		key, _, found := strings.Cut(entry, "=")
+		if !found {
+			continue
+		}
+		if _, overridden := overrides[key]; !overridden {
+			result = append(result, entry)
+		}
+	}
+	for key, value := range overrides {
+		result = append(result, key+"="+value)
+	}
+	return result
+}


### PR DESCRIPTION
## What changed

- trigger the Endpoint Explorer snapshot refresh after successful Preview and Stable S3 publication
- run each trigger as a terminal CircleCI job with no downstream release dependencies
- dispatch the existing `refresh-cli-data.yml` workflow with the published channel
- cap the dispatch request at five seconds and convert missing credentials, transport failures, and non-204 responses into warnings
- add release-script tests for accepted dispatches and each non-blocking failure path

## Why

The Endpoint Explorer should refresh when a public CLI channel changes, without waiting for the Explorer workflow or making CLI releases depend on Explorer availability.

The dispatch is best-effort. Once GitHub accepts the workflow request, the CLI pipeline does not follow or wait for the Explorer run. If the request cannot be made, the CLI release continues and the existing scheduled/manual Explorer refresh remains available as recovery.

## Validation

- `make format`
- `make lint`
- `go test ./... -skip TestBuildRecipeUsesGeneratedLSMetadataInLdflags` in `release-scripts`
- `bash -n release-scripts/trigger-endpoint-explorer-refresh.sh`
- YAML parse of `.circleci/config.yml`
- verified the live `snyk/endpoint-binary-explorer` workflow still accepts `workflow_dispatch` with `stable` and `preview` channel inputs

The unmodified `TestBuildRecipeUsesGeneratedLSMetadataInLdflags` currently fails because its temporary CLI fixture does not include the help Markdown now required by the build recipe; the remaining release-script suite passes.

## Deployment assumption

`HAMMERHEAD_GITHUB_PAT` must be able to dispatch Actions workflows in `snyk/endpoint-binary-explorer`. Missing or insufficient access is intentionally warning-only and does not fail the CLI release.
