### PR TITLE
chore: bump studio-mcp to 1.15.3 for fixes

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -227,7 +227,7 @@ require (
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
 	github.com/snyk/snyk-ls v0.0.0-20260804092303-865b318b1c8f // indirect
-	github.com/snyk/studio-mcp v1.15.1 // indirect
+	github.com/snyk/studio-mcp v1.15.3 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -606,8 +606,8 @@ github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRX
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
 github.com/snyk/snyk-ls v0.0.0-20260804092303-865b318b1c8f h1:egNW6/d4pz/yXxq7RKRXgD/JkqQRr1LEeiTWJE9iv6s=
 github.com/snyk/snyk-ls v0.0.0-20260804092303-865b318b1c8f/go.mod h1:zd9hsXBqnftPgvmqrUzQlb+qGg/IXMa9/HQTl5ScLWw=
-github.com/snyk/studio-mcp v1.15.1 h1:g0dw46B+EOQjd7LWa+O1t9SEzgzlcYFxbgo5cp2xaFc=
-github.com/snyk/studio-mcp v1.15.1/go.mod h1:3ZISZCgorkGg/iLQrryvmP34Db4KkvtfAARi7vMqM/4=
+github.com/snyk/studio-mcp v1.15.3 h1:t+vBRKGMWS6FLY1BAMzP2Vp+z8k8hK7kYKuAYlKEBHU=
+github.com/snyk/studio-mcp v1.15.3/go.mod h1:3ZISZCgorkGg/iLQrryvmP34Db4KkvtfAARi7vMqM/4=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd/go.mod h1:SULmZY7YNBsvNiQbrb/BEDdEJ84TGnfyUQxaHt8t8rY=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/snyk/go-httpauth v0.0.0-20240307114523-1f5ea3f55c65
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260804092303-865b318b1c8f
-	github.com/snyk/studio-mcp v1.15.1
+	github.com/snyk/studio-mcp v1.15.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -557,8 +557,8 @@ github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRX
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
 github.com/snyk/snyk-ls v0.0.0-20260804092303-865b318b1c8f h1:egNW6/d4pz/yXxq7RKRXgD/JkqQRr1LEeiTWJE9iv6s=
 github.com/snyk/snyk-ls v0.0.0-20260804092303-865b318b1c8f/go.mod h1:zd9hsXBqnftPgvmqrUzQlb+qGg/IXMa9/HQTl5ScLWw=
-github.com/snyk/studio-mcp v1.15.1 h1:g0dw46B+EOQjd7LWa+O1t9SEzgzlcYFxbgo5cp2xaFc=
-github.com/snyk/studio-mcp v1.15.1/go.mod h1:3ZISZCgorkGg/iLQrryvmP34Db4KkvtfAARi7vMqM/4=
+github.com/snyk/studio-mcp v1.15.3 h1:t+vBRKGMWS6FLY1BAMzP2Vp+z8k8hK7kYKuAYlKEBHU=
+github.com/snyk/studio-mcp v1.15.3/go.mod h1:3ZISZCgorkGg/iLQrryvmP34Db4KkvtfAARi7vMqM/4=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps the embedded `github.com/snyk/studio-mcp` dependency from v1.15.1 to v1.15.3
in both `cliv2/go.mod` and `cliv2-private/go.mod`.

Changes pulled in from studio-mcp:
- **Fix: send_feedback analytics encoded as scalars** (studio-mcp#52) — the analytics
  endpoint rejects non-scalar extension values (arrays/objects 400 the whole event),
  so `snyk_send_feedback` telemetry was being dropped. Now encoded as scalars.
- **Chore: retire the unused SSE transport** (studio-mcp#53) — removes the SSE listener,
  its loopback origin-check middleware, and port-scanning helpers. All shipped client
  configs already launch with `-t stdio`; that is now the default and any other transport
  fails fast at startup. No behavior change for the CLI.

## Where should the reviewer start?

`cliv2/go.mod` (line ~29) and `cliv2-private/go.mod` (+ `go.sum`) — the only changes are
the version pin from v1.15.1 → v1.15.3. Nothing in CLI source changed.

## How should this be manually tested?

Build the CLI and confirm MCP still starts over stdio:
- `snyk mcp -t stdio` starts and registers tools as before.
- Exercise `snyk_send_feedback` and confirm the analytics event is accepted (no 400 /
  event no longer dropped).
No SSE path to test — the CLI has always launched MCP with `-t stdio`.

## What's the product update that needs to be communicated to CLI users?

None. No user-facing CLI behavior changes. The send_feedback fix is internal telemetry,
and SSE was never exposed through the CLI (stdio-only).

<!---
## Risk assessment (Low | Medium | High)?

Low. Dependency version bump only — no CLI source changes. The one runtime-facing change
for CLI users is the send_feedback analytics fix (telemetry only). The SSE transport
removal drops surface the CLI never exercised (it always launches MCP with `-t stdio`),
and stdio remains the default. Rollback is a one-line revert of the version pin.

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
