### PR TITLE
test: add AXI user journey tests for agent subcommand

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/snyk/ambient-canary v0.0.0-20260722064253-fba619a134a9
-	github.com/snyk/cli-extension-axi v0.0.0-20260807132828-734c2ae85a0a
+	github.com/snyk/cli-extension-axi v0.0.0-20260812113949-210b479505a9
 	github.com/snyk/cli-extension-cos v0.0.0-20260804092425-a7e642ae7b3b
 	github.com/snyk/cli/cliv2 v0.0.0
 	github.com/snyk/remy-cli-extension v1.36.1

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -568,8 +568,8 @@ github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af h1:A
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af/go.mod h1:u4d7qoWWVx3II+ZnpLQGjAegaJLmgPefXKXJD/jp/wM=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260804095026-fdfc28cd38b8 h1:OiY6RfgGICJ1QCRW1WxWk9cm9G9Hd8aStIz5EASltw0=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260804095026-fdfc28cd38b8/go.mod h1:axE+HO8U9CIcTjQ7k7BOLgdyZfNGqMn5QvZ0aIkUY4U=
-github.com/snyk/cli-extension-axi v0.0.0-20260807132828-734c2ae85a0a h1:Q6CKMenoGNZAvl5NVm4ZCToKqsz01kE/H5pCdaXYGw8=
-github.com/snyk/cli-extension-axi v0.0.0-20260807132828-734c2ae85a0a/go.mod h1:oFvcbCp2bb4gPBDbFPnqGxmFTkQEcPolXTbif5hJ1FE=
+github.com/snyk/cli-extension-axi v0.0.0-20260812113949-210b479505a9 h1:6/YF4VHeT8E3abcxcF/oIrdEyrPM3fV/OfJOsZuYz5g=
+github.com/snyk/cli-extension-axi v0.0.0-20260812113949-210b479505a9/go.mod h1:oFvcbCp2bb4gPBDbFPnqGxmFTkQEcPolXTbif5hJ1FE=
 github.com/snyk/cli-extension-cos v0.0.0-20260804092425-a7e642ae7b3b h1:NXYzKYaGgB7OcGq4rV1GrmyGI+F7V8lpXaW50NQw4f4=
 github.com/snyk/cli-extension-cos v0.0.0-20260804092425-a7e642ae7b3b/go.mod h1:YpcOdcMBJOzwtla/OOoBOArx27Bc2v42Vcwd/FeGl9M=
 github.com/snyk/cli-extension-dep-graph/v2 v2.8.1 h1:ZlLN8KbMZiRN7QsiLzovFLsoIEVytC77+OESr+6wDhI=

--- a/test/jest/acceptance/snyk-agent/snyk-agent-scanners.spec.ts
+++ b/test/jest/acceptance/snyk-agent/snyk-agent-scanners.spec.ts
@@ -1,0 +1,96 @@
+import { resolve } from 'path';
+import { createProjectFromFixture } from '../../util/createProject';
+import { runSnykCLI } from '../../util/runSnykCLI';
+
+jest.setTimeout(1000 * 60 * 5);
+
+const EXIT_CODE_SUCCESS = 0;
+const EXIT_CODE_ACTION_NEEDED = 1;
+const scannerSection = (name: string): RegExp =>
+  new RegExp(`^${name}(?:\\[|:|_)`, 'm');
+
+describe('snyk agent scanner selection (real server)', () => {
+  let env: Record<string, string>;
+  let project: Awaited<ReturnType<typeof createProjectFromFixture>>;
+
+  beforeAll(async () => {
+    project = await createProjectFromFixture('npm/no-dependencies');
+    env = {
+      ...process.env,
+      SNYK_DISABLE_ANALYTICS: '1',
+    };
+  });
+
+  afterAll(async () => {
+    await project.remove();
+  });
+
+  const runAgentTest = (scanners = '') =>
+    runSnykCLI(`agent test${scanners ? ` ${scanners}` : ''}`, {
+      cwd: project.path(),
+      env,
+    });
+
+  const expectSections = (
+    stdout: string,
+    present: string[],
+    absent: string[],
+  ): void => {
+    for (const section of present) {
+      expect(stdout).toMatch(scannerSection(section));
+    }
+    for (const section of absent) {
+      expect(stdout).not.toMatch(scannerSection(section));
+    }
+  };
+
+  const expectCompletedScan = (code: number): void => {
+    expect([EXIT_CODE_SUCCESS, EXIT_CODE_ACTION_NEEDED]).toContain(code);
+  };
+
+  it('selects SCA, SAST, and Secrets by default, but not Container', async () => {
+    const { code, stdout } = await runAgentTest();
+
+    expectCompletedScan(code);
+    expectSections(stdout, ['sca', 'sast', 'secrets'], ['container']);
+  });
+
+  // Live SAST journeys require TEST_SNYK_TOKEN and the configured Snyk API.
+  it('selects only SAST and Secrets for the requested subset', async () => {
+    const { code, stdout } = await runAgentTest('sast secrets');
+
+    expectCompletedScan(code);
+    expectSections(stdout, ['sast', 'secrets'], ['sca', 'container']);
+  });
+
+  it.each([
+    ['sca', 'sca', ['sast', 'secrets', 'container']],
+    ['sast', 'sast', ['sca', 'secrets', 'container']],
+    ['secrets', 'secrets', ['sca', 'sast', 'container']],
+  ])(
+    'selects only the %s scanner',
+    async (scanner, outputSection, absentSections) => {
+      const { code, stdout } = await runAgentTest(scanner as string);
+
+      expectCompletedScan(code);
+      expectSections(
+        stdout,
+        [outputSection as string],
+        absentSections as string[],
+      );
+    },
+  );
+
+  it('passes an explicit local image only to Container', async () => {
+    const image = resolve(
+      __dirname,
+      '../../../fixtures/container-projects/python-with-pip-dependencies.tar',
+    );
+    const { code, stdout } = await runAgentTest(
+      `container --image=docker-archive:${image}`,
+    );
+
+    expectCompletedScan(code);
+    expectSections(stdout, ['container'], ['sca', 'sast', 'secrets']);
+  });
+});


### PR DESCRIPTION
## Summary

- add private-binary user journeys for the agent home view and input errors
- cover default, subset, and individual SCA, SAST, Secrets scanner selection
- cover Container image validation and local image selection

## Validation

- private build passed against local AXI checkout
- 2 Jest suites, 9 tests passed
- Prettier, ESLint, git diff check, and make lint passed

## Dependency

Draft pending publication of the AXI sast rename and subsequent cliv2-private Go module bump.

CLI-1700