### PR TITLE
chore: bump cli-extension-sbom for pruned SBOM graph [OSM-3869]

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -216,7 +216,7 @@ require (
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 // indirect
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e // indirect
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091 // indirect
-	github.com/snyk/cli-extension-sbom v0.0.0-20260728161808-90fff659c450 // indirect
+	github.com/snyk/cli-extension-sbom v0.0.0-20260811135250-99c30fb97642 // indirect
 	github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd // indirect
 	github.com/snyk/code-client-go v1.31.3 // indirect
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -580,8 +580,8 @@ github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e h1:HE
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e/go.mod h1:YN+M0+nNZ5VoQN2SxSvZSoTxs/PkdLgfNfUWvsKVL7o=
 github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091 h1:MDR3Tj4tFVNPonOtL+AzX0osWdOkNq0lEpQQehvjGak=
 github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091/go.mod h1:qNOr9aDWYUa3Tl74k+04hOCEgKcgpBLVcvs26L4ooN0=
-github.com/snyk/cli-extension-sbom v0.0.0-20260728161808-90fff659c450 h1:OZamCjj08Ss87/ELqWj2vI0uB14aotWtneLlPIHxq8o=
-github.com/snyk/cli-extension-sbom v0.0.0-20260728161808-90fff659c450/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
+github.com/snyk/cli-extension-sbom v0.0.0-20260811135250-99c30fb97642 h1:dWaIWLV0vucbUStVIJIlCmA2A4jlYkbUyAA6zoaEiMc=
+github.com/snyk/cli-extension-sbom v0.0.0-20260811135250-99c30fb97642/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd h1:sSVkD1CuL8v49boItrt2CnQ4DJIH+sjGwFGheGCVAxo=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd/go.mod h1:PrKXTT4fwEJPIzphT4n1tH5mwt2D1/qadP5HNCvub9Y=
 github.com/snyk/code-client-go v1.31.3 h1:X1vzubbdGXWpxwnjBkC3HchH1rWjDdqdn0cCz2to0TA=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091
-	github.com/snyk/cli-extension-sbom v0.0.0-20260728161808-90fff659c450
+	github.com/snyk/cli-extension-sbom v0.0.0-20260811135250-99c30fb97642
 	github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd
 	github.com/snyk/code-client-go v1.31.3
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -530,8 +530,8 @@ github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e h1:HE
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e/go.mod h1:YN+M0+nNZ5VoQN2SxSvZSoTxs/PkdLgfNfUWvsKVL7o=
 github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091 h1:MDR3Tj4tFVNPonOtL+AzX0osWdOkNq0lEpQQehvjGak=
 github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091/go.mod h1:qNOr9aDWYUa3Tl74k+04hOCEgKcgpBLVcvs26L4ooN0=
-github.com/snyk/cli-extension-sbom v0.0.0-20260728161808-90fff659c450 h1:OZamCjj08Ss87/ELqWj2vI0uB14aotWtneLlPIHxq8o=
-github.com/snyk/cli-extension-sbom v0.0.0-20260728161808-90fff659c450/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
+github.com/snyk/cli-extension-sbom v0.0.0-20260811135250-99c30fb97642 h1:dWaIWLV0vucbUStVIJIlCmA2A4jlYkbUyAA6zoaEiMc=
+github.com/snyk/cli-extension-sbom v0.0.0-20260811135250-99c30fb97642/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd h1:sSVkD1CuL8v49boItrt2CnQ4DJIH+sjGwFGheGCVAxo=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd/go.mod h1:PrKXTT4fwEJPIzphT4n1tH5mwt2D1/qadP5HNCvub9Y=
 github.com/snyk/code-client-go v1.31.3 h1:X1vzubbdGXWpxwnjBkC3HchH1rWjDdqdn0cCz2to0TA=

--- a/test/jest/acceptance/snyk-sbom/prune-effective-graph.spec.ts
+++ b/test/jest/acceptance/snyk-sbom/prune-effective-graph.spec.ts
@@ -1,0 +1,74 @@
+import { fakeServer } from '../../../acceptance/fake-server';
+import { createProjectFromWorkspace } from '../../util/createProject';
+import { getAvailableServerPort } from '../../util/getServerPort';
+import { runSnykCLI } from '../../util/runSnykCLI';
+
+jest.setTimeout(1000 * 60 * 5);
+
+// When `snyk sbom -p` runs and the `sbom-prune-effective-graph` feature flag is
+// enabled, the dep-graph extension must request the effective (pruned) graph from
+// the legacy CLI (`--print-effective-graph`) instead of the default `--print-graph`.
+// The legacy argv is only observable end-to-end here (the decision is compiled in
+// from cli-extension-sbom + cli-extension-dep-graph), and it is logged to stderr
+// under `--debug`.
+describe('snyk sbom --prune-repeated-subdependencies effective-graph feature flag', () => {
+  let server;
+  let env: Record<string, string>;
+
+  const orgId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+  const runArgs = `sbom --org ${orgId} --format=cyclonedx1.6+json -p --debug`;
+
+  beforeAll(async () => {
+    const port = await getAvailableServerPort(process);
+    const baseApi = '/api/v1';
+    env = {
+      ...process.env,
+      SNYK_API: 'http://localhost:' + port + baseApi,
+      SNYK_HOST: 'http://localhost:' + port,
+      SNYK_TOKEN: '123456789',
+      SNYK_DISABLE_ANALYTICS: '1',
+    };
+    server = fakeServer(baseApi, env.SNYK_TOKEN);
+    await server.listenPromise(port);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    server.restore();
+  });
+
+  afterAll((done) => {
+    server.close(() => {
+      done();
+    });
+  });
+
+  test('with the feature flag ON, requests the effective (pruned) graph', async () => {
+    server.setFeatureFlag('sbom-prune-effective-graph', true);
+    const project = await createProjectFromWorkspace('npm-package');
+
+    const { code, stderr } = await runSnykCLI(runArgs, {
+      cwd: project.path(),
+      env,
+    });
+
+    expect(code).toEqual(0);
+    expect(stderr).toContain('--print-effective-graph');
+    // `--print-effective-graph` does not contain the substring `--print-graph`.
+    expect(stderr).not.toContain('--print-graph');
+  });
+
+  test('with the feature flag OFF, keeps the default (unpruned) graph', async () => {
+    server.setFeatureFlag('sbom-prune-effective-graph', false);
+    const project = await createProjectFromWorkspace('npm-package');
+
+    const { code, stderr } = await runSnykCLI(runArgs, {
+      cwd: project.path(),
+      env,
+    });
+
+    expect(code).toEqual(0);
+    expect(stderr).toContain('--print-graph');
+    expect(stderr).not.toContain('--print-effective-graph');
+  });
+});


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable) — none
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___) — N/A
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps `cli-extension-sbom` to `v0.0.0-20260811135250-99c30fb97642`, which introduces the `sbom-prune-effective-graph` feature flag (default-off).

With the flag enabled, running `snyk sbom` with `--prune-repeated-subdependencies` (`-p`) requests the **effective (pruned)** dependency graph from the depgraph workflow (`--print-effective-graph`) instead of the raw, unpruned graph. Previously `-p` was forwarded but had no effect on the SBOM path, so the full graph was built and uploaded regardless. Requesting the pruned graph honours the flag and reduces the payload — and peak memory — for large dependency graphs.

No `cli-extension-dep-graph` bump is required: the pinned `v2.8.1` already supports the `effective-graph` / `effective-graph-with-errors` config keys this relies on.

Because the flag is default-off, this change is inert until it is enabled per-org.

## Where should the reviewer start?

- `cliv2/go.mod` (+ `cliv2/go.sum`) — the single-line `cli-extension-sbom` version bump.
- `test/jest/acceptance/snyk-sbom/prune-effective-graph.spec.ts` — new acceptance test.

## How should this be manually tested?

With the `sbom-prune-effective-graph` flag enabled for your org, in an npm project (or any ecosystem resolved via the legacy CLI):

```
snyk sbom --org <org-id> --format=cyclonedx1.6+json -p --debug
```

The debug output shows the legacy dependency-graph invocation using `--print-effective-graph` (with the flag off it uses `--print-graph`). The generated CycloneDX component set should match the non-pruned output.

## What's the product update that needs to be communicated to CLI users?

Once enabled, `snyk sbom --prune-repeated-subdependencies` prunes the dependency graph before generating the SBOM (matching `snyk test` behaviour), reducing memory use on large projects. This is gated behind a feature flag and rolls out per-org.

## Risk assessment (Low | Medium | High)?

**Low.** The behaviour change lives in `cli-extension-sbom` and is gated behind the default-off `sbom-prune-effective-graph` feature flag. This PR only bumps the dependency and adds a test, so it is inert until the flag is enabled per-org. Rollback is a dependency revert or a flag flip.

## What are the relevant tickets?

OSM-3869