### PR TITLE
fix: keep CLI-owned retry paths at the application layer [IDE-1890]

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -222,7 +222,7 @@ require (
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 // indirect
-	github.com/snyk/go-application-framework v0.16.1 // indirect
+	github.com/snyk/go-application-framework v0.18.1 // indirect
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -592,8 +592,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.16.1 h1:k4eyP4EX/kqnNyu5uuFLEw4wflTom22ea23ZuG74JU8=
-github.com/snyk/go-application-framework v0.16.1/go.mod h1:qJBU+FIY8s/lIg0IaKBj7WGeGERiWqyJvhajzxiA3Ls=
+github.com/snyk/go-application-framework v0.18.1 h1:YdaQkR/SF2/G9odf8K1WdEA0HnZ7AzBMTs75QqgDO1Q=
+github.com/snyk/go-application-framework v0.18.1/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.31.8
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6
-	github.com/snyk/go-application-framework v0.16.1
+	github.com/snyk/go-application-framework v0.18.1
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260814164657-a99d4cf1c3e7

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -542,8 +542,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.16.1 h1:k4eyP4EX/kqnNyu5uuFLEw4wflTom22ea23ZuG74JU8=
-github.com/snyk/go-application-framework v0.16.1/go.mod h1:qJBU+FIY8s/lIg0IaKBj7WGeGERiWqyJvhajzxiA3Ls=
+github.com/snyk/go-application-framework v0.18.1 h1:YdaQkR/SF2/G9odf8K1WdEA0HnZ7AzBMTs75QqgDO1Q=
+github.com/snyk/go-application-framework v0.18.1/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/pkg/core/configuration.go
+++ b/cliv2/pkg/core/configuration.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"os"
+	"strings"
 
 	"github.com/snyk/go-application-framework/pkg/auth"
 	"github.com/snyk/go-application-framework/pkg/configuration"
@@ -26,4 +27,29 @@ func defaultOAuthFF(config configuration.Configuration) configuration.DefaultVal
 
 		return true, nil
 	}
+}
+
+func defaultNetworkRequestRetryAllowedPaths() configuration.DefaultValueFunction {
+	callback := func(_ configuration.Configuration, existingValue interface{}) (interface{}, error) {
+		paths := []string{"oauth2/token", "test-dep-graph", "verify/token", "feature_flags/evaluation"}
+
+		if raw, ok := existingValue.(string); ok {
+			for _, part := range strings.Split(raw, ",") {
+				if trimmed := strings.TrimSpace(part); trimmed != "" {
+					paths = append(paths, trimmed)
+				}
+			}
+		} else if strSlice, ok := existingValue.([]string); ok {
+			paths = append(paths, strSlice...)
+		} else if ifaceSlice, ok := existingValue.([]interface{}); ok {
+			for _, v := range ifaceSlice {
+				if str, ok := v.(string); ok && str != "" {
+					paths = append(paths, str)
+				}
+			}
+		}
+
+		return paths, nil
+	}
+	return callback
 }

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -603,6 +603,7 @@ func mainWithErrorCode(additionalExts []workflow.ExtensionInit) int {
 
 	globalConfiguration.AddDefaultValue(configuration.FF_OAUTH_AUTH_FLOW_ENABLED, defaultOAuthFF(globalConfiguration))
 	globalConfiguration.AddDefaultValue(configuration.FF_TRANSFORMATION_WORKFLOW, configuration.StandardDefaultValueFunction(true))
+	globalConfiguration.AddDefaultValue(configuration.NETWORK_REQUEST_RETRY_ALLOWED_PATHS, defaultNetworkRequestRetryAllowedPaths())
 
 	if noProxyAuth := globalConfiguration.GetBool(basic_workflows.PROXY_NOAUTH); noProxyAuth {
 		globalConfiguration.Set(configuration.PROXY_AUTHENTICATION_MECHANISM, httpauth.StringFromAuthenticationMechanism(httpauth.NoAuth))

--- a/cliv2/pkg/core/main_test.go
+++ b/cliv2/pkg/core/main_test.go
@@ -893,3 +893,46 @@ func testHelpRouter() *helprouting.Router {
 		HasUserDoc: helpDocs.HasUserDoc,
 	}
 }
+
+func Test_defaultNetworkRequestRetryAllowedPaths(t *testing.T) {
+	tests := []struct {
+		name          string
+		existingValue interface{}
+		expected      interface{}
+	}{
+		{"nil yields CLI defaults", nil, []string{"oauth2/token", "test-dep-graph", "verify/token", "feature_flags/evaluation"}},
+		{"csv string splits and merges with defaults", "a,b", []string{"oauth2/token", "test-dep-graph", "verify/token", "feature_flags/evaluation", "a", "b"}},
+		{"csv string trims whitespace and merges", "a, b", []string{"oauth2/token", "test-dep-graph", "verify/token", "feature_flags/evaluation", "a", "b"}},
+		{"empty string yields just CLI defaults", "", []string{"oauth2/token", "test-dep-graph", "verify/token", "feature_flags/evaluation"}},
+		{"non-empty slice merges with defaults", []string{"x"}, []string{"oauth2/token", "test-dep-graph", "verify/token", "feature_flags/evaluation", "x"}},
+		{"empty slice yields CLI defaults", []string{}, []string{"oauth2/token", "test-dep-graph", "verify/token", "feature_flags/evaluation"}},
+		{"interface slice from JSON merges with defaults", []interface{}{"y", "z"}, []string{"oauth2/token", "test-dep-graph", "verify/token", "feature_flags/evaluation", "y", "z"}},
+	}
+
+	config := configuration.NewWithOpts()
+	defaultFunction := defaultNetworkRequestRetryAllowedPaths()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := defaultFunction(config, tt.existingValue)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_NetworkRequestRetryAllowedPaths_Integration(t *testing.T) {
+	defer cleanup()
+	oldArgs := append([]string{}, os.Args...)
+	os.Args = []string{"snyk", "--version"}
+	defer func() { os.Args = oldArgs }()
+
+	_ = mainWithErrorCode(nil)
+
+	paths := globalConfiguration.GetStringSlice(configuration.NETWORK_REQUEST_RETRY_ALLOWED_PATHS)
+	assert.Contains(t, paths, "oauth2/token")
+	assert.Contains(t, paths, "test-dep-graph")
+	assert.Contains(t, paths, "verify/token")
+	assert.Contains(t, paths, "feature_flags/evaluation")
+}

--- a/test/jest/acceptance/snyk-code/gaf-retry-allowed-paths.spec.ts
+++ b/test/jest/acceptance/snyk-code/gaf-retry-allowed-paths.spec.ts
@@ -1,0 +1,132 @@
+// Verifies that GAF's network-retry middleware actually retries a transient failure on
+// /feature_flags/evaluation -- one of the paths cliv2/pkg/core/configuration.go's
+// defaultNetworkRequestRetryAllowedPaths() adds back to GAF's default retry-allowed-paths
+// list. This endpoint is called directly by the Go binary (config_utils.AddFeatureFlagToConfig
+// -> featureflaggateway.EvaluateFlags), with no TypeScript-level retry wrapper, so it cleanly
+// isolates GAF's retry behavior from the CLI's own legacy retry loop.
+import { runSnykCLI } from '../../util/runSnykCLI';
+import { runCommand } from '../../util/runCommand';
+import { fakeServer } from '../../../acceptance/fake-server';
+import { fakeDeepCodeServer } from '../../../acceptance/deepcode-fake-server';
+import { getServerPort } from '../../util/getServerPort';
+import * as fs from 'fs';
+import * as os from 'os';
+import { join } from 'path';
+
+jest.setTimeout(1000 * 60);
+
+const ORG = '11111111-2222-3333-4444-555555555555';
+const EVALUATION_PATH = `/api/hidden/orgs/${ORG}/feature_flags/evaluation`;
+
+describe('GAF retry-allowed-paths: feature_flags/evaluation endpoint', () => {
+  let server: ReturnType<typeof fakeServer>;
+  let deepCodeServer: ReturnType<typeof fakeDeepCodeServer>;
+  let baseEnv: Record<string, string>;
+  const port = getServerPort(process);
+  const baseApi = '/api/v1';
+
+  beforeAll(async () => {
+    deepCodeServer = fakeDeepCodeServer();
+    await new Promise<void>((resolve) =>
+      deepCodeServer.listen(() => resolve()),
+    );
+    server = fakeServer(baseApi, 'snykToken');
+    await new Promise<void>((resolve) => server.listen(port, () => resolve()));
+
+    baseEnv = {
+      ...process.env,
+      SNYK_API: `http://localhost:${port}${baseApi}`,
+      SNYK_HOST: `http://localhost:${port}`,
+      SNYK_TOKEN: '123456789',
+      SNYK_CFG_ORG: ORG,
+      INTERNAL_SNYK_CODE_NATIVE_IMPLEMENTATION: 'true',
+      // Preview/dev builds force feature flags on locally, bypassing the remote
+      // evaluation call entirely (cliv2/pkg/core/workflows.go) -- without this override
+      // the endpoint under test is never even called, and every assertion below is vacuous.
+      INTERNAL_PREVIEW_FEATURES_ENABLED: 'false',
+    } as Record<string, string>;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => deepCodeServer.close(() => resolve()));
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  function configureServers() {
+    server.restore();
+    deepCodeServer.restore();
+    server.setOrgSetting('sast', true);
+    server.setLocalCodeEngineConfiguration({
+      enabled: true,
+      allowCloudUpload: true,
+      url: `http://localhost:${deepCodeServer.getPort()}`,
+    });
+    deepCodeServer.setFiltersResponse({ configFiles: [], extensions: ['.js'] });
+    deepCodeServer.setSarifResponse({
+      $schema: 'https://json.schemastore.org/sarif-2.1.0.json',
+      version: '2.1.0',
+      runs: [],
+    });
+    server.setFeatureFlag('clientFileFilterGitignore_MetaCharFix', true);
+  }
+
+  /** A minimal repo to scan with snyk code test. */
+  async function buildFixture(): Promise<string> {
+    const root = fs.mkdtempSync(join(os.tmpdir(), 'snyk-retry-test-'));
+    fs.writeFileSync(join(root, 'test.js'), 'const x = 0;\n');
+    await runCommand('git', ['init'], { cwd: root });
+    await runCommand('git', ['add', '.'], { cwd: root });
+    return root;
+  }
+
+  /**
+   * snyk code test naturally calls feature_flags/evaluation more than once (once per
+   * file-filter config variant it evaluates), so a raw hit count can't distinguish a real
+   * retry from that natural behavior. GAF's retry middleware reuses the same
+   * Snyk-Request-Id across attempts of the *same* logical request (see the duplicate-id
+   * check in resilience.spec.ts's "maintenance-window" scenario), so a duplicated id
+   * among requests to this path is the reliable signal that a retry occurred.
+   */
+  function hasDuplicateRequestId(): boolean {
+    const ids = server
+      .getRequests()
+      .filter((r) => (r.url as string).includes('feature_flags/evaluation'))
+      .map((r) => {
+        const header = r.headers?.['snyk-request-id'];
+        return Array.isArray(header) ? header[0] : header;
+      })
+      .filter(Boolean);
+    return new Set(ids).size < ids.length;
+  }
+
+  it('retries feature_flags/evaluation on a transient (500) failure when retries are enabled', async () => {
+    configureServers();
+    server.setEndpointStatusCodes(EVALUATION_PATH, [500, 200]);
+    const root = await buildFixture();
+
+    await runSnykCLI(`code test ${root}`, {
+      env: {
+        ...baseEnv,
+        INTERNAL_NETWORK_REQUEST_RETRIES_ENABLED: '1',
+        SNYK_MAX_ATTEMPTS: '3',
+      },
+    });
+
+    expect(hasDuplicateRequestId()).toBe(true);
+  });
+
+  it('does not retry feature_flags/evaluation when retries are disabled', async () => {
+    configureServers();
+    server.setEndpointStatusCodes(EVALUATION_PATH, [500, 200]);
+    const root = await buildFixture();
+
+    await runSnykCLI(`code test ${root}`, {
+      env: {
+        ...baseEnv,
+        INTERNAL_NETWORK_REQUEST_RETRIES_ENABLED: '0',
+      },
+    });
+
+    expect(hasDuplicateRequestId()).toBe(false);
+  });
+});


### PR DESCRIPTION
### **User description**
## Summary

- declare the CLI's unsafe-method retry paths at the CLI application boundary
- preserve user-supplied path overrides and keep network retries opt-in
- pin go-application-framework to the unmerged ownership change

## Dependency

This draft pins go-application-framework v0.18.1, which carries current GAF main
Tracking: [IDE-1890](https://snyksec.atlassian.net/browse/IDE-1890)

## Verification

- targeted CLI application configuration and engine tests pass
- `golangci-lint run ./...` passes
- public CLI build passes
- Snyk Code reports no new issues
- full Go suite was run; unrelated existing assertions in GAF presenter snapshots and CLI instrumentation scrubbing are not caused by this configuration-only diff


[IDE-1890]: https://snyksec.atlassian.net/browse/IDE-1890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Restore default network retry paths for GAF.

- Update `go-application-framework` dependency to v0.17.0.

- Add unit and acceptance tests for retry behavior.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Update go-application-framework dependency"] --> B["Define default retry paths function"];
  B --> C["Register default paths in CLI config"];
  C --> D["Add unit and acceptance tests"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>gaf-retry-allowed-paths.spec.ts</strong><dd><code>Add acceptance test for GAF retry behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/cli/pull/7116/changes#diff-0f8362719add74a5d593ca46e9cb25d99f2f6ee51d2baaf94fb29ff7c09f4b26">+132/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>main_test.go</strong><dd><code>Add unit and integration tests for retry paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/cli/pull/7116/changes#diff-a2875283ea90266858e58d9968722ded8c88e6209fa8e08613c5a5482868afb8">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>configuration.go</strong><dd><code>Implement default network retry paths function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/cli/pull/7116/changes#diff-0898c31f0dd8960d07c52b5d41182390bc3789fdad1a34d7a0458028b6fd3e52">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.go</strong><dd><code>Register default retry paths configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/cli/pull/7116/changes#diff-a2c35072f4a1cbb8e7f7f97317277678baa84038e2cc615f4a9addd50d847430">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>go.mod</strong><dd><code>Update go-application-framework dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/cli/pull/7116/changes#diff-cbb655c5982e6dc627b47d496cf640744939d8a3269e3806f8c9153365b88b6e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>go.sum</strong><dd><code>Update go.sum for dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/cli/pull/7116/changes#diff-9af73572a17d3dda01c2b4843253c81863dbf116ea56dd953ec8bbe7aa027cf1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>go.mod</strong><dd><code>Update go-application-framework dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/cli/pull/7116/changes#diff-0d2008944a74ca11209da1613b848d59c2a827cfe01651e4bf6fe9e2eb991148">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>go.sum</strong><dd><code>Update go.sum for dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/snyk/cli/pull/7116/changes#diff-99168ef18e854db7430ba8053649fc688af77bb34cedb25171e9f4763ec2f56d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

