### PR TITLE
chore: trigger axi npm package build on CLI release (CLI-1696)

### DIFF
--- a/release-scripts/upload-artifacts.sh
+++ b/release-scripts/upload-artifacts.sh
@@ -308,6 +308,12 @@ for arg in "${@}"; do
         DISTRIBUTION_FAILURE=1
     fi
 
+    # 4. Trigger axi
+    trigger_repository_event "axi" "cli_release"
+    if [ $? -ne 0 ]; then
+        DISTRIBUTION_FAILURE=1
+    fi
+
     # Exit 1 only after attempting all triggers
     if [ $DISTRIBUTION_FAILURE -eq 1 ]; then
         echo "One or more distribution channel triggers failed. Exiting with error."


### PR DESCRIPTION
## What does this PR do?
Adds `axi` as a 4th target in `trigger-distribution-channels`, alongside `snyk-images`, `scoop-snyk`, and `homebrew-tap`. Reuses the existing `trigger_repository_event` helper — fires a `repository_dispatch` with `event_type: cli_release` and `client_payload: {version, release_channel}` at github.com/snyk/axi/dispatches.

`axi`'s `build-on-cli-release.yml` already listens for `cli_release` and reads `client_payload.version`/`release_channel` so rc/preview builds don't clobber the npm `latest` tag.

[CLI-1696](https://snyksec.atlassian.net/browse/CLI-1696): create and publish the `@snyk/axi` npm package, triggered by CLI releases.

## Where should the reviewer start?
`trigger_repository_event` in `release-scripts/upload-artifacts.sh` — the new call is a straight copy of the existing snyk-images/scoop-snyk/homebrew-tap entries, just a different repo + event type.

## How should this be manually tested?
`shellcheck` clean. Simulated the JSON payload construction and confirmed it parses into the exact `version`/`release_channel` keys axi's workflow reads.

Live end-to-end validated: `@snyk/axi@0.1.0` has been bootstrap-published (npm requires an initial token-based publish before Trusted Publishing can be configured). axi's OIDC trusted-publishing workflow itself was separately dry-run tested end-to-end on a disposable package (`@nick-snyk/axi-test`) before landing, including the actual `npm publish` step succeeding via GitHub Actions OIDC. Trusted Publisher config for `@snyk/axi` is pending setup by someone with npm org access; this PR's dispatch call works independently of that.

## What's the product update that needs to be communicated to CLI users?
None — internal release plumbing, no user-facing change.

## Risk assessment
Low. `trigger_repository_event` failures are caught and logged, non-blocking to the rest of the release (per its existing docstring); a broken/missing axi dispatch does not fail the CLI release itself.

Supersedes #7117 (opened from a fork before I had direct write access to this repo).

[CLI-1696]: https://snyksec.atlassian.net/browse/CLI-1696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ