### PR TITLE
fix: resolve Gradle 7.4-8.2 dependency-scan crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "snyk-cpp-plugin": "^2.24.3",
         "snyk-docker-plugin": "9.19.0",
         "snyk-go-plugin": "2.2.1",
-        "snyk-gradle-plugin": "7.1.0",
+        "snyk-gradle-plugin": "7.1.2",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "4.9.2",
         "snyk-nodejs-lockfile-parser": "2.10.0",
@@ -19897,9 +19897,9 @@
       "integrity": "sha512-N5ixXjzTy4QDQH0Q9YFjqIWd6zH6936Djpl2m9QNFmDv5Fum8q8BjkpAcHNMzOFE0IwQrFhJWex3AN6kS0OSwg=="
     },
     "node_modules/snyk-gradle-plugin": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-7.1.0.tgz",
-      "integrity": "sha512-l68wt/tdNk+Vka9zJZFgFDH3XkDrWUXsWnbP7u5BXcLWNtFSsM5SNdkyenhgiSCjI/T1xHdpArroch2NZRrBIA==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-7.1.2.tgz",
+      "integrity": "sha512-hP+ga9IQKSTZjkt/pFhSVXBQYOwSufvxZiYLqnZ+QYLKhxMJe5ZR94h/L5hLeSwjUEHR9g9qrLT3+wbozUSfsg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@common.js/yocto-queue": "^1.1.1",
@@ -19909,7 +19909,7 @@
         "chalk": "^4.1.2",
         "p-map": "^4.0.0",
         "packageurl-js": "^1.2.1",
-        "shescape": "2.1.11",
+        "shescape": "2.1.14",
         "tmp": "^0.2.7",
         "tslib": "^2.8.1"
       },

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "snyk-cpp-plugin": "^2.24.3",
     "snyk-docker-plugin": "9.19.0",
     "snyk-go-plugin": "2.2.1",
-    "snyk-gradle-plugin": "7.1.0",
+    "snyk-gradle-plugin": "7.1.2",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "4.9.2",
     "snyk-nodejs-lockfile-parser": "2.10.0",


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are release-note ready
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes — n/a
- [x] Links to automated tests covering new functionality — see **Testing** below
- [x] Includes manual testing instructions
- [ ] Updates relevant GitBook documentation — n/a
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Upgrades `snyk-gradle-plugin` **7.1.0 → 7.1.2**.

Gradle dependency scans (`snyk test`, `snyk monitor`, …) on projects built with **Gradle 7.4–8.2** were failing with `java.util.ConcurrentModificationException` during dependency resolution. The plugin's injected init script iterated a configuration's attribute `keySet()` while realizing lazy (provider-based) attributes inside the loop, mutating the live key-set view mid-iteration. `snyk-gradle-plugin` 7.1.2 fixes this (upstream: snyk/snyk-gradle-plugin#349). Gradle changed the underlying attribute container in 8.3, so only 7.4–8.2 were affected.

The bump also pulls in **shescape 2.1.14** transitively (the plugin's own dependency).

## Where should the reviewer start?

`package.json` (the pin) and `package-lock.json` — the diff is the single dependency change plus its lockfile entry.

## Testing

**No new test is added in this repo — deliberately.** Reasoning:

- The bug and the fix live in `snyk-gradle-plugin`, and the regression is guarded there: snyk/snyk-gradle-plugin#349 adds a test that reproduces the `ConcurrentModificationException` on Gradle 7.4.2 and verifies the fix. Per this repo's testing strategy, tests belong in the same repo as the code they cover.
- The CLI's existing Gradle acceptance tests (`test/jest/acceptance/snyk-test/*`) already exercise dependency resolution through the bundled plugin on every PR, so they run against 7.1.2 here.
- A CLI-level reproduction of this specific crash would not be a reliable guard: CI installs **Gradle 9.0.0**, where the bug cannot occur. Forcing an older Gradle would require committing a pinned wrapper and only reproduces under specific invocation conditions — a brittle, low-signal test. The dependable guard is the upstream one.

## How should this be manually tested?

Run `snyk test` (or `snyk monitor`) against a Gradle project that builds with **Gradle 7.4–8.2** (e.g. via its wrapper) on a JDK ≤ 19. Before this bump the scan fails with `ConcurrentModificationException`; after it, the scan resolves the dependency graph.

## What's the product update that needs to be communicated to CLI users?

Fixes Gradle dependency scans crashing with `ConcurrentModificationException` on projects that build with Gradle 7.4–8.2.

## Risk assessment: Low

Patch-level dependency bump (7.1.0 → 7.1.2), behaviour-preserving. Exercised by the existing Gradle acceptance suite; the fix is independently tested upstream.
