### PR TITLE
fix(cli): prevent handled errors from producing duplicate output [CLI-1765]

### DIFF
--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -772,7 +772,7 @@ func processError(err error, errorList []error) ([]error, error) {
 	return resultErrorList, mostRelevant
 }
 
-//  Reports whether err is the command's own exit-code result
+// Reports whether err is the command's own exit-code result
 func commandOwnsOutput(err error) bool {
 	if _, ok := err.(*exec.ExitError); ok {
 		return true

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -456,11 +456,41 @@ func doctorTip(isCI bool) string {
 	return "Try snyk doctor: `snyk <command> -d 2>&1 | snyk doctor --stdin`"
 }
 
+// shouldSuppressDisplay reports whether err is worth printing.
+//
+// Joined errors match no direct type assertion, so they are unwrapped and checked
+// one at a time.
+func shouldSuppressDisplay(err error) bool {
+	if wrappedErr, ok := err.(interface{ Unwrap() []error }); ok {
+		unwrappedErrs := wrappedErr.Unwrap()
+		if len(unwrappedErrs) == 0 {
+			return false
+		}
+
+		for _, err := range unwrappedErrs {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) && exitErr.ExitCode() < constants.SNYK_EXIT_CODE_ERROR {
+				return true
+			}
+		}
+
+		for _, err := range unwrappedErrs {
+			if !shouldSuppressDisplay(err) {
+				return false
+			}
+		}
+		return true
+	}
+
+	_, isExitError := err.(*exec.ExitError)
+	_, isErrorWithCode := err.(*cli_errors.ErrorWithExitCode)
+
+	return isExitError || isErrorWithCode || errorHasBeenShown(err)
+}
+
 func displayError(err error, userInterface ui.UserInterface, config configuration.Configuration, ctx context.Context, isCI bool) {
 	if err != nil {
-		_, isExitError := err.(*exec.ExitError)
-		_, isErrorWithCode := err.(*cli_errors.ErrorWithExitCode)
-		if isExitError || isErrorWithCode || errorHasBeenShown(err) {
+		if shouldSuppressDisplay(err) {
 			return
 		}
 

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -456,18 +456,9 @@ func doctorTip(isCI bool) string {
 	return "Try snyk doctor: `snyk <command> -d 2>&1 | snyk doctor --stdin`"
 }
 
-// A successful command's exit-code error is not a reportable failure and does
-// not need to be printed.
+// Skip errors the command already reported
 func shouldSuppressDisplay(err error) bool {
-	if exitErr, ok := err.(*exec.ExitError); ok {
-		return exitErr.ExitCode() < constants.SNYK_EXIT_CODE_ERROR
-	}
-
-	if codeErr, ok := err.(*cli_errors.ErrorWithExitCode); ok {
-		return codeErr.ExitCode < constants.SNYK_EXIT_CODE_ERROR
-	}
-
-	return errorHasBeenShown(err)
+	return commandOwnsOutput(err) || errorHasBeenShown(err)
 }
 
 func displayError(err error, userInterface ui.UserInterface, config configuration.Configuration, ctx context.Context, isCI bool) {
@@ -524,13 +515,9 @@ func tearDown(err error, errorList []error, startTime time.Time, ua networking.U
 
 	outputError := err
 	allErrors := errorList
-	suppressDisplay := false
 
 	if err != nil {
 		allErrors, outputError = processError(err, errorList)
-
-		// Determine suppression from the original exit code
-		suppressDisplay = shouldSuppressDisplay(err) && errors.Is(outputError, err)
 
 		for _, tempError := range allErrors {
 			if tempError != nil {
@@ -542,7 +529,7 @@ func tearDown(err error, errorList []error, startTime time.Time, ua networking.U
 	exitCode := cliv2.DeriveExitCode(outputError)
 	globalLogger.Printf("Deriving Exit Code %d (cause: %v)", exitCode, outputError)
 
-	if !suppressDisplay {
+	if !shouldSuppressDisplay(outputError) {
 		displayError(outputError, globalEngine.GetUserInterface(), globalConfiguration, globalContext, cliAnalytics.IsCiEnvironment())
 	}
 
@@ -772,13 +759,30 @@ func processError(err error, errorList []error) ([]error, error) {
 	}
 
 	// determine the most relevant error to surface to the user and derive the exit code from
-	resultError = cli_errors.FindMostRelevantError(resultErrorList)
+	mostRelevant := cli_errors.FindMostRelevantError(resultErrorList)
+
+	if commandOwnsOutput(resultError) && errors.Is(mostRelevant, resultError) {
+		return resultErrorList, resultError
+	}
 
 	// ensure to apply exit code mapping based on errors
-	if exitCode := mapErrorToExitCode(resultError); exitCode != unsetExitCode {
-		resultError = createErrorWithExitCode(exitCode, resultError)
+	if exitCode := mapErrorToExitCode(mostRelevant); exitCode != unsetExitCode {
+		mostRelevant = createErrorWithExitCode(exitCode, mostRelevant)
 	}
-	return resultErrorList, resultError
+	return resultErrorList, mostRelevant
+}
+
+//  Reports whether err is the command's own exit-code result
+func commandOwnsOutput(err error) bool {
+	if _, ok := err.(*exec.ExitError); ok {
+		return true
+	}
+
+	if _, ok := err.(*cli_errors.ErrorWithExitCode); ok {
+		return true
+	}
+
+	return false
 }
 
 func setTimeout(config configuration.Configuration, onTimeout func()) {

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -456,44 +456,22 @@ func doctorTip(isCI bool) string {
 	return "Try snyk doctor: `snyk <command> -d 2>&1 | snyk doctor --stdin`"
 }
 
-// shouldSuppressDisplay reports whether err is worth printing.
-//
-// Joined errors match no direct type assertion, so they are unwrapped and checked
-// one at a time.
+// A successful command's exit-code error is not a reportable failure and does
+// not need to be printed.
 func shouldSuppressDisplay(err error) bool {
-	if wrappedErr, ok := err.(interface{ Unwrap() []error }); ok {
-		unwrappedErrs := wrappedErr.Unwrap()
-		if len(unwrappedErrs) == 0 {
-			return false
-		}
-
-		for _, err := range unwrappedErrs {
-			var exitErr *exec.ExitError
-			if errors.As(err, &exitErr) && exitErr.ExitCode() < constants.SNYK_EXIT_CODE_ERROR {
-				return true
-			}
-		}
-
-		for _, err := range unwrappedErrs {
-			if !shouldSuppressDisplay(err) {
-				return false
-			}
-		}
-		return true
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return exitErr.ExitCode() < constants.SNYK_EXIT_CODE_ERROR
 	}
 
-	_, isExitError := err.(*exec.ExitError)
-	_, isErrorWithCode := err.(*cli_errors.ErrorWithExitCode)
+	if codeErr, ok := err.(*cli_errors.ErrorWithExitCode); ok {
+		return codeErr.ExitCode < constants.SNYK_EXIT_CODE_ERROR
+	}
 
-	return isExitError || isErrorWithCode || errorHasBeenShown(err)
+	return errorHasBeenShown(err)
 }
 
 func displayError(err error, userInterface ui.UserInterface, config configuration.Configuration, ctx context.Context, isCI bool) {
 	if err != nil {
-		if shouldSuppressDisplay(err) {
-			return
-		}
-
 		if config.GetBool(output_workflow.OUTPUT_CONFIG_KEY_JSON) {
 			message := getErrorMessage(err)
 
@@ -546,9 +524,13 @@ func tearDown(err error, errorList []error, startTime time.Time, ua networking.U
 
 	outputError := err
 	allErrors := errorList
+	suppressDisplay := false
 
 	if err != nil {
 		allErrors, outputError = processError(err, errorList)
+
+		// Determine suppression from the original exit code
+		suppressDisplay = shouldSuppressDisplay(err) && errors.Is(outputError, err)
 
 		for _, tempError := range allErrors {
 			if tempError != nil {
@@ -560,7 +542,9 @@ func tearDown(err error, errorList []error, startTime time.Time, ua networking.U
 	exitCode := cliv2.DeriveExitCode(outputError)
 	globalLogger.Printf("Deriving Exit Code %d (cause: %v)", exitCode, outputError)
 
-	displayError(outputError, globalEngine.GetUserInterface(), globalConfiguration, globalContext, cliAnalytics.IsCiEnvironment())
+	if !suppressDisplay {
+		displayError(outputError, globalEngine.GetUserInterface(), globalConfiguration, globalContext, cliAnalytics.IsCiEnvironment())
+	}
 
 	updateInstrumentationDataBeforeSending(cliAnalytics, startTime, ua, exitCode)
 

--- a/cliv2/pkg/core/main_test.go
+++ b/cliv2/pkg/core/main_test.go
@@ -729,9 +729,9 @@ func Test_shouldSuppressDisplay(t *testing.T) {
 	}{
 		{"nil", nil, false},
 		{"exec exit 1", exitVulnerabilitiesFound, true},
-		{"exec exit 2", exitFailure, false},
+		{"exec exit 2", exitFailure, true},
 		{"ErrorWithExitCode 1", &clierrors.ErrorWithExitCode{ExitCode: 1}, true},
-		{"ErrorWithExitCode 2", &clierrors.ErrorWithExitCode{ExitCode: 2}, false},
+		{"ErrorWithExitCode 2", &clierrors.ErrorWithExitCode{ExitCode: 2}, true},
 		{"plain error", fmt.Errorf("connection refused"), false},
 		{"already-shown catalog error", authError(true), true},
 	}
@@ -884,6 +884,24 @@ func Test_processError(t *testing.T) {
 		exitCode := cliv2.DeriveExitCode(err)
 		assert.Equal(t, constants.SNYK_EXIT_CODE_EX_TEMPFAIL, exitCode)
 	})
+}
+
+func Test_processError_PreservesCodeTestResultWhenAuxiliaryRequestFails(t *testing.T) {
+	commandResult := &clierrors.ErrorWithExitCode{
+		ExitCode: constants.SNYK_EXIT_CODE_VULNERABILITIES_FOUND,
+	}
+	handledNetworkError := errors.New("handled auxiliary network error")
+	allErrors, outputError := processError(commandResult, []error{handledNetworkError})
+	assert.Len(t, allErrors, 2)
+	assert.Same(t, commandResult, outputError)
+}
+
+func Test_processError_PreservesLegacyCLIResultWhenAuxiliaryRequestFails(t *testing.T) {
+	commandResult := &exec.ExitError{ProcessState: &os.ProcessState{}}
+	handledNetworkError := errors.New("handled auxiliary network error")
+	allErrors, outputError := processError(commandResult, []error{handledNetworkError})
+	assert.Len(t, allErrors, 2)
+	assert.Same(t, commandResult, outputError)
 }
 
 func loadJsonFile(t *testing.T, filename string) []byte {

--- a/cliv2/pkg/core/main_test.go
+++ b/cliv2/pkg/core/main_test.go
@@ -729,6 +729,50 @@ func Test_displayError(t *testing.T) {
 	})
 }
 
+func Test_shouldSuppressDisplay(t *testing.T) {
+	exitVulnerabilitiesFound := exec.Command("sh", "-c", "exit 1").Run()
+	require.Error(t, exitVulnerabilitiesFound)
+	exitFailure := exec.Command("sh", "-c", "exit 2").Run()
+	require.Error(t, exitFailure)
+
+	authError := func(alreadyShown bool) snyk_errors.Error {
+		return snyk_errors.Error{
+			Title:     "Authentication error",
+			ErrorCode: "SNYK-0005",
+			Level:     "error",
+			Meta:      map[string]any{cliv2.ERROR_HAS_BEEN_DISPLAYED: alreadyShown},
+		}
+	}
+
+	testCases := []struct {
+		name     string
+		err      error
+		suppress bool
+	}{
+		{"nil", nil, false},
+		{"bare exit error", exitVulnerabilitiesFound, true},
+		{"error carrying only an exit code", &clierrors.ErrorWithExitCode{ExitCode: 1}, true},
+		{"error wrapping an exit error still shows its own message", &wrErr{wraps: exitVulnerabilitiesFound}, false},
+		{"plain error", fmt.Errorf("connection refused"), false},
+		{"catalog error", authError(false), false},
+
+		// The command failed: the user needs to know why.
+		{"failure combined with an error to report", errors.Join(exitFailure, authError(false)), false},
+		{"failure combined with an error already reported", errors.Join(exitFailure, authError(true)), true},
+
+		// The command produced valid output; anything collected is auxiliary and
+		// printing it would append a second, misleading result.
+		{"success combined with a collected error", errors.Join(exitVulnerabilitiesFound, fmt.Errorf("connection refused")), true},
+		{"success combined with an exit code carrier", errors.Join(exitVulnerabilitiesFound, &clierrors.ErrorWithExitCode{ExitCode: 2}), true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.suppress, shouldSuppressDisplay(tc.err))
+		})
+	}
+}
+
 func Test_doctorTip(t *testing.T) {
 	t.Run("CI advertises the --input flag", func(t *testing.T) {
 		tip := doctorTip(true)

--- a/cliv2/pkg/core/main_test.go
+++ b/cliv2/pkg/core/main_test.go
@@ -698,28 +698,6 @@ func Test_displayError(t *testing.T) {
 		displayError(err, userInterface, config, t.Context(), false)
 	})
 
-	scenarios := []struct {
-		name string
-		err  error
-	}{
-		{
-			name: "exec.ExitError",
-			err:  &exec.ExitError{},
-		},
-		{
-			name: "clierrors.ErrorWithExitCode",
-			err:  &clierrors.ErrorWithExitCode{ExitCode: 42},
-		},
-	}
-
-	for _, scenario := range scenarios {
-		t.Run(fmt.Sprintf("%s does not display anything", scenario.name), func(t *testing.T) {
-			config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
-			err := scenario.err
-			displayError(err, userInterface, config, t.Context(), false)
-		})
-	}
-
 	t.Run("prints messages of error wrapping exec.ExitError", func(t *testing.T) {
 		err := &wrErr{wraps: &exec.ExitError{}}
 		userInterface.EXPECT().OutputError(err, gomock.Any()).Times(1)
@@ -750,20 +728,12 @@ func Test_shouldSuppressDisplay(t *testing.T) {
 		suppress bool
 	}{
 		{"nil", nil, false},
-		{"bare exit error", exitVulnerabilitiesFound, true},
-		{"error carrying only an exit code", &clierrors.ErrorWithExitCode{ExitCode: 1}, true},
-		{"error wrapping an exit error still shows its own message", &wrErr{wraps: exitVulnerabilitiesFound}, false},
+		{"exec exit 1", exitVulnerabilitiesFound, true},
+		{"exec exit 2", exitFailure, false},
+		{"ErrorWithExitCode 1", &clierrors.ErrorWithExitCode{ExitCode: 1}, true},
+		{"ErrorWithExitCode 2", &clierrors.ErrorWithExitCode{ExitCode: 2}, false},
 		{"plain error", fmt.Errorf("connection refused"), false},
-		{"catalog error", authError(false), false},
-
-		// The command failed: the user needs to know why.
-		{"failure combined with an error to report", errors.Join(exitFailure, authError(false)), false},
-		{"failure combined with an error already reported", errors.Join(exitFailure, authError(true)), true},
-
-		// The command produced valid output; anything collected is auxiliary and
-		// printing it would append a second, misleading result.
-		{"success combined with a collected error", errors.Join(exitVulnerabilitiesFound, fmt.Errorf("connection refused")), true},
-		{"success combined with an exit code carrier", errors.Join(exitVulnerabilitiesFound, &clierrors.ErrorWithExitCode{ExitCode: 2}), true},
+		{"already-shown catalog error", authError(true), true},
 	}
 
 	for _, tc := range testCases {

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "semver": "^6.0.0",
         "snyk-config": "^5.0.0",
         "snyk-cpp-plugin": "^2.24.3",
-        "snyk-docker-plugin": "9.19.0",
+        "snyk-docker-plugin": "9.20.0",
         "snyk-go-plugin": "2.2.1",
         "snyk-gradle-plugin": "7.1.2",
         "snyk-module": "3.1.0",
@@ -19761,9 +19761,9 @@
       "license": "ISC"
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-9.19.0.tgz",
-      "integrity": "sha512-XVOEneK1YKfFxOqyUR8PRBHzxosRNnfEuejNZHIKUqRdFrJjfVzxPRNo5a2ypis8z26C0/Hgha18nCwitvejRA==",
+      "version": "9.20.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-9.20.0.tgz",
+      "integrity": "sha512-wzvEK7aO7od4/bp1ZXivQzzMJNRYSX9s3DY+sCB5wCw/MVx93R2fNcTqXt3HtObJYPSUtEm5pA8nYVSG77NqYw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "semver": "^6.0.0",
     "snyk-config": "^5.0.0",
     "snyk-cpp-plugin": "^2.24.3",
-    "snyk-docker-plugin": "9.19.0",
+    "snyk-docker-plugin": "9.20.0",
     "snyk-go-plugin": "2.2.1",
     "snyk-gradle-plugin": "7.1.2",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable) — none
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___) — n/a, no user-facing docs change
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

CLI Ticket: https://snyksec.atlassian.net/browse/CLI-1765?actionerId=712020%3Aed5c88da-ffa1-47ff-9ea7-b4345eaadf9f&sourceType=assign

Fixes:

json output being unparseable because an extra error was printed after the result. This happens when the CLI receives an error (aside from exit status 1), it prints it — so once teardown joins the exit error together with the handled network errors, the result is no longer exit status 1 and gets printed after the real output.

Also pins `snyk-docker-plugin` to `9.20.0` so CI exercises the failure being fixed. (Original PR: https://github.com/snyk/cli/pull/7047 + discussion: https://snyksec.atlassian.net/servicedesk/customer/portal/64/CLIA-1576)

## Where should the reviewer start?

`cliv2/pkg/core/main.go` — `shouldSuppressDisplay` and the third return value from `processError`, then the guarded `displayError` call in `tearDown`.

Then `cliv2/pkg/core/main_test.go` for the two new cases in `Test_processError` and the new `Test_shouldSuppressDisplay`.

## How should this be manually tested?

Against an image whose provenance fetch fails (SDP version 9.20.0 +):

```sh
snyk container test <image> --json > out.json
jq . out.json
```
The `container.spec.ts` acceptance job is the automated equivalent — it fails on 9.20.0 without this fix, which is why the pin is included here.

## What's the product update that needs to be communicated to CLI users?

n/a
