### PR TITLE
chore(language-server): integrate LS

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -226,7 +226,7 @@ require (
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
-	github.com/snyk/snyk-ls v0.0.0-20260814112015-c5325e836868 // indirect
+	github.com/snyk/snyk-ls v0.0.0-20260814164657-a99d4cf1c3e7 // indirect
 	github.com/snyk/studio-mcp v1.15.4 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -604,8 +604,8 @@ github.com/snyk/rift-cli-extension v1.1.1 h1:WeBeO8tUP/SWX/lqe9tTltOdeJDKNOQdOrF
 github.com/snyk/rift-cli-extension v1.1.1/go.mod h1:uZuSGZS6n/pBGTEoxtvVsfiNAPCXcTitpnQV9a3RgDI=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260814112015-c5325e836868 h1:hBuzcAYbQ9XkOWp8L31p3PcQZQksDJtq6yAtPf76USQ=
-github.com/snyk/snyk-ls v0.0.0-20260814112015-c5325e836868/go.mod h1:s4gqDKMyXZ4Z5GthWyM3D079/dT0woNbQyJ8UrHW6nE=
+github.com/snyk/snyk-ls v0.0.0-20260814164657-a99d4cf1c3e7 h1:wrnB8/yVj/BxcxqX3ppKNF+cZVlyCjmGgxhCtoRWlK8=
+github.com/snyk/snyk-ls v0.0.0-20260814164657-a99d4cf1c3e7/go.mod h1:ZfhCKJ6IGbmr0LfcAAm/WY0ECv2IO1+dXYFMepWHjpQ=
 github.com/snyk/studio-mcp v1.15.4 h1:MHrAtTZ7E1IY0p6pdKAZqM4bmS5dZNSK/eEjVX26FA8=
 github.com/snyk/studio-mcp v1.15.4/go.mod h1:o+eDJRfHPVzPvZGqamASOZf5drlBEiJVbbOJS7sJsbQ=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/snyk/go-application-framework v0.16.1
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20260814112015-c5325e836868
+	github.com/snyk/snyk-ls v0.0.0-20260814164657-a99d4cf1c3e7
 	github.com/snyk/studio-mcp v1.15.4
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -550,8 +550,8 @@ github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhk
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260814112015-c5325e836868 h1:hBuzcAYbQ9XkOWp8L31p3PcQZQksDJtq6yAtPf76USQ=
-github.com/snyk/snyk-ls v0.0.0-20260814112015-c5325e836868/go.mod h1:s4gqDKMyXZ4Z5GthWyM3D079/dT0woNbQyJ8UrHW6nE=
+github.com/snyk/snyk-ls v0.0.0-20260814164657-a99d4cf1c3e7 h1:wrnB8/yVj/BxcxqX3ppKNF+cZVlyCjmGgxhCtoRWlK8=
+github.com/snyk/snyk-ls v0.0.0-20260814164657-a99d4cf1c3e7/go.mod h1:ZfhCKJ6IGbmr0LfcAAm/WY0ECv2IO1+dXYFMepWHjpQ=
 github.com/snyk/studio-mcp v1.15.4 h1:MHrAtTZ7E1IY0p6pdKAZqM4bmS5dZNSK/eEjVX26FA8=
 github.com/snyk/studio-mcp v1.15.4/go.mod h1:o+eDJRfHPVzPvZGqamASOZf5drlBEiJVbbOJS7sJsbQ=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit a99d4cf1c3e77ab6374bbe3729fcbd8b4061df9b
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Fri Aug 14 17:46:57 2026 +0100

    feat: filter files with GAF's configuration-driven file filter [CLI-1721] (#1410)
    
    * feat: filter files with GAF's configuration-driven file filter [CLI-1721]
    
    Snyk Code scans skipped files that .gitignore lists but git tracks, because the
    file filter treated every ignore rule as authoritative regardless of what is in
    the index. GAF's file filter fixes this behind FF_GITIGNORE_RESPECT_TRACKED_FILES.
    
    Scanning now dispatches per folder: with the flag on, the filter is built from a
    configuration clone carrying the folder's organization and both file filter flag
    values, so GAF resolves nothing over the network mid-scan. With the flag off, the
    previous implementation runs unchanged — it is the control arm of the rollout and
    the rollback target.
    
    Both flags and the organization are read from the folder config the scan already
    carries. Resolving any of them by path builds a fresh folder config, which opens
    the repository with go-git to enrich it and writes it back to storage, so a scan
    would otherwise repeat that work per flag — on the legacy path too, where the
    flags cannot change what the filter does. A missing folder config is refused
    rather than defaulted, because reading its flags as off would filter the folder
    as though the rollout had never reached it.
    
    Requires GAF v0.14.1: v0.11.0 exports the configuration keys but does not read
    FF_GITIGNORE_RESPECT_TRACKED_FILES in its file filter.
    
    * docs(code): tighten file filtering comments per review

M	go.mod
M	go.sum
M	infrastructure/code/code.go
A	infrastructure/code/code_file_filter_test.go
M	infrastructure/code/code_test.go
M	infrastructure/featureflag/featureflag.go
M	infrastructure/featureflag/featureflag_test.go

commit cfd689beeddbb995cef649c41f667e0356281872
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Fri Aug 14 16:26:59 2026 +0100

    ci: enable Remy Open Source fixes [AG-387] (#1407)
    
    Opt the existing ProdSec security scan into agentic SCA remediation after a blocking gate result. Keep the current severity threshold, exclusions, and runtime contexts unchanged.
    
    Co-authored-by: Cursor Agent <cursoragent@cursor.com>

M	.circleci/config.yml

commit 1bfa374c59a4211e4c2d7348a707249bfc14e1f9
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Fri Aug 14 15:57:37 2026 +0100

    refactor: resolve GAF config keys from a list (#1409)
    
    The feature flag service resolved exactly one GAF configuration key, and did so
    through a name comparison in the middle of the per-flag fetch loop. Adding a
    second key meant adding a second branch.
    
    Flags whose value comes from a GAF configuration key are now listed in
    gafConfigResolvedFlags and resolved together by getConfigValues, separate from
    the flags the feature flag service resolves by platform name. The keys share one
    configuration clone: GAF caches a batched flag evaluation on the configuration
    object it is handed, so reading them from the same clone costs one request
    between them rather than one each. A key that cannot be resolved is reported as
    false alongside a joined error, so a failed lookup can never be mistaken for an
    enabled flag.
    
    No behaviour change: ignore_workflow.ConfigIgnoreApprovalEnabled is the same
    string as the IgnoreApprovalEnabled constant it replaces, so the key written to
    folder config is unchanged.

M	infrastructure/featureflag/featureflag.go
M	infrastructure/featureflag/featureflag_test.go
```

[CLI-1721]: https://snyksec.atlassian.net/browse/CLI-1721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLI-1721]: https://snyksec.atlassian.net/browse/CLI-1721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AG-387]: https://snyksec.atlassian.net/browse/AG-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ