### PR TITLE
feat: wire live Configuration into analytics instrumentation

### DIFF
--- a/cliv2/pkg/core/instrumentation.go
+++ b/cliv2/pkg/core/instrumentation.go
@@ -57,8 +57,14 @@ func addNetworkingDetails(instrumentor analytics.InstrumentationCollector, confi
 	instrumentor.AddExtension("network-request-attempts", config.GetInt(middleware.ConfigurationKeyRequestAttempts))
 }
 
+// clientMachineIdConfigKey is the config key Studio sets before exec'ing the snyk
+// binary (see Test_addClientMachineId). populateRedactionTerms in main.go must
+// exclude this value from its sweep, or the scrub chokepoint redacts it right back
+// out of the studio::client_machine_id extension it's meant to carry.
+const clientMachineIdConfigKey = "internal_snyk_client_machine_id"
+
 func addClientMachineId(instrumentor analytics.InstrumentationCollector, config configuration.Configuration) {
-	if id := config.GetString("internal_snyk_client_machine_id"); id != "" {
+	if id := config.GetString(clientMachineIdConfigKey); id != "" {
 		instrumentor.AddExtension("studio::client_machine_id", id)
 	}
 }
@@ -133,7 +139,7 @@ func sendInstrumentation(ctx context.Context, eng workflow.Engine, instrumentor 
 	}
 
 	logger.Print("Sending Instrumentation")
-	data, err := analytics.GetV2InstrumentationObject(instrumentor, analytics.WithLogger(logger))
+	data, err := analytics.GetV2InstrumentationObject(instrumentor, analytics.WithLogger(logger), analytics.WithConfiguration(eng.GetConfiguration()))
 	if err != nil {
 		logger.Err(err).Msg("Failed to derive data object")
 	}

--- a/cliv2/pkg/core/instrumentation_test.go
+++ b/cliv2/pkg/core/instrumentation_test.go
@@ -1,10 +1,16 @@
 package core
 
 import (
+	"context"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/rs/zerolog"
 	"github.com/snyk/go-application-framework/pkg/analytics"
 	"github.com/snyk/go-application-framework/pkg/configuration"
+	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
+	"github.com/snyk/go-application-framework/pkg/mocks"
+	"github.com/snyk/go-application-framework/pkg/workflow"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,6 +31,41 @@ func Test_shallSendInstrumentation(t *testing.T) {
 	instrumentor.SetCategory([]string{"analytics", "report", "inputData"})
 	actual = shallSendInstrumentation(config, instrumentor)
 	assert.False(t, actual)
+}
+
+func Test_sendInstrumentation_passesEngineConfigurationToInstrumentationObject(t *testing.T) {
+	globalConfiguration = configuration.NewWithOpts(configuration.WithAutomaticEnv())
+
+	mockController := gomock.NewController(t)
+	mockEngine := mocks.NewMockEngine(mockController)
+
+	// Mirrors production: populateRedactionTerms runs at startup and sweeps up any
+	// os.Environ() value it doesn't recognize. The client machine id is real Studio
+	// data, not a secret, so its own env var value must not end up in the terms
+	// this test's later scrub pass redacts against.
+	machineId := "studio-device-id-abc12345"
+	t.Setenv("INTERNAL_SNYK_CLIENT_MACHINE_ID", machineId)
+	engineConfig := configuration.NewWithOpts(configuration.WithAutomaticEnv())
+	mockEngine.EXPECT().GetWorkflows().Return([]workflow.Identifier{})
+	populateRedactionTerms(engineConfig, mockEngine)
+
+	// One call from shallSendInstrumentation, one to derive analytics.WithConfiguration.
+	// If the call site regresses to only passing WithLogger, this expectation goes unmet.
+	mockEngine.EXPECT().GetConfiguration().Return(engineConfig).Times(2)
+	mockEngine.EXPECT().Invoke(localworkflows.WORKFLOWID_REPORT_ANALYTICS, gomock.Any(), gomock.Any()).Return(nil, nil)
+
+	instrumentor := analytics.NewInstrumentationCollector()
+	addClientMachineId(instrumentor, engineConfig)
+	logger := zerolog.Nop()
+
+	sendInstrumentation(context.Background(), mockEngine, instrumentor, &logger)
+
+	// sendInstrumentation just ran the extension through the same scrub chokepoint;
+	// re-deriving the object (a pure read, doesn't mutate the collector) proves the
+	// machine id survived it rather than coming back "***".
+	obj, err := analytics.GetV2InstrumentationObject(instrumentor, analytics.WithConfiguration(engineConfig))
+	assert.NoError(t, err)
+	assert.Equal(t, machineId, (*obj.Data.Attributes.Interaction.Extension)["studio::client_machine_id"])
 }
 
 func Test_addClientMachineId(t *testing.T) {

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/snyk/cli/cliv2/internal/constants"
 
 	persona "github.com/snyk/cli/cliv2/internal/persona"
+	"github.com/snyk/cli/cliv2/internal/persona/agent"
 	cliv2utils "github.com/snyk/cli/cliv2/internal/utils"
 
 	localworkflows "github.com/snyk/go-application-framework/pkg/local_workflows"
@@ -507,6 +508,12 @@ func tearDown(err error, errorList []error, startTime time.Time, ua networking.U
 	teardownCtx, cancel := context.WithTimeout(context.Background(), teardownTimeout)
 	defer cancel()
 
+	// Populated here (post-command) rather than at startup so the analytics scrub chokepoint
+	// (which reads logging.REDACTION_TERMS off of config) sees these terms on every run, not
+	// just under --debug, without forcing an ORGANIZATION/ORGANIZATION_SLUG network lookup
+	// before the command's own requests run.
+	populateRedactionTerms(globalConfiguration, globalEngine)
+
 	outputError := err
 	allErrors := errorList
 
@@ -639,10 +646,8 @@ func mainWithErrorCode(additionalExts []workflow.ExtensionInit) int {
 
 	// We want to scrub the debug log of sensitive information. Since we have a list of commands we know can occur, we can intersect that with arguments we don't recognize, and automatically scrub all those from the logs.
 	if debugEnabled {
+		termsToRedact := populateRedactionTerms(globalConfiguration, globalEngine)
 		writeLogHeader(globalConfiguration, networkAccess)
-		knownTerms, _ := instrumentation.GetKnownCommandsAndFlags(globalEngine)
-		knownTerms = append(knownTerms, globalConfiguration.GetString(configuration.API_URL), globalConfiguration.GetString(configuration.ORGANIZATION), globalConfiguration.GetString(configuration.ORGANIZATION_SLUG))
-		termsToRedact := cliv2utils.GetUnknownParameters(os.Args[1:], os.Environ(), knownTerms)
 		scrubbedLogger.AddTermsToReplace(termsToRedact)
 	}
 
@@ -712,6 +717,27 @@ func mainWithErrorCode(additionalExts []workflow.ExtensionInit) int {
 	})
 
 	return finalExitCode
+}
+
+// populateRedactionTerms computes likely-secret literal values (unrecognized CLI
+// arguments and environment variables) and records them on config under
+// logging.REDACTION_TERMS, so the analytics scrub chokepoint can redact
+// them regardless of whether debug logging is enabled.
+func populateRedactionTerms(config configuration.Configuration, engine workflow.Engine) []string {
+	knownTerms, _ := instrumentation.GetKnownCommandsAndFlags(engine)
+	knownTerms = append(knownTerms, config.GetString(configuration.API_URL), config.GetString(configuration.ORGANIZATION), config.GetString(configuration.ORGANIZATION_SLUG), config.GetString(clientMachineIdConfigKey))
+	// AI_AGENT is trusted verbatim into the persona.agent extension (see
+	// agent.canonicalAgent) for any harness not on its short canonical list, so its
+	// raw value needs the same exclusion as the client machine id above.
+	// GetUnknownParameters tokenizes its input on whitespace, so a multi-word
+	// value only excludes as a whole if each of its words is excluded too.
+	if detectedAgent, ok := agent.DetectAgent(); ok {
+		knownTerms = append(knownTerms, string(detectedAgent))
+		knownTerms = append(knownTerms, strings.Fields(string(detectedAgent))...)
+	}
+	termsToRedact := cliv2utils.GetUnknownParameters(os.Args[1:], os.Environ(), knownTerms)
+	config.Set(logging.REDACTION_TERMS, termsToRedact)
+	return termsToRedact
 }
 
 func processError(err error, errorList []error) ([]error, error) {

--- a/cliv2/pkg/core/main_test.go
+++ b/cliv2/pkg/core/main_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/local_workflows/content_type"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/local_models"
+	"github.com/snyk/go-application-framework/pkg/logging"
 	"github.com/snyk/go-application-framework/pkg/mocks"
 	"github.com/snyk/go-application-framework/pkg/utils/ufm"
 	"github.com/snyk/go-application-framework/pkg/workflow"
@@ -66,6 +67,78 @@ func Test_mainWithErrorCode(t *testing.T) {
 		errCode := mainWithErrorCode(nil)
 		assert.Equal(t, 2, errCode)
 	})
+}
+
+func Test_populateRedactionTerms(t *testing.T) {
+	mockController := gomock.NewController(t)
+	mockEngine := mocks.NewMockEngine(mockController)
+	mockEngine.EXPECT().GetWorkflows().Return(nil)
+
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
+	t.Setenv("SNYK_TEST_REDACTION_MARKER", "unmistakably-secret-value")
+
+	// No debugEnabled anywhere in this call: populateRedactionTerms runs
+	// unconditionally at its call site, so proving it sets config here proves
+	// the behavior holds regardless of debugEnabled.
+	terms := populateRedactionTerms(config, mockEngine)
+
+	assert.Contains(t, terms, "unmistakably-secret-value")
+	assert.Equal(t, terms, config.GetStringSlice(logging.REDACTION_TERMS))
+}
+
+func Test_populateRedactionTerms_excludesClientMachineId(t *testing.T) {
+	mockController := gomock.NewController(t)
+	mockEngine := mocks.NewMockEngine(mockController)
+	mockEngine.EXPECT().GetWorkflows().Return(nil)
+
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
+	machineId := "studio-device-id-abc12345"
+	t.Setenv("INTERNAL_SNYK_CLIENT_MACHINE_ID", machineId)
+
+	terms := populateRedactionTerms(config, mockEngine)
+
+	assert.NotContains(t, terms, machineId, "client machine id must never be swept into REDACTION_TERMS, or the analytics scrub chokepoint strips it right back out of its own extension")
+}
+
+func Test_populateRedactionTerms_excludesDetectedAgent(t *testing.T) {
+	// Not on agent.canonicalAgent's short-circuit list, so AI_AGENT is trusted
+	// verbatim into the persona.agent extension. GetUnknownParameters
+	// tokenizes its input on whitespace, so a multi-word value only survives
+	// unredacted if each of its words is excluded too, not just the joined
+	// string as a whole.
+	cases := []struct {
+		name      string
+		agent     string
+		wantWords []string
+	}{
+		{
+			name:      "single word",
+			agent:     "some-unlisted-harness",
+			wantWords: []string{"some-unlisted-harness"},
+		},
+		{
+			name:      "words with spaces",
+			agent:     "My Custom Harness",
+			wantWords: []string{"My", "Custom", "Harness"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockController := gomock.NewController(t)
+			mockEngine := mocks.NewMockEngine(mockController)
+			mockEngine.EXPECT().GetWorkflows().Return(nil)
+
+			config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
+			t.Setenv("AI_AGENT", tc.agent)
+
+			terms := populateRedactionTerms(config, mockEngine)
+
+			for _, word := range tc.wantWords {
+				assert.NotContains(t, terms, word, "a caller-declared AI_AGENT value must never be swept into REDACTION_TERMS, or the analytics scrub chokepoint strips it right back out of the persona.agent extension")
+			}
+		})
+	}
 }
 
 func Test_initApplicationConfiguration_DisablesAnalytics(t *testing.T) {


### PR DESCRIPTION
## Summary
- Passes the engine's live `Configuration` through to `analytics.WithConfiguration` at the report-analytics chokepoint (GAF#704), so `logging.REDACTION_TERMS`-based scrubbing covers the CLI's own analytics extension data, not just debug logs.
- `populateRedactionTerms` excludes the client machine id and any detected AI agent name from its unknown-value sweep — both echo a raw env var value verbatim into an extension (`studio::client_machine_id`, `persona.agent`), so without the exclusion the scrub chokepoint stripped them right back out as if they were unrecognized secrets.

Squashed recreation of #7133 into a single commit (that PR had accumulated several unsquashed merge commits flagged by Danger). Same diff, same review comments should still apply — #7133 left open, not closed automatically.

## Test plan
- [x] `go build ./...` (cliv2)
- [x] `go vet ./...`
- [x] `golangci-lint run ./pkg/core/...`
- [x] `go test ./pkg/core/...` — full suite green, including new `Test_populateRedactionTerms_excludesClientMachineId`, `Test_populateRedactionTerms_excludesDetectedAgent`, and extended `Test_sendInstrumentation_passesEngineConfigurationToInstrumentationObject`
- [x] Verified fresh `GOMODCACHE` resolves `go-application-framework v0.15.0` from scratch (addresses stale "unresolvable dependency" review comment on #7133)