### PR TITLE
chore: bump up cli aibom version

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -211,7 +211,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.3.2 // indirect
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af // indirect
-	github.com/snyk/cli-extension-ai-bom v0.0.0-20260813135431-38a363dae403 // indirect
+	github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172 // indirect
 	github.com/snyk/cli-extension-dep-graph/v2 v2.8.1 // indirect
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 // indirect
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -566,8 +566,8 @@ github.com/snyk/ambient-canary v0.0.0-20260722064253-fba619a134a9 h1:d69mS5cTIs1
 github.com/snyk/ambient-canary v0.0.0-20260722064253-fba619a134a9/go.mod h1:n6GYt41xPhThEEEl/0RZuWpTX68iv6k+6HZ94uGNDGE=
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af h1:AgYHuCfs6oNkd/QFwsuEtvswclfBujhBfwbZUB4xEU4=
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af/go.mod h1:u4d7qoWWVx3II+ZnpLQGjAegaJLmgPefXKXJD/jp/wM=
-github.com/snyk/cli-extension-ai-bom v0.0.0-20260813135431-38a363dae403 h1:AC9TjNxCOkOLxx5r6zgjvvkwVqKBE5+6ZeupnDtdW6I=
-github.com/snyk/cli-extension-ai-bom v0.0.0-20260813135431-38a363dae403/go.mod h1:ieThzrb8z/Z88cDKdfqdfGh01xs6RkDKt5LbA+AE6U8=
+github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172 h1:dZQ2DnEnxV+v2yFRyuqUioSAGfXkiMcRQXndAeVsqi0=
+github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172/go.mod h1:ieThzrb8z/Z88cDKdfqdfGh01xs6RkDKt5LbA+AE6U8=
 github.com/snyk/cli-extension-axi v0.0.0-20260812113949-210b479505a9 h1:6/YF4VHeT8E3abcxcF/oIrdEyrPM3fV/OfJOsZuYz5g=
 github.com/snyk/cli-extension-axi v0.0.0-20260812113949-210b479505a9/go.mod h1:oFvcbCp2bb4gPBDbFPnqGxmFTkQEcPolXTbif5hJ1FE=
 github.com/snyk/cli-extension-cos v0.0.0-20260813100139-4d5c43e0785f h1:in98PD78zmxOtxoNr3kQNTDN5Sm4gbDImMLH+EZuZrk=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.35.1
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af
-	github.com/snyk/cli-extension-ai-bom v0.0.0-20260813135431-38a363dae403
+	github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172
 	github.com/snyk/cli-extension-dep-graph/v2 v2.8.1
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -520,8 +520,8 @@ github.com/skeema/knownhosts v1.3.2 h1:EDL9mgf4NzwMXCTfaxSD/o/a5fxDw/xL9nkU28Jjd
 github.com/skeema/knownhosts v1.3.2/go.mod h1:bEg3iQAuw+jyiw+484wwFJoKSLwcfd7fqRy+N0QTiow=
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af h1:AgYHuCfs6oNkd/QFwsuEtvswclfBujhBfwbZUB4xEU4=
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af/go.mod h1:u4d7qoWWVx3II+ZnpLQGjAegaJLmgPefXKXJD/jp/wM=
-github.com/snyk/cli-extension-ai-bom v0.0.0-20260813135431-38a363dae403 h1:AC9TjNxCOkOLxx5r6zgjvvkwVqKBE5+6ZeupnDtdW6I=
-github.com/snyk/cli-extension-ai-bom v0.0.0-20260813135431-38a363dae403/go.mod h1:ieThzrb8z/Z88cDKdfqdfGh01xs6RkDKt5LbA+AE6U8=
+github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172 h1:dZQ2DnEnxV+v2yFRyuqUioSAGfXkiMcRQXndAeVsqi0=
+github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172/go.mod h1:ieThzrb8z/Z88cDKdfqdfGh01xs6RkDKt5LbA+AE6U8=
 github.com/snyk/cli-extension-dep-graph/v2 v2.8.1 h1:ZlLN8KbMZiRN7QsiLzovFLsoIEVytC77+OESr+6wDhI=
 github.com/snyk/cli-extension-dep-graph/v2 v2.8.1/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSoQL0zYyFcGQjEPZcQgDkzM5PcgIHlIgzRuhg=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [x] Updates relevant GitBook documentation (PR link: https://github.com/snyk/user-docs/pull/1655)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps `github.com/snyk/cli-extension-ai-bom` to the latest commit on `main`:

- **Previous:** `v0.0.0-20260813135431-38a363dae403` (`38a363d`)
- **Updated:** `v0.0.0-20260817214817-d0a81ac40172` (`d0a81ac`)

This picks up [cli-extension-ai-bom#66](https://github.com/snyk/cli-extension-ai-bom/pull/66), which changes how `--severity-threshold` is applied for `snyk aibom test`. Issues below the configured threshold are now filtered from the raw API response before results are parsed, displayed, and summarized.

**Files changed:**
- `cliv2/go.mod` / `cliv2/go.sum`
- `cliv2-private/go.mod` / `cliv2-private/go.sum`

## Where should the reviewer start?

Review the dependency version bump in `cliv2/go.mod`, then inspect the upstream change in [cli-extension-ai-bom#66](https://github.com/snyk/cli-extension-ai-bom/pull/66), especially:

- `internal/commands/aibomcreate/aibomcreate.go` — applies severity filtering in the test flow
- `internal/commands/aibomcreate/testresultparser.go` — new `FilterTestResult` logic and summary severity ordering

## How should this be manually tested?

1. Build the CLI: `make build`
2. Run `snyk aibom test` against a project with AI-BOM policy findings
3. Re-run with `--severity-threshold=high` and confirm lower-severity issues are excluded from output
4. Verify JSON output remains valid when a severity threshold is set

## What's the product update that needs to be communicated to CLI users?

`snyk aibom test` now respects `--severity-threshold`, filtering out findings below the configured severity from CLI output and summaries.

## Risk assessment (Low | Medium | High)?

**Low** — dependency-only bump with no CLI code changes. Behavior change is scoped to `snyk aibom test` severity-threshold filtering.

## What are the relevant tickets?

https://snyksec.atlassian.net/browse/AIBOM-989

## Screenshots (if appropriate)

<img width="1629" height="326" alt="image" src="https://github.com/user-attachments/assets/052891f5-d98a-4e1b-bd9c-3ae445d15973" />
