### PR TITLE
fix: use config-aware file filtering for os-flows extension

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -215,7 +215,7 @@ require (
 	github.com/snyk/cli-extension-dep-graph/v2 v2.8.1 // indirect
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 // indirect
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e // indirect
-	github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091 // indirect
+	github.com/snyk/cli-extension-os-flows v0.0.0-20260817090032-8d54de054540 // indirect
 	github.com/snyk/cli-extension-sbom v0.0.0-20260811135250-99c30fb97642 // indirect
 	github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd // indirect
 	github.com/snyk/code-client-go v1.31.3 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -578,8 +578,8 @@ github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSo
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e h1:HE22F5/ivTJ4TlTUnjasZqfkDKVyfmYjf36RaIZqrs4=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e/go.mod h1:YN+M0+nNZ5VoQN2SxSvZSoTxs/PkdLgfNfUWvsKVL7o=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091 h1:MDR3Tj4tFVNPonOtL+AzX0osWdOkNq0lEpQQehvjGak=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091/go.mod h1:qNOr9aDWYUa3Tl74k+04hOCEgKcgpBLVcvs26L4ooN0=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260817090032-8d54de054540 h1:zaZQi62zwN8Fq/GlBGHJxuTkUrljYbrhMe+u4s68x5s=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260817090032-8d54de054540/go.mod h1:4v6N6VYNV8/KlIWZIJwTfJzsDYwZk68gLZIAaNb2H7w=
 github.com/snyk/cli-extension-sbom v0.0.0-20260811135250-99c30fb97642 h1:dWaIWLV0vucbUStVIJIlCmA2A4jlYkbUyAA6zoaEiMc=
 github.com/snyk/cli-extension-sbom v0.0.0-20260811135250-99c30fb97642/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd h1:sSVkD1CuL8v49boItrt2CnQ4DJIH+sjGwFGheGCVAxo=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/snyk/cli-extension-dep-graph/v2 v2.8.1
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e
-	github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091
+	github.com/snyk/cli-extension-os-flows v0.0.0-20260817090032-8d54de054540
 	github.com/snyk/cli-extension-sbom v0.0.0-20260811135250-99c30fb97642
 	github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd
 	github.com/snyk/code-client-go v1.31.3

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -528,8 +528,8 @@ github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSo
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e h1:HE22F5/ivTJ4TlTUnjasZqfkDKVyfmYjf36RaIZqrs4=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e/go.mod h1:YN+M0+nNZ5VoQN2SxSvZSoTxs/PkdLgfNfUWvsKVL7o=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091 h1:MDR3Tj4tFVNPonOtL+AzX0osWdOkNq0lEpQQehvjGak=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260722114313-168a09671091/go.mod h1:qNOr9aDWYUa3Tl74k+04hOCEgKcgpBLVcvs26L4ooN0=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260817090032-8d54de054540 h1:zaZQi62zwN8Fq/GlBGHJxuTkUrljYbrhMe+u4s68x5s=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260817090032-8d54de054540/go.mod h1:4v6N6VYNV8/KlIWZIJwTfJzsDYwZk68gLZIAaNb2H7w=
 github.com/snyk/cli-extension-sbom v0.0.0-20260811135250-99c30fb97642 h1:dWaIWLV0vucbUStVIJIlCmA2A4jlYkbUyAA6zoaEiMc=
 github.com/snyk/cli-extension-sbom v0.0.0-20260811135250-99c30fb97642/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd h1:sSVkD1CuL8v49boItrt2CnQ4DJIH+sjGwFGheGCVAxo=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Enabled the config aware FileFilter for the os-flows extension.

## Where should the reviewer start?

- Extension [PR](https://github.com/snyk/cli-extension-os-flows/pull/269)

## How should this be manually tested?

Switching the FF on/off should show the difference in behaviour for the uploaded files by the os-flows-extension.

## What's the product update that needs to be communicated to CLI users?

N/A

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->
