### PR TITLE
chore: bump extensions for SBOM per-component results

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -215,14 +215,14 @@ require (
 	github.com/snyk/cli-extension-dep-graph/v2 v2.10.0 // indirect
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 // indirect
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e // indirect
-	github.com/snyk/cli-extension-os-flows v0.0.0-20260818092349-91c745a9ee7a // indirect
+	github.com/snyk/cli-extension-os-flows v0.0.0-20260819132524-22322184e7a2 // indirect
 	github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9 // indirect
 	github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd // indirect
 	github.com/snyk/code-client-go v1.31.3 // indirect
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 // indirect
-	github.com/snyk/go-application-framework v0.16.0 // indirect
+	github.com/snyk/go-application-framework v0.16.1 // indirect
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -578,8 +578,8 @@ github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSo
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e h1:HE22F5/ivTJ4TlTUnjasZqfkDKVyfmYjf36RaIZqrs4=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e/go.mod h1:YN+M0+nNZ5VoQN2SxSvZSoTxs/PkdLgfNfUWvsKVL7o=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260818092349-91c745a9ee7a h1:K7FSLoYnw9TI7s7Rpa8m/7cJZOgIT5LHaWKZGeiqukA=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260818092349-91c745a9ee7a/go.mod h1:91aclTGWI/QndVS1ouK7ScIonHK9nAGr64NL3JutkFg=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260819132524-22322184e7a2 h1:LgqUW/yHNPH/XdLcnqsP+f5n4myklTQJF5CJDLjuCkM=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260819132524-22322184e7a2/go.mod h1:ukSD97e6hc9w0UkrbI/OV2GeDpsEyUsIzE38vdzRbZ8=
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9 h1:Kz/UCPae7vRVeFlkkYHnyFRYue9gaO16enVnN7aclco=
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd h1:sSVkD1CuL8v49boItrt2CnQ4DJIH+sjGwFGheGCVAxo=
@@ -592,8 +592,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.16.0 h1:mH+KQoD6XcuSl4tGBo6otfO1YQd/7GvEcNfVWOdolLM=
-github.com/snyk/go-application-framework v0.16.0/go.mod h1:qJBU+FIY8s/lIg0IaKBj7WGeGERiWqyJvhajzxiA3Ls=
+github.com/snyk/go-application-framework v0.16.1 h1:k4eyP4EX/kqnNyu5uuFLEw4wflTom22ea23ZuG74JU8=
+github.com/snyk/go-application-framework v0.16.1/go.mod h1:qJBU+FIY8s/lIg0IaKBj7WGeGERiWqyJvhajzxiA3Ls=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -16,13 +16,13 @@ require (
 	github.com/snyk/cli-extension-dep-graph/v2 v2.10.0
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e
-	github.com/snyk/cli-extension-os-flows v0.0.0-20260818092349-91c745a9ee7a
+	github.com/snyk/cli-extension-os-flows v0.0.0-20260819132524-22322184e7a2
 	github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9
 	github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd
 	github.com/snyk/code-client-go v1.31.3
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6
-	github.com/snyk/go-application-framework v0.16.0
+	github.com/snyk/go-application-framework v0.16.1
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260814112015-c5325e836868

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -528,8 +528,8 @@ github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSo
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e h1:HE22F5/ivTJ4TlTUnjasZqfkDKVyfmYjf36RaIZqrs4=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e/go.mod h1:YN+M0+nNZ5VoQN2SxSvZSoTxs/PkdLgfNfUWvsKVL7o=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260818092349-91c745a9ee7a h1:K7FSLoYnw9TI7s7Rpa8m/7cJZOgIT5LHaWKZGeiqukA=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260818092349-91c745a9ee7a/go.mod h1:91aclTGWI/QndVS1ouK7ScIonHK9nAGr64NL3JutkFg=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260819132524-22322184e7a2 h1:LgqUW/yHNPH/XdLcnqsP+f5n4myklTQJF5CJDLjuCkM=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260819132524-22322184e7a2/go.mod h1:ukSD97e6hc9w0UkrbI/OV2GeDpsEyUsIzE38vdzRbZ8=
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9 h1:Kz/UCPae7vRVeFlkkYHnyFRYue9gaO16enVnN7aclco=
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd h1:sSVkD1CuL8v49boItrt2CnQ4DJIH+sjGwFGheGCVAxo=
@@ -542,8 +542,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.16.0 h1:mH+KQoD6XcuSl4tGBo6otfO1YQd/7GvEcNfVWOdolLM=
-github.com/snyk/go-application-framework v0.16.0/go.mod h1:qJBU+FIY8s/lIg0IaKBj7WGeGERiWqyJvhajzxiA3Ls=
+github.com/snyk/go-application-framework v0.16.1 h1:k4eyP4EX/kqnNyu5uuFLEw4wflTom22ea23ZuG74JU8=
+github.com/snyk/go-application-framework v0.16.1/go.mod h1:qJBU+FIY8s/lIg0IaKBj7WGeGERiWqyJvhajzxiA3Ls=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable) — none
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___) — n/a
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Dependency bumps only, no source changes. Both `cliv2` and `cliv2-private`:

| Module | From (current main) | To | Upstream PR |
|---|---|---|---|
| `go-application-framework` | `v0.16.0` | `v0.16.1-0.20260819102712-53729422c5cd` (`5372942`) | snyk/go-application-framework#707 |
| `cli-extension-os-flows` | `v0.0.0-20260818092349-91c745a9ee7a` | `v0.0.0-20260819103218-611f8d16dc54` (`611f8d1`) | snyk/cli-extension-os-flows#270 |

Together they change how SBOM test results are presented:

- **snyk/cli-extension-os-flows#270** — an SBOM test covers many components but the test API reports it as one test, so the CLI showed a single combined result. It now reports one result per component, matching how `snyk test --all-projects` reports one result per project.
- **snyk/go-application-framework#707** — that split made the asset inventory link print once per component, because the template rendered it inside each result's footer. It now renders once, below the overall test summary.

**Draft:** both pins are branch commits on unmerged PRs. Needs re-pointing at `main` pseudo-versions once they land, then it can come out of draft.

## Where should the reviewer start?

`cliv2/go.mod` and `cliv2-private/go.mod`, plus the corresponding `go.sum` entries. No source changes.

## How should this be manually tested?

Requires an org with SBOM testing and asset inventory enabled:

```
snyk sbom test --experimental --file=<multi-component-sbom>.json --report
```

- One result section per component, each with its own header and test summary, then an overall test summary — rather than one combined result.
- `View your asset(s) at: …` appears exactly once, immediately below the `Overall Test Summary` box. Before, it appeared once per component, mid-output.

Worth smoke testing that plain `snyk test` and `snyk test --all-projects` are unchanged — neither reports an asset, so neither should print that line at all.

## What's the product update that needs to be communicated to CLI users?

`snyk sbom test` now reports one result per component in the SBOM, rather than a single combined result. With `--report`, the asset inventory link is shown once at the end of the results instead of under every component.

## Risk assessment (Low | Medium | High)?

**Medium.** Two things carry the risk, neither of them in this repo:

- The os-flows half changes the shape of `snyk sbom test` output — one result per component, and one entry per component in the legacy JSON — so anything parsing that output sees a different structure.
- The GAF half is presentation-only: one template block moves, and a helper reads the link from whichever result carries it. No payload or API change.

## Any background context you want to provide?

A modelling gap sits underneath the asset link fix: `asset` is a property of the *test*, but the UFM payload is a bare array of results with nowhere to put test-level facts, so it is copied onto every result and then stripped from all but one by the producer. Closing that gap is prepared separately, stacked on these branches — it also needs a change to `cli-extension-axi`, which parses the payload itself rather than using the framework's decoder. Not part of this PR.

## Links to automated tests

Both upstream PRs carry their own coverage:

- GAF: `multi_project_with_asset` in `Test_UfmPresenter_HumanReadable` — there was no test for the asset link at all before.
- os-flows: `Test_RunSbomFlow_ReportsTestWideLinksOnce` and the `TestUnifiedFindingPresenter_AssetLink` subtests.

Both modules build clean here (`go build ./...` in `cliv2` and `cliv2-private`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)










