### PR TITLE
chore: bump cli-extension-dep-graph to v2.10.0

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -212,7 +212,7 @@ require (
 	github.com/skeema/knownhosts v1.3.2 // indirect
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af // indirect
 	github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172 // indirect
-	github.com/snyk/cli-extension-dep-graph/v2 v2.8.1 // indirect
+	github.com/snyk/cli-extension-dep-graph/v2 v2.10.0 // indirect
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 // indirect
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e // indirect
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260818092349-91c745a9ee7a // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -572,8 +572,8 @@ github.com/snyk/cli-extension-axi v0.0.0-20260818155424-6ae9a45c0c55 h1:h1K21m3f
 github.com/snyk/cli-extension-axi v0.0.0-20260818155424-6ae9a45c0c55/go.mod h1:C45YTforGksm9KhbB7RtgMCqeXP1fk/zjN+8ly4EQVg=
 github.com/snyk/cli-extension-cos v0.0.0-20260818151318-d63bb9db9484 h1:lgFISU/Opo4I1w7tHdivXR9OU6tsgbfmo4t9SewjuQE=
 github.com/snyk/cli-extension-cos v0.0.0-20260818151318-d63bb9db9484/go.mod h1:YpcOdcMBJOzwtla/OOoBOArx27Bc2v42Vcwd/FeGl9M=
-github.com/snyk/cli-extension-dep-graph/v2 v2.8.1 h1:ZlLN8KbMZiRN7QsiLzovFLsoIEVytC77+OESr+6wDhI=
-github.com/snyk/cli-extension-dep-graph/v2 v2.8.1/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
+github.com/snyk/cli-extension-dep-graph/v2 v2.10.0 h1:JQ8JXb/wDPExuMhnYurlOyc2/PWuggyRNAgs+GC215E=
+github.com/snyk/cli-extension-dep-graph/v2 v2.10.0/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSoQL0zYyFcGQjEPZcQgDkzM5PcgIHlIgzRuhg=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e h1:HE22F5/ivTJ4TlTUnjasZqfkDKVyfmYjf36RaIZqrs4=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af
 	github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172
-	github.com/snyk/cli-extension-dep-graph/v2 v2.8.1
+	github.com/snyk/cli-extension-dep-graph/v2 v2.10.0
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260818092349-91c745a9ee7a

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -522,8 +522,8 @@ github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af h1:A
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af/go.mod h1:u4d7qoWWVx3II+ZnpLQGjAegaJLmgPefXKXJD/jp/wM=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172 h1:dZQ2DnEnxV+v2yFRyuqUioSAGfXkiMcRQXndAeVsqi0=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172/go.mod h1:ieThzrb8z/Z88cDKdfqdfGh01xs6RkDKt5LbA+AE6U8=
-github.com/snyk/cli-extension-dep-graph/v2 v2.8.1 h1:ZlLN8KbMZiRN7QsiLzovFLsoIEVytC77+OESr+6wDhI=
-github.com/snyk/cli-extension-dep-graph/v2 v2.8.1/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
+github.com/snyk/cli-extension-dep-graph/v2 v2.10.0 h1:JQ8JXb/wDPExuMhnYurlOyc2/PWuggyRNAgs+GC215E=
+github.com/snyk/cli-extension-dep-graph/v2 v2.10.0/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSoQL0zYyFcGQjEPZcQgDkzM5PcgIHlIgzRuhg=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260515141409-fb475901bb8e h1:HE22F5/ivTJ4TlTUnjasZqfkDKVyfmYjf36RaIZqrs4=


### PR DESCRIPTION
Bumps `cli-extension-dep-graph` from v2.8.1 to v2.10.0 in **both** Go modules — `cliv2` and `cliv2-private`.

`cliv2-private` consumes `cliv2` through a `replace` directive, so it records the extension as an indirect dependency with its own resolved version. Left at v2.8.1 it would keep building the private binary against the old extension, so the two have to move together. That one was resolved with `go mod tidy` rather than by hand, since the requirement comes from the replaced module.

### What this picks up

- A placeholder .NET dependency resolver, registered behind the `internal-dotnet-resolver` feature flag and **disabled by default**. It discovers .NET target files and reports an empty dep graph, so it can be exercised end to end before any resolution logic exists.
- An ownership transfer and a CI context change, from v2.8.2.

### Behaviour

No change for users. The resolver sits behind two independent gates that are both off by default: the `--use-sbom-resolution` flag, and the org feature flag above. With either unset, dep-graph resolution is byte-identical to v2.8.1.

### Verification

- 3 lines per module across `go.mod` / `go.sum`, 6 in total — `go mod tidy` pulled in no transitive changes to either.
- `go build ./...` passes in both `cliv2` and `cliv2-private`.
- `go list -deps` confirms `pkg/ecosystems/dotnet/nuget` is linked into both binaries, so the flag has something to gate rather than this being a no-op bump.
- `release-scripts`, the repo's third Go module, has no dependency on the extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
