### PR TITLE
chore: preserve integration name

### DIFF
--- a/ts-binary-wrapper/src/common.ts
+++ b/ts-binary-wrapper/src/common.ts
@@ -189,7 +189,8 @@ export function runWrapper(executable: string, cliArguments: string[]): number {
     stdio: 'inherit',
     env: {
       ...process.env,
-      SNYK_INTEGRATION_NAME: integrationName,
+      SNYK_INTEGRATION_NAME:
+        process.env.SNYK_INTEGRATION_NAME || integrationName,
       SNYK_INTEGRATION_VERSION: getCurrentVersion(versionFile),
       SNYK_INTEGRATION_ENVIRONMENT: 'node',
       SNYK_INTEGRATION_ENVIRONMENT_VERSION: process.versions.node,

--- a/ts-binary-wrapper/test/unit/common.spec.ts
+++ b/ts-binary-wrapper/test/unit/common.spec.ts
@@ -155,6 +155,26 @@ describe('Configuration', () => {
 });
 
 describe('Testing binary wrapper', () => {
+  const captureIntegrationEnvironment = () => {
+    const outputFile = path.join(
+      __dirname,
+      'integration-environment-' + Math.random() + '.json',
+    );
+    const script =
+      "require('fs').writeFileSync(process.argv[1], JSON.stringify({" +
+      'name: process.env.SNYK_INTEGRATION_NAME,' +
+      'version: process.env.SNYK_INTEGRATION_VERSION' +
+      '}))';
+
+    expect(
+      common.runWrapper(process.execPath, ['-e', script, outputFile]),
+    ).toEqual(0);
+
+    const environment = JSON.parse(fs.readFileSync(outputFile, 'utf8'));
+    fs.unlinkSync(outputFile);
+    return environment;
+  };
+
   it('getCliArguments() filter important stuff', async () => {
     const indexFile = path.join(__dirname, '..', '..', 'src', 'index.ts');
     const input = ['ignore', indexFile, 'important', 'stuff'];
@@ -177,6 +197,31 @@ describe('Testing binary wrapper', () => {
     const expected = 0;
     const actual = common.runWrapper(executable, cliArguments);
     expect(actual).toEqual(expected);
+  });
+
+  it('runWrapper() preserves an explicit integration name only', () => {
+    process.env.SNYK_INTEGRATION_NAME = 'CUSTOM_INTEGRATION';
+    process.env.SNYK_INTEGRATION_VERSION = '1.2.3';
+
+    try {
+      expect(captureIntegrationEnvironment()).toEqual({
+        name: 'CUSTOM_INTEGRATION',
+        version: common.getCurrentVersion(common.versionFile),
+      });
+    } finally {
+      delete process.env.SNYK_INTEGRATION_NAME;
+      delete process.env.SNYK_INTEGRATION_VERSION;
+    }
+  });
+
+  it('runWrapper() keeps the default integration identity', () => {
+    delete process.env.SNYK_INTEGRATION_NAME;
+    delete process.env.SNYK_INTEGRATION_VERSION;
+
+    expect(captureIntegrationEnvironment()).toEqual({
+      name: common.integrationName,
+      version: common.getCurrentVersion(common.versionFile),
+    });
   });
 
   it('runWrapper() fail', async () => {


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [x] Updates relevant GitBook documentation (not applicable; internal instrumentation only)
- [x] Includes product update to be announced in the next stable release notes (not applicable; no user-visible behavior change)

## What does this PR do?

Preserves a caller-supplied `SNYK_INTEGRATION_NAME` when the npm wrapper starts the native CLI. This allows wrapper-based integrations to retain their own analytics identity instead of being reported as `TS_BINARY_WRAPPER`.

Ordinary npm CLI invocations continue using `TS_BINARY_WRAPPER`. Integration version and Node environment fields retain their existing behavior.

Automated coverage verifies that:

- an explicit integration name is preserved while integration version remains the CLI version;
- the default wrapper identity remains unchanged.

Tests: `ts-binary-wrapper/test/unit/common.spec.ts`

## Where should the reviewer start?

Start with `ts-binary-wrapper/src/common.ts`, then review the two focused `runWrapper` tests in `ts-binary-wrapper/test/unit/common.spec.ts`.

## How should this be manually tested?

1. Build the wrapper with `cd ts-binary-wrapper && npm run build`.
2. Launch `runWrapper` with a custom `SNYK_INTEGRATION_NAME` and inspect the child environment.
3. Confirm the child receives the custom integration name, generated CLI version, and `node` integration environment.
4. Repeat without an override and confirm the integration name remains `TS_BINARY_WRAPPER`.

Local verification completed:

- two focused Jest tests passed;
- wrapper TypeScript build passed;
- ESLint and Prettier checks passed;
- compiled-wrapper name override and default behavior were verified manually.

## What's the product update that needs to be communicated to CLI users?

None. This is internal instrumentation plumbing and does not change CLI behavior or output.

## Risk assessment (Low | Medium | High)?

Low. The change affects one environment value at the npm-wrapper process boundary, preserves the existing default, and adds no dependencies or schema changes.

## Any background context you want to provide?

The npm wrapper previously overwrote integration identity supplied by an outer caller. This change preserves only the integration name; version and environment overrides are intentionally out of scope.

## What are the relevant tickets?

CLI-1784
