### PR TITLE
chore: transfer ownership to @snyk/engines_sca-scanners [CMPA-724]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 * @snyk/developer-experience_cli
 
 # Unify
-src/lib/plugins/uv/ @snyk/open-source_unify @snyk/developer-experience_cli
+src/lib/plugins/uv/ @snyk/engines_sca-scanners @snyk/developer-experience_cli


### PR DESCRIPTION
### What?

- `.github/CODEOWNERS`: the ownership rule assigning `@snyk/open-source_unify` moves to `@snyk/engines_sca-scanners`.
- Other co-owners on the same line are unchanged (`@snyk/developer-experience_cli`).

### Why?

The paths previously owned by that team move to `@snyk/engines_sca-scanners`, so review requests should land with them rather than the previous team.

`catalog-info.yaml` is deliberately left alone — changing the Backstage owner there would re-route Datadog/FireHydrant alerting, which is out of scope for this change.

---

> [!NOTE]
> **Low Risk**
> Metadata-only ownership update; no runtime or behavior changes.
