### PR TITLE
chore: Bump code-client-go to record GetFilters API duration

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -218,7 +218,7 @@ require (
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260819132524-22322184e7a2 // indirect
 	github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9 // indirect
 	github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd // indirect
-	github.com/snyk/code-client-go v1.31.3 // indirect
+	github.com/snyk/code-client-go v1.31.8 // indirect
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -584,8 +584,8 @@ github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9 h1:Kz/UCPa
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd h1:sSVkD1CuL8v49boItrt2CnQ4DJIH+sjGwFGheGCVAxo=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd/go.mod h1:PrKXTT4fwEJPIzphT4n1tH5mwt2D1/qadP5HNCvub9Y=
-github.com/snyk/code-client-go v1.31.3 h1:X1vzubbdGXWpxwnjBkC3HchH1rWjDdqdn0cCz2to0TA=
-github.com/snyk/code-client-go v1.31.3/go.mod h1:Yl1x9g7Y6JOcEWoaxyrKFvrj76JkaeRFUpEkXVjRhS8=
+github.com/snyk/code-client-go v1.31.8 h1:3o9vJKsgXiKkwiOPplJejw41nqTPylDzXqQmq5Daor8=
+github.com/snyk/code-client-go v1.31.8/go.mod h1:pHrCXCt5BJmG2L99KO5d8Qm4xdSOpbE9HEs61WsoHSo=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea h1:/v48hCMPiZVjplylgE2FX1ib8Qd8LN/vf8ZIKfA+wkI=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea/go.mod h1:P5yW8+jkwhYBsj5l2jtHeWujyX+SAtvkC8+LELKdlWI=
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3YKLR5LJbqL8WJmUYgDSbFKREIY79g0=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260819132524-22322184e7a2
 	github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9
 	github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd
-	github.com/snyk/code-client-go v1.31.3
+	github.com/snyk/code-client-go v1.31.8
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6
 	github.com/snyk/go-application-framework v0.16.1

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -534,8 +534,8 @@ github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9 h1:Kz/UCPa
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd h1:sSVkD1CuL8v49boItrt2CnQ4DJIH+sjGwFGheGCVAxo=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd/go.mod h1:PrKXTT4fwEJPIzphT4n1tH5mwt2D1/qadP5HNCvub9Y=
-github.com/snyk/code-client-go v1.31.3 h1:X1vzubbdGXWpxwnjBkC3HchH1rWjDdqdn0cCz2to0TA=
-github.com/snyk/code-client-go v1.31.3/go.mod h1:Yl1x9g7Y6JOcEWoaxyrKFvrj76JkaeRFUpEkXVjRhS8=
+github.com/snyk/code-client-go v1.31.8 h1:3o9vJKsgXiKkwiOPplJejw41nqTPylDzXqQmq5Daor8=
+github.com/snyk/code-client-go v1.31.8/go.mod h1:pHrCXCt5BJmG2L99KO5d8Qm4xdSOpbE9HEs61WsoHSo=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea h1:/v48hCMPiZVjplylgE2FX1ib8Qd8LN/vf8ZIKfA+wkI=
 github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea/go.mod h1:P5yW8+jkwhYBsj5l2jtHeWujyX+SAtvkC8+LELKdlWI=
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3YKLR5LJbqL8WJmUYgDSbFKREIY79g0=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps `code-client-go` in both `cliv2` and `cliv2-private` to pick up new instrumentation around the Snyk Code `GET /filters` call:

- `github.com/snyk/code-client-go`: `v1.31.3` -> `v1.31.8-0.20260819135052-ffaac534a2eb`
- `github.com/snyk/go-application-framework`: `v0.16.0` -> `v0.16.1` (pulled in transitively; `code-client-go` now requires `v0.16.1` as its minimum)

The `code-client-go` change adds two analytics values emitted per scan:

- `get_filters_ms` - cumulative wall time spent in the `GET /filters` HTTP call
- `get_filters_calls` - how many times that call was made

These let us subtract network time from the file-filter duration that the framework reports as `filter.durationMs`. That metric currently absorbs the `/filters` round trip, because the filter feeds files over an unbuffered channel and the consumer performs the fetch lazily on the first file it receives - so filtering appears slower than it is. With these two values, pure filtering time becomes a subtraction rather than a guess.

`get_filters_calls` also acts as a cheap health signal: the filter cache treats "both extension and config-file caches are empty" as "not loaded yet", so a response that stores no entries causes a re-fetch for every file. Any value above 1 in telemetry means we hit that path.

**Do not merge before the dependency PR lands.** The pin currently references a commit on the `code-client-go` feature branch rather than `main`. Once snyk/code-client-go PR ___ is merged, this PR needs `go get github.com/snyk/code-client-go@<new main commit>` plus `go mod tidy` in both module directories, and a force-push.

## Where should the reviewer start?

There is no CLI source change here - only dependency pins. Worth confirming:

- `cliv2/go.mod` and `cliv2-private/go.mod` - the two version lines are identical across both modules
- `cliv2/go.sum` and `cliv2-private/go.sum` - checksum updates only
- That all `replace` directives remain commented out in both files, so no local module paths leak in

## How should this be manually tested?

1. `cd cliv2 && make build`
2. Run a Code scan with analytics visible, against a repository large enough for filtering to be measurable:
   `SNYK_LOG_LEVEL=debug ./bin/snyk code test <path-to-repo>`
3. In the analytics payload, confirm `get_filters_ms` and `get_filters_calls` are present under the extension values.
4. Confirm `get_filters_calls` is `1`. A value matching the scanned file count indicates the empty-filters re-fetch path, which would mean the backend returned no usable filters.
5. Confirm `filter.durationMs` minus `get_filters_ms` is a plausible pure-filtering time.
6. `cd cliv2-private && make build` to confirm the private module still builds against the same pin.

## What's the product update that needs to be communicated to CLI users?

None. This is internal telemetry with no user-facing behaviour change.

<!---
## Risk assessment (Low | Medium | High)?

Low. Dependency bump only, with no CLI source changes. The added instrumentation is additive analytics; the guarded metric accumulation in code-client-go is mutex-protected and runs once or twice per scan, not per file.

## Any background context you want to provide?

While investigating file-filter performance we found that the duration reported for filtering includes the `GET /filters` network round trip. The filter hands files to the consumer over an unbuffered channel, and the consumer fetches filters lazily when the first file arrives, so the producer blocks on the network and that latency is attributed to filtering. Rather than restructure the channel, we measure the API call directly so it can be subtracted during analysis.

## What are the relevant tickets?

[CLI-1786]: https://snyksec.atlassian.net/browse/CLI-1786

## Screenshots (if appropriate)

N/A
--->

[CLI-1786]: https://snyksec.atlassian.net/browse/CLI-1786