### PR TITLE
chore(mcp): [AG-403] bump studio-mcp version to add Secrets to full profile

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -227,7 +227,7 @@ require (
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
 	github.com/snyk/snyk-ls v0.0.0-20260814112015-c5325e836868 // indirect
-	github.com/snyk/studio-mcp v1.15.3 // indirect
+	github.com/snyk/studio-mcp v1.15.4 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -606,8 +606,8 @@ github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRX
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
 github.com/snyk/snyk-ls v0.0.0-20260814112015-c5325e836868 h1:hBuzcAYbQ9XkOWp8L31p3PcQZQksDJtq6yAtPf76USQ=
 github.com/snyk/snyk-ls v0.0.0-20260814112015-c5325e836868/go.mod h1:s4gqDKMyXZ4Z5GthWyM3D079/dT0woNbQyJ8UrHW6nE=
-github.com/snyk/studio-mcp v1.15.3 h1:t+vBRKGMWS6FLY1BAMzP2Vp+z8k8hK7kYKuAYlKEBHU=
-github.com/snyk/studio-mcp v1.15.3/go.mod h1:3ZISZCgorkGg/iLQrryvmP34Db4KkvtfAARi7vMqM/4=
+github.com/snyk/studio-mcp v1.15.4 h1:MHrAtTZ7E1IY0p6pdKAZqM4bmS5dZNSK/eEjVX26FA8=
+github.com/snyk/studio-mcp v1.15.4/go.mod h1:o+eDJRfHPVzPvZGqamASOZf5drlBEiJVbbOJS7sJsbQ=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd/go.mod h1:SULmZY7YNBsvNiQbrb/BEDdEJ84TGnfyUQxaHt8t8rY=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260814112015-c5325e836868
-	github.com/snyk/studio-mcp v1.15.3
+	github.com/snyk/studio-mcp v1.15.4
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -552,8 +552,8 @@ github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRX
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
 github.com/snyk/snyk-ls v0.0.0-20260814112015-c5325e836868 h1:hBuzcAYbQ9XkOWp8L31p3PcQZQksDJtq6yAtPf76USQ=
 github.com/snyk/snyk-ls v0.0.0-20260814112015-c5325e836868/go.mod h1:s4gqDKMyXZ4Z5GthWyM3D079/dT0woNbQyJ8UrHW6nE=
-github.com/snyk/studio-mcp v1.15.3 h1:t+vBRKGMWS6FLY1BAMzP2Vp+z8k8hK7kYKuAYlKEBHU=
-github.com/snyk/studio-mcp v1.15.3/go.mod h1:3ZISZCgorkGg/iLQrryvmP34Db4KkvtfAARi7vMqM/4=
+github.com/snyk/studio-mcp v1.15.4 h1:MHrAtTZ7E1IY0p6pdKAZqM4bmS5dZNSK/eEjVX26FA8=
+github.com/snyk/studio-mcp v1.15.4/go.mod h1:o+eDJRfHPVzPvZGqamASOZf5drlBEiJVbbOJS7sJsbQ=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd/go.mod h1:SULmZY7YNBsvNiQbrb/BEDdEJ84TGnfyUQxaHt8t8rY=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Update studio MCP to latest version.

The new MCP versions brings Secrets to the "full" profile, besides the previous "experimental" only.

## Where should the reviewer start?
n/a
## How should this be manually tested?
n/a

## What's the product update that needs to be communicated to CLI users?
 Snyk MCP now brings Secrets to "full" profile availability.
