### PR TITLE
chore(language-server): integrate LS

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -226,7 +226,7 @@ require (
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
-	github.com/snyk/snyk-ls v0.0.0-20260814164657-a99d4cf1c3e7 // indirect
+	github.com/snyk/snyk-ls v0.0.0-20260824150100-a207e801a57e // indirect
 	github.com/snyk/studio-mcp v1.15.4 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -604,8 +604,8 @@ github.com/snyk/rift-cli-extension v1.1.1 h1:WeBeO8tUP/SWX/lqe9tTltOdeJDKNOQdOrF
 github.com/snyk/rift-cli-extension v1.1.1/go.mod h1:uZuSGZS6n/pBGTEoxtvVsfiNAPCXcTitpnQV9a3RgDI=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260814164657-a99d4cf1c3e7 h1:wrnB8/yVj/BxcxqX3ppKNF+cZVlyCjmGgxhCtoRWlK8=
-github.com/snyk/snyk-ls v0.0.0-20260814164657-a99d4cf1c3e7/go.mod h1:ZfhCKJ6IGbmr0LfcAAm/WY0ECv2IO1+dXYFMepWHjpQ=
+github.com/snyk/snyk-ls v0.0.0-20260824150100-a207e801a57e h1:Sf7aMRGEcWA1OppdIbyLFYBFeCdNNTIuZX+zBDJMrYc=
+github.com/snyk/snyk-ls v0.0.0-20260824150100-a207e801a57e/go.mod h1:FGFf9FVpq7kNDZ+Tg77lsA2dtXMsta44lFRiUeXqJQw=
 github.com/snyk/studio-mcp v1.15.4 h1:MHrAtTZ7E1IY0p6pdKAZqM4bmS5dZNSK/eEjVX26FA8=
 github.com/snyk/studio-mcp v1.15.4/go.mod h1:o+eDJRfHPVzPvZGqamASOZf5drlBEiJVbbOJS7sJsbQ=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/snyk/go-application-framework v0.18.1
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20260814164657-a99d4cf1c3e7
+	github.com/snyk/snyk-ls v0.0.0-20260824150100-a207e801a57e
 	github.com/snyk/studio-mcp v1.15.4
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -550,8 +550,8 @@ github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhk
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260814164657-a99d4cf1c3e7 h1:wrnB8/yVj/BxcxqX3ppKNF+cZVlyCjmGgxhCtoRWlK8=
-github.com/snyk/snyk-ls v0.0.0-20260814164657-a99d4cf1c3e7/go.mod h1:ZfhCKJ6IGbmr0LfcAAm/WY0ECv2IO1+dXYFMepWHjpQ=
+github.com/snyk/snyk-ls v0.0.0-20260824150100-a207e801a57e h1:Sf7aMRGEcWA1OppdIbyLFYBFeCdNNTIuZX+zBDJMrYc=
+github.com/snyk/snyk-ls v0.0.0-20260824150100-a207e801a57e/go.mod h1:FGFf9FVpq7kNDZ+Tg77lsA2dtXMsta44lFRiUeXqJQw=
 github.com/snyk/studio-mcp v1.15.4 h1:MHrAtTZ7E1IY0p6pdKAZqM4bmS5dZNSK/eEjVX26FA8=
 github.com/snyk/studio-mcp v1.15.4/go.mod h1:o+eDJRfHPVzPvZGqamASOZf5drlBEiJVbbOJS7sJsbQ=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit a207e801a57ee57d2989eff52204f81b3c7e653a
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Mon Aug 24 16:01:00 2026 +0100

    fix(scanner): preserve folder enablement for reference scans [IDE-2493] (#1413)
    
    - Treat the real workspace folder’s product-enablement gate as authoritative for reference scans.
    - Skip only the redundant local enablement lookup against the synthetic reference checkout path.
    - Apply the same behavior to Secrets, Code, Open Source, and IaC scanners.
    - Preserve working-directory enablement, authentication, Code SAST enablement, Secrets entitlement, and product validation.
    - Add a production-path regression proving `DelegatingConcurrentScanner.Scan` supplies Reference context and persists the baseline against the real folder.
    
    ---------
    
    Co-authored-by: Cursor Agent <cursoragent@cursor.com>

M	domain/snyk/scanner/scanner_test.go
M	infrastructure/code/code.go
A	infrastructure/code/reference_scan_test.go
M	infrastructure/iac/iac.go
A	infrastructure/iac/reference_scan_test.go
M	infrastructure/oss/cli_scanner.go
A	infrastructure/oss/reference_scan_test.go
A	infrastructure/secrets/reference_scan_test.go
M	infrastructure/secrets/secrets.go
M	internal/scannercommon/scan.go
M	internal/scannercommon/scan_test.go
A	internal/testutil/context.go

commit e4e0037e35824847bcd49744cc913f4c40ecb2cd
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Mon Aug 24 10:01:06 2026 +0100

    fix(secrets): use organization entitlement instead of feature flag [IDE-2476] [IDA-775] [IDA-770] (#1411)
    
    - Always render the global and per-folder Snyk Secrets controls in the shared LS settings UI.
    - Remove the Language Server-owned `isSecretsEnabled` lookup, cache, scanner precondition, and dead constructor dependency.
    - Upgrade `cli-extension-secrets` so organization availability comes from its legacy-flag-or-REST-settings flow.
    - Normalize only `SNYK-CLI-0016` to the existing `Secrets (disabled at Snyk)` UX while preserving other errors and cached findings.
    - Preserve and test all four folder-effective organization selection paths for workflow invocation.
    
    The CLI repository remains authoritative for the extension version included in released CLI binaries. The LS pin is updated so this repository’s standalone/local engine and tests compile and exercise the current extension contract. The accompanying go.mod movements are selected by that extension through MVS; `xsync` only moves from indirect to direct because LS imports it directly.
    
    ---------
    
    Co-authored-by: Cursor Agent <cursoragent@cursor.com>

M	application/di/init.go
M	application/server/secrets_smoke_test.go
M	docs/configuration-dialog.md
M	domain/ide/treeview/tree_builder_test.go
M	go.mod
M	go.sum
M	infrastructure/configuration/config_html.go
M	infrastructure/configuration/config_html_test.go
M	infrastructure/configuration/template/config.html
M	infrastructure/featureflag/featureflag.go
M	infrastructure/secrets/errors.go
M	infrastructure/secrets/secrets.go
M	infrastructure/secrets/secrets_test.go
M	infrastructure/utils/error_messages.go
M	internal/vcs/git_cloner_test.go
M	js-tests/snapshots/form-payload.json
M	licenses/github.com/cyphar/filepath-securejoin/.github/workflows/ci.yml
M	licenses/github.com/cyphar/filepath-securejoin/CHANGELOG.md
M	licenses/github.com/cyphar/filepath-securejoin/VERSION
M	licenses/github.com/cyphar/filepath-securejoin/go.mod
M	licenses/github.com/cyphar/filepath-securejoin/go.sum
M	licenses/github.com/cyphar/filepath-securejoin/pathrs-lite/open_libpathrs.go
M	scripts/config-dialog/config_output_multi_project.html
M	scripts/config-dialog/config_output_no_projects.html
M	scripts/config-dialog/config_output_single_solution.html
M	scripts/config-dialog/main.go

commit a8fa156bbca577c9ce41319698ebe37b65f453ef
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Fri Aug 21 17:39:24 2026 +0100

    refactor: log delta pre-filter before/after counts in FilterIssues [IDE-2477] (#1412)
    
    `filterIssuesWithConfig` applies a delta pre-filter (`filterByIsNew`) ahead of its reason-counted filter loop, so an issue set emptied there produced no distinguishing log line — a debug log could show "No issues were filtered out" while diagnostics came out empty, with no way to tell why.
    
    Folds the drop count into the existing `filterReasonCounts` mechanism via a new `FilterReasonNotNetNew` reason, computed only when delta filtering is enabled. `filterByIsNew` now classifies and counts dropped issues in the same pass it filters them (returning `(snyk.IssuesByFile, int)`) rather than diffing two separate before/after counts; nil entries are skipped without being counted as a drop. `GetDelta`, `filterByIsNew`'s other caller, discards the count. Both `filterReasonCounts` log lines now also carry a `deltaEnabled` field.
    
    Also adds direct coverage for `filterByIsNew`'s filtered/dropped return values (including the nil-skip case), and for the previously-untested direction of `FilterIssues` where a non-new issue passes through when delta filtering is disabled.

M	domain/ide/workspace/folder.go
M	domain/ide/workspace/folder_test.go

commit 07e8f4e3676d1382a8d87760d3712a6215fb10df
Author: Andrew Robinson Hodges <andrew.robinsonhodges@snyk.io>
Date:   Fri Aug 21 12:10:53 2026 +0100

    fix: link secrets rule ids to documentation [IDE-2329] (#1403)

M	application/server/server.go
M	application/server/unified_test_api_smoke_test.go
M	domain/ide/converter/converter.go
M	domain/ide/converter/converter_test.go
M	infrastructure/secrets/convert.go
M	infrastructure/secrets/convert_test.go
M	infrastructure/sentry/sentry_error_reporter_test.go
M	internal/notification/notification_test.go
M	internal/notification/notifier.go
M	internal/notification/notifier_mock.go
M	internal/types/lsp.go
```

[IDE-2493]: https://snyksec.atlassian.net/browse/IDE-2493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-2476]: https://snyksec.atlassian.net/browse/IDE-2476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ