### PR TITLE
feat: update agent scan workflow

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -210,7 +210,7 @@ require (
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/skeema/knownhosts v1.3.2 // indirect
-	github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af // indirect
+	github.com/snyk/cli-extension-agent-scan v0.0.0-20260821092236-dc228259a004 // indirect
 	github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172 // indirect
 	github.com/snyk/cli-extension-dep-graph/v2 v2.10.1 // indirect
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -564,8 +564,8 @@ github.com/skeema/knownhosts v1.3.2 h1:EDL9mgf4NzwMXCTfaxSD/o/a5fxDw/xL9nkU28Jjd
 github.com/skeema/knownhosts v1.3.2/go.mod h1:bEg3iQAuw+jyiw+484wwFJoKSLwcfd7fqRy+N0QTiow=
 github.com/snyk/ambient-canary v0.0.0-20260722064253-fba619a134a9 h1:d69mS5cTIs1eOcmMMUwr1kfvtiDyuSNLxET4lp/mCa4=
 github.com/snyk/ambient-canary v0.0.0-20260722064253-fba619a134a9/go.mod h1:n6GYt41xPhThEEEl/0RZuWpTX68iv6k+6HZ94uGNDGE=
-github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af h1:AgYHuCfs6oNkd/QFwsuEtvswclfBujhBfwbZUB4xEU4=
-github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af/go.mod h1:u4d7qoWWVx3II+ZnpLQGjAegaJLmgPefXKXJD/jp/wM=
+github.com/snyk/cli-extension-agent-scan v0.0.0-20260821092236-dc228259a004 h1:7A+MUWAat7cn80gNB26J2gb2PnD/tpwVVcck8NJrSRk=
+github.com/snyk/cli-extension-agent-scan v0.0.0-20260821092236-dc228259a004/go.mod h1:u4d7qoWWVx3II+ZnpLQGjAegaJLmgPefXKXJD/jp/wM=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172 h1:dZQ2DnEnxV+v2yFRyuqUioSAGfXkiMcRQXndAeVsqi0=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172/go.mod h1:ieThzrb8z/Z88cDKdfqdfGh01xs6RkDKt5LbA+AE6U8=
 github.com/snyk/cli-extension-axi v0.0.0-20260818155424-6ae9a45c0c55 h1:h1K21m3flUtfM18TxY3zD/Y9li++ib0RbGm61DRsE3I=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/mattn/go-isatty v0.0.24
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.35.1
-	github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af
+	github.com/snyk/cli-extension-agent-scan v0.0.0-20260821092236-dc228259a004
 	github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172
 	github.com/snyk/cli-extension-dep-graph/v2 v2.10.1
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -518,8 +518,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skeema/knownhosts v1.3.2 h1:EDL9mgf4NzwMXCTfaxSD/o/a5fxDw/xL9nkU28JjdBg=
 github.com/skeema/knownhosts v1.3.2/go.mod h1:bEg3iQAuw+jyiw+484wwFJoKSLwcfd7fqRy+N0QTiow=
-github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af h1:AgYHuCfs6oNkd/QFwsuEtvswclfBujhBfwbZUB4xEU4=
-github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af/go.mod h1:u4d7qoWWVx3II+ZnpLQGjAegaJLmgPefXKXJD/jp/wM=
+github.com/snyk/cli-extension-agent-scan v0.0.0-20260821092236-dc228259a004 h1:7A+MUWAat7cn80gNB26J2gb2PnD/tpwVVcck8NJrSRk=
+github.com/snyk/cli-extension-agent-scan v0.0.0-20260821092236-dc228259a004/go.mod h1:u4d7qoWWVx3II+ZnpLQGjAegaJLmgPefXKXJD/jp/wM=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172 h1:dZQ2DnEnxV+v2yFRyuqUioSAGfXkiMcRQXndAeVsqi0=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172/go.mod h1:ieThzrb8z/Z88cDKdfqdfGh01xs6RkDKt5LbA+AE6U8=
 github.com/snyk/cli-extension-dep-graph/v2 v2.10.1 h1:jZUPQX0CktKDDeLV9cVKuVIDdKRiJ/Btt0VgDYPWoNg=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?
Bumps the version of cli-extension-agent-scan used. This points to v0.6.0 of agent-scan CLI now.

## Where should the reviewer start?
Experimental module agent-scan version bump, so no formal communication required.

## How should this be manually tested?
<Some-path>/cli/binary-releases/snyk-macos-arm64 agent-scan \
  --experimental \
  --show-analysis-results \

## What's the product update that needs to be communicated to CLI users?
Output is now changed to risk based instead of issue codes based.

However due to that this is experimental and we don't have any customer usage, (see [log](https://app.datadoghq.com/logs?query=service%3A%2Aanalytics-service%2A%20%40analytics-service.interaction.categories%3Aagent-scan%20%40polaris.environment%3Aprod&agg_m=count&agg_m_source=base&agg_q=%40analytics-service.groupId&agg_q_source=base&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=toplist&x_missing=true&from_ts=1786006345099&to_ts=1787302345099&live=true)) no formal customer communication is needed practically.

It's a breaking change from 0.5.x to 0.6.0 in that the output is now risk based instead of issue codes. So if there were anyone using `--json` and do some post-processing of the JSON output it would be a breaking change. But we did the analytics lookup already we haven't found any such CI user that processes the JSON output. 

In the release notes we could briefly mention the output date from issue codes to risk indicators.

## Risk assessment (Low | Medium | High)?
Low

## Any background context you want to provide?
https://github.com/snyk/agent-scan/pull/431
https://github.com/snyk/cli-extension-agent-scan/pull/40

## What are the relevant tickets?
https://snyksec.atlassian.net/browse/ADS-853

## Screenshots (if appropriate)
<img width="1243" height="463" alt="Screenshot 2026-08-21 at 15 32 19" src="https://github.com/user-attachments/assets/0f3be83a-ff72-478d-8316-2c8107f899d5" />
<img width="1233" height="188" alt="Screenshot 2026-08-21 at 15 32 32" src="https://github.com/user-attachments/assets/2ec6e3c8-4f3b-41c7-b4e8-c1257ede5bf6" />
