### PR TITLE
fix: bump cli-extension-dep-graph to v2.11.0

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -212,7 +212,7 @@ require (
 	github.com/skeema/knownhosts v1.3.2 // indirect
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260821092236-dc228259a004 // indirect
 	github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172 // indirect
-	github.com/snyk/cli-extension-dep-graph/v2 v2.10.1 // indirect
+	github.com/snyk/cli-extension-dep-graph/v2 v2.11.0 // indirect
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 // indirect
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f // indirect
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260821101812-a52aa2dd8c3b // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -572,8 +572,8 @@ github.com/snyk/cli-extension-axi v0.0.0-20260818155424-6ae9a45c0c55 h1:h1K21m3f
 github.com/snyk/cli-extension-axi v0.0.0-20260818155424-6ae9a45c0c55/go.mod h1:C45YTforGksm9KhbB7RtgMCqeXP1fk/zjN+8ly4EQVg=
 github.com/snyk/cli-extension-cos v0.0.0-20260818151318-d63bb9db9484 h1:lgFISU/Opo4I1w7tHdivXR9OU6tsgbfmo4t9SewjuQE=
 github.com/snyk/cli-extension-cos v0.0.0-20260818151318-d63bb9db9484/go.mod h1:YpcOdcMBJOzwtla/OOoBOArx27Bc2v42Vcwd/FeGl9M=
-github.com/snyk/cli-extension-dep-graph/v2 v2.10.1 h1:jZUPQX0CktKDDeLV9cVKuVIDdKRiJ/Btt0VgDYPWoNg=
-github.com/snyk/cli-extension-dep-graph/v2 v2.10.1/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
+github.com/snyk/cli-extension-dep-graph/v2 v2.11.0 h1:hNIlg5G30VQGk+sfeEzWdAQiYI8Kq1CASSOubOZruQM=
+github.com/snyk/cli-extension-dep-graph/v2 v2.11.0/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSoQL0zYyFcGQjEPZcQgDkzM5PcgIHlIgzRuhg=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f h1:EPaHfaWDJq/lrsrATMqAyKJRfstb9LZnPXYNwXdL32c=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260821092236-dc228259a004
 	github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172
-	github.com/snyk/cli-extension-dep-graph/v2 v2.10.1
+	github.com/snyk/cli-extension-dep-graph/v2 v2.11.0
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260821101812-a52aa2dd8c3b

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -522,8 +522,8 @@ github.com/snyk/cli-extension-agent-scan v0.0.0-20260821092236-dc228259a004 h1:7
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260821092236-dc228259a004/go.mod h1:u4d7qoWWVx3II+ZnpLQGjAegaJLmgPefXKXJD/jp/wM=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172 h1:dZQ2DnEnxV+v2yFRyuqUioSAGfXkiMcRQXndAeVsqi0=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172/go.mod h1:ieThzrb8z/Z88cDKdfqdfGh01xs6RkDKt5LbA+AE6U8=
-github.com/snyk/cli-extension-dep-graph/v2 v2.10.1 h1:jZUPQX0CktKDDeLV9cVKuVIDdKRiJ/Btt0VgDYPWoNg=
-github.com/snyk/cli-extension-dep-graph/v2 v2.10.1/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
+github.com/snyk/cli-extension-dep-graph/v2 v2.11.0 h1:hNIlg5G30VQGk+sfeEzWdAQiYI8Kq1CASSOubOZruQM=
+github.com/snyk/cli-extension-dep-graph/v2 v2.11.0/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSoQL0zYyFcGQjEPZcQgDkzM5PcgIHlIgzRuhg=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f h1:EPaHfaWDJq/lrsrATMqAyKJRfstb9LZnPXYNwXdL32c=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable) — none
- [ ] Links to automated tests covering new functionality — none needed, no behaviour change (see below)
- [ ] Includes manual testing instructions (if necessary) — none needed
- [ ] Updates relevant GitBook documentation (PR link: ___) — n/a
- [ ] Includes product update to be announced in the next stable release notes — n/a, no user-facing change

## What does this PR do?

Bumps `github.com/snyk/cli-extension-dep-graph/v2` from v2.10.1 to v2.11.0 in both Go modules — `cliv2` and `cliv2-private`. `cliv2-private` consumes `cliv2` through a `replace` directive, so it records the extension as an indirect dependency with its own resolved version; both were moved together via `go get` (cliv2) + `go mod tidy` (cliv2-private).

This picks up [snyk/cli-extension-dep-graph#235](https://github.com/snyk/cli-extension-dep-graph/pull/235): SDK-style (PackageReference) .NET project resolution from `project.assets.json`, replacing the placeholder empty graph. It sits behind the existing `internal-dotnet-resolver` feature flag, which remains **disabled by default**.

Similar to a previous bump: [#7153](https://github.com/snyk/cli/pull/7153).

## Risk assessment (Low | Medium | High)?

Low. The new resolution logic is gated behind the `internal-dotnet-resolver` feature flag (off by default) and the `--use-sbom-resolution` flag. With either unset, behaviour is byte-identical to v2.10.1.

## Where should the reviewer start?

`cliv2/go.mod` / `cliv2/go.sum` and `cliv2-private/go.mod` / `cliv2-private/go.sum` — a 3-line diff per module, no transitive changes.

## How should this be manually tested?

No manual testing needed for this bump itself; `go build ./...` passes in both `cliv2` and `cliv2-private`.
