### PR TITLE
chore: cherry-pick fixes for rc

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -4,7 +4,7 @@ go 1.26.6
 
 require (
 	github.com/snyk/ambient-canary v0.0.0-20260722064253-fba619a134a9
-	github.com/snyk/cli-extension-axi v0.0.0-20260818155424-6ae9a45c0c55
+	github.com/snyk/cli-extension-axi v0.0.0-20260825145801-2e6df22df8aa
 	github.com/snyk/cli-extension-cos v0.0.0-20260818151318-d63bb9db9484
 	github.com/snyk/cli/cliv2 v0.0.0
 	github.com/snyk/remy-cli-extension v1.36.1

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -568,8 +568,8 @@ github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af h1:A
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260803112735-0ad462cba2af/go.mod h1:u4d7qoWWVx3II+ZnpLQGjAegaJLmgPefXKXJD/jp/wM=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172 h1:dZQ2DnEnxV+v2yFRyuqUioSAGfXkiMcRQXndAeVsqi0=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172/go.mod h1:ieThzrb8z/Z88cDKdfqdfGh01xs6RkDKt5LbA+AE6U8=
-github.com/snyk/cli-extension-axi v0.0.0-20260818155424-6ae9a45c0c55 h1:h1K21m3flUtfM18TxY3zD/Y9li++ib0RbGm61DRsE3I=
-github.com/snyk/cli-extension-axi v0.0.0-20260818155424-6ae9a45c0c55/go.mod h1:C45YTforGksm9KhbB7RtgMCqeXP1fk/zjN+8ly4EQVg=
+github.com/snyk/cli-extension-axi v0.0.0-20260825145801-2e6df22df8aa h1:zqKisoNsbgdKT71KzM+PIsBbXkw329CJfIMajXUBNFY=
+github.com/snyk/cli-extension-axi v0.0.0-20260825145801-2e6df22df8aa/go.mod h1:C45YTforGksm9KhbB7RtgMCqeXP1fk/zjN+8ly4EQVg=
 github.com/snyk/cli-extension-cos v0.0.0-20260818151318-d63bb9db9484 h1:lgFISU/Opo4I1w7tHdivXR9OU6tsgbfmo4t9SewjuQE=
 github.com/snyk/cli-extension-cos v0.0.0-20260818151318-d63bb9db9484/go.mod h1:YpcOdcMBJOzwtla/OOoBOArx27Bc2v42Vcwd/FeGl9M=
 github.com/snyk/cli-extension-dep-graph/v2 v2.10.1 h1:jZUPQX0CktKDDeLV9cVKuVIDdKRiJ/Btt0VgDYPWoNg=

--- a/test/jest/acceptance/snyk-agent/snyk-agent-scanners.spec.ts
+++ b/test/jest/acceptance/snyk-agent/snyk-agent-scanners.spec.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'path';
 import { createProjectFromFixture } from '../../util/createProject';
 import { runSnykCLI } from '../../util/runSnykCLI';
+import { EXIT_CODES } from '../../../../src/cli/exit-codes';
 
 jest.setTimeout(1000 * 60 * 5);
 
@@ -26,7 +27,7 @@ describe('snyk agent scanner selection (real server)', () => {
   });
 
   const runAgentTest = (scanners = '') =>
-    runSnykCLI(`agent test${scanners ? ` ${scanners}` : ''}`, {
+    runSnykCLI(`agent test${scanners ? ` ${scanners}` : ''} --experimental`, {
       cwd: project.path(),
       env,
     });
@@ -47,6 +48,17 @@ describe('snyk agent scanner selection (real server)', () => {
   const expectCompletedScan = (code: number): void => {
     expect([EXIT_CODE_SUCCESS, EXIT_CODE_ACTION_NEEDED]).toContain(code);
   };
+
+  it('requires --experimental', async () => {
+    const { code, stdout, stderr } = await runSnykCLI('agent test', {
+      cwd: project.path(),
+      env,
+    });
+
+    expect(code).toBe(EXIT_CODES.ERROR);
+    expect(stdout).toContain('SNYK-CLI-0015');
+    expect(stderr).toEqual('');
+  });
 
   it('selects SCA, SAST, and Secrets by default, but not Container', async () => {
     const { code, stdout } = await runAgentTest();


### PR DESCRIPTION
## Summary
- Cherry-pick of #7175 (feat/agent-experimental-gate) onto release-candidate, since v1.1307.0 cuts from RC and its release notes already describe `snyk agent` as experimental without the CLI enforcing it.
- Bumps the `cli-extension-axi` pin to the commit that marks all four `agent` workflows experimental, and updates the `snyk-agent-scanners` acceptance suite for the new gate.

## Test plan
- [x] `go build ./...` in `cliv2-private` on this branch
- [x] Full `snyk-agent-scanners.spec.ts` suite (7/7) run against a locally built private binary