### PR TITLE
fix: wait for npm publish before axi release

### DIFF
--- a/release-scripts/upload-artifacts.sh
+++ b/release-scripts/upload-artifacts.sh
@@ -123,6 +123,23 @@ upload_npm() {
   fi
 }
 
+wait_for_npm_package() {
+  local version="${VERSION_TAG#v}"
+
+  echo "Waiting for snyk@$version to become available on npm..."
+  for attempt in {1..80}; do
+    if npm view --prefer-online "snyk@$version" version >/dev/null 2>&1; then
+      echo "snyk@$version is available on npm."
+      return 0
+    fi
+    echo "npm availability check $attempt failed, retrying in 30s"
+    sleep 30
+  done
+
+  echo "snyk@$version did not become available on npm."
+  return 1
+}
+
 # Trigger event for a given repository
 # Failure mode is to log and continue as these steps
 # are non blocking to a release.
@@ -308,9 +325,8 @@ for arg in "${@}"; do
         DISTRIBUTION_FAILURE=1
     fi
 
-    # 4. Trigger axi
-    trigger_repository_event "axi" "cli_release"
-    if [ $? -ne 0 ]; then
+    # 4. Trigger axi once the published CLI version is available on npm
+    if ! wait_for_npm_package || ! trigger_repository_event "axi" "cli_release"; then
         DISTRIBUTION_FAILURE=1
     fi
 


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (none)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions
- [x] Updates relevant GitBook documentation (not applicable)
- [x] Includes product update to be announced in the next stable release notes (not applicable; release infrastructure only)

## What does this PR do?

Waits for the exact `snyk` CLI version to become visible on npm before dispatching the `cli_release` event to `snyk/axi`.

The release pipeline already runs distribution-channel triggers after `npm publish`, but npm can accept a publish and continue processing it asynchronously. During the `1.1307.0` release, `npm publish` completed successfully at 14:18:25 UTC, while the package became available at 14:43:37 UTC. The AXI workflow exhausted its own retries at 14:41:23 UTC and failed with `ETARGET` because the package was still unavailable.

This change polls npm every 30 seconds for up to 40 minutes. Other distribution channels are triggered immediately; only AXI waits for npm readiness. If the package never becomes available, the distribution job fails instead of dispatching a workflow that cannot succeed.

Failed AXI job: https://github.com/snyk/axi/actions/runs/32979700168/job/98213031126

## Where should the reviewer start?

`wait_for_npm_package` and its use immediately before the AXI dispatch in `release-scripts/upload-artifacts.sh`.

## How should this be manually tested?

```shell
bash -n release-scripts/upload-artifacts.sh
```

Verify with mocked `npm` and `sleep` commands that:

1. Failed npm lookups are retried every 30 seconds.
2. AXI dispatch proceeds once the exact version becomes visible.
3. AXI is not dispatched after all 80 checks fail.

## What's the product update that needs to be communicated to CLI users?

None. This only changes release orchestration.

## Risk assessment (Low | Medium | High)?

Low. The change affects only AXI dispatch timing. Existing Snyk Images, Scoop, and Homebrew dispatches remain unchanged. Worst case, the distribution job waits up to 40 minutes and fails if npm never exposes the published version.

## Any background context you want to provide?

`npm publish` printed: `Your package is being processed and may take a few minutes to become available.` Its successful exit therefore confirms upload acceptance, not registry readiness.

## What are the relevant tickets?

None.
