### PR TITLE
fix: create missing parent directory for --json-file-output [OSF-482]

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -215,7 +215,7 @@ require (
 	github.com/snyk/cli-extension-dep-graph/v2 v2.11.0 // indirect
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 // indirect
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f // indirect
-	github.com/snyk/cli-extension-os-flows v0.0.0-20260821101812-a52aa2dd8c3b // indirect
+	github.com/snyk/cli-extension-os-flows v0.0.0-20260827130811-28d01cea6a08 // indirect
 	github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9 // indirect
 	github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd // indirect
 	github.com/snyk/code-client-go v1.31.8 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -578,8 +578,8 @@ github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSo
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f h1:EPaHfaWDJq/lrsrATMqAyKJRfstb9LZnPXYNwXdL32c=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f/go.mod h1:JoubAvjOyuB3y0HxulaiAEiVthMOa9abElpL72C5zz4=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260821101812-a52aa2dd8c3b h1:pAiAfZzN9JCu7/+PqO39sUUmvros+ckJ5n15qy+s0oA=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260821101812-a52aa2dd8c3b/go.mod h1:ukSD97e6hc9w0UkrbI/OV2GeDpsEyUsIzE38vdzRbZ8=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260827130811-28d01cea6a08 h1:AUyfZQm9jduoMVfT9h4Y+ZQYHdL2HzsoiT8Hc1DUdQs=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260827130811-28d01cea6a08/go.mod h1:ukSD97e6hc9w0UkrbI/OV2GeDpsEyUsIzE38vdzRbZ8=
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9 h1:Kz/UCPae7vRVeFlkkYHnyFRYue9gaO16enVnN7aclco=
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd h1:sSVkD1CuL8v49boItrt2CnQ4DJIH+sjGwFGheGCVAxo=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/snyk/cli-extension-dep-graph/v2 v2.11.0
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f
-	github.com/snyk/cli-extension-os-flows v0.0.0-20260821101812-a52aa2dd8c3b
+	github.com/snyk/cli-extension-os-flows v0.0.0-20260827130811-28d01cea6a08
 	github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9
 	github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd
 	github.com/snyk/code-client-go v1.31.8

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -528,8 +528,8 @@ github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSo
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f h1:EPaHfaWDJq/lrsrATMqAyKJRfstb9LZnPXYNwXdL32c=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f/go.mod h1:JoubAvjOyuB3y0HxulaiAEiVthMOa9abElpL72C5zz4=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260821101812-a52aa2dd8c3b h1:pAiAfZzN9JCu7/+PqO39sUUmvros+ckJ5n15qy+s0oA=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260821101812-a52aa2dd8c3b/go.mod h1:ukSD97e6hc9w0UkrbI/OV2GeDpsEyUsIzE38vdzRbZ8=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260827130811-28d01cea6a08 h1:AUyfZQm9jduoMVfT9h4Y+ZQYHdL2HzsoiT8Hc1DUdQs=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260827130811-28d01cea6a08/go.mod h1:ukSD97e6hc9w0UkrbI/OV2GeDpsEyUsIzE38vdzRbZ8=
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9 h1:Kz/UCPae7vRVeFlkkYHnyFRYue9gaO16enVnN7aclco=
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd h1:sSVkD1CuL8v49boItrt2CnQ4DJIH+sjGwFGheGCVAxo=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable) — none
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___) — not applicable, no documented behaviour changes
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps `cli-extension-os-flows` to pick up [snyk/cli-extension-os-flows#275](https://github.com/snyk/cli-extension-os-flows/pull/275), which restores `--json-file-output` parity between the unified test flow and the legacy flow. Four divergences are fixed:

| | before | after (= legacy) |
|---|---|---|
| missing parent directory | `ENOENT`, command fails | created recursively |
| file mode | `0600` | `0666` before umask |
| trailing byte | none | `\n` |
| write failure | fails an otherwise successful scan | printed to stderr and swallowed, exit code preserved |

The trigger was the first row. Reported via case 00135982: a customer runs `snyk-maven-plugin` with `--json-file-output=target/site/dependency-scan-results.json`. During the `test` phase `target/site/` does not exist yet — `maven-site-plugin` creates it later — so the scan succeeded and the CLI then died:

```
ERROR   Unspecified Error (SNYK-CLI-0000)
failed to write JSON output to file: open target/site/dependency-scan-results.json: no such file or directory
```

The other three rows were found while verifying the fix against the legacy implementation and are corrected in the same change, so the two flows now produce byte-identical files with identical failure semantics.

Only orgs on `internal_snyk_cli_use_test_shim_for_os_cli_test` reach the affected path; everyone else was already on the legacy behaviour.

## Where should the reviewer start?

This PR is a version bump only — four lines across `cliv2/go.mod`, `cliv2-private/go.mod` and their sums. The substance is in [snyk/cli-extension-os-flows#275](https://github.com/snyk/cli-extension-os-flows/pull/275):

- `internal/outputworkflow/file_utils.go` — the new `SaveJSONToFile`, which reproduces legacy's two stderr branches: raw error alone on a write failure, raw error plus `could not create directory <dir>` on a mkdir failure.
- `internal/commands/ostest/depgraph_flow.go` — `handleOutput` now delegates to it instead of calling `os.WriteFile` directly, and keys its emptiness check off the serialized bytes rather than the finding count, matching legacy's `outputFile && (jsonResults || !isEmpty(jsonPayload))`.

Reference implementation for comparison: `src/lib/json-file-output.ts` and `saveResultsToFile` in `src/cli/main.ts`.

## How should this be manually tested?

Requires an org with `internal_snyk_cli_use_test_shim_for_os_cli_test` enabled. From any project with a supported manifest:

```bash
rm -rf target
snyk test --json-file-output=target/site/results.json; echo "exit=$?"
```

Expected: exit 0, `target/site/results.json` present and parseable. Before the fix: exit 2 with `SNYK-CLI-0000`.

The other three behaviours:

```bash
# mode 0644 under a default 022 umask, and a trailing newline
stat -f '%Sp' target/site/results.json
tail -c1 target/site/results.json | xxd

# write failure is swallowed — exit 0, error on stderr, nothing on stdout
echo 'not a directory' > blocker
snyk test --json-file-output=blocker/results.json; echo "exit=$?"
```

Running the same commands with the flag off gives the baseline to compare against.

## What's the product update that needs to be communicated to CLI users?

Fixed `snyk test --json-file-output` failing with `SNYK-CLI-0000 ... no such file or directory` when the output path's directory didn't exist yet.

## Risk assessment (Low | Medium | High)?

**Low.** No code in this repo changes. The affected path is gated behind a server-side feature flag, and the change moves that path onto behaviour the legacy flow has shipped for years. The one behaviour that is newly *permissive* — swallowing write failures instead of failing — matches legacy exactly and is covered by tests that assert the failure is still reported on stderr.

## Any background context you want to provide?

Two related gaps were found during this work and are deliberately **not** addressed here:

1. With `--json` *and* `--json-file-output`, the file is written twice — once by the extension and once by the host's output workflow, which returns its error and exits 2 after a successful scan. Legacy exits 0. Not fixable in the extension.
2. Legacy writes the JSON file from its error handler (`src/cli/main.ts`), so a *failed* scan still produces one. The unified flow returns the error before `handleOutput` runs, so `--json-file-output` writes nothing on failure.

## What are the relevant tickets?

OSF-482 · Support case 00135982

🤖 Generated with [Claude Code](https://claude.com/claude-code)
