### PR TITLE
fix: report SNYK-CLI-0008 for repos with no testable projects [OSF-481]

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -215,7 +215,7 @@ require (
 	github.com/snyk/cli-extension-dep-graph/v2 v2.11.0 // indirect
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 // indirect
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f // indirect
-	github.com/snyk/cli-extension-os-flows v0.0.0-20260821101812-a52aa2dd8c3b // indirect
+	github.com/snyk/cli-extension-os-flows v0.0.0-20260831095357-9cc236689fc1 // indirect
 	github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9 // indirect
 	github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd // indirect
 	github.com/snyk/code-client-go v1.31.8 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -592,8 +592,8 @@ github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSo
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f h1:EPaHfaWDJq/lrsrATMqAyKJRfstb9LZnPXYNwXdL32c=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f/go.mod h1:JoubAvjOyuB3y0HxulaiAEiVthMOa9abElpL72C5zz4=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260821101812-a52aa2dd8c3b h1:pAiAfZzN9JCu7/+PqO39sUUmvros+ckJ5n15qy+s0oA=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260821101812-a52aa2dd8c3b/go.mod h1:ukSD97e6hc9w0UkrbI/OV2GeDpsEyUsIzE38vdzRbZ8=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260831095357-9cc236689fc1 h1:r13WOBFc4Jtq7NM1Kj6whKts2B7DLci7CU24aNqNQx8=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260831095357-9cc236689fc1/go.mod h1:ukSD97e6hc9w0UkrbI/OV2GeDpsEyUsIzE38vdzRbZ8=
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9 h1:Kz/UCPae7vRVeFlkkYHnyFRYue9gaO16enVnN7aclco=
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd h1:sSVkD1CuL8v49boItrt2CnQ4DJIH+sjGwFGheGCVAxo=

--- a/cliv2/cmd/cliv2/behavior/maperrortoexitcode.go
+++ b/cliv2/cmd/cliv2/behavior/maperrortoexitcode.go
@@ -2,6 +2,7 @@ package behavior
 
 import (
 	"github.com/snyk/error-catalog-golang-public/aibom"
+	snyk_cli_errors "github.com/snyk/error-catalog-golang-public/cli"
 	"github.com/snyk/error-catalog-golang-public/code"
 	"github.com/snyk/error-catalog-golang-public/snyk"
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
@@ -14,9 +15,10 @@ var MapErrorCatalogToExitCode func(err *snyk_errors.Error, defaultValue int) int
 // mapErrorToExitCode maps error catalog errors to exit codes. Please extend the switch statement if new error codes need to be mapped.
 func mapErrorToExitCode(err *snyk_errors.Error, defaultValue int) int {
 	var errorCatalogToExitCodeMap = map[string]int{
-		code.NewUnsupportedProjectError("").ErrorCode: constants.SNYK_EXIT_CODE_UNSUPPORTED_PROJECTS,
-		aibom.NewNoSupportedFilesError("").ErrorCode:  constants.SNYK_EXIT_CODE_UNSUPPORTED_PROJECTS,
-		snyk.NewMaintenanceWindowError("").ErrorCode:  constants.SNYK_EXIT_CODE_EX_TEMPFAIL,
+		code.NewUnsupportedProjectError("").ErrorCode:               constants.SNYK_EXIT_CODE_UNSUPPORTED_PROJECTS,
+		aibom.NewNoSupportedFilesError("").ErrorCode:                constants.SNYK_EXIT_CODE_UNSUPPORTED_PROJECTS,
+		snyk.NewMaintenanceWindowError("").ErrorCode:                constants.SNYK_EXIT_CODE_EX_TEMPFAIL,
+		snyk_cli_errors.NewNoSupportedFilesFoundError("").ErrorCode: constants.SNYK_EXIT_CODE_UNSUPPORTED_PROJECTS,
 		// Add new mappings here
 	}
 

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/snyk/cli-extension-dep-graph/v2 v2.11.0
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f
-	github.com/snyk/cli-extension-os-flows v0.0.0-20260821101812-a52aa2dd8c3b
+	github.com/snyk/cli-extension-os-flows v0.0.0-20260831095357-9cc236689fc1
 	github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9
 	github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd
 	github.com/snyk/code-client-go v1.31.8

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -542,8 +542,8 @@ github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSo
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f h1:EPaHfaWDJq/lrsrATMqAyKJRfstb9LZnPXYNwXdL32c=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f/go.mod h1:JoubAvjOyuB3y0HxulaiAEiVthMOa9abElpL72C5zz4=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260821101812-a52aa2dd8c3b h1:pAiAfZzN9JCu7/+PqO39sUUmvros+ckJ5n15qy+s0oA=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260821101812-a52aa2dd8c3b/go.mod h1:ukSD97e6hc9w0UkrbI/OV2GeDpsEyUsIzE38vdzRbZ8=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260831095357-9cc236689fc1 h1:r13WOBFc4Jtq7NM1Kj6whKts2B7DLci7CU24aNqNQx8=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260831095357-9cc236689fc1/go.mod h1:ukSD97e6hc9w0UkrbI/OV2GeDpsEyUsIzE38vdzRbZ8=
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9 h1:Kz/UCPae7vRVeFlkkYHnyFRYue9gaO16enVnN7aclco=
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd h1:sSVkD1CuL8v49boItrt2CnQ4DJIH+sjGwFGheGCVAxo=

--- a/cliv2/pkg/core/exitcode_test.go
+++ b/cliv2/pkg/core/exitcode_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"testing"
 
+	snyk_cli_errors "github.com/snyk/error-catalog-golang-public/cli"
 	"github.com/snyk/error-catalog-golang-public/code"
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 
@@ -74,6 +75,15 @@ func TestMapErrorToExitCode(t *testing.T) {
 	t.Run("wrapped unsupported project error returns UNSUPPORTED_PROJECTS", func(t *testing.T) {
 		unsupportedErr := code.NewUnsupportedProjectError("test project")
 		wrappedErr := errors.Join(unsupportedErr, errors.New("additional context"))
+		exitCode := mapErrorToExitCode(wrappedErr)
+		if exitCode != constants.SNYK_EXIT_CODE_UNSUPPORTED_PROJECTS {
+			t.Errorf("expected exit code %d, got %d", constants.SNYK_EXIT_CODE_UNSUPPORTED_PROJECTS, exitCode)
+		}
+	})
+
+	t.Run("wrapped no supported files found error returns UNSUPPORTED_PROJECTS", func(t *testing.T) {
+		noFilesErr := snyk_cli_errors.NewNoSupportedFilesFoundError("Could not detect supported target files in /tmp/x.")
+		wrappedErr := errors.Join(noFilesErr, errors.New("failed to get dependency graph"))
 		exitCode := mapErrorToExitCode(wrappedErr)
 		if exitCode != constants.SNYK_EXIT_CODE_UNSUPPORTED_PROJECTS {
 			t.Errorf("expected exit code %d, got %d", constants.SNYK_EXIT_CODE_UNSUPPORTED_PROJECTS, exitCode)

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -474,7 +474,9 @@ func displayError(err error, userInterface ui.UserInterface, config configuratio
 			}
 
 			jsonErrorBuffer, _ := json.MarshalIndent(jsonError, "", "  ")
-			_ = userInterface.OutputError(fmt.Errorf("%s", jsonErrorBuffer))
+			// This document is the command's structured output, so it goes to
+			// stdout; OutputError would route it to stderr in structured mode.
+			_ = userInterface.Output(string(jsonErrorBuffer))
 		} else {
 			ctx = context.WithValue(ctx, uitypes.ErrorTipKey, doctorTip(isCI))
 			uiError := userInterface.OutputError(err, ui.WithContext(ctx))

--- a/test/jest/acceptance/snyk-test/equivalenceHelpers.ts
+++ b/test/jest/acceptance/snyk-test/equivalenceHelpers.ts
@@ -173,14 +173,7 @@ export function assertEquivalent(
   const bothEmpty =
     legacy.submissionCount === 0 && unified.submissionCount === 0;
 
-  if (options.expectNoSubmissions && bothEmpty) {
-    // Both paths produced nothing to scan — that's the expected outcome.
-    // Exit codes legitimately differ (TS CLI exits 3, os-flows exits 2) so
-    // we don't compare them here.
-    return { ok: true };
-  }
-
-  if (!options.expectNoSubmissions && bothEmpty) {
+  if (bothEmpty && !options.expectNoSubmissions) {
     return {
       ok: false,
       reason: 'inconclusive: both runs produced zero submissions',
@@ -201,10 +194,27 @@ export function assertEquivalent(
     };
   }
 
+  if (bothEmpty) {
+    // Nothing was scanned, so there are no dep graphs to compare — stdout here
+    // is an error payload rather than project results.
+    return { ok: true };
+  }
+
   if (legacy.submissionCount !== unified.submissionCount) {
     return {
       ok: false,
       reason: `project count mismatch: legacy=${legacy.submissionCount} unified=${unified.submissionCount}`,
+      detail: {
+        legacyTargets: legacy.projects.map((p) => p.displayTargetFile),
+        unifiedTargets: unified.projects.map((p) => p.displayTargetFile),
+      },
+    };
+  }
+
+  if (legacy.projects.length !== unified.projects.length) {
+    return {
+      ok: false,
+      reason: `parsed project count mismatch: legacy=${legacy.projects.length} unified=${unified.projects.length}`,
       detail: {
         legacyTargets: legacy.projects.map((p) => p.displayTargetFile),
         unifiedTargets: unified.projects.map((p) => p.displayTargetFile),

--- a/test/jest/acceptance/snyk-test/no-testable-projects-user-journey.spec.ts
+++ b/test/jest/acceptance/snyk-test/no-testable-projects-user-journey.spec.ts
@@ -1,0 +1,61 @@
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+
+import { runSnykCLI } from '../../util/runSnykCLI';
+import { EXIT_CODES } from '../../../../src/cli/exit-codes';
+import { makeTmpDirectory } from '../../../utils';
+
+jest.setTimeout(1000 * 300);
+
+type Route = {
+  name: string;
+  env: Record<string, string>;
+};
+
+const routes: Route[] = [
+  {
+    name: 'legacy',
+    env: { SNYK_FORCE_LEGACY_CLI: 'true' },
+  },
+  {
+    name: 'unified test API',
+    env: { INTERNAL_SNYK_CLI_USE_UNIFIED_TEST_API_FOR_OS_CLI_TEST: 'true' },
+  },
+];
+
+describe('snyk test on a directory with no supported target files', () => {
+  let projectPath: string;
+
+  beforeAll(async () => {
+    projectPath = await makeTmpDirectory();
+    writeFileSync(join(projectPath, 'README.md'), '# no manifests here\n');
+  });
+
+  describe.each(routes)('$name', ({ env: routeEnv }) => {
+    const env = { ...process.env, ...routeEnv };
+
+    test('reports SNYK-CLI-0008 and exits with NO_SUPPORTED_PROJECTS_DETECTED', async () => {
+      const { code, stdout } = await runSnykCLI(`test ${projectPath}`, { env });
+
+      expect(stdout).toContain('SNYK-CLI-0008');
+      expect(stdout).toContain('No supported files found');
+      expect(code).toBe(EXIT_CODES.NO_SUPPORTED_PROJECTS_DETECTED);
+    });
+
+    test('writes the --json error document to stdout', async () => {
+      const { code, stdout } = await runSnykCLI(`test ${projectPath} --json`, {
+        env,
+      });
+
+      expect(JSON.parse(stdout)).toEqual(
+        expect.objectContaining({
+          ok: false,
+          error: expect.stringContaining(
+            'Could not detect supported target files in',
+          ),
+        }),
+      );
+      expect(code).toBe(EXIT_CODES.NO_SUPPORTED_PROJECTS_DETECTED);
+    });
+  });
+});


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable) — n/a, this restores previous behaviour
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: n/a — no documented behaviour changes; exit code 3 and SNYK-CLI-0008 are already documented)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Restores `SNYK-CLI-0008` ("No supported files found") and exit code **3** for `snyk test` in a directory with no supported manifest files, when the unified test API feature flag is enabled.

[Reported in Slack](https://snyk.slack.com/archives/C0BQRUH0UCR/p1787761635731579): with `FFUseUnifiedTestAPIForOSCliTest` enabled, routing no longer falls back to `useLegacy`, and the os-flows extension surfaced a generic `SNYK-CLI-0000` with `failed to get dependency graph: no testable projects found` and exit **2**. CI pipelines that scan repositories without testable projects ([snyk/homebrew-tap](https://github.com/snyk/homebrew-tap), [snyk/scoop-snyk](https://github.com/snyk/scoop-snyk)) treat `SNYK-CLI-0008` / exit 3 as "nothing to scan", so this broke them.

Three changes:

1. **Bumps `cli-extension-os-flows`** to pick up snyk/cli-extension-os-flows#278, which returns a typed Error Catalog error instead of a bare `fmt.Errorf` when no project is detected.
2. **Adds the missing exit-code mapping.** `SNYK-CLI-0008` was never in the central error-catalog → exit-code map, because the legacy TS CLI derived exit 3 itself by substring-matching its own message (`src/cli/main.ts`). With the flag on, that TypeScript code never runs, and `DeriveExitCode` only recognises an `exec.ExitError` or an `ErrorWithExitCode` — so a correctly typed error from Go still fell through to the generic exit 2. Follows the existing `aibom.NoSupportedFiles` precedent.
3. **Sends the `--json` error document to stdout** instead of the error stream. The error stream is deliberately routed to stderr whenever the default output is structured, so error text can't corrupt a JSON payload — but this document *is* the structured output, so `snyk test --json` left stdout empty and wrote the JSON to stderr. This affected every error on a Go workflow, not just this one, and diverged from both the legacy CLI and the rest of the CLI's own contract (the IaC acceptance tests already expect `"ok": false` on stdout).

## Where should the reviewer start?

`cliv2/cmd/cliv2/behavior/maperrortoexitcode.go` — the one-line map entry, and the reason it's needed.

Then `cliv2/pkg/core/main.go` (`displayError`) for the stdout/stderr change, and `test/jest/acceptance/snyk-test/equivalenceHelpers.ts` for why the equivalence suite couldn't catch this: `assertEquivalent` returned early for no-submission fixtures, with a comment stating that exit codes "legitimately differ (TS CLI exits 3, os-flows exits 2)". That escape hatch excused the exact divergence being fixed.

## How should this be manually tested?

```bash
make build
mkdir /tmp/no-projects && echo hi > /tmp/no-projects/README.txt && cd /tmp/no-projects

# unified path
INTERNAL_SNYK_CLI_USE_UNIFIED_TEST_API_FOR_OS_CLI_TEST=true snyk test; echo "exit=$?"

# legacy path, for comparison
SNYK_FORCE_LEGACY_CLI=true snyk test; echo "exit=$?"
```

Both should print `No supported files found (SNYK-CLI-0008)` and exit **3**. Repeat with `--json > out.json` — `out.json` must be non-empty and identical on both paths (before this change it was empty on the unified path).

## What's the product update that needs to be communicated to CLI users?

**Fixed:** `snyk test` on a repository with no supported manifest files again reports `SNYK-CLI-0008` and exits 3 instead of a generic `SNYK-CLI-0000` with exit 2, and `snyk test --json` again writes the error document to stdout instead of stderr.

## Risk assessment (Low | Medium | High)?

**Low.** The exit-code mapping is additive — one entry keyed on an error code nothing else produces. The stdout change affects only the `--json` error path, moving output onto the stream the legacy CLI and the rest of the CLI already use; verified that `code test`, `iac test` and `sbom` in `--json` mode still emit a single payload on stdout with stderr empty.

## Any background context you want to provide?

### Automated tests

- `cliv2/pkg/core/exitcode_test.go` — `SNYK-CLI-0008` → exit 3, added to the existing `TestMapErrorToExitCode` table.
- `test/jest/acceptance/snyk-test/unified-test-api-equivalence.spec.ts` — the `no-supported-target-files` fixture is the regression guard. Now that `assertEquivalent` compares exit codes for no-submission fixtures, legacy 3 vs unified 2 fails the suite.
- Extension-side coverage lives in snyk/cli-extension-os-flows#278.

### Known cosmetic difference

The two paths are not byte-identical in **human-readable** output: the unified path additionally renders the catalog *description* line. This is not caused by this change — `error-catalog`'s JSON:API mapping never carries `Description` in either direction (`MarshalToJSONAPIError` doesn't write it, `MarshalFromJSONAPIError` doesn't read it), so every error the legacy CLI reports over the IPC loses its description while errors constructed in Go keep theirs. Worth fixing upstream via `meta.description`; out of scope here. `--json` output is identical.

## What are the relevant tickets?

- [OSF-481](https://snyksec.atlassian.net/browse/OSF-481)
- snyk/cli-extension-os-flows#278 (merged)


[OSF-481]: https://snyksec.atlassian.net/browse/OSF-481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

