### PR TITLE
feat: support .slnx solution files on --file

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -325,11 +325,11 @@ export async function main(): Promise<void> {
     if (
       globalArgs.options.file &&
       typeof globalArgs.options.file === 'string' &&
-      (globalArgs.options.file as string).match(/\.sln$/)
+      sln.isSolutionFile(globalArgs.options.file as string)
     ) {
       if (globalArgs.options['project-name']) {
         throw new UnsupportedOptionCombinationError([
-          'file=*.sln',
+          `file=*${sln.solutionExtension(globalArgs.options.file as string)}`,
           'project-name',
         ]);
       }

--- a/src/lib/sln/index.ts
+++ b/src/lib/sln/index.ts
@@ -7,31 +7,134 @@ import { FileFlagBadInputError } from '../errors';
 
 const debug = Debug('snyk');
 
+// The two .NET solution formats. `.slnx` is the XML replacement for the text
+// `.sln`: the .NET SDK reads it from 9.0.200, and `dotnet new sln` creates it by
+// default from .NET 10.
+const SLN_EXTENSION = '.sln';
+const SLNX_EXTENSION = '.slnx';
+
+// Returns the solution extension `file` ends with, lower-cased, or '' when it is
+// not a solution file. Matched on the suffix rather than with path.extname,
+// which reports no extension at all for a name that is only an extension
+// (`.slnx`) and would send it to the wrong parser. Lower-casing also keeps the
+// message this feeds identical to the one cli-extension-os-flows produces.
+export const solutionExtension = (file: string): string => {
+  const lowerCased = file.toLowerCase();
+
+  if (lowerCased.endsWith(SLNX_EXTENSION)) {
+    return SLNX_EXTENSION;
+  }
+  if (lowerCased.endsWith(SLN_EXTENSION)) {
+    return SLN_EXTENSION;
+  }
+
+  return '';
+};
+
+export const isSolutionFile = (file: string): boolean =>
+  solutionExtension(file) !== '';
+
 // slnFile should exist.
 // returns array of project paths (path/to/manifest.file)
 export const parsePathsFromSln = (slnFile) => {
-  // read project scopes from solution file
-  // [\s\S] is like ., but with newlines!
-  // *? means grab the shortest match
-  const projectScopes =
-    loadFile(path.resolve(slnFile)).match(/Project[\s\S]*?EndProject/g) || [];
+  const contents = loadFile(path.resolve(slnFile));
 
-  const paths = projectScopes
-    .map((projectScope) => {
-      const secondArg = projectScope.split(',')[1];
-      // expected ` "path/to/manifest.file"`, clean it up
-      return secondArg && secondArg.trim().replace(/"/g, '');
-    })
-    // drop falsey values
-    .filter(Boolean)
-    // convert path separators
-    .map((projectPath) => {
-      return path.dirname(projectPath.replace(/\\/g, path.sep));
-    });
+  // Each format reduces a project path to its folder its own way; they do not
+  // agree, and `.sln` has to keep behaving exactly as it always has.
+  const paths =
+    solutionExtension(slnFile) === SLNX_EXTENSION
+      ? parseProjectPathsFromSlnx(contents).map(slnxProjectFolder)
+      : parseProjectPathsFromSln(contents).map(slnProjectFolder);
 
   debug('extracted paths from solution file: ', paths);
   return paths;
 };
+
+// The original text format: `Project(...) = "Name", "path\to\project.csproj", "{guid}"`.
+function parseProjectPathsFromSln(contents: string): string[] {
+  // read project scopes from solution file
+  // [\s\S] is like ., but with newlines!
+  // *? means grab the shortest match
+  const projectScopes = contents.match(/Project[\s\S]*?EndProject/g) || [];
+
+  return (
+    projectScopes
+      .map((projectScope) => {
+        const secondArg = projectScope.split(',')[1];
+        // expected ` "path/to/manifest.file"`, clean it up
+        return secondArg && secondArg.trim().replace(/"/g, '');
+      })
+      // drop falsey values
+      .filter(Boolean)
+  );
+}
+
+// `.slnx` is XML: a <Solution> of <Project Path="..." /> elements, which may be
+// nested inside <Folder> elements to any depth. All we need out of it is the
+// project paths, so we match the Project elements rather than pull an XML parser
+// into the CLI's dependency tree. Comments are stripped first so a commented-out
+// project isn't scanned.
+function parseProjectPathsFromSlnx(contents: string): string[] {
+  const projectElements =
+    contents.replace(/<!--[\s\S]*?-->/g, '').match(/<Project\b[^>]*>/g) || [];
+
+  return projectElements
+    .map((element) => {
+      const attribute = element.match(/\sPath\s*=\s*("([^"]*)"|'([^']*)')/);
+      // one of the two capture groups holds the value; which one depends on the
+      // quote style the author used
+      return attribute && (attribute[2] ?? attribute[3]);
+    })
+    .filter(Boolean)
+    .map(decodeXmlEntities);
+}
+
+function decodeXmlEntities(value: string): string {
+  return (
+    value
+      // Numeric character references first. `&#47;` is a path separator, so
+      // leaving these encoded doesn't just misname a folder, it collapses the
+      // path to the solution's own directory.
+      .replace(/&#x([0-9a-f]+);/gi, (_, hex) =>
+        String.fromCodePoint(parseInt(hex, 16)),
+      )
+      .replace(/&#(\d+);/g, (_, decimal) =>
+        String.fromCodePoint(parseInt(decimal, 10)),
+      )
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&apos;/g, "'")
+      // Ampersand last, so `&amp;#47;` decodes to the literal text `&#47;`
+      // rather than to a separator.
+      .replace(/&amp;/g, '&')
+  );
+}
+
+function toOsSeparators(projectPath: string): string {
+  return projectPath.replace(/\\/g, path.sep);
+}
+
+// Unchanged from before `.slnx` existed, deliberately. An ASP.NET Website
+// project is written with a trailing separator (`..\WebSites\Site1\`) and has
+// always resolved to the folder *above* it. That may well be wrong, but it
+// decides which projects a `.sln` scan covers, so correcting it belongs in its
+// own change with its own release note — not smuggled in with a new format.
+function slnProjectFolder(projectPath: string): string {
+  return path.dirname(toOsSeparators(projectPath));
+}
+
+// A `.slnx` project path normally names the project file, whose folder holds the
+// manifest. A path written with a trailing separator names a folder instead —
+// that is how an ASP.NET Website project is recorded, which has no project file
+// at all — so the folder itself is what gets scanned.
+function slnxProjectFolder(projectPath: string): string {
+  const normalised = toOsSeparators(projectPath);
+
+  return /[\\/]$/.test(projectPath)
+    ? normalised.slice(0, -1)
+    : path.dirname(normalised);
+}
 
 export const updateArgs = (args) => {
   if (!args.options.file || typeof args.options.file !== 'string') {

--- a/test/acceptance/workspaces/emptySolution.slnx
+++ b/test/acceptance/workspaces/emptySolution.slnx
@@ -1,0 +1,3 @@
+<Solution>
+  <Project Path="NoSuchFolder/NoSuchFile.csproj" />
+</Solution>

--- a/test/acceptance/workspaces/sln-example-app/mySolution.slnx
+++ b/test/acceptance/workspaces/sln-example-app/mySolution.slnx
@@ -1,0 +1,6 @@
+<Solution>
+  <Folder Name="/src/">
+    <Project Path="dotnet2_new_mvc_project/new_mvc_project.csproj" />
+  </Folder>
+  <Project Path="WebApplication2\WebApplication2.csproj" />
+</Solution>

--- a/test/acceptance/workspaces/sln-no-supported-files/mySolution.slnx
+++ b/test/acceptance/workspaces/sln-no-supported-files/mySolution.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="dotnet2_new_mvc_project/new_mvc_project.csproj" />
+  <Project Path="WebApplication2/WebApplication2.csproj" />
+</Solution>

--- a/test/acceptance/workspaces/sln-website-project/mySolution.sln
+++ b/test/acceptance/workspaces/sln-website-project/mySolution.sln
@@ -1,0 +1,8 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "WebSite1", "..\..\WebSites\WebSite1\", "{26B9B59B-C5AC-49CE-9BD6-4C72940DAC89}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApplication2", "WebApplication2\WebApplication2.csproj", "{9A79CF26-C7E8-47A3-B718-C5E654AA2701}"
+EndProject
+Global
+EndGlobal

--- a/test/acceptance/workspaces/slnxSolution.slnx
+++ b/test/acceptance/workspaces/slnxSolution.slnx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Solution>
+  <Project Path="nuget-app\doesnt_matter.csproj">
+    <BuildType Solution="Debug|Any CPU" Project="Debug" />
+  </Project>
+  <Folder Name="/tests/">
+    <Project Path="../workspaces/nuget-app-2.1/doesnt_matter.csproj" />
+  </Folder>
+  <Project Path="NoSuchFolder/NoSuchFile.csproj" />
+  <!-- <Project Path="removed-app/doesnt_matter.csproj" /> -->
+</Solution>

--- a/test/fixtures/nuget-sln/Service.slnx
+++ b/test/fixtures/nuget-sln/Service.slnx
@@ -1,0 +1,3 @@
+<Solution>
+  <Project Path="Service/Service.csproj" />
+</Solution>

--- a/test/jest/acceptance/cli-args.spec.ts
+++ b/test/jest/acceptance/cli-args.spec.ts
@@ -155,6 +155,20 @@ describe.each(userJourneyWorkflows)(
           expect(code).toEqual(2);
         });
 
+        test('snyk test --file=file.slnx --project-name=NAME', async () => {
+          const { code, stdout } = await runSnykCLI(
+            `test --file=file.slnx --project-name=NAME`,
+            {
+              env,
+            },
+          );
+
+          expect(stdout).toContainText(
+            'The following option combination is not currently supported: file=*.slnx + project-name',
+          );
+          expect(code).toEqual(2);
+        });
+
         test('snyk test --file=blah --scan-all-unmanaged', async () => {
           const { code, stdout } = await runSnykCLI(
             `test --file=blah --scan-all-unmanaged`,

--- a/test/jest/acceptance/snyk-sbom/nuget-options.spec.ts
+++ b/test/jest/acceptance/snyk-sbom/nuget-options.spec.ts
@@ -147,4 +147,24 @@ describe('snyk sbom: nuget options (mocked server only)', () => {
     expect(bom.metadata.component.name).toEqual('Service');
     expect(bom.components).toHaveLength(51);
   });
+
+  test('`sbom --file` generates an SBOM for the NuGet project by using the file flag with a .slnx solution file', async () => {
+    const project = await createProjectFromFixture('nuget-sln');
+
+    const { code, stdout } = await runSnykCLI(
+      `sbom --org aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee --format cyclonedx1.4+json --file=Service.slnx`,
+      {
+        cwd: project.path(),
+        env,
+      },
+    );
+    let bom;
+
+    expect(code).toEqual(0);
+    expect(() => {
+      bom = JSON.parse(stdout);
+    }).not.toThrow();
+    expect(bom.metadata.component.name).toEqual('Service');
+    expect(bom.components).toHaveLength(51);
+  });
 });

--- a/test/jest/unit/lib/sln.spec.ts
+++ b/test/jest/unit/lib/sln.spec.ts
@@ -1,0 +1,185 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as sln from '../../../../src/lib/sln';
+import { getWorkspacePath } from '../../util/getWorkspacePath';
+
+const basenames = (paths: string[]) => paths.map((p) => path.basename(p));
+
+// For solution contents that only need to be parsed, not scanned — no project
+// folders have to exist on disk.
+const writeTempSolution = (contents: string): string => {
+  const file = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'snyk-slnx-')),
+    'mySolution.slnx',
+  );
+  fs.writeFileSync(file, contents);
+
+  return file;
+};
+
+// The extension decides three things: whether --file is a solution at all,
+// which parser reads it, and which extension the unsupported-combination error
+// names. cli-extension-os-flows produces that same message from its own
+// suffix match, so this has to agree with it — including on case.
+describe('solutionExtension', () => {
+  it.each([
+    ['mySolution.sln', '.sln'],
+    ['mySolution.slnx', '.slnx'],
+    ['MYSOLUTION.SLNX', '.slnx'],
+    ['mySolution.SlNx', '.slnx'],
+    ['path/to/mySolution.slnx', '.slnx'],
+    // Only an extension, so path.extname reports nothing — it would send this
+    // to the text parser.
+    ['.slnx', '.slnx'],
+    ['.sln', '.sln'],
+    ['mySolution.slnf', ''],
+    ['myProject.csproj', ''],
+    ['slnx', ''],
+    ['dir.slnx/myProject.csproj', ''],
+  ])('%s -> "%s"', (file, expected) => {
+    expect(sln.solutionExtension(file)).toBe(expected);
+    expect(sln.isSolutionFile(file)).toBe(expected !== '');
+  });
+});
+
+// An ASP.NET Website project is written into a `.sln` with a trailing
+// separator, and has always resolved to the folder above it. Adding `.slnx`
+// must not change which folder a `.sln` scan covers.
+describe('parsePathsFromSln for .sln solutions', () => {
+  it('resolves a trailing-separator project path to its parent folder', () => {
+    const slnFile = getWorkspacePath('sln-website-project/mySolution.sln');
+
+    expect(sln.parsePathsFromSln(slnFile)).toEqual([
+      path.join('..', '..', 'WebSites'),
+      'WebApplication2',
+    ]);
+  });
+});
+
+describe('parsePathsFromSln for .slnx solutions', () => {
+  it('extracts project folders, including from solution folders', () => {
+    const slnxFile = getWorkspacePath('sln-example-app/mySolution.slnx');
+
+    expect(sln.parsePathsFromSln(slnxFile)).toEqual([
+      'dotnet2_new_mvc_project',
+      'WebApplication2',
+    ]);
+  });
+
+  it('extracts the same folders as the equivalent .sln solution', () => {
+    const workspace = 'sln-example-app/mySolution';
+
+    expect(
+      sln.parsePathsFromSln(getWorkspacePath(`${workspace}.slnx`)),
+    ).toEqual(sln.parsePathsFromSln(getWorkspacePath(`${workspace}.sln`)));
+  });
+
+  it('ignores commented out projects', () => {
+    const slnxFile = getWorkspacePath('slnxSolution.slnx');
+
+    expect(sln.parsePathsFromSln(slnxFile)).not.toContain('removed-app');
+  });
+
+  it('throws when the solution file does not exist', () => {
+    const slnxFile = getWorkspacePath('sln-example-app/noSuchSolution.slnx');
+
+    expect(() => sln.parsePathsFromSln(slnxFile)).toThrow('File not found: ');
+  });
+
+  // Solution paths are XML attribute values, so anything an XML writer is
+  // allowed to escape has to be unescaped before it is used as a path. A
+  // numeric reference for a separator is the case that matters: left encoded,
+  // the path collapses to the solution's own folder.
+  it.each([
+    ['a named entity', 'R&amp;D Lib/RD.Lib.csproj', 'R&D Lib'],
+    ['a hex numeric reference', 'R&#x26;D Lib/RD.Lib.csproj', 'R&D Lib'],
+    ['a decimal numeric reference', 'R&#38;D Lib/RD.Lib.csproj', 'R&D Lib'],
+    ['an encoded separator', 'src&#47;App/App.csproj', path.join('src', 'App')],
+    ['an escaped ampersand', 'R&amp;amp;D/RD.csproj', 'R&amp;D'],
+  ])('decodes %s in a project path', (_, written, expected) => {
+    const slnxFile = writeTempSolution(
+      `<Solution><Project Path="${written}" /></Solution>`,
+    );
+
+    expect(sln.parsePathsFromSln(slnxFile)).toEqual([expected]);
+  });
+
+  it('reads a single-quoted Path attribute', () => {
+    const slnxFile = writeTempSolution(
+      `<Solution><Project Path='Service/Service.csproj' /></Solution>`,
+    );
+
+    expect(sln.parsePathsFromSln(slnxFile)).toEqual(['Service']);
+  });
+
+  it('finds no projects in an empty solution', () => {
+    const slnxFile = writeTempSolution('<Solution />');
+
+    expect(sln.parsePathsFromSln(slnxFile)).toEqual([]);
+  });
+});
+
+describe('updateArgs for .slnx solutions', () => {
+  it('replaces --file with the folders of the projects it holds', () => {
+    const args = {
+      options: {
+        file: getWorkspacePath('sln-example-app/mySolution.slnx'),
+        _: [],
+      },
+    };
+
+    sln.updateArgs(args);
+
+    expect(args.options.file).toBeUndefined();
+    args.options._.pop();
+    expect(basenames(args.options._)).toEqual([
+      'dotnet2_new_mvc_project',
+      'WebApplication2',
+    ]);
+  });
+
+  it('resolves project paths relative to the solution file', () => {
+    const args = {
+      options: {
+        file: getWorkspacePath('slnxSolution.slnx'),
+        _: [],
+      },
+    };
+
+    sln.updateArgs(args);
+
+    expect(args.options.file).toBeUndefined();
+    args.options._.pop();
+    expect(basenames(args.options._)).toEqual(['nuget-app', 'nuget-app-2.1']);
+  });
+
+  it('throws when no project in the solution has a supported manifest', () => {
+    const args = {
+      options: {
+        file: getWorkspacePath('sln-no-supported-files/mySolution.slnx'),
+        _: [],
+      },
+    };
+
+    expect(() => sln.updateArgs(args)).toThrow(
+      'Could not detect supported target files in dotnet2_new_mvc_project, WebApplication2',
+    );
+  });
+
+  it('throws when the solution holds no resolvable project', () => {
+    const args = {
+      options: { file: getWorkspacePath('emptySolution.slnx'), _: [] },
+    };
+
+    expect(() => sln.updateArgs(args)).toThrow(
+      /Could not detect supported target files in/,
+    );
+  });
+
+  it('throws when --file is empty', () => {
+    expect(() => sln.updateArgs({ options: { _: [] } })).toThrow(
+      /Empty --file argument/,
+    );
+  });
+});


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows CONTRIBUTING guidelines
- [x] Commit messages are release-note ready
- [x] Includes detailed description of changes
- [x] Contains risk assessment
- [x] Highlights breaking API changes (none)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions
- [ ] Updates relevant GitBook documentation (PR link: **not yet — see below**)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Makes `--file=*.slnx` work the way `--file=*.sln` already does.

`--file=*.sln` is a **target selector, not a manifest**: the CLI parses the solution, keeps the projects whose folders hold a supported manifest, deletes `--file`, and rewrites argv as if the user had passed those folders. It sits between one `.csproj` and `--all-projects`.

`.slnx` — the XML solution format the .NET SDK reads from 9.0.200 and creates by default from .NET 10 — was not recognised at all. It fell through to package-manager detection and failed with "could not detect package manager". Customers converting `.sln` → `.slnx` as part of a .NET 9/10 upgrade hit this and their pipelines break.

Ticket: CMPA-766.

## Where should the reviewer start?

`src/lib/sln/index.ts`. Three things worth a careful look:

1. **No new dependency.** Project paths are matched out of the XML with a regex after stripping comments, rather than pulling an XML parser into the CLI bundle. Reviewed adversarially against a 45-input differential vs a real XML parser: the divergences that exist are only reachable by inputs no .NET tool produces (CDATA, processing instructions, namespaced elements, duplicate attributes). Verified identical on real `dotnet sln migrate` output, including a directory name containing `&amp;`.
2. **`.sln` folder resolution is deliberately untouched.** The two formats disagree about a project path written with a trailing separator: in `.slnx` it names a folder, while a `.sln` ASP.NET Website entry (`..\..\WebSites\Site1\`) has always resolved to the folder *above*. An earlier revision of this PR shared one code path and silently changed which folder a `.sln` scan covers — that would have added projects on `monitor` and vulns on `test` for existing users. Each format now has its own rule and `sln-website-project/mySolution.sln` pins the `.sln` one.
3. **`solutionExtension()`** replaces `path.extname` so a file named only `.slnx` reaches the right parser, and so the unsupported-combination message matches the one `cli-extension-os-flows` produces for the same rejection.

Two deliberate, disclosed side-effects on `.sln`, both arguably fixes but both behaviour changes:
- the extension is now matched **case-insensitively**, so `--file=App.SLN` is expanded where it previously fell through to manifest detection;
- that error message now names the extension in **lower case** (`file=*.SLNX` → `file=*.slnx`).

## How should this be manually tested?

```sh
cd test/fixtures/nuget-sln            # holds Service.sln and Service.slnx side by side
snyk test --file=Service.slnx         # same projects as --file=Service.sln
snyk sbom --format=cyclonedx1.4+json --file=Service.slnx
snyk test --file=Service.slnx --project-name=x   # rejected, naming .slnx
```

Automated coverage: `test/jest/unit/lib/sln.spec.ts` (28 tests — parsing, XML entity decoding including numeric character references, single-quoted attributes, empty solutions, path resolution relative to the solution, and the `.sln` regression above), plus acceptance tests in `test/jest/acceptance/cli-args.spec.ts` and `test/jest/acceptance/snyk-sbom/nuget-options.spec.ts`.

## What's the product update that needs to be communicated to CLI users?

`--file` now accepts `.slnx` solution files as well as `.sln`, on `snyk test`, `snyk monitor` and `snyk sbom`. No feature flag or enablement needed.

**Docs are not updated by this PR and are the only shipped surface still saying `.sln` only** — `help/` is authored in GitBook, so `help/cli-commands/{test,monitor,sbom}.md` need the `--file=<filename>.sln` sections retitled and a minimum CLI version added. Worth noting the demand evidence includes an account that has not adopted `.slnx` *because the documented support matrix says we don't support it*, so the docs change carries most of the customer value here.

## Risk assessment: Medium

Low in what it adds (`.slnx` was previously a hard failure, so there is no behaviour to regress), medium in where it sits: `src/lib/sln/` is on the hot path for every `--file=*.sln` scan across all ecosystems, not just .NET. The two disclosed `.sln` side-effects above are the whole of the risk; the trailing-separator regression is fixed and pinned by a test.

## Related PRs

The same gap in the two extensions, for reviewers tracing the whole feature:
- snyk/cli-extension-os-flows#276 — same rejection for `--file=*.slnx + --project-name`
- snyk/cli-extension-dep-graph#237 — native `.slnx` resolution in the unified .NET resolver

**This PR should land first.** The unified resolver hands a solution it cannot fully claim back to the legacy CLI, which needs this change to understand `.slnx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)