### PR TITLE
fix: restore moduleName, triageAdvice, functions_new in JSON [OSF-479]

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -218,14 +218,14 @@ require (
 	github.com/snyk/cli-extension-dep-graph/v2 v2.14.0 // indirect
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 // indirect
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f // indirect
-	github.com/snyk/cli-extension-os-flows v0.0.0-20260902112609-53cb856541b8 // indirect
+	github.com/snyk/cli-extension-os-flows v0.0.0-20260903073306-ad447d86c87d // indirect
 	github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9 // indirect
 	github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd // indirect
 	github.com/snyk/code-client-go v1.31.8 // indirect
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 // indirect
-	github.com/snyk/go-application-framework v0.18.2 // indirect
+	github.com/snyk/go-application-framework v0.19.1 // indirect
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
@@ -280,7 +280,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
-	golang.org/x/crypto v0.55.0 // indirect
+	golang.org/x/crypto v0.56.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/net v0.58.0 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -595,8 +595,8 @@ github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSo
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f h1:EPaHfaWDJq/lrsrATMqAyKJRfstb9LZnPXYNwXdL32c=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f/go.mod h1:JoubAvjOyuB3y0HxulaiAEiVthMOa9abElpL72C5zz4=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260902112609-53cb856541b8 h1:7HX6ho6Wbf5lZD2PalRTPrJLWZI+yKUyME9OTnHs+/0=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260902112609-53cb856541b8/go.mod h1:ukSD97e6hc9w0UkrbI/OV2GeDpsEyUsIzE38vdzRbZ8=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260903073306-ad447d86c87d h1:fiy5lWcG6l0xrVQ6XGY8GecF7CLTWj8wlqP0XkGHyoY=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260903073306-ad447d86c87d/go.mod h1:NoQ87QIOH6FSsytBKr5LQbPBjS2rPDY5maZYNYJ5s9c=
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9 h1:Kz/UCPae7vRVeFlkkYHnyFRYue9gaO16enVnN7aclco=
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd h1:sSVkD1CuL8v49boItrt2CnQ4DJIH+sjGwFGheGCVAxo=
@@ -609,8 +609,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.18.2 h1:dlhHzdSLr5/e8eaD+eX9k16A9WhpwZ6KBVkSf9YTFLc=
-github.com/snyk/go-application-framework v0.18.2/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
+github.com/snyk/go-application-framework v0.19.1 h1:HmIxqrGafFVJgt/y6A3o8x6ekP5RbHGezTBgsfd8t9I=
+github.com/snyk/go-application-framework v0.19.1/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=
@@ -770,8 +770,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -16,13 +16,13 @@ require (
 	github.com/snyk/cli-extension-dep-graph/v2 v2.14.0
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f
-	github.com/snyk/cli-extension-os-flows v0.0.0-20260902112609-53cb856541b8
+	github.com/snyk/cli-extension-os-flows v0.0.0-20260903073306-ad447d86c87d
 	github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9
 	github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd
 	github.com/snyk/code-client-go v1.31.8
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6
-	github.com/snyk/go-application-framework v0.18.2
+	github.com/snyk/go-application-framework v0.19.1
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260902080529-bf1230ca471b
@@ -246,7 +246,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.45.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
-	golang.org/x/crypto v0.55.0 // indirect
+	golang.org/x/crypto v0.56.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -542,8 +542,8 @@ github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSo
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f h1:EPaHfaWDJq/lrsrATMqAyKJRfstb9LZnPXYNwXdL32c=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f/go.mod h1:JoubAvjOyuB3y0HxulaiAEiVthMOa9abElpL72C5zz4=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260902112609-53cb856541b8 h1:7HX6ho6Wbf5lZD2PalRTPrJLWZI+yKUyME9OTnHs+/0=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260902112609-53cb856541b8/go.mod h1:ukSD97e6hc9w0UkrbI/OV2GeDpsEyUsIzE38vdzRbZ8=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260903073306-ad447d86c87d h1:fiy5lWcG6l0xrVQ6XGY8GecF7CLTWj8wlqP0XkGHyoY=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260903073306-ad447d86c87d/go.mod h1:NoQ87QIOH6FSsytBKr5LQbPBjS2rPDY5maZYNYJ5s9c=
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9 h1:Kz/UCPae7vRVeFlkkYHnyFRYue9gaO16enVnN7aclco=
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd h1:sSVkD1CuL8v49boItrt2CnQ4DJIH+sjGwFGheGCVAxo=
@@ -556,8 +556,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.18.2 h1:dlhHzdSLr5/e8eaD+eX9k16A9WhpwZ6KBVkSf9YTFLc=
-github.com/snyk/go-application-framework v0.18.2/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
+github.com/snyk/go-application-framework v0.19.1 h1:HmIxqrGafFVJgt/y6A3o8x6ekP5RbHGezTBgsfd8t9I=
+github.com/snyk/go-application-framework v0.19.1/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=
@@ -694,8 +694,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable) — none
- [x] Links to automated tests covering new functionality — in the dependency repos, see below
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: n/a — no documented behaviour changes; these fields were always part of the `--json` contract)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Restores three fields that the new unified Open Source test flow had stopped emitting in `snyk test --json`: `vulnerabilities[].moduleName`, `vulnerabilities[].insights.triageAdvice`, and `vulnerabilities[].functions_new`.
This is a dependency bump only — no CLI source changes in this repo:

| Module | From | To |
| --- | --- | --- |
| `github.com/snyk/go-application-framework` | `v0.18.2` | `v0.19.1` |
| `github.com/snyk/cli-extension-os-flows` | `v0.0.0-20260902112609-53cb856541b8` | `v0.0.0-20260903073306-ad447d86c87d` |

Applied to both `cliv2` and `cliv2-private`; `make validate-gomod-sync` passes.

Bump crypto package to 0.56.0 in order to fix vuln SNYK-GOLANG-GOLANGORGXCRYPTOSSH-19504090

Recorded in this PR because it has **no PR of its own**. snyk/cli#7179 carried it, but the pin reached `main` first through `a22a5635f` (the OSF-485 bump), whose message mentions only OSF-485 — so #7179 was closed as already-merged and OSF-482 has no release-note entry anywhere. Nothing below is introduced by *this* bump: snyk/cli-extension-os-flows#275 merged 2026-08-27 and is an ancestor of both the old and the new pin. It is written down here so the fix reaches the release notes.

[snyk/cli-extension-os-flows#275](https://github.com/snyk/cli-extension-os-flows/pull/275) restores `--json-file-output` parity between the unified test flow and legacy. Four divergences:

## Where should the reviewer start?

`cliv2/go.mod` — the two changed `require` lines. The diff is exactly those two pins in each of the two modules plus the four matching `go.sum` hash pairs, and nothing else.

The behaviour worth reviewing lives in snyk/cli-extension-os-flows#279, specifically `internal/legacy/transform/transform.go` (`setVulnInsights`, `setMavenModuleName`, `setVulnFunctionsNew`).

## How should this be manually tested?

Build a binary from this branch, then diff the same project across both flows. Assert the routing rather than assuming it — unsetting `SNYK_FORCE_LEGACY_CLI` does not by itself select the new flow:

```bash
snyk test --json --debug 2>&1 >/dev/null | grep "Using legacy flow"   # must be true, then false
SNYK_FORCE_LEGACY_CLI=true snyk test --json > legacy.json
INTERNAL_SNYK_CLI_USE_TEST_SHIM_FOR_OS_CLI_TEST=true snyk test --json > new.json
```

`moduleName`, `insights.triageAdvice` and `functions_new` should agree element-for-element.

Verified before opening this PR, on a binary embedding these exact pins:

| Fixture | Vulns | `functions_new` | `insights` | `moduleName` |
| --- | --- | --- | --- | --- |
| java-goof (`todolist-core`, Maven) | 14 | 14/14 match | 14/14 | 14/14 |
| npm7-goof | 461 | 461/461 | 461/461 | 461/461 |
| nodejs-goof | 491 | 491/491 | 491/491 | 491/491 |

`functionId` is ecosystem-discriminated and both flows agree on the shape: Java emits `{className, functionName}`, npm emits `{filePath, functionName}`, never both, and with no empty-string `filePath` on either side. Ignored vulnerabilities were checked separately — with a `.snyk` ignoring `SNYK-JAVA-ORGHIBERNATE-1041788`, both flows retain `triageAdvice` under `filtered.ignore[]`.

**Automated coverage** lives in snyk/cli-extension-os-flows#279: `TestFindingToLegacyVulns_Maven` and its snapshot, whose fixture was extended to carry `insights.triage_advice`, `module_name` and a `vulnerable_functions_list` entry with a `class_name`. There are no new tests in this repo — a pin bump has no in-tree behaviour to cover.

## What's the product update that needs to be communicated to CLI users?

`moduleName`, `insights.triageAdvice` and `functions_new` are emitted again for `snyk test --json`

Fixed `snyk test --json-file-output` failing with `SNYK-CLI-0000 ... no such file or directory` when the output path's directory didn't exist yet.

Bump crypto package to 0.56.0 in order to fix vuln SNYK-GOLANG-GOLANGORGXCRYPTOSSH-19504090

## Risk assessment: Low

Dependency pins only, no CLI source changes. The change is purely additive to the JSON document — three fields reappear on a code path that is still behind a feature flag. Consumers that had adapted to their absence read them as optional, and the legacy flow is untouched. Both modules build; `make validate-gomod-sync` passes.

## What are the relevant tickets?

OSF-479 · OSF-482 · Support case 00135982

Carries forward the description of the closed snyk/cli#7179.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only `go.mod`/`go.sum` pins change; JSON additions are additive on a feature-flagged path and legacy flow is unchanged.
> 
> **Overview**
> **Dependency-only change** — no CLI source edits. `cliv2` and `cliv2-private` both refresh pins for `github.com/snyk/cli-extension-os-flows` and `github.com/snyk/go-application-framework`, with matching `go.sum` checksum updates.
> 
> | Module | From | To |
> | --- | --- | --- |
> | `go-application-framework` | `v0.18.2` | `v0.19.1` |
> | `cli-extension-os-flows` | `…0902112609-53cb856541b8` | `…0903073306-ad447d86c87d` |
> 
> Shipped behavior (in those libraries, not in this diff): the unified Open Source test path again emits legacy `snyk test --json` fields — `vulnerabilities[].moduleName`, `vulnerabilities[].insights.triageAdvice`, and `vulnerabilities[].functions_new` — and aligns `--json-file-output` with the legacy flow where applicable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eab1109c6e08062718ebb9fe2e410ce6709a2e8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->






