### PR TITLE
fix(deps): upgrade bundled semver to 7.5.2 for CVE-2022-25883

### DIFF
--- a/ts-binary-wrapper/package-lock.json
+++ b/ts-binary-wrapper/package-lock.json
@@ -1919,9 +1919,9 @@
       }
     },
     "node_modules/global-agent/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
       "inBundle": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -5362,7 +5362,7 @@
         "es6-error": "^4.1.1",
         "matcher": "^3.0.0",
         "roarr": "^2.15.3",
-        "semver": "^7.3.2",
+        "semver": "7.5.2",
         "serialize-error": "^7.0.1"
       },
       "dependencies": {
@@ -5375,9 +5375,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+          "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
           "requires": {
             "lru-cache": "^6.0.0"
           }

--- a/ts-binary-wrapper/package.json
+++ b/ts-binary-wrapper/package.json
@@ -53,6 +53,11 @@
     "@sentry/node": "^7.36.0",
     "global-agent": "^3.0.0"
   },
+  "overrides": {
+    "global-agent": {
+      "semver@7.3.8": "7.5.2"
+    }
+  },
   "bundleDependencies": [
     "global-agent",
     "roarr",


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Upgrades the bundled `semver` dependency (via `global-agent`) in `ts-binary-wrapper` from `7.3.8` to `7.5.2`, fixing CVE-2022-25883 (ReDoS, HIGH).

Since `global-agent` is in `bundleDependencies`, the vulnerable `semver@7.3.8` ships in the published `snyk` npm package. Customers scanning the Snyk CLI installation directory flag it as a HIGH finding.

## Where should the reviewer start?

- `ts-binary-wrapper/package.json` — npm override added
- `ts-binary-wrapper/package-lock.json` — resolved version bumped

## How should this be manually tested?

```sh
snyk test --file=ts-binary-wrapper/package-lock.json
```
Confirm SNYK-JS-SEMVER-3247795 no longer appears.

## What's the product update that needs to be communicated to CLI users?
Upgraded an internal dependency to address a known security advisory.