### PR TITLE
chore: bump rift-cli-extension to v1.2.1 [RIFT-139]

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/snyk/cli-extension-cos v0.0.0-20260818151318-d63bb9db9484
 	github.com/snyk/cli/cliv2 v0.0.0
 	github.com/snyk/remy-cli-extension v1.36.1
-	github.com/snyk/rift-cli-extension v1.2.0
+	github.com/snyk/rift-cli-extension v1.2.1
 )
 
 require (

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -600,8 +600,8 @@ github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhk
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
 github.com/snyk/remy-cli-extension v1.36.1 h1:TFiJL7XlqXklGsplIhlnhyRp+nyi4rV7L2Nze4ggR9Q=
 github.com/snyk/remy-cli-extension v1.36.1/go.mod h1:ez/NUC+xzLRJB7+H0GTUjv4O1x2U+UWArSLdLVCcY3w=
-github.com/snyk/rift-cli-extension v1.2.0 h1:Vo1rAFJ6pWZF3F84HDTPNr7XSBfp2f1kWf25SjjrLTQ=
-github.com/snyk/rift-cli-extension v1.2.0/go.mod h1:jc+VhpfPQpNoWKpjfKbeRkuevdJpzb81RjxHjl4p9hY=
+github.com/snyk/rift-cli-extension v1.2.1 h1:oM9kx6a+rzEH+/5LcZLosNcT3NUcTd2dopvV1SVTenA=
+github.com/snyk/rift-cli-extension v1.2.1/go.mod h1:jc+VhpfPQpNoWKpjfKbeRkuevdJpzb81RjxHjl4p9hY=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
 github.com/snyk/snyk-ls v0.0.0-20260824150100-a207e801a57e h1:Sf7aMRGEcWA1OppdIbyLFYBFeCdNNTIuZX+zBDJMrYc=


### PR DESCRIPTION
## Summary
- Bumps `cliv2-private` to rift-cli-extension [v1.2.1](https://github.com/snyk/rift-cli-extension/releases/tag/v1.2.1), which includes [snyk/rift-cli-extension#15](https://github.com/snyk/rift-cli-extension/pull/15) — `snyk rift test` now sends the focus name that rift-service expects, instead of one the service rejects.
- `rift-cli-extension` is registered only in the private build, so `cliv2` is untouched apart from the tidy/sync check.

## Test plan
- [x] `go build ./...` passes in both `cliv2` and `cliv2-private`
- [x] `make tidy` reports the `cliv2` / `cliv2-private` go.mod files already in sync and produces no further drift

## Risk assessment
Low — a patch bump of a dependency used by a single experimental command (`snyk rift test`) in the private build only.

Made with [Cursor](https://cursor.com)