### PR TITLE
fix: handle .snyk policy edge cases in the new snyk test flow [OSF-485]

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -215,7 +215,7 @@ require (
 	github.com/snyk/cli-extension-dep-graph/v2 v2.11.0 // indirect
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 // indirect
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f // indirect
-	github.com/snyk/cli-extension-os-flows v0.0.0-20260831095357-9cc236689fc1 // indirect
+	github.com/snyk/cli-extension-os-flows v0.0.0-20260902112609-53cb856541b8 // indirect
 	github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9 // indirect
 	github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd // indirect
 	github.com/snyk/code-client-go v1.31.8 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -592,8 +592,8 @@ github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSo
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f h1:EPaHfaWDJq/lrsrATMqAyKJRfstb9LZnPXYNwXdL32c=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f/go.mod h1:JoubAvjOyuB3y0HxulaiAEiVthMOa9abElpL72C5zz4=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260831095357-9cc236689fc1 h1:r13WOBFc4Jtq7NM1Kj6whKts2B7DLci7CU24aNqNQx8=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260831095357-9cc236689fc1/go.mod h1:ukSD97e6hc9w0UkrbI/OV2GeDpsEyUsIzE38vdzRbZ8=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260902112609-53cb856541b8 h1:7HX6ho6Wbf5lZD2PalRTPrJLWZI+yKUyME9OTnHs+/0=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260902112609-53cb856541b8/go.mod h1:ukSD97e6hc9w0UkrbI/OV2GeDpsEyUsIzE38vdzRbZ8=
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9 h1:Kz/UCPae7vRVeFlkkYHnyFRYue9gaO16enVnN7aclco=
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd h1:sSVkD1CuL8v49boItrt2CnQ4DJIH+sjGwFGheGCVAxo=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/snyk/cli-extension-dep-graph/v2 v2.11.0
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f
-	github.com/snyk/cli-extension-os-flows v0.0.0-20260831095357-9cc236689fc1
+	github.com/snyk/cli-extension-os-flows v0.0.0-20260902112609-53cb856541b8
 	github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9
 	github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd
 	github.com/snyk/code-client-go v1.31.8

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -542,8 +542,8 @@ github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSo
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f h1:EPaHfaWDJq/lrsrATMqAyKJRfstb9LZnPXYNwXdL32c=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f/go.mod h1:JoubAvjOyuB3y0HxulaiAEiVthMOa9abElpL72C5zz4=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260831095357-9cc236689fc1 h1:r13WOBFc4Jtq7NM1Kj6whKts2B7DLci7CU24aNqNQx8=
-github.com/snyk/cli-extension-os-flows v0.0.0-20260831095357-9cc236689fc1/go.mod h1:ukSD97e6hc9w0UkrbI/OV2GeDpsEyUsIzE38vdzRbZ8=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260902112609-53cb856541b8 h1:7HX6ho6Wbf5lZD2PalRTPrJLWZI+yKUyME9OTnHs+/0=
+github.com/snyk/cli-extension-os-flows v0.0.0-20260902112609-53cb856541b8/go.mod h1:ukSD97e6hc9w0UkrbI/OV2GeDpsEyUsIzE38vdzRbZ8=
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9 h1:Kz/UCPae7vRVeFlkkYHnyFRYue9gaO16enVnN7aclco=
 github.com/snyk/cli-extension-sbom v0.0.0-20260818092356-16ee760085f9/go.mod h1:YUDazoukFqA0OpYuACIoqVEsfPCAFXo9XotUk9RjmUY=
 github.com/snyk/cli-extension-secrets v0.0.0-20260811115637-ee872c26b0cd h1:sSVkD1CuL8v49boItrt2CnQ4DJIH+sjGwFGheGCVAxo=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable) — none; no flags, output shapes or exit-code contracts are added or removed
- [ ] Links to automated tests covering new functionality — **no test lands in this repo**, see [Where should the reviewer start?](#where-should-the-reviewer-start)
- [x] Includes manual testing instructions (if necessary)
- [x] Updates relevant GitBook documentation (PR link: _n/a — no user-facing docs change_)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Fixes `.snyk` policy handling in the unified `snyk test` flow, by pinning `github.com/snyk/cli-extension-os-flows` to `v0.0.0-20260902112609-53cb856541b8` — the merge commit of [snyk/cli-extension-os-flows#280](https://github.com/snyk/cli-extension-os-flows/pull/280).

Before this, scans that succeed under `SNYK_FORCE_LEGACY_CLI=true` could abort or report the wrong result on a range of `.snyk` shapes — including ones the legacy CLI writes itself. The upstream fix closes eleven discrepancies against legacy behaviour:

- empty, whitespace-only and comment-only policy files
- legacy's own `ignore: []` default block
- non-mapping YAML documents
- date-only and zone-less timestamps
- unparseable timestamps
- null rule bodies — these previously **panicked**
- tab indentation
- the old `.snyk` format message
- null `ignores` sent to the test API
- four stacked Go error wrappers where legacy prints one sentence
- `ok` reported as `false` when every finding was ignored

Only `cliv2/go.mod`, `cliv2/go.sum`, `cliv2-private/go.mod` and `cliv2-private/go.sum` change here; `go mod tidy` re-synced the private module. No application code in this repo is touched.

## Where should the reviewer start?

The diff is four lines of dependency pin — the substance is upstream in [cli-extension-os-flows#280](https://github.com/snyk/cli-extension-os-flows/pull/280), which is where the parser change and its unit tests live.

**Please note the test-coverage gap.** Two acceptance workspaces (`npm-package-empty-snyk-policy`, `npm-package-date-only-snyk-policy`) and their entries in the unified test-API equivalence suite were written for this branch and then **removed on request**, so this PR carries only the bump. The parser behaviour is covered by unit tests in the extension repo; there is currently **no regression guard in this repo** for these `.snyk` shapes.

## How should this be manually tested?

```sh
make build
./binary-releases/snyk-macos-arm64 --version   # adjust for your platform
```

Then, in a project with an npm dependency vulnerability, compare the two flows against an edge-case `.snyk`:

```sh
printf '' > .snyk   # empty policy; also try a date-only `expires`, or `ignore: []`
SNYK_FORCE_LEGACY_CLI=true ./binary-releases/snyk-macos-arm64 test --json
INTERNAL_SNYK_CLI_USE_TEST_SHIM_FOR_OS_CLI_TEST=true ./binary-releases/snyk-macos-arm64 test --json
```

Exit code, `ok`, vulnerability count and filtered-ignore count should now agree between the two.

**Automated verification already run on this branch:** a 38-case `.snyk` input-parity matrix over `npm-package-single-vuln`, driving both flows with routing asserted per run, comparing exit code, `ok`, vulnerability count, filtered-ignore count, `filesystemPolicy`, error text and the human-output error-catalog code.

> **27/38 cases differed against a pre-bump binary; 3/38 differ with this bump — 24 fixed, 0 new regressions.**

The 3 remaining differences are error-message wording only; exit code, `ok`, counts and error-catalog code (`SNYK-CLI-0000`) all match. Two of the three compare against a raw JavaScript internal error from legacy (`Cannot assign to read only property '0' of string …`), which is not a contract worth reproducing.

## What's the product update that needs to be communicated to CLI users?

`snyk test` now reads `.snyk` policy files correctly.

## Risk assessment (Low | Medium | High)?

**Medium.** The diff in this repo is a dependency pin, but it changes how `.snyk` policies are parsed and applied during `snyk test`, which can alter exit codes, results and error text for some policy shapes. Mitigating factors: the 38-case parity matrix shows 24 fixes and no regressions, and every change moves the new flow *towards* long-standing legacy behaviour rather than introducing new semantics. Aggravating factor: no regression test guards this in the CLI repo (see above).

## What are the relevant tickets?

[OSF-485](https://snyksec.atlassian.net/browse/OSF-485)


[OSF-485]: https://snyksec.atlassian.net/browse/OSF-485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumping os-flows changes how `.snyk` policies are parsed and applied during `snyk test`, which can alter results and exit codes for some projects, without in-repo regression tests for those shapes.
> 
> **Overview**
> This PR **only bumps** `github.com/snyk/cli-extension-os-flows` to `v0.0.0-20260902112609-53cb856541b8` in `cliv2` and `cliv2-private` (`go.mod` / `go.sum`). No application code in this repo changes; the unified `snyk test` flow picks up upstream fixes from [cli-extension-os-flows#280](https://github.com/snyk/cli-extension-os-flows/pull/280) via `osflows.Init` in `cliv2/pkg/core/workflows.go`.
> 
> That upstream release aligns `.snyk` policy handling with legacy CLI behavior for edge cases (empty or comment-only files, `ignore: []`, odd YAML/timestamps, null rule bodies that could panic, tab indentation, ignored-findings `ok` semantics, and related API/error wrapping). Exit codes, `ok`, counts, and catalog codes are intended to match legacy more closely; a few error-message wording gaps may remain.
> 
> **Note:** There is no new regression test in this repo for these policy shapes—coverage lives in the extension repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a22a5635f2cb119fdb676c786a10b1fd8cb8a804. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->