### PR TITLE
fix(cli): classify non-failure exit codes in tearDown to prevent duplicate output [CLI-1765]

### DIFF
--- a/cliv2/internal/errors/errors.go
+++ b/cliv2/internal/errors/errors.go
@@ -3,9 +3,12 @@ package cli_errors
 import (
 	"errors"
 	"fmt"
+	"os/exec"
 
 	"github.com/snyk/error-catalog-golang-public/snyk"
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
+
+	"github.com/snyk/cli/cliv2/internal/constants"
 )
 
 type ErrorWithExitCode struct {
@@ -14,6 +17,32 @@ type ErrorWithExitCode struct {
 
 func (e ErrorWithExitCode) Error() string {
 	return fmt.Sprintf("exit code: %d", e.ExitCode)
+}
+
+// IsFailure reports whether err represents an actual failure that needs error
+// processing, as opposed to a command result that merely carries a known
+// non-failure exit code (vulnerabilities found or unsupported projects).
+func IsFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return !isNonFailureExitCode(exitErr.ExitCode())
+	}
+	if exitCodeErr, ok := err.(*ErrorWithExitCode); ok {
+		return !isNonFailureExitCode(exitCodeErr.ExitCode)
+	}
+	return true
+}
+
+func isNonFailureExitCode(code int) bool {
+	switch code {
+	case constants.SNYK_EXIT_CODE_VULNERABILITIES_FOUND,
+		constants.SNYK_EXIT_CODE_UNSUPPORTED_PROJECTS:
+		return true
+	default:
+		return false
+	}
 }
 
 // FindMostRelevantError determines the most relevant error from a list of errors, inspecting the full error chain. The returned error can be used for display and exit code mapping.

--- a/cliv2/internal/errors/errors_test.go
+++ b/cliv2/internal/errors/errors_test.go
@@ -3,11 +3,13 @@ package cli_errors
 import (
 	"errors"
 	"fmt"
+	"os/exec"
 	"testing"
 
 	"github.com/snyk/error-catalog-golang-public/snyk"
 	"github.com/snyk/error-catalog-golang-public/snyk_errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFindMostRelevantError_Empty(t *testing.T) {
@@ -135,6 +137,37 @@ func TestFindMostRelevantError_PreservesErrorWithExitCodeAmongOthers(t *testing.
 	var resultExitCode *ErrorWithExitCode
 	assert.True(t, errors.As(result, &resultExitCode))
 	assert.Equal(t, 1, resultExitCode.ExitCode)
+}
+
+func TestIsFailure(t *testing.T) {
+	exitWithCode := func(code int) error {
+		err := exec.Command("sh", "-c", fmt.Sprintf("exit %d", code)).Run()
+		require.Error(t, err)
+		return err
+	}
+
+	tests := []struct {
+		name    string
+		err     error
+		failure bool
+	}{
+		{"nil", nil, false},
+		{"exec exit 1 (vulnerabilities found)", exitWithCode(1), false},
+		{"exec exit 2 (error)", exitWithCode(2), true},
+		{"exec exit 3 (unsupported projects)", exitWithCode(3), false},
+		{"exec exit 44 (TS CLI terminated)", exitWithCode(44), true},
+		{"ErrorWithExitCode 1", &ErrorWithExitCode{ExitCode: 1}, false},
+		{"ErrorWithExitCode 2", &ErrorWithExitCode{ExitCode: 2}, true},
+		{"ErrorWithExitCode 3", &ErrorWithExitCode{ExitCode: 3}, false},
+		{"plain error", fmt.Errorf("connection refused"), true},
+		{"joined error with ErrorWithExitCode", errors.Join(fmt.Errorf("data error"), &ErrorWithExitCode{ExitCode: 3}), true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.failure, IsFailure(tc.err))
+		})
+	}
 }
 
 func TestMaxRecursionDepth(t *testing.T) {

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -519,13 +519,13 @@ func tearDown(err error, errorList []error, startTime time.Time, ua networking.U
 	outputError := err
 	allErrors := errorList
 
-	if err != nil {
+	if cli_errors.IsFailure(err) {
 		allErrors, outputError = processError(err, errorList)
+	}
 
-		for _, tempError := range allErrors {
-			if tempError != nil {
-				cliAnalytics.AddError(tempError)
-			}
+	for _, tempError := range allErrors {
+		if tempError != nil {
+			cliAnalytics.AddError(tempError)
 		}
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "semver": "^6.0.0",
         "snyk-config": "^5.0.0",
         "snyk-cpp-plugin": "^2.24.3",
-        "snyk-docker-plugin": "9.19.0",
+        "snyk-docker-plugin": "9.20.0",
         "snyk-go-plugin": "2.2.1",
         "snyk-gradle-plugin": "7.1.2",
         "snyk-module": "3.1.0",
@@ -19761,9 +19761,9 @@
       "license": "ISC"
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-9.19.0.tgz",
-      "integrity": "sha512-XVOEneK1YKfFxOqyUR8PRBHzxosRNnfEuejNZHIKUqRdFrJjfVzxPRNo5a2ypis8z26C0/Hgha18nCwitvejRA==",
+      "version": "9.20.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-9.20.0.tgz",
+      "integrity": "sha512-wzvEK7aO7od4/bp1ZXivQzzMJNRYSX9s3DY+sCB5wCw/MVx93R2fNcTqXt3HtObJYPSUtEm5pA8nYVSG77NqYw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@snyk/composer-lockfile-parser": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "semver": "^6.0.0",
     "snyk-config": "^5.0.0",
     "snyk-cpp-plugin": "^2.24.3",
-    "snyk-docker-plugin": "9.19.0",
+    "snyk-docker-plugin": "9.20.0",
     "snyk-go-plugin": "2.2.1",
     "snyk-gradle-plugin": "7.1.2",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable) — none
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___) — n/a, no user-facing docs change
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

CLI Ticket: https://snyksec.atlassian.net/browse/CLI-1765

### Problem

When a CLI command completes successfully but with a non-zero exit code (e.g. exit 1 = vulnerabilities found), and an auxiliary network error was handled during the run (e.g. a provenance fetch failure in `snyk-docker-plugin` 9.20.0), `tearDown` feeds both errors into `processError`. Inside `processError`, `FindMostRelevantError` joins them via `errors.Join`, producing a new error whose concrete type is neither `*exec.ExitError` nor `*ErrorWithExitCode`. The existing guard in `displayError` uses direct type assertions, so it fails to recognise the joined error as a command result and prints it after the command's own JSON output — making the output unparseable.

### Root cause

The condition `if err != nil` in `tearDown` (line 519) treats every non-nil error the same. But Go's `error` interface is used for two distinct purposes here:

1. **Command results** — `*exec.ExitError` (exit 1, 3) or `*ErrorWithExitCode` that carry a known non-failure exit code. The command already produced its output.
2. **Actual failures** — errors that need decoration, prioritisation, and display.

Sending command results through `processError` → `FindMostRelevantError` → `errors.Join` destroys the type information that the rest of the pipeline depends on.

### Fix

Replace `if err != nil` with `if cli_errors.IsFailure(err)`. `IsFailure` checks both the error type and the specific exit code:

- `*exec.ExitError` or `*ErrorWithExitCode` with exit code 1 (vulnerabilities found) or 3 (unsupported projects) → **not a failure**, skip `processError`, preserve the original type
- `*exec.ExitError` with exit code 44 (TS CLI terminated) → **is a failure**, goes through `processError` where the existing terminate filter handles it
- Everything else (exit code 2, plain errors, catalog errors) → **is a failure**, full processing as before

This also pins `snyk-docker-plugin` to `9.20.0`, which is the version that triggers the auxiliary network errors that exposed this bug.

## Where should the reviewer start?

`cliv2/internal/errors/errors.go` — `IsFailure` and `isNonFailureExitCode`, then the one-line change in `cliv2/pkg/core/main.go` `tearDown`.

Then `cliv2/internal/errors/errors_test.go` — `TestIsFailure` covers nil, exit codes 1/2/3/44, `ErrorWithExitCode`, plain errors, and joined errors.

## How should this be manually tested?

Against an image whose provenance fetch fails (snyk-docker-plugin 9.20.0+):

```sh
snyk container test <image> --json > out.json
jq . out.json
```

With the fix, `out.json` should be valid JSON with no trailing error text. Without the fix, an extra error line is appended after the JSON.

## What's the product update that needs to be communicated to CLI users?

n/a — this fixes an internal error-handling issue; no user-facing behavior change beyond the bug fix.

## Risk assessment (Low | Medium | High)?

Low — the change gates a single `if` condition in `tearDown` with a well-defined predicate. Command results with exit codes 1 and 3 skip `processError` (which was a no-op for them in the single-error case anyway). All other error paths are unchanged. Exit code 44 (TS CLI terminated) intentionally remains classified as a failure so the existing filter in `processError` continues to handle it.

## Any background context you want to provide?

Alternative to #7130, which patches the same bug inside `processError` (short-circuit when command owns output) and adds a `shouldSuppressDisplay` guard before `displayError`. This PR instead fixes it at the call site — command results never enter the error processing pipeline, so `errors.Join` never destroys the type, and `displayError`'s existing guard works unchanged.

## What are the relevant tickets?

- https://snyksec.atlassian.net/browse/CLI-1765
- Original PR: https://github.com/snyk/cli/pull/7130
- Discussion: https://snyksec.atlassian.net/servicedesk/customer/portal/64/CLIA-1576
