### PR TITLE
fix: only sweep the values of undeclared flags into analytics redaction terms

### DIFF
--- a/cliv2/internal/utils/args.go
+++ b/cliv2/internal/utils/args.go
@@ -128,6 +128,19 @@ var allowedWords = map[string]bool{
 // Environment variables need no special case. They arrive joined as "--NAME VALUE" and
 // an environment variable name is never a declared flag, so their values stay candidates.
 func GetUnknownParameters(osArgs []string, envVars []string, knownCommands []string, knownFlags []string) []string {
+	return unknownParameters(osArgs, envVars, knownCommands, knownFlags, true)
+}
+
+// GetAllUnknownParameters is the wider sweep: every bare token that clears the length
+// floor, the known command check and the allow list is a candidate, whatever precedes it.
+// It over-redacts, which is only the right trade for the debug log, where the user reads
+// the output before sharing it. Analytics has no human in the loop, so it uses
+// GetUnknownParameters instead.
+func GetAllUnknownParameters(osArgs []string, envVars []string, knownCommands []string) []string {
+	return unknownParameters(osArgs, envVars, knownCommands, nil, false)
+}
+
+func unknownParameters(osArgs []string, envVars []string, knownCommands []string, knownFlags []string, onlyUndeclaredFlagValues bool) []string {
 	argsOneString := strings.Join(osArgs, " ")
 	if len(envVars) > 0 {
 		argsOneString = argsOneString + " --" + strings.Join(envVars, " --")
@@ -144,10 +157,11 @@ func GetUnknownParameters(osArgs []string, envVars []string, knownCommands []str
 			continue
 		}
 
+		isCandidatePosition := prevWasUnknownFlag || !onlyUndeclaredFlagValues
 		isKnownCommand := slices.Contains(knownCommands, arg)
 		isAllowedWord := allowedWords[strings.ToLower(arg)]
 		isPotentiallySensitive := len(arg) >= MIN_ARG_LENGTH
-		if prevWasUnknownFlag && !isKnownCommand && !isAllowedWord && isPotentiallySensitive {
+		if isCandidatePosition && !isKnownCommand && !isAllowedWord && isPotentiallySensitive {
 			argValues = append(argValues, arg)
 		}
 		prevWasUnknownFlag = false

--- a/cliv2/internal/utils/args.go
+++ b/cliv2/internal/utils/args.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"slices"
 	"strings"
+
+	"github.com/snyk/go-application-framework/pkg/logging"
 )
 
 const (
@@ -116,7 +118,16 @@ var allowedWords = map[string]bool{
 	"proxy":    true,
 }
 
-func GetUnknownParameters(osArgs []string, envVars []string, knownCommands []string) []string {
+// GetUnknownParameters returns the tokens of osArgs and envVars that could plausibly
+// be secrets. A bare token qualifies only when the token immediately before it is a
+// flag that no registered workflow declared: the value of a declared flag, and any
+// positional operand, is something the CLI knowingly accepts and so is not guessed at.
+// The length floor, the known command check and the allow list then narrow that
+// candidate set further.
+//
+// Environment variables need no special case. They arrive joined as "--NAME VALUE" and
+// an environment variable name is never a declared flag, so their values stay candidates.
+func GetUnknownParameters(osArgs []string, envVars []string, knownCommands []string, knownFlags []string) []string {
 	argsOneString := strings.Join(osArgs, " ")
 	if len(envVars) > 0 {
 		argsOneString = argsOneString + " --" + strings.Join(envVars, " --")
@@ -126,18 +137,43 @@ func GetUnknownParameters(osArgs []string, envVars []string, knownCommands []str
 	argsSplitAgain := strings.Split(argsOneString, " ")
 
 	argValues := []string{}
+	prevWasUnknownFlag := false
 	for _, arg := range argsSplitAgain {
-		isFlag := strings.HasPrefix(arg, FLAG_PREFIX)
+		if strings.HasPrefix(arg, FLAG_PREFIX) {
+			prevWasUnknownFlag = !isTrustedFlag(strings.TrimLeft(arg, FLAG_PREFIX), knownFlags)
+			continue
+		}
+
 		isKnownCommand := slices.Contains(knownCommands, arg)
 		isAllowedWord := allowedWords[strings.ToLower(arg)]
 		isPotentiallySensitive := len(arg) >= MIN_ARG_LENGTH
-		if !isFlag && !isKnownCommand && !isAllowedWord && isPotentiallySensitive {
+		if prevWasUnknownFlag && !isKnownCommand && !isAllowedWord && isPotentiallySensitive {
 			argValues = append(argValues, arg)
 		}
+		prevWasUnknownFlag = false
 	}
 
 	slices.Sort(argValues)
 	argValues = slices.Compact(argValues)
 
 	return argValues
+}
+
+// isTrustedFlag reports whether the value following the flag named name can be left
+// alone. A flag some workflow declared is trusted, unless its name matches one of the
+// sensitive field names the scrubber already knows about (--tfc-token, --username and
+// friends) — a declared flag can still be the one carrying the secret.
+func isTrustedFlag(name string, knownFlags []string) bool {
+	if !slices.Contains(knownFlags, name) {
+		return false
+	}
+
+	lowercaseName := strings.ToLower(name)
+	for _, sensitive := range logging.SENSITIVE_FIELD_NAMES {
+		if strings.Contains(lowercaseName, sensitive) {
+			return false
+		}
+	}
+
+	return true
 }

--- a/cliv2/internal/utils/args.go
+++ b/cliv2/internal/utils/args.go
@@ -118,17 +118,39 @@ var allowedWords = map[string]bool{
 	"proxy":    true,
 }
 
-// GetUnknownParameters returns the tokens of osArgs and envVars that could plausibly
-// be secrets. A bare token qualifies only when the token immediately before it is a
-// flag that no registered workflow declared: the value of a declared flag, and any
-// positional operand, is something the CLI knowingly accepts and so is not guessed at.
-// The length floor, the known command check and the allow list then narrow that
-// candidate set further.
+// envFlagPrefix renders an environment entry into the token stream as a flag token that
+// no declared flag can ever match: a pflag name never starts with a dash, so "---NAME"
+// leaves a name of "-NAME". That keeps every environment value a redaction candidate
+// under the general rule instead of a special case inside it, including when the
+// variable is named after a real flag in lower case (CLI-1819).
+const envFlagPrefix = FLAG_PREFIX + FLAG_PREFIX + FLAG_PREFIX
+
+// GetUnknownParameters returns the tokens of osArgs and envVars that could plausibly be
+// secrets. A bare token qualifies once a flag no registered workflow declared has been
+// seen, and keeps qualifying until the next flag token: the value of a declared flag,
+// and any positional operand, is something the CLI knowingly accepts and so is not
+// guessed at, while an undeclared flag's value can be several whitespace-separated words
+// and every one of them is suspect. The length floor, the known command check and the
+// allow list then narrow that candidate set further.
 //
-// Environment variables need no special case. They arrive joined as "--NAME VALUE" and
-// an environment variable name is never a declared flag, so their values stay candidates.
+// Environment variables need no special case. They arrive rendered as a flag token
+// nothing can declare (see envFlagPrefix), so their values stay candidates.
 func GetUnknownParameters(osArgs []string, envVars []string, knownCommands []string, knownFlags []string) []string {
-	return unknownParameters(osArgs, envVars, knownCommands, knownFlags, true)
+	argValues := []string{}
+	afterUndeclaredFlag := false
+
+	for _, arg := range tokenize(osArgs, envVars) {
+		if name, isFlag := flagName(arg); isFlag {
+			afterUndeclaredFlag = !isTrustedFlag(name, knownFlags)
+			continue
+		}
+
+		if afterUndeclaredFlag && isPossibleSecret(arg, knownCommands) {
+			argValues = append(argValues, arg)
+		}
+	}
+
+	return sortedUnique(argValues)
 }
 
 // GetAllUnknownParameters is the wider sweep: every bare token that clears the length
@@ -137,46 +159,54 @@ func GetUnknownParameters(osArgs []string, envVars []string, knownCommands []str
 // the output before sharing it. Analytics has no human in the loop, so it uses
 // GetUnknownParameters instead.
 func GetAllUnknownParameters(osArgs []string, envVars []string, knownCommands []string) []string {
-	return unknownParameters(osArgs, envVars, knownCommands, nil, false)
-}
-
-func unknownParameters(osArgs []string, envVars []string, knownCommands []string, knownFlags []string, onlyUndeclaredFlagValues bool) []string {
-	argsOneString := strings.Join(osArgs, " ")
-	if len(envVars) > 0 {
-		argsOneString = argsOneString + " --" + strings.Join(envVars, " --")
-	}
-
-	argsOneString = strings.ReplaceAll(argsOneString, "=", " ")
-	argsSplitAgain := strings.Split(argsOneString, " ")
-
 	argValues := []string{}
-	prevWasUnknownFlag := false
-	for _, arg := range argsSplitAgain {
-		if strings.HasPrefix(arg, FLAG_PREFIX) {
-			prevWasUnknownFlag = !isTrustedFlag(strings.TrimLeft(arg, FLAG_PREFIX), knownFlags)
-			continue
-		}
 
-		isCandidatePosition := prevWasUnknownFlag || !onlyUndeclaredFlagValues
-		isKnownCommand := slices.Contains(knownCommands, arg)
-		isAllowedWord := allowedWords[strings.ToLower(arg)]
-		isPotentiallySensitive := len(arg) >= MIN_ARG_LENGTH
-		if isCandidatePosition && !isKnownCommand && !isAllowedWord && isPotentiallySensitive {
+	for _, arg := range tokenize(osArgs, envVars) {
+		if !strings.HasPrefix(arg, FLAG_PREFIX) && isPossibleSecret(arg, knownCommands) {
 			argValues = append(argValues, arg)
 		}
-		prevWasUnknownFlag = false
 	}
 
-	slices.Sort(argValues)
-	argValues = slices.Compact(argValues)
+	return sortedUnique(argValues)
+}
 
-	return argValues
+// tokenize flattens the command line and the environment into one whitespace-separated
+// token stream. An "=" is treated as a separator, so both "--flag=value" and an
+// environment entry split into a flag token and its value.
+func tokenize(osArgs []string, envVars []string) []string {
+	argsOneString := strings.Join(osArgs, " ")
+	if len(envVars) > 0 {
+		argsOneString = argsOneString + " " + envFlagPrefix + strings.Join(envVars, " "+envFlagPrefix)
+	}
+
+	return strings.Split(strings.ReplaceAll(argsOneString, "=", " "), " ")
+}
+
+// flagName returns the name of a flag token, which is the token with its leading dashes
+// removed. At most two are removed, so an environment entry keeps the marker dash
+// envFlagPrefix gave it. The second result is false when the token is not a flag at all:
+// the POSIX end-of-options marker "--" and a negative number such as "-5" both look like
+// one to a prefix test, and what follows either of them is an operand, not a flag value.
+func flagName(arg string) (string, bool) {
+	if !strings.HasPrefix(arg, FLAG_PREFIX) {
+		return "", false
+	}
+
+	name := strings.TrimPrefix(strings.TrimPrefix(arg, FLAG_PREFIX), FLAG_PREFIX)
+	if name == "" || (name[0] >= '0' && name[0] <= '9') {
+		return "", false
+	}
+
+	return name, true
 }
 
 // isTrustedFlag reports whether the value following the flag named name can be left
 // alone. A flag some workflow declared is trusted, unless its name matches one of the
 // sensitive field names the scrubber already knows about (--tfc-token, --username and
 // friends) — a declared flag can still be the one carrying the secret.
+//
+// knownFlags holds long names only, so a shorthand such as -d never matches and its
+// value keeps being swept. That over-redacts and does not leak.
 func isTrustedFlag(name string, knownFlags []string) bool {
 	if !slices.Contains(knownFlags, name) {
 		return false
@@ -190,4 +220,15 @@ func isTrustedFlag(name string, knownFlags []string) bool {
 	}
 
 	return true
+}
+
+// isPossibleSecret applies the checks both sweeps share to a token already known to sit
+// in a candidate position.
+func isPossibleSecret(arg string, knownCommands []string) bool {
+	return len(arg) >= MIN_ARG_LENGTH && !slices.Contains(knownCommands, arg) && !allowedWords[strings.ToLower(arg)]
+}
+
+func sortedUnique(values []string) []string {
+	slices.Sort(values)
+	return slices.Compact(values)
 }

--- a/cliv2/internal/utils/args_test.go
+++ b/cliv2/internal/utils/args_test.go
@@ -32,14 +32,20 @@ func Test_CaptureAllArgs(t *testing.T) {
 			env: []string{},
 			expectedResult: []string{
 				"dasas",
-				"primary/path/to/file",
 				"secret\"password",
 				"sensitive",
 				"super.secret",
 			},
 		},
 		{
-			name: "multiple subcommands with options",
+			// CLI-1819, deliberate reversal. This case used to assert that every bare
+			// positional operand is swept up as a candidate secret. That is what made
+			// the sweep destroy real analytics values: `snyk agent feedback "<prose>"`
+			// redacted its own assessment text, because the prose was an argv token.
+			// A positional operand is now a value the CLI knowingly accepts, so none of
+			// these tokens is a candidate any more. Only the value of a flag no workflow
+			// declared is.
+			name: "bare positional operands are no longer swept",
 			command: []string{
 				"super.secret",
 				"dasas",
@@ -48,26 +54,21 @@ func Test_CaptureAllArgs(t *testing.T) {
 				"trace",
 				"primary/path/to/file",
 			},
-			env: []string{},
-			expectedResult: []string{
-				"dasas",
-				"primary/path/to/file",
-				"secret\"password",
-				"sensitive",
-				"super.secret",
-			},
+			env:            []string{},
+			expectedResult: []string{},
 		},
 		{
-			name: "basic command with options and env vars",
+			name: "env vars, with duplicate values collapsed",
 			command: []string{
 				"super.secret",
 				"dasas",
 			},
-			env: []string{"SNYK_TOKEN=mySuperSecretToken"},
+			env: []string{
+				"SNYK_TOKEN=mySuperSecretToken",
+				"SNYK_OTHER_TOKEN=mySuperSecretToken",
+			},
 			expectedResult: []string{
-				"dasas",
 				"mySuperSecretToken",
-				"super.secret",
 			},
 		},
 		{
@@ -97,17 +98,17 @@ func Test_CaptureAllArgs(t *testing.T) {
 				"api.helloworld.io",
 				"dasas",
 				"mySuperSecretToken",
-				"primary/path/to/file",
 				"super.secret",
 			},
 		},
 	}
 
 	knownCommands := []string{"test", "iac", "container", "update-exclude-policy"}
+	knownFlags := []string{"log-level", "filepath"}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualResult := GetUnknownParameters(tc.command, tc.env, knownCommands)
+			actualResult := GetUnknownParameters(tc.command, tc.env, knownCommands, knownFlags)
 			assert.Equal(t, tc.expectedResult, actualResult)
 		})
 	}

--- a/cliv2/internal/utils/args_test.go
+++ b/cliv2/internal/utils/args_test.go
@@ -14,6 +14,10 @@ func Test_CaptureAllArgs(t *testing.T) {
 		expectedResult []string
 	}{
 		{
+			// --filepath is declared, so primary/path/to/file is a value the CLI knowingly
+			// accepts and is deliberately absent from the expectations. --report-path is
+			// not declared, so a path-shaped value behind it keeps being swept, which is
+			// the coverage the declared flag would otherwise have taken with it.
 			name: "basic command with options",
 			command: []string{
 				"test",
@@ -28,10 +32,13 @@ func Test_CaptureAllArgs(t *testing.T) {
 				"--log-level=trace",
 				"--filepath",
 				"primary/path/to/file",
+				"--report-path",
+				"secondary/path/to/file",
 			},
 			env: []string{},
 			expectedResult: []string{
 				"dasas",
+				"secondary/path/to/file",
 				"secret\"password",
 				"sensitive",
 				"super.secret",
@@ -58,9 +65,12 @@ func Test_CaptureAllArgs(t *testing.T) {
 			expectedResult: []string{},
 		},
 		{
-			name: "env vars, with duplicate values collapsed",
+			// dasas sits behind an undeclared flag rather than standing alone as an
+			// operand, which is what it takes for an argv value to be swept now. The two
+			// environment entries carry the same value to pin the deduplication.
+			name: "argv and env values together, with duplicates collapsed",
 			command: []string{
-				"super.secret",
+				"--not-a-declared-flag",
 				"dasas",
 			},
 			env: []string{
@@ -68,10 +78,14 @@ func Test_CaptureAllArgs(t *testing.T) {
 				"SNYK_OTHER_TOKEN=mySuperSecretToken",
 			},
 			expectedResult: []string{
+				"dasas",
 				"mySuperSecretToken",
 			},
 		},
 		{
+			// As in the first case, primary/path/to/file is absent because --filepath is
+			// declared; anotherFlagValue stands in for a path-shaped value behind a flag
+			// that is not.
 			name: "multiple subcommands with options, operands and env vars",
 			command: []string{
 				"container",
@@ -100,6 +114,60 @@ func Test_CaptureAllArgs(t *testing.T) {
 				"mySuperSecretToken",
 				"super.secret",
 			},
+		},
+		{
+			// CLI-1819: an undeclared flag's value can be several whitespace-separated
+			// words. Sweeping only the first would leave the rest of the secret in the
+			// clear, which is exactly what `--custom-header "Bearer <token>"` looks like.
+			name: "a multi-word value behind an undeclared flag is swept whole",
+			command: []string{
+				"test",
+				"--custom-header",
+				"Bearer abc123xyz",
+			},
+			env: []string{},
+			expectedResult: []string{
+				"Bearer",
+				"abc123xyz",
+			},
+		},
+		{
+			name:    "a multi-word environment value is swept whole",
+			command: []string{"test"},
+			env: []string{
+				"CUSTOM_HEADER=Bearer abc123xyz",
+			},
+			expectedResult: []string{
+				"Bearer",
+				"abc123xyz",
+			},
+		},
+		{
+			// CLI-1819: environment entries are rendered into the token stream as a flag
+			// token no declared flag can match, so a variable that happens to share a
+			// declared flag's name in lower case cannot borrow that flag's trust.
+			name:    "an environment variable named after a declared flag is still swept",
+			command: []string{"test"},
+			env: []string{
+				"filepath=mySuperSecretToken",
+			},
+			expectedResult: []string{
+				"mySuperSecretToken",
+			},
+		},
+		{
+			// Neither the POSIX end-of-options marker nor a negative number is a flag, so
+			// neither turns the operand after it into a flag value.
+			name: "the end-of-options marker and a negative number are not flags",
+			command: []string{
+				"test",
+				"--",
+				"positional-operand-value",
+				"-5",
+				"another-operand-value",
+			},
+			env:            []string{},
+			expectedResult: []string{},
 		},
 	}
 

--- a/cliv2/internal/utils/args_test.go
+++ b/cliv2/internal/utils/args_test.go
@@ -12,6 +12,9 @@ func Test_CaptureAllArgs(t *testing.T) {
 		command        []string
 		env            []string
 		expectedResult []string
+		// expectedAllResult, when set, additionally pins GetAllUnknownParameters for the
+		// same input. Only the case where the two sweeps disagree needs it.
+		expectedAllResult []string
 	}{
 		{
 			// --filepath is declared, so primary/path/to/file is a value the CLI knowingly
@@ -63,6 +66,26 @@ func Test_CaptureAllArgs(t *testing.T) {
 			},
 			env:            []string{},
 			expectedResult: []string{},
+		},
+		{
+			// CLI-1819, and the limit of "a positional operand is a value the CLI
+			// knowingly accepts": that only holds while no undeclared flag comes first.
+			// The candidate state is sticky. It turns on at an undeclared flag and stays
+			// on until the next flag token, so ./my-project is swept along with hunter2
+			// even though ./my-project is a plain operand and the CLI does accept it.
+			// Deliberate: an undeclared flag's value can be several whitespace-separated
+			// words, and nothing in the token stream says where the value stops and the
+			// next operand starts. Ending the candidate run after one word would leave
+			// the tail of a multi-word secret in the clear, so the operand pays instead.
+			name: "a positional operand after an undeclared flag is still swept",
+			command: []string{
+				"test",
+				"--weird-flag",
+				"hunter2",
+				"./my-project",
+			},
+			env:            []string{},
+			expectedResult: []string{"./my-project", "hunter2"},
 		},
 		{
 			// dasas sits behind an undeclared flag rather than standing alone as an
@@ -169,6 +192,25 @@ func Test_CaptureAllArgs(t *testing.T) {
 			env:            []string{},
 			expectedResult: []string{},
 		},
+		{
+			// CLI-1819: the two sweeps disagree about a dash-then-digit token, so the
+			// narrow list is NOT a subset of the wide one. flagName rejects -12345678
+			// because a negative number is not a flag, which leaves the narrow sweep
+			// looking at a bare word sitting behind an undeclared flag, and it takes it.
+			// The wide sweep only tests for a leading dash, so it skips the same token.
+			// Anything reasoning that the debug log redacts at least what analytics
+			// does - the natural assumption, given the wide sweep is the aggressive one
+			// - is wrong for this token shape.
+			name: "a dash-then-digit token: the narrow sweep takes it, the wide sweep does not",
+			command: []string{
+				"test",
+				"--mystery",
+				"-12345678",
+			},
+			env:               []string{},
+			expectedResult:    []string{"-12345678"},
+			expectedAllResult: []string{},
+		},
 	}
 
 	knownCommands := []string{"test", "iac", "container", "update-exclude-policy"}
@@ -178,6 +220,10 @@ func Test_CaptureAllArgs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			actualResult := GetUnknownParameters(tc.command, tc.env, knownCommands, knownFlags)
 			assert.Equal(t, tc.expectedResult, actualResult)
+
+			if tc.expectedAllResult != nil {
+				assert.Equal(t, tc.expectedAllResult, GetAllUnknownParameters(tc.command, tc.env, knownCommands))
+			}
 		})
 	}
 }

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -649,9 +649,9 @@ func mainWithErrorCode(additionalExts []workflow.ExtensionInit) int {
 
 	// We want to scrub the debug log of sensitive information. Since we have a list of commands we know can occur, we can intersect that with arguments we don't recognize, and automatically scrub all those from the logs.
 	if debugEnabled {
-		termsToRedact := populateRedactionTerms(globalConfiguration, globalEngine)
+		populateRedactionTerms(globalConfiguration, globalEngine)
 		writeLogHeader(globalConfiguration, networkAccess)
-		scrubbedLogger.AddTermsToReplace(termsToRedact)
+		scrubbedLogger.AddTermsToReplace(debugRedactionTerms(globalConfiguration, globalEngine))
 	}
 
 	if err != nil {
@@ -727,21 +727,38 @@ func mainWithErrorCode(additionalExts []workflow.ExtensionInit) int {
 // logging.REDACTION_TERMS, so the analytics scrub chokepoint can redact
 // them regardless of whether debug logging is enabled.
 func populateRedactionTerms(config configuration.Configuration, engine workflow.Engine) []string {
-	knownTerms, knownFlags := instrumentation.GetKnownCommandsAndFlags(engine)
+	knownTerms, knownFlags := knownRedactionTerms(config, engine)
+	termsToRedact := cliv2utils.GetUnknownParameters(os.Args[1:], os.Environ(), knownTerms, knownFlags)
+	config.Set(logging.REDACTION_TERMS, termsToRedact)
+	return termsToRedact
+}
+
+// debugRedactionTerms computes the wider sweep the debug log keeps (CLI-1819): every
+// bare token, not only the values of flags no workflow declared. Over-redacting a log
+// the user reads before pasting it into a support ticket costs nothing, while
+// under-redacting it leaks. Analytics has no human in that loop, which is why
+// populateRedactionTerms narrows the same sweep.
+func debugRedactionTerms(config configuration.Configuration, engine workflow.Engine) []string {
+	knownTerms, _ := knownRedactionTerms(config, engine)
+	return cliv2utils.GetAllUnknownParameters(os.Args[1:], os.Environ(), knownTerms)
+}
+
+// knownRedactionTerms lists the commands and values that neither sweep may treat as a
+// secret, alongside the flags every registered workflow declares.
+func knownRedactionTerms(config configuration.Configuration, engine workflow.Engine) (knownTerms []string, knownFlags []string) {
+	knownTerms, knownFlags = instrumentation.GetKnownCommandsAndFlags(engine)
 	knownTerms = append(knownTerms, config.GetString(configuration.API_URL), config.GetString(configuration.ORGANIZATION), config.GetString(configuration.ORGANIZATION_SLUG), config.GetString(clientMachineIdConfigKey))
 	// AI_AGENT is trusted verbatim by agent.DetectAgent, and persona.Report
 	// falls back to that same raw value whenever the Harness name/version split
 	// or canonicalisation does not apply, so its raw value needs the same
-	// exclusion as the client machine id above. GetUnknownParameters tokenizes
-	// its input on whitespace, so a multi-word value only excludes as a whole if
-	// each of its words is excluded too.
+	// exclusion as the client machine id above. The sweep tokenizes its input on
+	// whitespace, so a multi-word value only excludes as a whole if each of its
+	// words is excluded too.
 	if detectedAgent, ok := agent.DetectAgent(); ok {
 		knownTerms = append(knownTerms, detectedAgent)
 		knownTerms = append(knownTerms, strings.Fields(detectedAgent)...)
 	}
-	termsToRedact := cliv2utils.GetUnknownParameters(os.Args[1:], os.Environ(), knownTerms, knownFlags)
-	config.Set(logging.REDACTION_TERMS, termsToRedact)
-	return termsToRedact
+	return knownTerms, knownFlags
 }
 
 func processError(err error, errorList []error) ([]error, error) {

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -649,9 +649,12 @@ func mainWithErrorCode(additionalExts []workflow.ExtensionInit) int {
 
 	// We want to scrub the debug log of sensitive information. Since we have a list of commands we know can occur, we can intersect that with arguments we don't recognize, and automatically scrub all those from the logs.
 	if debugEnabled {
-		populateRedactionTerms(globalConfiguration, globalEngine)
+		// One walk of the engine feeds both sweeps: the narrow list recorded on config
+		// for analytics, and the wider list the debug log scrubber gets.
+		knownTerms, knownFlags := knownRedactionTerms(globalConfiguration, globalEngine)
+		recordRedactionTerms(globalConfiguration, knownTerms, knownFlags)
 		writeLogHeader(globalConfiguration, networkAccess)
-		scrubbedLogger.AddTermsToReplace(debugRedactionTerms(globalConfiguration, globalEngine))
+		scrubbedLogger.AddTermsToReplace(debugRedactionTerms(knownTerms))
 	}
 
 	if err != nil {
@@ -728,6 +731,12 @@ func mainWithErrorCode(additionalExts []workflow.ExtensionInit) int {
 // them regardless of whether debug logging is enabled.
 func populateRedactionTerms(config configuration.Configuration, engine workflow.Engine) []string {
 	knownTerms, knownFlags := knownRedactionTerms(config, engine)
+	return recordRedactionTerms(config, knownTerms, knownFlags)
+}
+
+// recordRedactionTerms is populateRedactionTerms once the engine has already been walked,
+// so a debug run does not walk it twice.
+func recordRedactionTerms(config configuration.Configuration, knownTerms []string, knownFlags []string) []string {
 	termsToRedact := cliv2utils.GetUnknownParameters(os.Args[1:], os.Environ(), knownTerms, knownFlags)
 	config.Set(logging.REDACTION_TERMS, termsToRedact)
 	return termsToRedact
@@ -738,8 +747,7 @@ func populateRedactionTerms(config configuration.Configuration, engine workflow.
 // the user reads before pasting it into a support ticket costs nothing, while
 // under-redacting it leaks. Analytics has no human in that loop, which is why
 // populateRedactionTerms narrows the same sweep.
-func debugRedactionTerms(config configuration.Configuration, engine workflow.Engine) []string {
-	knownTerms, _ := knownRedactionTerms(config, engine)
+func debugRedactionTerms(knownTerms []string) []string {
 	return cliv2utils.GetAllUnknownParameters(os.Args[1:], os.Environ(), knownTerms)
 }
 

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -722,12 +722,12 @@ func mainWithErrorCode(additionalExts []workflow.ExtensionInit) int {
 	return finalExitCode
 }
 
-// populateRedactionTerms computes likely-secret literal values (unrecognized CLI
-// arguments and environment variables) and records them on config under
+// populateRedactionTerms computes likely-secret literal values (the values of CLI
+// flags no workflow declared, and environment variables) and records them on config under
 // logging.REDACTION_TERMS, so the analytics scrub chokepoint can redact
 // them regardless of whether debug logging is enabled.
 func populateRedactionTerms(config configuration.Configuration, engine workflow.Engine) []string {
-	knownTerms, _ := instrumentation.GetKnownCommandsAndFlags(engine)
+	knownTerms, knownFlags := instrumentation.GetKnownCommandsAndFlags(engine)
 	knownTerms = append(knownTerms, config.GetString(configuration.API_URL), config.GetString(configuration.ORGANIZATION), config.GetString(configuration.ORGANIZATION_SLUG), config.GetString(clientMachineIdConfigKey))
 	// AI_AGENT is trusted verbatim by agent.DetectAgent, and persona.Report
 	// falls back to that same raw value whenever the Harness name/version split
@@ -739,7 +739,7 @@ func populateRedactionTerms(config configuration.Configuration, engine workflow.
 		knownTerms = append(knownTerms, detectedAgent)
 		knownTerms = append(knownTerms, strings.Fields(detectedAgent)...)
 	}
-	termsToRedact := cliv2utils.GetUnknownParameters(os.Args[1:], os.Environ(), knownTerms)
+	termsToRedact := cliv2utils.GetUnknownParameters(os.Args[1:], os.Environ(), knownTerms, knownFlags)
 	config.Set(logging.REDACTION_TERMS, termsToRedact)
 	return termsToRedact
 }

--- a/cliv2/pkg/core/main_test.go
+++ b/cliv2/pkg/core/main_test.go
@@ -256,6 +256,38 @@ func Test_populateRedactionTerms_sweepsOnlyValuesOfUndeclaredFlags(t *testing.T)
 	})
 }
 
+// CLI-1819, the accepted cost of trusting declared flags, recorded here deliberately.
+// Exempting a declared flag's value is what buys back the analytics data the old sweep
+// destroyed, and it is not free. --client-id and --tenant-id are declared flags (the
+// first by GAF's auth workflow, the second by the agent-scan workflow's flagset) and
+// neither name contains any of logging.SENSITIVE_FIELD_NAMES, so their values now reach
+// analytics in the clear where the old sweep would have redacted them. That is the price
+// of the trade rather than an oversight: a registered workflow put its name to those
+// flags, so the CLI knows what they carry and chooses to keep it.
+//
+// The safety net is the only thing standing between that trade and a declared flag being
+// a way to smuggle a credential into analytics, which is why it gets its own case below.
+// --client-secret is declared exactly as --client-id is, and the single reason its value
+// stays out of analytics is the word "secret" in its name. A flag carrying something that
+// must not be logged has to be named so the net catches it.
+func Test_populateRedactionTerms_theCostOfTrustingDeclaredFlags(t *testing.T) {
+	declaredFlags := []string{"client-id", "tenant-id", "client-secret"}
+
+	for _, flag := range []string{"client-id", "tenant-id"} {
+		t.Run("--"+flag+", a declared flag with a non-sensitive name, contributes no term", func(t *testing.T) {
+			terms := redactionTermsFor(t, []string{"auth", "--" + flag, "unmistakably-secret-value"}, declaredFlags)
+
+			assert.NotContains(t, terms, "unmistakably-secret-value", "the value of a declared flag whose name looks harmless now reaches analytics unredacted, and that is the accepted cost of trusting declared flags")
+		})
+	}
+
+	t.Run("--client-secret, a declared flag whose name contains a sensitive substring, still contributes a term", func(t *testing.T) {
+		terms := redactionTermsFor(t, []string{"auth", "--client-secret", "unmistakably-secret-value"}, declaredFlags)
+
+		assert.Contains(t, terms, "unmistakably-secret-value", "the safety net is the only reason a declared flag cannot be used to smuggle a credential into analytics")
+	})
+}
+
 // CLI-1819: only analytics narrowed. A debug log is read by the person who pastes it
 // into a support ticket, so it keeps redacting everything it cannot name, including the
 // values analytics deliberately stopped treating as secrets.

--- a/cliv2/pkg/core/main_test.go
+++ b/cliv2/pkg/core/main_test.go
@@ -141,6 +141,80 @@ func Test_populateRedactionTerms_excludesDetectedAgent(t *testing.T) {
 	}
 }
 
+// redactionTermsFor runs populateRedactionTerms with args standing in for the command
+// line, against an engine holding one registered workflow that declares declaredFlags.
+// That is the only route by which a flag counts as declared, so it is what separates
+// "the CLI accepts this flag" from "nobody has ever heard of this flag" in the sweep.
+func redactionTermsFor(t *testing.T, args []string, declaredFlags []string) []string {
+	t.Helper()
+
+	flagset := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	for _, flagName := range declaredFlags {
+		flagset.String(flagName, "", "")
+	}
+
+	mockController := gomock.NewController(t)
+	workflowEntry := mocks.NewMockEntry(mockController)
+	workflowEntry.EXPECT().GetConfigurationOptions().Return(workflow.ConfigurationOptionsFromFlagset(flagset))
+	workflowId := workflow.NewWorkflowIdentifier("agent")
+	mockEngine := mocks.NewMockEngine(mockController)
+	mockEngine.EXPECT().GetWorkflows().Return([]workflow.Identifier{workflowId})
+	mockEngine.EXPECT().GetWorkflow(workflowId).Return(workflowEntry, true)
+
+	oldArgs := os.Args
+	os.Args = append([]string{"snyk"}, args...)
+	t.Cleanup(func() { os.Args = oldArgs })
+
+	return populateRedactionTerms(configuration.NewWithOpts(configuration.WithAutomaticEnv()), mockEngine)
+}
+
+// CLI-1819: the sweep used to treat every argv token it could not name as a secret, so
+// it redacted the CLI's own analytics values out of its own events. A token is now a
+// candidate only when the token before it is a flag no workflow declared.
+func Test_populateRedactionTerms_sweepsOnlyValuesOfUndeclaredFlags(t *testing.T) {
+	t.Run("a positional operand contributes no terms", func(t *testing.T) {
+		assessment := "the scan missed a hardcoded credential in the deploy script"
+
+		terms := redactionTermsFor(t, []string{"agent", "feedback", assessment}, nil)
+
+		for _, word := range strings.Fields(assessment) {
+			assert.NotContains(t, terms, word, "a positional operand is a value the CLI accepts, not a secret to guess at")
+		}
+	})
+
+	t.Run("a declared flag's value contributes no term", func(t *testing.T) {
+		terms := redactionTermsFor(t, []string{"agent", "feedback", "--use-case", "code-review-automation"}, []string{"use-case"})
+
+		assert.NotContains(t, terms, "code-review-automation", "a workflow declared --use-case, so its value is not a guessed-at secret")
+	})
+
+	t.Run("an undeclared flag's value still contributes a term", func(t *testing.T) {
+		terms := redactionTermsFor(t, []string{"agent", "--not-a-declared-flag", "unmistakably-secret-value"}, []string{"use-case"})
+
+		assert.Contains(t, terms, "unmistakably-secret-value", "nothing declared this flag, so its value is still assumed to be a secret")
+	})
+
+	t.Run("an environment variable value still contributes a term", func(t *testing.T) {
+		// Environment variables reach the sweep joined as "--NAME VALUE" and an
+		// environment variable name is never a declared flag, so they stay candidates
+		// without the sweep carrying a special case for them.
+		t.Setenv("SNYK_TEST_REDACTION_MARKER", "unmistakably-secret-value")
+
+		terms := redactionTermsFor(t, []string{"agent"}, []string{"use-case"})
+
+		assert.Contains(t, terms, "unmistakably-secret-value", "environment variable values must keep being redacted")
+	})
+
+	t.Run("a declared flag with a sensitive name still contributes a term", func(t *testing.T) {
+		// Trusting declared flags is only safe while no declared flag carries a secret,
+		// and some do (--tfc-token ships today). A declared flag whose name matches the
+		// scrubber's own sensitive field names keeps being swept.
+		terms := redactionTermsFor(t, []string{"agent", "--auth-token", "unmistakably-secret-value"}, []string{"auth-token"})
+
+		assert.Contains(t, terms, "unmistakably-secret-value", "a declared flag whose name looks sensitive must keep being swept")
+	})
+}
+
 func Test_initApplicationConfiguration_DisablesAnalytics(t *testing.T) {
 	t.Run("via SNYK_DISABLE_ANALYTICS (true)", func(t *testing.T) {
 		c := configuration.NewWithOpts(configuration.WithAutomaticEnv())

--- a/cliv2/pkg/core/main_test.go
+++ b/cliv2/pkg/core/main_test.go
@@ -148,6 +148,22 @@ func Test_populateRedactionTerms_excludesDetectedAgent(t *testing.T) {
 func redactionTermsFor(t *testing.T, args []string, declaredFlags []string) []string {
 	t.Helper()
 
+	config, engine := redactionSweepInput(t, args, declaredFlags)
+	return populateRedactionTerms(config, engine)
+}
+
+// debugRedactionTermsFor is redactionTermsFor against the other sweep, the one whose
+// terms reach the debug log scrubber.
+func debugRedactionTermsFor(t *testing.T, args []string, declaredFlags []string) []string {
+	t.Helper()
+
+	config, engine := redactionSweepInput(t, args, declaredFlags)
+	return debugRedactionTerms(config, engine)
+}
+
+func redactionSweepInput(t *testing.T, args []string, declaredFlags []string) (configuration.Configuration, workflow.Engine) {
+	t.Helper()
+
 	flagset := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	for _, flagName := range declaredFlags {
 		flagset.String(flagName, "", "")
@@ -165,7 +181,7 @@ func redactionTermsFor(t *testing.T, args []string, declaredFlags []string) []st
 	os.Args = append([]string{"snyk"}, args...)
 	t.Cleanup(func() { os.Args = oldArgs })
 
-	return populateRedactionTerms(configuration.NewWithOpts(configuration.WithAutomaticEnv()), mockEngine)
+	return configuration.NewWithOpts(configuration.WithAutomaticEnv()), mockEngine
 }
 
 // CLI-1819: the sweep used to treat every argv token it could not name as a secret, so
@@ -212,6 +228,25 @@ func Test_populateRedactionTerms_sweepsOnlyValuesOfUndeclaredFlags(t *testing.T)
 		terms := redactionTermsFor(t, []string{"agent", "--auth-token", "unmistakably-secret-value"}, []string{"auth-token"})
 
 		assert.Contains(t, terms, "unmistakably-secret-value", "a declared flag whose name looks sensitive must keep being swept")
+	})
+}
+
+// CLI-1819: only analytics narrowed. A debug log is read by the person who pastes it
+// into a support ticket, so it keeps redacting everything it cannot name, including the
+// values analytics deliberately stopped treating as secrets.
+func Test_debugRedactionTerms_keepsTheAggressiveSweep(t *testing.T) {
+	t.Run("a positional operand", func(t *testing.T) {
+		args := []string{"agent", "feedback", "could-be-a-secret-pasted-as-an-operand"}
+
+		assert.NotContains(t, redactionTermsFor(t, args, nil), "could-be-a-secret-pasted-as-an-operand")
+		assert.Contains(t, debugRedactionTermsFor(t, args, nil), "could-be-a-secret-pasted-as-an-operand", "the debug log must keep scrubbing what the analytics sweep now lets through")
+	})
+
+	t.Run("a declared flag's value", func(t *testing.T) {
+		args := []string{"agent", "feedback", "--use-case", "could-be-a-secret-behind-a-known-flag"}
+
+		assert.NotContains(t, redactionTermsFor(t, args, []string{"use-case"}), "could-be-a-secret-behind-a-known-flag")
+		assert.Contains(t, debugRedactionTermsFor(t, args, []string{"use-case"}), "could-be-a-secret-behind-a-known-flag", "the debug log must keep scrubbing what the analytics sweep now lets through")
 	})
 }
 

--- a/cliv2/pkg/core/main_test.go
+++ b/cliv2/pkg/core/main_test.go
@@ -158,7 +158,8 @@ func debugRedactionTermsFor(t *testing.T, args []string, declaredFlags []string)
 	t.Helper()
 
 	config, engine := redactionSweepInput(t, args, declaredFlags)
-	return debugRedactionTerms(config, engine)
+	knownTerms, _ := knownRedactionTerms(config, engine)
+	return debugRedactionTerms(knownTerms)
 }
 
 func redactionSweepInput(t *testing.T, args []string, declaredFlags []string) (configuration.Configuration, workflow.Engine) {
@@ -211,14 +212,38 @@ func Test_populateRedactionTerms_sweepsOnlyValuesOfUndeclaredFlags(t *testing.T)
 	})
 
 	t.Run("an environment variable value still contributes a term", func(t *testing.T) {
-		// Environment variables reach the sweep joined as "--NAME VALUE" and an
-		// environment variable name is never a declared flag, so they stay candidates
-		// without the sweep carrying a special case for them.
+		// Environment entries are rendered into the token stream as a flag token nothing
+		// can declare, so they stay candidates without the sweep carrying a special case
+		// for them.
 		t.Setenv("SNYK_TEST_REDACTION_MARKER", "unmistakably-secret-value")
 
 		terms := redactionTermsFor(t, []string{"agent"}, []string{"use-case"})
 
 		assert.Contains(t, terms, "unmistakably-secret-value", "environment variable values must keep being redacted")
+	})
+
+	t.Run("an environment variable named after a declared flag still contributes a term", func(t *testing.T) {
+		// The declared-flag check is case sensitive and "org" is a real declared flag,
+		// so a variable of that name must not be able to borrow the flag's trust.
+		t.Setenv("org", "unmistakably-secret-value")
+
+		terms := redactionTermsFor(t, []string{"agent"}, []string{"use-case"})
+
+		assert.Contains(t, terms, "unmistakably-secret-value", "an environment variable name is not a declared flag, whatever it is called")
+	})
+
+	t.Run("every word of a multi-word undeclared flag value contributes a term", func(t *testing.T) {
+		terms := redactionTermsFor(t, []string{"agent", "--custom-header", "Bearer unmistakably-secret-value"}, []string{"use-case"})
+
+		assert.Contains(t, terms, "unmistakably-secret-value", "sweeping only the first word of a secret leaves the rest of it in the clear")
+	})
+
+	t.Run("every word of a multi-word environment value contributes a term", func(t *testing.T) {
+		t.Setenv("SNYK_TEST_REDACTION_MARKER", "Bearer unmistakably-secret-value")
+
+		terms := redactionTermsFor(t, []string{"agent"}, []string{"use-case"})
+
+		assert.Contains(t, terms, "unmistakably-secret-value", "sweeping only the first word of a secret leaves the rest of it in the clear")
 	})
 
 	t.Run("a declared flag with a sensitive name still contributes a term", func(t *testing.T) {


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages)
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable) - none
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___) - no user-facing docs affected
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

### The rule, and what it costs

The CLI builds a list of strings it treats as possible secrets, then replaces every one of them
with `***` in the analytics event before sending it. The old rule put almost every word of our
own command line on that list, which is why analytics arrived full of `***`.

The new rule is one sentence. **Only censor a word if it came right after an option the CLI does
not recognise.** If the CLI knows the option, it knows the value is an ordinary option value. If
it has never heard of the option, the value could be anything, so it gets censored.

There is a safety net on top. A recognised option whose *name* contains one of
`logging.SENSITIVE_FIELD_NAMES`, meaning `headers`, `user`, `passw`, `token`, `key` or `secret`,
has its value censored anyway. Without that, declaring a flag would be a way to smuggle a
credential into analytics.

**The cost.** `--client-secret` is caught by the safety net, purely because the word `secret`
appears in its name. `--client-id` and `--tenant-id` are declared flags, neither name matches
any of the six substrings, so both values now reach analytics where they were previously
censored. That is the real price of trusting declared flags, it is not an oversight, and it is
the part of this change I would most like a second opinion on.

Worked example. `snyk test --org acme-corp ./my-project` used to put `acme-corp` and
`./my-project` on the censor list, so the analytics event reported `legacycli::org` as `***`.
Now the list is empty for that command and the event carries the real org.

Stops the argv and environment redaction sweep from eating analytics values that were
never secrets.

The sweep worked by negation. Every whitespace separated token in our own argv and
environment counted as a secret unless it was shorter than 5 characters, started with a
dash, matched one of about 20 known commands, or appeared in a hand written list of about
80 English words. An 80 word allow list was standing in for the English language, and it
lost. Those terms are then stripped from every string in the analytics interaction
extension, so any value that collided with a token from the same invocation vanished.

Measured over two weeks, 2.21% of customer analytics events carried a `***`, against 0.29%
in the control window. Real collisions from production: `snyk-***-lockfile-parser` where
`nodejs` collided, `bundled:***` where maven and gradle collided, and
`c-runtime-details: ldd (*** GLIBC 2.36-9) 2.36` where `Debian` collided. The worst case is
`snyk agent feedback "<assessment>"`, where the assessment is itself an argv token and so
redacts itself.

The rule is now the other way round. A bare token is a candidate secret only when the token
immediately before it is a flag that no registered workflow declared. Positional operands,
and the values of flags some workflow actually declared, are values we chose to accept, so
we stop guessing at them. The length floor, the known command check and the word allow list
all stay exactly as they were, applied to the narrower candidate set. `populateRedactionTerms`
already called `instrumentation.GetKnownCommandsAndFlags` and threw the flags half away, so
the data was already there.

Security posture is unchanged in four ways:

- A secret passed to an unrecognised flag is still swept.
- Environment values are still swept, and needed no special case. They arrive joined as
  `--NAME VALUE`, and an environment variable name is never a declared flag, so they stay
  candidates by the general rule. There is a test for this rather than a branch in the code.
- A declared flag whose name matches `logging.SENSITIVE_FIELD_NAMES` is still swept, so
  declaring a flag cannot be used to smuggle a credential through. That check reuses the
  list the scrubber already builds its JSON key regex from, rather than introducing a
  second vocabulary.
- The client machine id and detected AI agent exclusions stay. Both come from environment
  variables, which the new rule still sweeps.

The `--debug` log keeps the old aggressive sweep, unchanged. Over-redacting a log the user
reads before pasting it into a support ticket costs nothing, while under-redacting it leaks.
Analytics has no human in that loop and no raw argument dump, so the same filter there only
destroys data. The two now come from separate functions, `debugRedactionTerms` and
`populateRedactionTerms`, over one shared tokenizer with no duplicated predicates.

Feedback text is covered by the general rule rather than by a per command exception. An
assessment is a positional operand and `--model`, `--use-case` and `--interaction-id` are
declared flags of a registered workflow, so all four survive without the CLI core learning
anything about the agent extension. A fourth hardcoded exclusion alongside the client
machine id and the AI agent would have re-created the pattern this change exists to end.

## Where should the reviewer start?

`cliv2/internal/utils/args.go`. `unknownParameters` holds the tokenizer and every filter
predicate; `GetUnknownParameters` (narrow, analytics) and `GetAllUnknownParameters`
(aggressive, debug log) are one line wrappers. Then `isTrustedFlag` just below it, which is
where the security argument lives. Then `populateRedactionTerms` and `debugRedactionTerms`
in `cliv2/pkg/core/main.go`.

Tests are at the seam, not on the tokenizer:

- `Test_populateRedactionTerms_sweepsOnlyValuesOfUndeclaredFlags` in
  `cliv2/pkg/core/main_test.go`, with subtests for a positional operand, a declared flag's
  value, an undeclared flag's value, an environment variable value, and a declared flag with
  a sensitive name. These register a mock workflow declaring real pflags, so "declared"
  means declared through the engine rather than hardcoded in the test.
- `Test_debugRedactionTerms_keepsTheAggressiveSweep` in the same file, asserting the same
  token is absent from the analytics list and present in the debug list.

One tokenizer case reverses on purpose. `Test_CaptureAllArgs` previously asserted that bare
positional operands are swept. Under the new rule they are not, so the case is rewritten
rather than deleted and carries a comment naming CLI-1819.

## How should this be manually tested?

Build the CLI and run a scan with a branch name that would previously have collided, for
example `snyk test --target-reference=my-feature-branch`, then check the analytics event
carries the real branch rather than `***`. For the security side, pass a value to a flag no
workflow declares, for example `snyk test --not-a-real-flag=hunter2supersecret`, and confirm
`hunter2supersecret` is still redacted. Run the same command with `--debug` and confirm the
log still redacts positional operands.

## What's the product update that needs to be communicated to CLI users?

None directly. This changes what reaches Snyk's analytics, not what the CLI does or prints.
No schema change, no API contract change, no configuration key added or removed. Worth
noting internally that analytics from before this ships are unrecoverable for the affected
fields, so dashboards covering that window need annotating.

## Risk assessment: Low

The change narrows what gets redacted from analytics. The failure mode if the rule is wrong
is a value reaching analytics that should not have, which is why the sensitive flag name
denylist and the environment variable property both have dedicated tests, and why the debug
log path is deliberately left on the old behaviour.

### Since the first push

Four review findings changed behaviour and are worth a reviewer's attention:

A value is now swept whole, not just its first word. The first cut reset the "previous token
was an undeclared flag" state after one bare token, which meant
`--custom-header "Bearer abc123xyz"` contributed `Bearer` and dropped `abc123xyz`, and a
multi-word environment value leaked everything past its first word. The spec's prototype has
that hole; the security constraints override it. A bare token now stays a candidate until the
next flag token.

Flag names are parsed with a prefix strip rather than `strings.TrimLeft`, which takes a cutset.
Bare `--` used to reduce to the empty string and `-5` to `5`, so in both cases the following
token was swept. `flagName` now strips at most two dashes and rejects an empty name or one
starting with a digit.

Environment entries render as `---NAME VALUE` rather than `--NAME VALUE`, leaving a flag name of
`-NAME`. A pflag name never starts with a dash, so a lowercase environment variable named after
a real declared flag, `debug` or `org` for instance, can no longer be mistaken for one and have
its value trusted. This keeps the "no special case in the rule" property: the general rule still
does the work, only the rendering changed.

The workflow engine is walked once per run instead of twice.

Two known limits, neither a leak:

Shorthand flags stay over-redacted. `instrumentation.GetKnownCommandsAndFlags` builds its list
from `flag.Name` and never reads `flag.Shorthand`, so `-d` reads as undeclared and the token
after it is swept. Fixing that needs a change in go-application-framework.

`GetKnownCommandsAndFlags` seeds `knownFlags` from a static list in go-application-framework
(`pkg/instrumentation/categories.go`) before adding the flags each registered workflow declares,
so around 80 flag names count as declared whether or not any Go workflow declares them, and the
values of `--command`, `--init-script`, `--var-file` and `--config-dir` now reach analytics
unswept. Narrowing to engine-declared flags would need a change in another repo and would
re-expose the legacy TypeScript CLI, whose flags (`--project-name`, `--severity-threshold`,
`--remote-repo-url` and the rest) have no Go workflow to declare them and would all start being
swept again, which is the over-redaction this ticket exists to stop.

## What are the relevant tickets?

[CLI-1819](https://snyksec.atlassian.net/browse/CLI-1819)

Two other changes from the same spec ship separately:
[snyk/go-application-framework#717](https://github.com/snyk/go-application-framework/pull/717)
fixes the username scrub corrupting analytics keys, and a PR in `snyk/cli-extension-axi`
adds the permanent regression test for feedback. The three are independent and can land in
any order.


[CLI-1819]: https://snyksec.atlassian.net/browse/CLI-1819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Analytics redaction is intentionally narrower—declared flags like `--client-id` / `--tenant-id` may reach analytics unredacted unless their names hit the sensitive substring net—while secrets behind unknown flags and env values should still be scrubbed.
> 
> **Overview**
> Fixes **CLI-1819** by changing how the CLI builds `logging.REDACTION_TERMS` for **analytics**: instead of treating almost every argv/env token as a secret, **`GetUnknownParameters`** now only redacts bare tokens that follow a **workflow-undeclared** flag (sticky until the next flag), while **positional operands** and **declared flag values** are left alone. Declared flags whose names match **`logging.SENSITIVE_FIELD_NAMES`** are still swept; env vars are tokenized via **`---NAME`** so they stay candidates without a special case.
> 
> **`--debug`** keeps the old aggressive behavior through new **`GetAllUnknownParameters`** and **`debugRedactionTerms`**, while **`populateRedactionTerms`** uses the narrow sweep. **`main.go`** walks the engine once (`knownRedactionTerms`) and feeds both paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32ad0d85e40f9e443ea5c36503bd1fd70e720375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->