### PR TITLE
chore(language-server): integrate LS

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -226,7 +226,7 @@ require (
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
-	github.com/snyk/snyk-ls v0.0.0-20260828190357-83d0e592d905 // indirect
+	github.com/snyk/snyk-ls v0.0.0-20260902080529-bf1230ca471b // indirect
 	github.com/snyk/studio-mcp v1.15.4 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -618,8 +618,8 @@ github.com/snyk/rift-cli-extension v1.2.0 h1:Vo1rAFJ6pWZF3F84HDTPNr7XSBfp2f1kWf2
 github.com/snyk/rift-cli-extension v1.2.0/go.mod h1:jc+VhpfPQpNoWKpjfKbeRkuevdJpzb81RjxHjl4p9hY=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260828190357-83d0e592d905 h1:WbBuMHekIc1G6pptClPRp35Ozsoba4boqPRX1FV3Z4Y=
-github.com/snyk/snyk-ls v0.0.0-20260828190357-83d0e592d905/go.mod h1:Jg8T0PYITm53Y3jjVRI9KBnc3chDmYHAN5Foq94vSRQ=
+github.com/snyk/snyk-ls v0.0.0-20260902080529-bf1230ca471b h1:M/bfw7AnAhjX9thlEs/XsdugM/gh2fQ8z2ygAE8M1yo=
+github.com/snyk/snyk-ls v0.0.0-20260902080529-bf1230ca471b/go.mod h1:Jg8T0PYITm53Y3jjVRI9KBnc3chDmYHAN5Foq94vSRQ=
 github.com/snyk/studio-mcp v1.15.4 h1:MHrAtTZ7E1IY0p6pdKAZqM4bmS5dZNSK/eEjVX26FA8=
 github.com/snyk/studio-mcp v1.15.4/go.mod h1:o+eDJRfHPVzPvZGqamASOZf5drlBEiJVbbOJS7sJsbQ=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/snyk/go-application-framework v0.18.2
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20260828190357-83d0e592d905
+	github.com/snyk/snyk-ls v0.0.0-20260902080529-bf1230ca471b
 	github.com/snyk/studio-mcp v1.15.4
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -564,8 +564,8 @@ github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhk
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260828190357-83d0e592d905 h1:WbBuMHekIc1G6pptClPRp35Ozsoba4boqPRX1FV3Z4Y=
-github.com/snyk/snyk-ls v0.0.0-20260828190357-83d0e592d905/go.mod h1:Jg8T0PYITm53Y3jjVRI9KBnc3chDmYHAN5Foq94vSRQ=
+github.com/snyk/snyk-ls v0.0.0-20260902080529-bf1230ca471b h1:M/bfw7AnAhjX9thlEs/XsdugM/gh2fQ8z2ygAE8M1yo=
+github.com/snyk/snyk-ls v0.0.0-20260902080529-bf1230ca471b/go.mod h1:Jg8T0PYITm53Y3jjVRI9KBnc3chDmYHAN5Foq94vSRQ=
 github.com/snyk/studio-mcp v1.15.4 h1:MHrAtTZ7E1IY0p6pdKAZqM4bmS5dZNSK/eEjVX26FA8=
 github.com/snyk/studio-mcp v1.15.4/go.mod h1:o+eDJRfHPVzPvZGqamASOZf5drlBEiJVbbOJS7sJsbQ=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit bf1230ca471b47e2a06c8f994cea280c26aa0335
Author: Bastian Doetsch <bastian.doetsch@snyk.io>
Date:   Wed Sep 2 10:05:29 2026 +0200

    test: make the suite pass on a developer machine, not just in CI (#1422)
    
    * test: make git fixtures independent of developer git config
    
    Test helpers that create throwaway repositories inherited the developer's
    global git configuration. With commit signing enabled — which this project
    requires of its contributors — every one of them failed:
    
      git [commit -m init]: error: sign broker unavailable
      fatal: failed to write commit object
    
    Disable signing in the fixture repo itself, alongside the user.name and
    user.email these helpers already set. server_smoke_test.go had solved this
    at one call site already; the other four had not.
    
    * test: stop asserting failure paths that need an unreachable Snyk API
    
    Four tests exercised error and fallback branches by assuming the API could
    not be reached. One said so outright: "the resolution will fail because we
    don't have a real API connection". On a machine logged in to Snyk the call
    succeeds, a real organization comes back, and the branch under test is
    never entered — so they passed in CI and failed for developers.
    
    Drive the failure deterministically instead: mock the configuration so org
    resolution returns the slug unchanged, and mock the engine so the PAT check
    finds no credentials. Test_prepareScanCommand now pins the organization it
    expects in the command rather than asserting a bare argument count.
    
    All four pass with and without network access.
    
    * build: key the tools cache by OS and arch, and set the pact test token
    
    TOOLS_BIN was keyed by path alone, so a checkout shared between a host and
    a container of a different platform got one cache for both. The pact bundle
    ships a platform-specific Ruby, and the mismatch surfaced as a misleading
    "CLI tools are out of date" rather than an exec format error. Key the
    directory by GOOS-GOARCH so each platform keeps its own, and put the
    resolved pact directory on PATH for the test target.
    
    TestSnykApiPact separately sent no Authorization header, because the test
    configured no credential for the framework's authenticated client to use.
    The contract requires one; the test now sets it itself instead of relying
    on whatever the developer happens to have in the environment.
    
    * test: disable signing in the remaining git fixtures
    
    A full run without any external git override showed the same defect in five
    more fixtures — 87 sign-broker errors across remediation, command and server
    tests. The earlier commit fixed only the helpers whose tests were failing at
    the time; these were masked because the run carried a GIT_CONFIG override.
    
    That completes the sweep: nine fixture sites shell out to git, and all nine
    now configure the repo they create. The rest use go-git or the existing
    GitEnvWithoutInheritedRepoConfig helper and were already safe.
    
    INTEG_TESTS=1 go test ./... now passes on a machine with commit signing
    enabled; on main it fails 102 tests across 10 packages.
    
    * test: wait for the notification each smoke step actually caused
    
    Initialization emits two $/snyk.configuration notifications. The helper
    returned on the first match and ClearNotifications() wiped only that one,
    so the second landed after the clear and the next step's wait latched onto
    a payload predating its own change. Which step got poisoned depended on how
    many baseline waits preceded the clear — hence a different subset of the
    precedence family failing on every run.
    
    Gate the match on evidence the step caused it: either the alternating
    additional_parameters token the trigger already sent, or the setting value
    the step just wrote. A notification emitted earlier can no longer satisfy
    the wait.
    
    The two invalid-credential tests failed for a related reason: they relied on
    the network rejecting a deliberately invalid token, but handleProviderInconsistencies
    reset the injected fake back to the real provider, and the token was written
    through a key GetToken does not read, so IsAuthenticated returned early on an
    empty token and no message was ever produced. Inject the provider through the
    harness and set the token via the token service.
    
    * test: correlate the org-selection wait with the opt-in it asserts
    
    Test_SmokeOrgSelection failed on main for the same reason as the precedence
    family: it waited for any folder-config notification and got one predating
    the opt-in, so OrgSetByUser was still true. Wait for the notification that
    carries the opted-in value.
    
    * ci-watch: fix dupl lint on Test_resolveOrgToUUID (duplicate subtests)
    
    Collapse the two near-identical gomock subtests into a table-driven loop
    so golangci-lint dupl passes.
    
    Co-authored-by: bastian.doetsch <bastian.doetsch@snyk.io>
    
    * ci-watch: fix Test_BDDSteps_ScenarioSubtest_FailsOnStepError (subprocess inherited SMOKE_TESTS TestMain)
    
    When SMOKE_TESTS=1, the BDD helper subprocess triggered smoke TestMain
    including a shared CLI download; a failed download prevented the helper
    from running and broke the assertion. Skip smoke TestMain setup when
    BDD_STEPS_HELPER_PROCESS=1.
    
    Co-authored-by: bastian.doetsch <bastian.doetsch@snyk.io>
    
    * ci-watch: fix Test_SmokeScanUnmanaged (shard-1 CLI contention returned 0 OSS issues)
    
    Move the unmanaged C/C++ smoke test to SMOKE_SHARD_4 and wait for delta scans
    to finish before asserting publishDiagnostics volume, matching other OSS smoke tests.
    
    Co-authored-by: bastian.doetsch <bastian.doetsch@snyk.io>
    
    * test: use reflect.DeepEqual for interface{} comparison in folderConfigsCarrySetting
    
    Replace == comparison with reflect.DeepEqual to safely handle non-comparable types
    like slices and maps in setting values.
    
    Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
    
    * test: preserve orgSet state across configWrapper.Clone()
    
    Change hardcoded orgSet: false to orgSet: cw.orgSet so the clone preserves
    the parent's explicit org selection state.
    
    Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
    
    * test: use maxIntegTestDuration for Code scan diagnostics wait in Test_SmokeSnykCodeFileScan
    
    Replace hardcoded 2*time.Minute timeout with maxIntegTestDuration (15 minutes)
    to match the pattern used by all other tests waiting on Code-scan diagnostics.
    This eliminates the CI flake where the race-detector build's overhead could cause
    the scan to exceed the 2-minute budget, triggering a false "Condition never satisfied"
    failure even though the scan succeeded.
    
    Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
    
    * test: move 2 precedence smoke tests from shard 3 to shard 2
    
    Shard 3 was the consistent runtime bottleneck across ubuntu/macos CI
    runs (~7.6m avg vs 4.9-5.7m for the other shards). These two tests
    declare their shard inline rather than through a shared setup helper,
    so moving them is a one-line change each with no other side effects.
    
    * ci-watch: address review comment 3902471631,3902623345,3902853219
    
    Drop invalidAuthProvider mock from auth smoke tests; use real OAuth token
    flow for 401/expiration checks. Shorten Test_SmokeSnykCodeFileScan diag wait
    to 5m. Document single-validator fast path in countValidatedFolderConfigs.
    
    Co-authored-by: bastian.doetsch <bastian.doetsch@snyk.io>
    
    * ci-watch: address review comment 3903277066,3903286722
    
    Co-authored-by: bastian.doetsch <bastian.doetsch@snyk.io>
    
    * ci-watch: address review comments 3902471631, 3903286722, 3904496793 (rrama PR 1422)
    
    Use garbage token in auth smoke test for real 401 path.
    Use require in pat_provider_test error assertion.
    Reuse UnitTestWithMockEngine in code_test resolveOrgToUUID cases.
    
    Co-authored-by: bastian.doetsch <bastian.doetsch@snyk.io>
    
    * ci-watch: fix Test_InvalidExpiredCredentialsSendMessageRequest (UUID pre-seed triggered MethodChangedMessage instead of expiry/invalid creds)
    
    Align pre-initialize auth state with OAuth: set authentication method and
    token to the OAuth JSON used in initialize so configureProviders does not
    emit MethodChangedMessage instead of expiry/invalid-creds prompts.
    
    Co-authored-by: bastian.doetsch <bastian.doetsch@snyk.io>
    
    * ci-watch: address review comment 3905437311 (stale pact paths after platform-specific TOOLS_BIN)
    
    Co-authored-by: bastian.doetsch <bastian.doetsch@snyk.io>
    
    * ci-watch: address review comments 3904684732, 3904733865
    
    Drop logger from UnitTestWithMockEngine return value per review nit.
    Use Lenf assert message for org passthrough check in oss_test.
    
    Co-authored-by: bastian.doetsch <bastian.doetsch@snyk.io>
    
    * ci-watch: address review comment 3904496793 (use UnitTestWithMockEngine in Test_resolveOrgToUUID UUID subtest)
    
    Co-authored-by: bastian.doetsch <bastian.doetsch@snyk.io>
    
    * ci-watch: fix TestClearCacheCommandScanFolderCtxCanceledOnShutdown (Windows CLI download locked temp dir on shutdown)
    
    Disable automatic CLI download and wait for background init in scan-context
    shutdown tests so Windows integration runs do not leave snyk-win.exe locked
    during t.TempDir cleanup.
    
    Co-authored-by: bastian.doetsch <bastian.doetsch@snyk.io>
    
    * ci-watch: retrigger CI for Test_SmokeWorkspaceScan macOS flake (gh run rerun unavailable)
    
    Co-authored-by: bastian.doetsch <bastian.doetsch@snyk.io>
    
    ---------
    
    Co-authored-by: Cursor Agent <cursoragent@cursor.com>
    Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>

M	.envrc
M	.github/docker-based-tests/entrypoint.sh
M	.github/workflows/build.yaml
M	.github/workflows/release.yaml
M	Makefile
M	README.md
M	application/di/init_fix_folder_test.go
M	application/server/authentication_smoke_test.go
M	application/server/bdd_steps_test.go
M	application/server/precedence_smoke_test.go
M	application/server/scan_context_command_test.go
M	application/server/secrets_smoke_test.go
M	application/server/server_smoke_test.go
M	application/server/server_test.go
M	application/server/smoke_main_helpers_test.go
M	application/server/smoke_main_test.go
M	domain/ide/command/remediation_fix_folder_test.go
M	domain/snyk/remediation/remy_test.go
M	infrastructure/authentication/pat_provider_test.go
M	infrastructure/cli/cli_extension_executor_test.go
M	infrastructure/code/code_test.go
M	infrastructure/oss/oss_test.go
M	infrastructure/snyk_api/snyk_api_pact_test.go
M	internal/folderconfig/git_test.go
M	internal/testutil/test_setup.go
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replacing the embedded language-server dependency can affect scan, auth, and IDE protocol behavior at runtime even though this repo diff is lockfile-only.
> 
> **Overview**
> **Bumps the bundled Snyk Language Server** in `cliv2` and `cliv2-private` by updating `github.com/snyk/snyk-ls` from `…20260828190357-83d0e592d905` to `…20260902080529-bf1230ca471b`, with matching `go.sum` entries in both trees.
> 
> There are **no CLI source changes** in this diff—only the module lockfiles. The integrated LS revision (`bf1230ca471b`) is dominated by **test and CI hardening** (git fixture signing, deterministic mocks instead of live API assumptions, smoke notification correlation, shard/timeout tweaks, and related fixes) so LS development and integration tests behave consistently on developer machines as well as in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f277a8af4f8e15153271d17540fcc0e4ec052a51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->