### PR TITLE
fix: stop analytics consuming the argv and environment redaction sweep [CLI-1819]

### DIFF
--- a/cliv2/pkg/core/instrumentation.go
+++ b/cliv2/pkg/core/instrumentation.go
@@ -58,7 +58,7 @@ func addNetworkingDetails(instrumentor analytics.InstrumentationCollector, confi
 }
 
 // clientMachineIdConfigKey is the config key Studio sets before exec'ing the snyk
-// binary (see Test_addClientMachineId). populateRedactionTerms in main.go must
+// binary (see Test_addClientMachineId). collectRedactionTerms in main.go must
 // exclude this value from its sweep, or a --debug run masks it out of every log
 // line that carries it, which is the one place the id is useful to read.
 const clientMachineIdConfigKey = "internal_snyk_client_machine_id"

--- a/cliv2/pkg/core/instrumentation.go
+++ b/cliv2/pkg/core/instrumentation.go
@@ -59,8 +59,8 @@ func addNetworkingDetails(instrumentor analytics.InstrumentationCollector, confi
 
 // clientMachineIdConfigKey is the config key Studio sets before exec'ing the snyk
 // binary (see Test_addClientMachineId). populateRedactionTerms in main.go must
-// exclude this value from its sweep, or the scrub chokepoint redacts it right back
-// out of the studio::client_machine_id extension it's meant to carry.
+// exclude this value from its sweep, or a --debug run masks it out of every log
+// line that carries it, which is the one place the id is useful to read.
 const clientMachineIdConfigKey = "internal_snyk_client_machine_id"
 
 func addClientMachineId(instrumentor analytics.InstrumentationCollector, config configuration.Configuration) {

--- a/cliv2/pkg/core/instrumentation_test.go
+++ b/cliv2/pkg/core/instrumentation_test.go
@@ -66,17 +66,16 @@ func Test_sendInstrumentation_passesEngineConfigurationToInstrumentationObject(t
 	assert.Equal(t, machineId, (*obj.Data.Attributes.Interaction.Extension)["studio::client_machine_id"])
 }
 
-// sendOneExtension drives one extension field through the real send path and returns
-// the extension as analytics received it. populateRedactionTerms runs first, exactly as
-// the --debug path runs it, so any leak of the argv/environment sweep into configuration
-// is redacting by the time the payload is built.
+// sendOneExtension runs collectRedactionTerms first, exactly as the --debug path does,
+// then drives one extension field through the real send path. If that sweep ever leaked
+// back into configuration, the extension it returns would come back redacted and fail.
 func sendOneExtension(t *testing.T, engineConfig configuration.Configuration, key string, value any) map[string]interface{} {
 	t.Helper()
 	globalConfiguration = configuration.NewWithOpts(configuration.WithAutomaticEnv())
 
 	mockEngine := mocks.NewMockEngine(gomock.NewController(t))
 	mockEngine.EXPECT().GetWorkflows().Return([]workflow.Identifier{})
-	populateRedactionTerms(engineConfig, mockEngine)
+	collectRedactionTerms(engineConfig, mockEngine)
 
 	mockEngine.EXPECT().GetConfiguration().Return(engineConfig).Times(2)
 	mockEngine.EXPECT().Invoke(localworkflows.WORKFLOWID_REPORT_ANALYTICS, gomock.Any(), gomock.Any()).Return(nil, nil)

--- a/cliv2/pkg/core/instrumentation_test.go
+++ b/cliv2/pkg/core/instrumentation_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -12,6 +13,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/mocks"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_shallSendInstrumentation(t *testing.T) {
@@ -39,15 +41,11 @@ func Test_sendInstrumentation_passesEngineConfigurationToInstrumentationObject(t
 	mockController := gomock.NewController(t)
 	mockEngine := mocks.NewMockEngine(mockController)
 
-	// Mirrors production: populateRedactionTerms runs at startup and sweeps up any
-	// os.Environ() value it doesn't recognize. The client machine id is real Studio
-	// data, not a secret, so its own env var value must not end up in the terms
-	// this test's later scrub pass redacts against.
+	// The client machine id is real Studio data, not a secret, so it has to come back
+	// verbatim rather than as "***".
 	machineId := "studio-device-id-abc12345"
 	t.Setenv("INTERNAL_SNYK_CLIENT_MACHINE_ID", machineId)
 	engineConfig := configuration.NewWithOpts(configuration.WithAutomaticEnv())
-	mockEngine.EXPECT().GetWorkflows().Return([]workflow.Identifier{})
-	populateRedactionTerms(engineConfig, mockEngine)
 
 	// One call from shallSendInstrumentation, one to derive analytics.WithConfiguration.
 	// If the call site regresses to only passing WithLogger, this expectation goes unmet.
@@ -66,6 +64,75 @@ func Test_sendInstrumentation_passesEngineConfigurationToInstrumentationObject(t
 	obj, err := analytics.GetV2InstrumentationObject(instrumentor, analytics.WithConfiguration(engineConfig))
 	assert.NoError(t, err)
 	assert.Equal(t, machineId, (*obj.Data.Attributes.Interaction.Extension)["studio::client_machine_id"])
+}
+
+// sendOneExtension drives one extension field through the real send path and returns
+// the extension as analytics received it. populateRedactionTerms runs first, exactly as
+// the --debug path runs it, so any leak of the argv/environment sweep into configuration
+// is redacting by the time the payload is built.
+func sendOneExtension(t *testing.T, engineConfig configuration.Configuration, key string, value any) map[string]interface{} {
+	t.Helper()
+	globalConfiguration = configuration.NewWithOpts(configuration.WithAutomaticEnv())
+
+	mockEngine := mocks.NewMockEngine(gomock.NewController(t))
+	mockEngine.EXPECT().GetWorkflows().Return([]workflow.Identifier{})
+	populateRedactionTerms(engineConfig, mockEngine)
+
+	mockEngine.EXPECT().GetConfiguration().Return(engineConfig).Times(2)
+	mockEngine.EXPECT().Invoke(localworkflows.WORKFLOWID_REPORT_ANALYTICS, gomock.Any(), gomock.Any()).Return(nil, nil)
+
+	instrumentor := analytics.NewInstrumentationCollector()
+	instrumentor.AddExtension(key, value)
+	logger := zerolog.Nop()
+
+	sendInstrumentation(context.Background(), mockEngine, instrumentor, &logger)
+
+	// Re-deriving the object is a pure read, so it reports what sendInstrumentation
+	// itself just put through the scrub chokepoint.
+	obj, err := analytics.GetV2InstrumentationObject(instrumentor, analytics.WithConfiguration(engineConfig))
+	require.NoError(t, err)
+	require.NotNil(t, obj.Data.Attributes.Interaction.Extension)
+	return *obj.Data.Attributes.Interaction.Extension
+}
+
+func Test_sendInstrumentation_keepsValueCollidingWithArgvToken(t *testing.T) {
+	oldArgs := append([]string{}, os.Args...)
+	os.Args = []string{"snyk", "test", "--target-reference", "my-feature-branch"}
+	defer func() { os.Args = oldArgs }()
+
+	engineConfig := configuration.NewWithOpts(configuration.WithAutomaticEnv())
+	extension := sendOneExtension(t, engineConfig, "legacycli::metadata__targetBranch", "my-feature-branch")
+
+	assert.Equal(t, "my-feature-branch", extension["legacycli::metadata__targetBranch"])
+}
+
+func Test_sendInstrumentation_keepsValueCollidingWithEnvironmentValue(t *testing.T) {
+	t.Setenv("SNYK_TEST_PLUGIN_MARKER", "snyk-nodejs-lockfile-parser")
+
+	engineConfig := configuration.NewWithOpts(configuration.WithAutomaticEnv())
+	extension := sendOneExtension(t, engineConfig, "legacycli::metadata__pluginName", "snyk-nodejs-lockfile-parser")
+
+	assert.Equal(t, "snyk-nodejs-lockfile-parser", extension["legacycli::metadata__pluginName"])
+}
+
+func Test_sendInstrumentation_redactsAuthenticationToken(t *testing.T) {
+	// Not token-shaped, so only the exact-value layer can catch it.
+	engineConfig := configuration.NewWithOpts(configuration.WithAutomaticEnv())
+	engineConfig.Set(configuration.AUTHENTICATION_TOKEN, "an-exact-credential-the-cli-holds")
+
+	extension := sendOneExtension(t, engineConfig, "legacycli::metadata__targetBranch", "branch an-exact-credential-the-cli-holds")
+
+	assert.Equal(t, "branch ***", extension["legacycli::metadata__targetBranch"])
+}
+
+func Test_sendInstrumentation_redactsTokenShapedValue(t *testing.T) {
+	// Nothing in config or argv names this value; the shape pattern is all that stands between
+	// it and analytics, and it is the layer this change leans on.
+	engineConfig := configuration.NewWithOpts(configuration.WithAutomaticEnv())
+
+	extension := sendOneExtension(t, engineConfig, "legacycli::metadata__targetBranch", "ghp_016C7e42F292c6912E7710c838347Ae178B4a")
+
+	assert.Equal(t, "ghp_***", extension["legacycli::metadata__targetBranch"])
 }
 
 func Test_addClientMachineId(t *testing.T) {

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -510,12 +510,6 @@ func tearDown(err error, errorList []error, startTime time.Time, ua networking.U
 	teardownCtx, cancel := context.WithTimeout(context.Background(), teardownTimeout)
 	defer cancel()
 
-	// Populated here (post-command) rather than at startup so the analytics scrub chokepoint
-	// (which reads logging.REDACTION_TERMS off of config) sees these terms on every run, not
-	// just under --debug, without forcing an ORGANIZATION/ORGANIZATION_SLUG network lookup
-	// before the command's own requests run.
-	populateRedactionTerms(globalConfiguration, globalEngine)
-
 	outputError := err
 	allErrors := errorList
 
@@ -723,9 +717,11 @@ func mainWithErrorCode(additionalExts []workflow.ExtensionInit) int {
 }
 
 // populateRedactionTerms computes likely-secret literal values (unrecognized CLI
-// arguments and environment variables) and records them on config under
-// logging.REDACTION_TERMS, so the analytics scrub chokepoint can redact
-// them regardless of whether debug logging is enabled.
+// arguments and environment variables) for the debug log scrubber, which takes
+// them by direct call from the caller. They are deliberately never written to
+// configuration: that is what the analytics scrub chokepoint reads, and this sweep
+// guesses, so anything it reaches over-redacts (CLI-1819). Over-redacting the debug
+// log is free, since a human reviews it before sharing.
 func populateRedactionTerms(config configuration.Configuration, engine workflow.Engine) []string {
 	knownTerms, _ := instrumentation.GetKnownCommandsAndFlags(engine)
 	knownTerms = append(knownTerms, config.GetString(configuration.API_URL), config.GetString(configuration.ORGANIZATION), config.GetString(configuration.ORGANIZATION_SLUG), config.GetString(clientMachineIdConfigKey))
@@ -740,7 +736,6 @@ func populateRedactionTerms(config configuration.Configuration, engine workflow.
 		knownTerms = append(knownTerms, strings.Fields(detectedAgent)...)
 	}
 	termsToRedact := cliv2utils.GetUnknownParameters(os.Args[1:], os.Environ(), knownTerms)
-	config.Set(logging.REDACTION_TERMS, termsToRedact)
 	return termsToRedact
 }
 

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -643,7 +643,7 @@ func mainWithErrorCode(additionalExts []workflow.ExtensionInit) int {
 
 	// We want to scrub the debug log of sensitive information. Since we have a list of commands we know can occur, we can intersect that with arguments we don't recognize, and automatically scrub all those from the logs.
 	if debugEnabled {
-		termsToRedact := populateRedactionTerms(globalConfiguration, globalEngine)
+		termsToRedact := collectRedactionTerms(globalConfiguration, globalEngine)
 		writeLogHeader(globalConfiguration, networkAccess)
 		scrubbedLogger.AddTermsToReplace(termsToRedact)
 	}
@@ -716,13 +716,13 @@ func mainWithErrorCode(additionalExts []workflow.ExtensionInit) int {
 	return finalExitCode
 }
 
-// populateRedactionTerms computes likely-secret literal values (unrecognized CLI
+// collectRedactionTerms computes likely-secret literal values (unrecognized CLI
 // arguments and environment variables) for the debug log scrubber, which takes
 // them by direct call from the caller. They are deliberately never written to
 // configuration: that is what the analytics scrub chokepoint reads, and this sweep
 // guesses, so anything it reaches over-redacts (CLI-1819). Over-redacting the debug
 // log is free, since a human reviews it before sharing.
-func populateRedactionTerms(config configuration.Configuration, engine workflow.Engine) []string {
+func collectRedactionTerms(config configuration.Configuration, engine workflow.Engine) []string {
 	knownTerms, _ := instrumentation.GetKnownCommandsAndFlags(engine)
 	knownTerms = append(knownTerms, config.GetString(configuration.API_URL), config.GetString(configuration.ORGANIZATION), config.GetString(configuration.ORGANIZATION_SLUG), config.GetString(clientMachineIdConfigKey))
 	// AI_AGENT is trusted verbatim by agent.DetectAgent, and persona.Report

--- a/cliv2/pkg/core/main_test.go
+++ b/cliv2/pkg/core/main_test.go
@@ -81,13 +81,31 @@ func Test_populateRedactionTerms(t *testing.T) {
 	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	t.Setenv("SNYK_TEST_REDACTION_MARKER", "unmistakably-secret-value")
 
-	// No debugEnabled anywhere in this call: populateRedactionTerms runs
-	// unconditionally at its call site, so proving it sets config here proves
-	// the behavior holds regardless of debugEnabled.
 	terms := populateRedactionTerms(config, mockEngine)
 
 	assert.Contains(t, terms, "unmistakably-secret-value")
-	assert.Equal(t, terms, config.GetStringSlice(logging.REDACTION_TERMS))
+	// Configuration is how the sweep would reach the analytics scrub chokepoint, and
+	// this is the same call the --debug path makes, so a debug run must not corrupt
+	// analytics in a way a normal run does not.
+	assert.Empty(t, config.GetStringSlice(logging.REDACTION_TERMS))
+}
+
+func Test_populateRedactionTerms_sweepsBarePositionalOperand(t *testing.T) {
+	mockController := gomock.NewController(t)
+	mockEngine := mocks.NewMockEngine(mockController)
+	mockEngine.EXPECT().GetWorkflows().Return(nil)
+
+	oldArgs := append([]string{}, os.Args...)
+	os.Args = []string{"snyk", "test", "unrecognised-operand"}
+	defer func() { os.Args = oldArgs }()
+
+	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
+
+	terms := populateRedactionTerms(config, mockEngine)
+
+	// The debug log still wants the aggressive sweep. Analytics no longer reading it
+	// is not a reason to delete it.
+	assert.Contains(t, terms, "unrecognised-operand")
 }
 
 func Test_populateRedactionTerms_excludesClientMachineId(t *testing.T) {
@@ -101,15 +119,15 @@ func Test_populateRedactionTerms_excludesClientMachineId(t *testing.T) {
 
 	terms := populateRedactionTerms(config, mockEngine)
 
-	assert.NotContains(t, terms, machineId, "client machine id must never be swept into REDACTION_TERMS, or the analytics scrub chokepoint strips it right back out of its own extension")
+	assert.NotContains(t, terms, machineId, "client machine id must never be swept into the debug log's term list, or a --debug run masks it out of the log lines that carry it")
 }
 
 func Test_populateRedactionTerms_excludesDetectedAgent(t *testing.T) {
 	// Not on agent.canonicalAgent's short-circuit list, so AI_AGENT is trusted
-	// verbatim into the persona.agent extension. GetUnknownParameters
-	// tokenizes its input on whitespace, so a multi-word value only survives
-	// unredacted if each of its words is excluded too, not just the joined
-	// string as a whole.
+	// verbatim, and the harness name is what a debug log is read for.
+	// GetUnknownParameters tokenizes its input on whitespace, so a multi-word
+	// value only survives unredacted if each of its words is excluded too, not
+	// just the joined string as a whole.
 	cases := []struct {
 		name      string
 		agent     string
@@ -139,7 +157,7 @@ func Test_populateRedactionTerms_excludesDetectedAgent(t *testing.T) {
 			terms := populateRedactionTerms(config, mockEngine)
 
 			for _, word := range tc.wantWords {
-				assert.NotContains(t, terms, word, "a caller-declared AI_AGENT value must never be swept into REDACTION_TERMS, or the analytics scrub chokepoint strips it right back out of the persona.agent extension")
+				assert.NotContains(t, terms, word, "a caller-declared AI_AGENT value must never be swept into the debug log's term list, or a --debug run masks the harness name out of the log")
 			}
 		})
 	}

--- a/cliv2/pkg/core/main_test.go
+++ b/cliv2/pkg/core/main_test.go
@@ -73,7 +73,7 @@ func Test_mainWithErrorCode(t *testing.T) {
 	})
 }
 
-func Test_populateRedactionTerms(t *testing.T) {
+func Test_collectRedactionTerms(t *testing.T) {
 	mockController := gomock.NewController(t)
 	mockEngine := mocks.NewMockEngine(mockController)
 	mockEngine.EXPECT().GetWorkflows().Return(nil)
@@ -81,7 +81,7 @@ func Test_populateRedactionTerms(t *testing.T) {
 	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	t.Setenv("SNYK_TEST_REDACTION_MARKER", "unmistakably-secret-value")
 
-	terms := populateRedactionTerms(config, mockEngine)
+	terms := collectRedactionTerms(config, mockEngine)
 
 	assert.Contains(t, terms, "unmistakably-secret-value")
 	// Configuration is how the sweep would reach the analytics scrub chokepoint, and
@@ -90,25 +90,30 @@ func Test_populateRedactionTerms(t *testing.T) {
 	assert.Empty(t, config.GetStringSlice(logging.REDACTION_TERMS))
 }
 
-func Test_populateRedactionTerms_sweepsBarePositionalOperand(t *testing.T) {
+func Test_collectRedactionTerms_sweepsBarePositionalOperand(t *testing.T) {
 	mockController := gomock.NewController(t)
 	mockEngine := mocks.NewMockEngine(mockController)
 	mockEngine.EXPECT().GetWorkflows().Return(nil)
 
 	oldArgs := append([]string{}, os.Args...)
-	os.Args = []string{"snyk", "test", "unrecognised-operand"}
+	// "monitor" comes from instrumentation.KNOWN_COMMANDS, the base list
+	// GetKnownCommandsAndFlags returns whatever workflows are registered, and it is long
+	// enough to clear utils.MIN_ARG_LENGTH — so only the known-command rule can spare it,
+	// unlike "test", which the length floor spares regardless.
+	os.Args = []string{"snyk", "monitor", "unrecognised-operand"}
 	defer func() { os.Args = oldArgs }()
 
 	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 
-	terms := populateRedactionTerms(config, mockEngine)
+	terms := collectRedactionTerms(config, mockEngine)
 
 	// The debug log still wants the aggressive sweep. Analytics no longer reading it
 	// is not a reason to delete it.
 	assert.Contains(t, terms, "unrecognised-operand")
+	assert.NotContains(t, terms, "monitor")
 }
 
-func Test_populateRedactionTerms_excludesClientMachineId(t *testing.T) {
+func Test_collectRedactionTerms_excludesClientMachineId(t *testing.T) {
 	mockController := gomock.NewController(t)
 	mockEngine := mocks.NewMockEngine(mockController)
 	mockEngine.EXPECT().GetWorkflows().Return(nil)
@@ -117,12 +122,12 @@ func Test_populateRedactionTerms_excludesClientMachineId(t *testing.T) {
 	machineId := "studio-device-id-abc12345"
 	t.Setenv("INTERNAL_SNYK_CLIENT_MACHINE_ID", machineId)
 
-	terms := populateRedactionTerms(config, mockEngine)
+	terms := collectRedactionTerms(config, mockEngine)
 
 	assert.NotContains(t, terms, machineId, "client machine id must never be swept into the debug log's term list, or a --debug run masks it out of the log lines that carry it")
 }
 
-func Test_populateRedactionTerms_excludesDetectedAgent(t *testing.T) {
+func Test_collectRedactionTerms_excludesDetectedAgent(t *testing.T) {
 	// Not on agent.canonicalAgent's short-circuit list, so AI_AGENT is trusted
 	// verbatim, and the harness name is what a debug log is read for.
 	// GetUnknownParameters tokenizes its input on whitespace, so a multi-word
@@ -154,7 +159,7 @@ func Test_populateRedactionTerms_excludesDetectedAgent(t *testing.T) {
 			config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 			t.Setenv("AI_AGENT", tc.agent)
 
-			terms := populateRedactionTerms(config, mockEngine)
+			terms := collectRedactionTerms(config, mockEngine)
 
 			for _, word := range tc.wantWords {
 				assert.NotContains(t, terms, word, "a caller-declared AI_AGENT value must never be swept into the debug log's term list, or a --debug run masks the harness name out of the log")


### PR DESCRIPTION
Fixes the main cause in [CLI-1819](https://snyksec.atlassian.net/browse/CLI-1819): analytics stops consuming the argv and environment sweep.

## What was wrong

The CLI treats every whitespace-separated token in its own argv and environment as a secret unless the token is shorter than 5 characters, starts with a dash, matches one of about 20 known commands, or appears in a hand-written list of 80 English words. Those terms then get stripped from every string in the analytics interaction extension, so any value that collides with a token from the same invocation disappears.

Real collisions seen in production: `snyk-***-lockfile-parser` where `nodejs` collided, `bundled:***` where maven and gradle collided, `persona.agent: ***-code_2-1-220_harness` where `claude` collided, and `c-runtime-details: ldd (*** GLIBC 2.36-9) 2.36` where `Debian` collided. The worst case is `snyk agent feedback "<assessment>"`, where the assessment text is itself an argv token and so redacts itself.

Customer-facing redaction went from 0.29% to 2.21% over two weeks, roughly 356,000 corrupted customer events, with the daily rate still climbing.

## Why this is a revert, not a redesign

The sweep was written in August 2025 for one consumer, the debug console log. There the output is unstructured text, a human reviews it before sharing, and the CLI prints a warning saying so. Over-redaction costs nothing.

On 2026-08-18 the analytics chokepoint was wired to the same dictionary builder, so analytics inherited a filter built for a context where being wrong is free. This reverts that half and keeps the half that added shape scrubbing.

## The change

`populateRedactionTerms` no longer writes to `logging.REDACTION_TERMS`, and the call in `tearDown` that existed only to feed analytics is gone. The debug log path is untouched: it already took the terms by direct call into `scrubbedLogger.AddTermsToReplace`.

The sweep itself, its tokenizer, its length floor, its known-command check and its word allowlist are byte-identical. `cliv2/internal/utils/args.go` is not touched at all.

The terms reach configuration on no code path, including under `--debug`. If a debug run wrote them, that run would corrupt analytics while a normal run did not, which is worse than the bug being fixed because it would be intermittent.

The configuration key stays defined in the framework. Other hosts may set it. The CLI just stops.

## What analytics keeps

Five layers, all positive detection, all anchored to a keyword, a known prefix, or a value the CLI already holds:

- shape patterns for Snyk PATs, GitHub tokens, bearer headers, URL credentials and JSON `key: value` pairs
- the authentication token, by exact value
- the authentication bearer token, by exact value
- the OAuth client id and client secret, by exact value
- the OAuth access and refresh tokens, by exact value

The sweep was the sixth and the only one that produces false positives.

## What analytics loses, deliberately

A literal word from argv or the environment that matches no shape pattern and is not a credential the CLI holds. Concretely: a password typed after an unrecognised flag, or a bare high-entropy API key in an environment variable with no recognisable keyword prefix.

This is the residue the shape patterns do not catch. Accepting it is the point of the spec rather than a side effect. It reverses two security requirements from the spec's previous revision, and the ticket asks for explicit agreement from whoever owns the security posture rather than settling it in code review. Flagging it here so that decision is visible and not discovered later.

## Tests

Four at the `sendInstrumentation` seam, which is the highest point in the CLI where the whole redaction chain runs beneath it. They assert on the returned analytics payload, never on the scrub dictionary or rule ordering.

- a value colliding with an argv token reaches analytics intact
- a value colliding with an environment variable value reaches analytics intact
- the authentication token is still redacted, using a value that is not token-shaped so only the exact-value layer can catch it
- a token-shaped value in an extension field is still redacted

One more in `main_test.go` pins that a bare positional operand still contributes a term to the list handed to the log scrubber. That is the guard against someone later deleting the sweep on the grounds that analytics no longer uses it.

`Test_populateRedactionTerms` inverts its config assertion: the terms must now be absent from configuration.

Three comments claiming the sweep protects analytics are reworded. The client machine id and AI agent exclusions stay, since a `--debug` run masking the harness name out of the log defeats the reason to read the log.

Checked by temporarily restoring `config.Set(logging.REDACTION_TERMS, …)`: the argv-collision, env-collision and config-absence assertions all fail, and the two redaction tests keep passing.

## Test plan

- `go build ./...` clean
- `go test ./pkg/core/... ./internal/utils/...`: 130 pass, 0 fail
- `golangci-lint run ./pkg/core/...`: 0 issues

## Not in scope

The username half of the ticket (analytics keys corrupted by unbounded username matching) is separate and independently shippable.


[CLI-1819]: https://snyksec.atlassian.net/browse/CLI-1819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes telemetry redaction boundaries: fewer false positives in analytics but less blanket scrubbing of arbitrary argv/env literals that are not credential-shaped.
> 
> **Overview**
> Fixes **CLI-1819** by decoupling analytics redaction from the aggressive argv/environment “unknown token” sweep that was falsely masking legitimate extension values (branch names, plugin names, OS strings, etc.).
> 
> **`populateRedactionTerms`** is renamed to **`collectRedactionTerms`** and no longer writes **`logging.REDACTION_TERMS`** on configuration; the teardown call that fed analytics is removed. The same sweep still runs under **`--debug`**, passed straight into the log scrubber—over-redaction there is acceptable, but wiring those terms into config let analytics inherit the same dictionary and over-redact.
> 
> Analytics keeps credential-focused scrubbing (exact tokens in config, token-shaped patterns). New **`sendInstrumentation`** tests assert argv/env collisions survive while auth and **`ghp_`**-shaped values still redact; **`main_test`** asserts debug-only behavior (terms not on config, bare positionals still collected).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f91c00381c1a17051f9e7704a1d91a1f50871b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->