### PR TITLE
chore: bump GAF for html rendering support

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -225,7 +225,7 @@ require (
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 // indirect
-	github.com/snyk/go-application-framework v0.19.1 // indirect
+	github.com/snyk/go-application-framework v0.19.3-0.20260903115722-da69471ff337 // indirect
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -609,8 +609,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.19.1 h1:HmIxqrGafFVJgt/y6A3o8x6ekP5RbHGezTBgsfd8t9I=
-github.com/snyk/go-application-framework v0.19.1/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
+github.com/snyk/go-application-framework v0.19.3-0.20260903115722-da69471ff337 h1:a/bJxelrVSDWGsIOuWtgwg50XqLVW8+UBAgdkM0Nclg=
+github.com/snyk/go-application-framework v0.19.3-0.20260903115722-da69471ff337/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.31.8
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6
-	github.com/snyk/go-application-framework v0.19.1
+	github.com/snyk/go-application-framework v0.19.3-0.20260903115722-da69471ff337
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260902080529-bf1230ca471b

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -556,8 +556,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.19.1 h1:HmIxqrGafFVJgt/y6A3o8x6ekP5RbHGezTBgsfd8t9I=
-github.com/snyk/go-application-framework v0.19.1/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
+github.com/snyk/go-application-framework v0.19.3-0.20260903115722-da69471ff337 h1:a/bJxelrVSDWGsIOuWtgwg50XqLVW8+UBAgdkM0Nclg=
+github.com/snyk/go-application-framework v0.19.3-0.20260903115722-da69471ff337/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

## Where should the reviewer start?

## How should this be manually tested?

## What's the product update that needs to be communicated to CLI users?

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only bump with no local logic changes; any behavior shift is confined to the upgraded GAF version used by CLI extensions.
> 
> **Overview**
> Updates **`github.com/snyk/go-application-framework`** from **v0.19.1** to pre-release **v0.19.3-0.20260903115722-da69471ff337** in **`cliv2`** and **`cliv2-private`**, with matching **`go.sum`** checksums.
> 
> There are **no application code changes** in this repo—the CLI picks up the newer GAF build so extensions and shared framework behavior (including **HTML rendering support** called out in the PR title) come from the updated dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f90c3591a6ce46ca67733d6b155bd9b0b68fbd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->