### PR TITLE
chore: bump cli-extension-dep-graph to v2.14.0

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -215,7 +215,7 @@ require (
 	github.com/skeema/knownhosts v1.3.2 // indirect
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260821092236-dc228259a004 // indirect
 	github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172 // indirect
-	github.com/snyk/cli-extension-dep-graph/v2 v2.11.0 // indirect
+	github.com/snyk/cli-extension-dep-graph/v2 v2.14.0 // indirect
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 // indirect
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f // indirect
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260902112609-53cb856541b8 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -589,8 +589,8 @@ github.com/snyk/cli-extension-axi v0.0.0-20260825145801-2e6df22df8aa h1:zqKisoNs
 github.com/snyk/cli-extension-axi v0.0.0-20260825145801-2e6df22df8aa/go.mod h1:C45YTforGksm9KhbB7RtgMCqeXP1fk/zjN+8ly4EQVg=
 github.com/snyk/cli-extension-cos v0.0.0-20260818151318-d63bb9db9484 h1:lgFISU/Opo4I1w7tHdivXR9OU6tsgbfmo4t9SewjuQE=
 github.com/snyk/cli-extension-cos v0.0.0-20260818151318-d63bb9db9484/go.mod h1:YpcOdcMBJOzwtla/OOoBOArx27Bc2v42Vcwd/FeGl9M=
-github.com/snyk/cli-extension-dep-graph/v2 v2.11.0 h1:hNIlg5G30VQGk+sfeEzWdAQiYI8Kq1CASSOubOZruQM=
-github.com/snyk/cli-extension-dep-graph/v2 v2.11.0/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
+github.com/snyk/cli-extension-dep-graph/v2 v2.14.0 h1:MWu0m0sOtZAEBR3KNWvo2hKtqyTz7boCXv/90mQlVoY=
+github.com/snyk/cli-extension-dep-graph/v2 v2.14.0/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSoQL0zYyFcGQjEPZcQgDkzM5PcgIHlIgzRuhg=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f h1:EPaHfaWDJq/lrsrATMqAyKJRfstb9LZnPXYNwXdL32c=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260821092236-dc228259a004
 	github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172
-	github.com/snyk/cli-extension-dep-graph/v2 v2.11.0
+	github.com/snyk/cli-extension-dep-graph/v2 v2.14.0
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260902112609-53cb856541b8

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -536,8 +536,8 @@ github.com/snyk/cli-extension-agent-scan v0.0.0-20260821092236-dc228259a004 h1:7
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260821092236-dc228259a004/go.mod h1:u4d7qoWWVx3II+ZnpLQGjAegaJLmgPefXKXJD/jp/wM=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172 h1:dZQ2DnEnxV+v2yFRyuqUioSAGfXkiMcRQXndAeVsqi0=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172/go.mod h1:ieThzrb8z/Z88cDKdfqdfGh01xs6RkDKt5LbA+AE6U8=
-github.com/snyk/cli-extension-dep-graph/v2 v2.11.0 h1:hNIlg5G30VQGk+sfeEzWdAQiYI8Kq1CASSOubOZruQM=
-github.com/snyk/cli-extension-dep-graph/v2 v2.11.0/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
+github.com/snyk/cli-extension-dep-graph/v2 v2.14.0 h1:MWu0m0sOtZAEBR3KNWvo2hKtqyTz7boCXv/90mQlVoY=
+github.com/snyk/cli-extension-dep-graph/v2 v2.14.0/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSoQL0zYyFcGQjEPZcQgDkzM5PcgIHlIgzRuhg=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f h1:EPaHfaWDJq/lrsrATMqAyKJRfstb9LZnPXYNwXdL32c=


### PR DESCRIPTION
Brings the .NET resolver's real dependency resolution into the CLI.

The CLI has been pinned at `v2.11.0`, which resolves SDK-style projects from `project.assets.json` only. `v2.14.0` adds the two older .NET manifests — `packages.config` (.NET Framework) and `project.json` (pre-RTM .NET Core) — resolved statically from the manifest plus the `packages/` folder `nuget restore` populates. No `dotnet` or `nuget` invocation.

Extension-side PRs: snyk/cli-extension-dep-graph#239, #240, #241, #242 (CMPA-717).

Both `cliv2` and `cliv2-private` are updated, via the repo's tidy + gomodsync sequence. `go mod tidy -diff` is clean in both modules and both build.

Still gated behind `--use-sbom-resolution` **and** the `internal-dotnet-resolver` org flag, so this changes nothing for anyone until that flag is turned on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no CLI code changes; new .NET resolution is behind existing feature flags.
> 
> **Overview**
> Bumps **`github.com/snyk/cli-extension-dep-graph/v2`** from **v2.11.0** to **v2.14.0** in **`cliv2`** (direct require) and **`cliv2-private`** (transitive via `cliv2`), with matching **`go.sum`** updates.
> 
> That extension version adds static .NET dependency resolution for **`packages.config`** and **`project.json`** (manifest + restored **`packages/`** layout), alongside the existing SDK-style **`project.assets.json`** path—without invoking **`dotnet`** or **`nuget`**. Behavior only applies when **`--use-sbom-resolution`** and the **`internal-dotnet-resolver`** org flag are enabled; default CLI flows are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfd6e96fc3fca3485072fb0ca62e9e6b1cd03d73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->