### PR TITLE
feat: IANDT-27: capture contributors

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -225,7 +225,7 @@ require (
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 // indirect
-	github.com/snyk/go-application-framework v0.20.0 // indirect
+	github.com/snyk/go-application-framework v0.21.0 // indirect
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -609,8 +609,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.20.0 h1:9LyEAT+Z6JrardT4y+5/L4htiPWfWq1AzX4qOkIFAJQ=
-github.com/snyk/go-application-framework v0.20.0/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
+github.com/snyk/go-application-framework v0.21.0 h1:nsTxFM5+FkzK1HtkNyNwhTQ2C6KJH5nilL63O9W8+2E=
+github.com/snyk/go-application-framework v0.21.0/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.31.8
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6
-	github.com/snyk/go-application-framework v0.20.0
+	github.com/snyk/go-application-framework v0.21.0
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260902080529-bf1230ca471b

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -556,8 +556,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.20.0 h1:9LyEAT+Z6JrardT4y+5/L4htiPWfWq1AzX4qOkIFAJQ=
-github.com/snyk/go-application-framework v0.20.0/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
+github.com/snyk/go-application-framework v0.21.0 h1:nsTxFM5+FkzK1HtkNyNwhTQ2C6KJH5nilL63O9W8+2E=
+github.com/snyk/go-application-framework v0.21.0/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/test/jest/acceptance/resilience.spec.ts
+++ b/test/jest/acceptance/resilience.spec.ts
@@ -296,6 +296,10 @@ describe('Resilience - Consistent CLI Behavior', () => {
       SNYK_TOKEN: '123456789',
       SNYK_HTTP_PROTOCOL_UPGRADE: '0',
       SNYK_CFG_ORG: FAKE_ORG,
+      // Reading this flag triggers a network call earlier than the tests
+      // expect, which breaks due to the slow network calls mechanism these
+      // tests use to trigger timeouts.
+      INTERNAL_SNYK_CONTRIBUTORS_ENABLED: 'false',
     };
 
     server = fakeServer(baseApi, baseEnv.SNYK_TOKEN);


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [x] Highlights breaking API changes (if applicable)
- [x] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

This PR enables counting contributors for CLI tests by upgrading go-application-framework. The functionality is conditionally registered based on the rollout flag visible in the source, but the early feature flag lookup interferes with the tests that assert on CLI timeouts based on slow network calls, so the flag is hardcoded to false to skip the lookup. 

This process is transparent to users of the CLI - no new output is added, and failures are not surfaced to the user.

## Where should the reviewer start?

See the revelant PRs in go-application-framework for more details and relevant tests:
- https://github.com/snyk/go-application-framework/pull/697
- https://github.com/snyk/go-application-framework/pull/703
- https://github.com/snyk/go-application-framework/pull/721

## How should this be manually tested?

The process involves running stateful CLI tests and inspecting internal telemetry to verify the correct data was produced. 
This has already been manually tested.

## What's the product update that needs to be communicated to CLI users?

None.

## Risk assessment (Low)?

Rollout is controlled by a flag, and failures do not impact users directly.

## Any background context you want to provide?

None.

## What are the relevant tickets?

IANDT-27