### PR TITLE
chore(language-server): integrate LS

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -229,7 +229,7 @@ require (
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect
-	github.com/snyk/snyk-ls v0.0.0-20260902080529-bf1230ca471b // indirect
+	github.com/snyk/snyk-ls v0.0.0-20260907062128-ef4a43fa0dbf // indirect
 	github.com/snyk/studio-mcp v1.15.4 // indirect
 	github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -621,8 +621,8 @@ github.com/snyk/rift-cli-extension v1.2.2 h1:FXNqsby+nZJvrxQzzIc4kIffv4nTQ5IaIM4
 github.com/snyk/rift-cli-extension v1.2.2/go.mod h1:jc+VhpfPQpNoWKpjfKbeRkuevdJpzb81RjxHjl4p9hY=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260902080529-bf1230ca471b h1:M/bfw7AnAhjX9thlEs/XsdugM/gh2fQ8z2ygAE8M1yo=
-github.com/snyk/snyk-ls v0.0.0-20260902080529-bf1230ca471b/go.mod h1:Jg8T0PYITm53Y3jjVRI9KBnc3chDmYHAN5Foq94vSRQ=
+github.com/snyk/snyk-ls v0.0.0-20260907062128-ef4a43fa0dbf h1:+us9PFIqjsmSh7qhY77GPGfjnBw6BSPvx+wqs1GbMvw=
+github.com/snyk/snyk-ls v0.0.0-20260907062128-ef4a43fa0dbf/go.mod h1:WKJTlF8wxoFVnp4CoVxsvnePYRnS8DQqdl7VZvHurgY=
 github.com/snyk/studio-mcp v1.15.4 h1:MHrAtTZ7E1IY0p6pdKAZqM4bmS5dZNSK/eEjVX26FA8=
 github.com/snyk/studio-mcp v1.15.4/go.mod h1:o+eDJRfHPVzPvZGqamASOZf5drlBEiJVbbOJS7sJsbQ=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/snyk/go-application-framework v0.21.0
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc
 	github.com/snyk/snyk-iac-capture v0.6.5
-	github.com/snyk/snyk-ls v0.0.0-20260902080529-bf1230ca471b
+	github.com/snyk/snyk-ls v0.0.0-20260907062128-ef4a43fa0dbf
 	github.com/snyk/studio-mcp v1.15.4
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -564,8 +564,8 @@ github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhk
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=
 github.com/snyk/snyk-iac-capture v0.6.5/go.mod h1:e47i55EmM0F69ZxyFHC4sCi7vyaJW6DLoaamJJCzWGk=
-github.com/snyk/snyk-ls v0.0.0-20260902080529-bf1230ca471b h1:M/bfw7AnAhjX9thlEs/XsdugM/gh2fQ8z2ygAE8M1yo=
-github.com/snyk/snyk-ls v0.0.0-20260902080529-bf1230ca471b/go.mod h1:Jg8T0PYITm53Y3jjVRI9KBnc3chDmYHAN5Foq94vSRQ=
+github.com/snyk/snyk-ls v0.0.0-20260907062128-ef4a43fa0dbf h1:+us9PFIqjsmSh7qhY77GPGfjnBw6BSPvx+wqs1GbMvw=
+github.com/snyk/snyk-ls v0.0.0-20260907062128-ef4a43fa0dbf/go.mod h1:WKJTlF8wxoFVnp4CoVxsvnePYRnS8DQqdl7VZvHurgY=
 github.com/snyk/studio-mcp v1.15.4 h1:MHrAtTZ7E1IY0p6pdKAZqM4bmS5dZNSK/eEjVX26FA8=
 github.com/snyk/studio-mcp v1.15.4/go.mod h1:o+eDJRfHPVzPvZGqamASOZf5drlBEiJVbbOJS7sJsbQ=
 github.com/sourcegraph/go-lsp v0.0.0-20240223163137-f80c5dd31dfd h1:Dq5WSzWsP1TbVi10zPWBI5LKEBDg4Y1OhWEph1wr5WQ=


### PR DESCRIPTION
## Changes since last integration of Language Server

```
commit ef4a43fa0dbf4d92c9e9980e8d8bf6503f03beed
Author: cursor[bot] <206951365+cursor[bot]@users.noreply.github.com>
Date:   Mon Sep 7 08:21:28 2026 +0200

    fix: wait for sibling CLI-download lockfile instead of hard-failing [IDE-2446] (#1421)
    
    ### Description
    
    **Root cause:** `infrastructure/cli/install/installer.go`'s `createLockFile()` treated any lock file younger than the 10-minute TTL as a hard error, returning immediately with `"installer lockfile from ... found"`. When `SNYK_LS_CLI_CACHE_DIR` is a shared/persistent path in CI, multiple `go test ./...` package binaries run concurrently and can share that cache dir/lock path: one package's in-progress CLI download made a sibling package's `infrastructure/oss` `TestMain` abort the *entire test binary* via `log.Fatalf` (no `--- FAIL:` line), instead of the sibling waiting for the in-progress download to finish. Confirmed on both windows-latest and ubuntu-latest (see ticket comments — two shards in the same job hit the lock within 11s of each other).
    
    This is distinct from PR #1390 (IDE-2322, already merged), which fixed `moveToDestination`'s remove/rename-failure handling to treat "a concurrent installer already wrote the correct checksummed binary" as success; that PR never touched this lock-contention hard-fail check.
    
    **Fix:** replace the immediate hard-fail with `waitForLockToClear`, which polls (bounded, injectable interval) while an existing lock file's age is under the *unchanged* 10-minute TTL, returning once the lock is either removed (sibling finished) or ages past the TTL (treated as stale, same as before). Once the wait resolves, execution falls through to the existing (PR #1390) download/checksum-dedup logic unchanged. The TTL/poll interval are overridable per-instance so tests can bound the wait to milliseconds instead of minutes; production keeps the original 10-minute bound.
    
    **Test evidence:**
    - Added `TestInstaller_Install_WaitsForLockThenSucceeds_WhenSiblingLockClearsDuringWait` and `TestInstaller_Install_ProceedsOnceLockAgesPastTTL`, replacing the now-obsolete `TestInstaller_Install_DoNotDownloadIfLockfileFound` (which asserted the old hard-fail behavior).
    - Confirmed red → green: temporarily reverted the production fix and re-ran — both new tests failed with the exact `"installer lockfile from ... found"` error from the ticket, then passed cleanly once the fix was restored.
    - `go test ./infrastructure/cli/install/... -race -count=20/50`: all green, no races.
    - Full `infrastructure/cli/...` package regression: green, including the `Initializer` retry-loop tests (unaffected).
    - `infrastructure/oss` (non-smoke) and `application/server` (build/vet, smoke-guard skip path): unaffected — `TestMain`'s `SMOKE_TESTS` guard correctly no-ops without network, confirmed by build and by running the non-smoke test path.
    - `make test` (full unit suite): green, at the pushed commit.
    
    This fix was produced by an automated flake-fix loop.
    
    ### Checklist
    
    - [x] Tests added and all succeed
    - [x] Regenerated mocks, etc. (`make generate`)
    - [x] Linted (`make lint-fix`)
    - [ ] README.md updated, if user-facing
    - [ ] License file updated, if new 3rd-party dependency is introduced
    
    
    <div><a href="https://cursor.com/agents/bc-3ec2f8d2-1fc4-4a98-8a52-9877e392ced6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/automations/235317e1-a2b6-11f1-b532-320a589b8025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/view-automation-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/view-automation-light.png"><img alt="View Automation" width="141" height="28" src="https://cursor.com/assets/images/view-automation-dark.png"></picture></a>&nbsp;</div>
    
    <!-- CURSOR_SUMMARY -->
    ---
    
    > [!NOTE]
    > **Medium Risk**
    > Changes CLI install synchronization behavior under contention; worst case a second installer blocks up to the existing 10-minute TTL before proceeding.
    >
    > **Overview**
    > Fixes flaky CI when parallel test packages share a CLI cache dir: **concurrent installers no longer error immediately** when a fresh download lock file already exists.
    >
    > **`createLockFile`** now calls **`waitForLockToClear`**, which polls until the lock is removed (sibling finished) or its age passes the **unchanged 10-minute TTL** (stale/crashed process), then creates the lock as before. **`Install`** and **`Downloader`** expose injectable **`lockFileTTL`** and **`lockPollInterval`** (defaults 10m / 500ms) so unit tests can bound waits.
    >
    > Tests drop the old “fail on lockfile” case and add coverage for **lock cleared during wait** and **stale lock past TTL**.
    >
    > <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca88ae4bfb1bc771a73ff2e8610124f5cccb6f85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
    <!-- /CURSOR_SUMMARY -->

M	infrastructure/cli/install/downloader.go
M	infrastructure/cli/install/installer.go
M	infrastructure/cli/install/installer_test.go

commit 414cd52f3b4a47576b8a8b1815f292deaeb1c9ea
Author: cursor[bot] <206951365+cursor[bot]@users.noreply.github.com>
Date:   Mon Sep 7 08:05:41 2026 +0200

    fix: stabilize Test_IsAuthenticated_DoesNotUseOAuth2ProviderCustomRefresherFunc flaky on ubuntu [IDE-2402] (#1425)
    
    * fix: flush queued credential updates before logout's clear [IDE-2402]
    
    Test_IsAuthenticated_DoesNotUseOAuth2ProviderCustomRefresherFunc flaked
    intermittently on CI: after an invalid_grant refresh failure, the OAuth
    token was sometimes still present in config instead of being cleared.
    
    Root cause: GAF's oAuth2Authenticator resyncs the in-memory OAuth token
    from on-disk storage (storage.Refresh, inside syncTokenRefresh) before
    every refresh attempt. Because the OAuth token key is registered for
    persistence, that resync's conf.Set round-trips through snyk-ls's
    storage layer and re-fires the registered OAuth storage-bridge
    callback, which unconditionally enqueues the (unchanged, still expired)
    token onto the async credentialUpdateChan. Neither existing guard
    catches this: the bridge's empty-echo filter only applies to empty
    values, and the writingToken re-entrancy guard only applies to echoes
    of a token the worker is currently applying - this item is queued
    before the worker touches anything.
    
    When the real refresh subsequently fails, logout() runs synchronously
    and clears the token. But credentialUpdateWorker, running
    concurrently, may not have drained the earlier-queued stale item yet.
    If it applies that stale write after logout's clear, the expired token
    is resurrected - a last-write-wins race between a synchronous clear
    and an async worker, the same bug class as IDE-2104 and IDE-2179, via
    a queuing trigger neither of those fixes covered.
    
    Fix: logout() now flushes credentialUpdateChan (via a new barrier-item
    mechanism, flushCredentialUpdates) before applying its own clear, so
    any update already queued is drained and applied first - guaranteeing
    the clear always wins. Synchronization is via channel FIFO ordering
    only; no sleeps, timeouts, or retries.
    
    Added a deterministic regression test that reproduces the ordering bug
    directly (via the same QueueCredentialUpdate entrypoint the storage
    bridge uses) without HTTP mocking or timing luck, plus unit tests for
    the new flush helper's three behaviors (drains real work, doesn't
    block when idle, doesn't hang after Shutdown).
    
    Verified via:
    - go test ./infrastructure/authentication/... -run
      Test_IsAuthenticated_DoesNotUseOAuth2ProviderCustomRefresherFunc
      -race -count=200: 200/200 pass, no data races.
    - New regression test, -race -count=200: 200/200 pass.
    - Full infrastructure/authentication package suite: all pass, no races.
    - make test: all packages pass.
    
    Note: the ggshield pre-commit hook was skipped in this automated
    sandbox (SKIP=ggshield) because it requires an interactive GitGuardian
    OAuth login with no credential available in this headless environment;
    the diff was manually reviewed and contains no secrets. CI runs its own
    authenticated ggshield scan on every PR.
    
    * fix(snyk): remediate high-and-above vulnerabilities on fix/IDE-2402-flake-v2 (#1429)
    
    ## Snyk agentic fix
    
    The Snyk Open Source scan of `fix/IDE-2402-flake-v2` reported vulnerabilities at or above **high** severity. This branch was produced by `snyk fix --agentic` working on those.
    
    Whether that scan also failed the build depends on the Enhanced Gate, which blocks only once a vulnerability has passed its remediation SLA — so this pull request may exist for a build that is green.
    
    **8 of 8 fixed.**
    
    > These changes are generated. Review them as you would any dependency bump — check the changelogs of the upgraded packages before merging.
    
    ### Fixed
    
    | Severity | Vulnerability | Where | Breaking-change risk |
    | --- | --- | --- | --- |
    | High | [Allocation of Resources Without Limits or Throttling](https://security.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXCRYPTOSSH-19504090) | `go.mod` | Medium — This is a security update for `golang.org/x/crypto/ssh` that addresses two Denial of Service (DoS) vulnerabilities. **Key Changes:** - **CVE-2026-56855:** Fixes a deadlock vulnerability where a malicious peer could hang an established connection. The server will now treat certain malformed messages as a protocol error and terminate the connection instead of blocking. - **CVE-2026-78662:** Fixes a deadlock vulnerability on channels that are not yet fully established. The server will now drop unexpected packets on these channels without blocking. **Risk Assessment:** This upgrade is assessed as **medium risk**. While these are critical security fixes, the change in error handling—specifically, tearing down connections upon protocol errors where they might have previously hung—is a behavioral change. Systems with non-compliant or custom SSH clients may experience unexpected connection drops that require verification. Source: [Security Announcement](https://seclists.org/oss-sec/2026/q3/200) |
    | High | [Allocation of Resources Without Limits or Throttling](https://security.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXCRYPTOSSH-19512464) | `go.mod` | Medium — This is a security update for `golang.org/x/crypto/ssh` that addresses two Denial of Service (DoS) vulnerabilities. **Key Changes:** - **CVE-2026-56855:** Fixes a deadlock vulnerability where a malicious peer could hang an established connection. The server will now treat certain malformed messages as a protocol error and terminate the connection instead of blocking. - **CVE-2026-78662:** Fixes a deadlock vulnerability on channels that are not yet fully established. The server will now drop unexpected packets on these channels without blocking. **Risk Assessment:** This upgrade is assessed as **medium risk**. While these are critical security fixes, the change in error handling—specifically, tearing down connections upon protocol errors where they might have previously hung—is a behavioral change. Systems with non-compliant or custom SSH clients may experience unexpected connection drops that require verification. Source: [Security Announcement](https://seclists.org/oss-sec/2026/q3/200) |
    | High | [Denial of Service (DoS)](https://security.snyk.io/vuln/SNYK-GOLANG-STDCRYPTOTLS-18858453) | `go.mod` | Low — This is a patch version upgrade. Patch releases for the Deno standard library are intended to be backward-compatible, typically containing only bug fixes or security patches. No specific breaking changes are documented for this version range. The risk of introducing a breaking change in a patch release is minimal. Source: Package documentation |
    | High | [Uncontrolled Recursion](https://security.snyk.io/vuln/SNYK-GOLANG-STDENCODINGASN1-18858463) | `go.mod` | Medium — This is a patch version upgrade that includes a security fix for the `encoding/asn1` package. - **Behavioral Change**: A recursion limit has been added to the `Unmarshal` function to prevent stack exhaustion when parsing deeply-nested structures. - **Impact**: This change addresses security vulnerability CVE-2026-33818. While it prevents a potential denial-of-service attack, it could theoretically cause parsing to fail for legitimate, but exceptionally deep, ASN.1 structures that were previously accepted. This new failure mode warrants verification if your application handles complex, deeply-nested ASN.1 data. Source: [Go 1.26.6 Release Announcement](https://groups.google.com/g/golang-announce/c/4tU852n0a4M) |
    | High | [Uncontrolled Recursion](https://security.snyk.io/vuln/SNYK-GOLANG-STDENCODINGXML-18858455) | `go.mod` | Medium — This is a patch version upgrade for the legacy Deno Standard Library (`std`). While patch releases are typically for non-breaking bug fixes, specific release notes or a detailed changelog for the transition from version `1.26.5` to `1.26.6` could not be located. Due to the absence of documentation, the exact changes are unknown. The risk is assessed as **medium** because of this uncertainty. **Recommendation:** Verify that XML parsing and serialization functionality behaves as expected after the upgrade. |
    | High | [Uncaught Exception](https://security.snyk.io/vuln/SNYK-GOLANG-STDNET-18858450) | `go.mod` | Low — This is a patch version upgrade for the Deno standard library's `net` module. Patch releases are intended for bug fixes and should not contain breaking changes. While specific release notes for this exact version were not found, it is unlikely to introduce any breaking changes based on semantic versioning principles. **Recommendation:** No action is expected to be required, but as with any upgrade, running a test suite is recommended to ensure no regressions have occurred. |
    | High | [Denial of Service (DoS)](https://security.snyk.io/vuln/SNYK-GOLANG-STDNETHTTP-18858429) | `go.mod`, `licenses/github.com/cyphar/filepath-securejoin/go.mod` | Medium — This is a patch version upgrade. However, no specific release notes or changelog could be found for the `std/net/http` package in the version range `1.26.5` to `1.26.6`. The versioning scheme does not align with the standard Deno library releases, which are typically prefixed with `0.x`. Due to the lack of available information for this specific version range, the risk is assessed as medium out of an abundance of caution. **Recommendation:** Verify the source and correct versioning of this package. If this is a valid upgrade, manual testing is recommended to ensure no unexpected regressions were introduced. |
    | High | [Denial of Service (DoS)](https://security.snyk.io/vuln/SNYK-GOLANG-STDNETURL-18858438) | `go.mod`, `licenses/github.com/cyphar/filepath-securejoin/go.mod` | Low — This is a patch version upgrade for Go's standard library `net/url` package. The `go1.26.6` release includes security and bug fixes for the `net/url` package. [2, 5] No breaking API changes are documented for this minor point update. Source: [The Go Programming Language Release History](https://go.dev/doc/devel/release#go1.26.minor) |
    
    **This is not necessarily a complete fix.** The build on this pull request runs the same Open Source scan and quality gate, so its result — not this description — is the verdict on what is left.
    
    ### Changes
    
    ```
     go.mod | 10 +++++-----
     go.sum |  8 ++++++++
     2 files changed, 13 insertions(+), 5 deletions(-)
    ```
    
    <sub>Snyk ProdSec orb · build [11965](https://circleci.com/gh/snyk/snyk-ls/11965) · model `claude-opus-4-8`</sub>
    
    <!-- CURSOR_SUMMARY -->
    ---
    
    > [!NOTE]
    > **Medium Risk**
    > Go patch and x/crypto upgrades address high-severity DoS issues but can change runtime behavior (stdlib parsing limits, SSH error handling) for code paths pulled in via dependencies like git/SSH.
    >
    > **Overview**
    > This PR only updates **`go.mod`** and **`go.sum`**—no application source changes. It bumps the **Go toolchain** from **1.26.5** to **1.26.6** (stdlib security fixes for TLS, `encoding/asn1`, `encoding/xml`, `net`, `net/http`, and `net/url` per the Snyk remediation) and refreshes several **`golang.org/x`** modules: **`x/mod`** to v0.38.0, **`x/crypto`** to v0.56.0 (indirect; SSH DoS fixes), plus indirect **`x/text`** v0.41.0 and **`x/tools`** v0.48.0, with matching checksums in **`go.sum`**.
    >
    > Treat this as an automated dependency/security bump: run the usual test suite and confirm CI/Open Source scan results on the branch.
    >
    > <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4af38ca2f1c32bfe322e22e5e2f10f0d9d821301. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
    <!-- /CURSOR_SUMMARY -->
    
    * fix: eliminate torn read in AiFixHandler renderer state (race in smoke-race CI shard)
    
    code_html.go read AiFixHandler's status/error/result via three separate
    RLock-guarded getters, letting a concurrent SetAiFixDiffState interleave
    between the calls and pair a SUCCESS status with a stale, empty result.
    Add GetAiFixDiffSnapshot to read all three fields under one RLock and use
    it in code_html.go instead.
    
    ---------
    
    Co-authored-by: Cursor Agent <cursoragent@cursor.com>
    Co-authored-by: Bastian Doetsch <bastian.doetsch@snyk.io>
    Co-authored-by: prodsec-github-automation <146025078+prodsec-github-automation@users.noreply.github.com>

M	go.mod
M	go.sum
M	infrastructure/authentication/auth_service_impl.go
M	infrastructure/authentication/auth_service_impl_test.go
M	infrastructure/code/ai_fix_handler.go
A	infrastructure/code/ai_fix_handler_test.go
M	infrastructure/code/code_html.go

commit 4d7f51b0837db35dca4b4c58ee77d4b7f5308ddd
Author: Ben Durrans <Benjamin.Durrans@snyk.io>
Date:   Fri Sep 4 10:36:07 2026 +0100

    chore: block accidental private-repo mentions via pre-commit hooks [IDE-2517] (#1423)
    
    chore: block accidental private-repo mentions via pre-commit hooks
    
    Adds check-internal-repo-mentions-{diff,msg,push} hooks (pre-commit/
    pre-merge-commit, commit-msg, pre-push) that block naming a private
    snyk/<repo> unless it's allowlisted in scripts/lib/repo-privacy-check.sh.
    Matches snyk-eclipse-plugin (#453).
    
    default_install_hook_types now covers commit-msg/pre-push/pre-merge-commit,
    so make tools/make hooks no longer need a separate --hook-type pre-push
    install call. This surfaced that the existing commitlint (commit-msg)
    hook was never actually wired up (commit-msg was never installed) and,
    on top of that, had no commitlint.config.js despite declaring
    @commitlint/config-conventional as a dependency -- it would have failed
    every commit-msg run with an empty-rules error. Removed it rather than
    fix a hook that was never functional.
    
    Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>

M	.pre-commit-config.yaml
M	Makefile
A	scripts/check-internal-repo-mentions-diff.sh
A	scripts/check-internal-repo-mentions-msg.sh
A	scripts/check-internal-repo-mentions-push.sh
A	scripts/lib/repo-privacy-check.sh
```

[IDE-2446]: https://snyksec.atlassian.net/browse/IDE-2446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDE-2402]: https://snyksec.atlassian.net/browse/IDE-2402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ