### PR TITLE
feat: add TOON format selection and writer integration

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -225,7 +225,7 @@ require (
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 // indirect
-	github.com/snyk/go-application-framework v0.19.1 // indirect
+	github.com/snyk/go-application-framework v0.20.0 // indirect
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -609,8 +609,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.19.1 h1:HmIxqrGafFVJgt/y6A3o8x6ekP5RbHGezTBgsfd8t9I=
-github.com/snyk/go-application-framework v0.19.1/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
+github.com/snyk/go-application-framework v0.20.0 h1:9LyEAT+Z6JrardT4y+5/L4htiPWfWq1AzX4qOkIFAJQ=
+github.com/snyk/go-application-framework v0.20.0/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.31.8
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6
-	github.com/snyk/go-application-framework v0.19.1
+	github.com/snyk/go-application-framework v0.20.0
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260902080529-bf1230ca471b

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -556,8 +556,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.19.1 h1:HmIxqrGafFVJgt/y6A3o8x6ekP5RbHGezTBgsfd8t9I=
-github.com/snyk/go-application-framework v0.19.1/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
+github.com/snyk/go-application-framework v0.20.0 h1:9LyEAT+Z6JrardT4y+5/L4htiPWfWq1AzX4qOkIFAJQ=
+github.com/snyk/go-application-framework v0.20.0/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=


### PR DESCRIPTION
### **User description**
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are release-note ready
- [x] Includes a detailed description of changes
- [x] Contains risk assessment
- [x] No breaking API changes
- [x] GAF functionality is covered by [snyk/go-application-framework#723](https://github.com/snyk/go-application-framework/pull/723)
- [x] Includes manual validation
- [x] GitBook documentation is not required for this dependency-only change
- [x] Includes the product-update assessment

## What does this PR do?

Bumps `github.com/snyk/go-application-framework` from `v0.19.1` to `v0.20.0` in the public and private Go modules, including the corresponding sums. GAF `v0.20.0` adds TOON format selection and writer integration.

GAF currently provides the TOON writers and configuration keys but does not register `--toon` or `--toon-file-output` in `InitOutputWorkflow`; this dependency bump alone therefore does not expose those flags through the CLI.

## Where should the reviewer start?

Review `cliv2/go.mod` and `cliv2-private/go.mod`; the remaining changes are generated `go.sum` updates.

## How should this be manually tested?

Validated with:

```sh
make format
make lint
cd cliv2 && go test ./pkg/core
```

## What's the product update that needs to be communicated to CLI users?

None from this dependency bump alone; user-facing TOON flags still require CLI registration.

## Risk assessment (Low | Medium | High)?

Low. The change only updates GAF to its latest released version and refreshes module sums.

## What are the relevant tickets?

[CLI-1825](https://snyksec.atlassian.net/browse/CLI-1825)


[CLI-1825]: https://snyksec.atlassian.net/browse/CLI-1825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no application code changes; low blast radius unless GAF v0.20.0 introduces regressions in shared framework behavior.
> 
> **Overview**
> Bumps **`github.com/snyk/go-application-framework`** from **v0.19.1** to **v0.20.0** in `cliv2/go.mod` and `cliv2-private/go.mod`, with matching **`go.sum`** checksum updates only—no CLI source changes.
> 
> The newer GAF release brings **TOON** output format selection and writer plumbing; this repo change does **not** register user-facing `--toon` / `--toon-file-output` flags, so CLI behavior for end users should be unchanged until a follow-up wires `InitOutputWorkflow` (or equivalent).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eb2ad2866571b6a6cc21cac9ebad0ecd0a9e6fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

### **PR Type**
Enhancement


___

### **Description**
- Update Snyk go-application-framework to v0.20.0.

- Incorporate TOON format selection capabilities from GAF.

- Prepare CLI for future integrations and features.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[cliv2/go.mod] -- "Updates" --> B(github.com/snyk/go-application-framework v0.20.0)
  C[cliv2-private/go.mod] -- "Updates" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependency</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Update go-application-framework dependency in private module</code></dd></summary>
<hr>

cliv2-private/go.mod

<ul><li>Updated the <code>github.com/snyk/go-application-framework</code> dependency from <br><code>v0.19.1</code> to <code>v0.20.0</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/cli/pull/7224/changes#diff-cbb655c5982e6dc627b47d496cf640744939d8a3269e3806f8c9153365b88b6e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>go.sum</strong><dd><code>Update go.sum checksums for private module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cliv2-private/go.sum

<ul><li>Added new checksums corresponding to the updated <br><code>github.com/snyk/go-application-framework</code> v0.20.0 module.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/cli/pull/7224/changes#diff-9af73572a17d3dda01c2b4843253c81863dbf116ea56dd953ec8bbe7aa027cf1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Update go-application-framework dependency in public module</code></dd></summary>
<hr>

cliv2/go.mod

<ul><li>Updated the <code>github.com/snyk/go-application-framework</code> dependency from <br><code>v0.19.1</code> to <code>v0.20.0</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/cli/pull/7224/changes#diff-0d2008944a74ca11209da1613b848d59c2a827cfe01651e4bf6fe9e2eb991148">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>go.sum</strong><dd><code>Update go.sum checksums for public module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cliv2/go.sum

<ul><li>Added new checksums corresponding to the updated <br><code>github.com/snyk/go-application-framework</code> v0.20.0 module.</ul>


</details>


  </td>
  <td><a href="https://github.com/snyk/cli/pull/7224/changes#diff-99168ef18e854db7430ba8053649fc688af77bb34cedb25171e9f4763ec2f56d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

