### PR TITLE
chore: verify GAF CLI-1826 TOON UFM presenter

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -225,7 +225,7 @@ require (
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 // indirect
-	github.com/snyk/go-application-framework v0.21.0 // indirect
+	github.com/snyk/go-application-framework v0.21.1-0.20260907073310-e772767e253b // indirect
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -609,8 +609,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.21.0 h1:nsTxFM5+FkzK1HtkNyNwhTQ2C6KJH5nilL63O9W8+2E=
-github.com/snyk/go-application-framework v0.21.0/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
+github.com/snyk/go-application-framework v0.21.1-0.20260907073310-e772767e253b h1:okrj33qOamD2B+FG0l2wJ9RbtpATTpoPkUg6sgczXVs=
+github.com/snyk/go-application-framework v0.21.1-0.20260907073310-e772767e253b/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.31.8
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6
-	github.com/snyk/go-application-framework v0.21.0
+	github.com/snyk/go-application-framework v0.21.1-0.20260907073310-e772767e253b
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260902080529-bf1230ca471b

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -556,8 +556,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.21.0 h1:nsTxFM5+FkzK1HtkNyNwhTQ2C6KJH5nilL63O9W8+2E=
-github.com/snyk/go-application-framework v0.21.0/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
+github.com/snyk/go-application-framework v0.21.1-0.20260907073310-e772767e253b h1:okrj33qOamD2B+FG0l2wJ9RbtpATTpoPkUg6sgczXVs=
+github.com/snyk/go-application-framework v0.21.1-0.20260907073310-e772767e253b/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are release-note ready
- [x] Includes detailed description of changes
- [x] Contains risk assessment
- [x] No breaking API changes
- [x] GAF functionality is covered by [snyk/go-application-framework#739](https://github.com/snyk/go-application-framework/pull/739)
- [x] Includes manual validation
- [x] GitBook documentation is not required for this dependency-only change
- [x] No product update for CLI users yet

## What does this PR do?

Verifies [GAF PR #739](https://github.com/snyk/go-application-framework/pull/739) (CLI-1826) by bumping `github.com/snyk/go-application-framework` from `v0.20.0` to pre-release `v0.21.1-0.20260904162906-1889c7c76491` (`1889c7c`) in `cliv2` and `cliv2-private`.

This GAF change adds SCA and Secrets UFM TOON presentation (byte-matched to CLI-1824 goldens) and wires `TOON_MIME_TYPE` into `HandleContentTypeUnifiedModel`. This CLI PR is dependency-only; user-facing `--toon` flags are still not registered in the CLI.

## Where should the reviewer start?

Review `cliv2/go.mod` and `cliv2-private/go.mod`; remaining changes are generated `go.sum` updates.

## How should this be manually tested?

Validated locally against GAF `feat/CLI-1826` @ `1889c7c764911fcdb0fddd81073ca976314e11d5`:

```sh
cd cliv2 && go get github.com/snyk/go-application-framework@1889c7c764911fcdb0fddd81073ca976314e11d5
cd cliv2 && go mod tidy
cd cliv2-private && go get github.com/snyk/go-application-framework@1889c7c764911fcdb0fddd81073ca976314e11d5
cd cliv2-private && go mod tidy
cd cliv2 && make test          # exit 0
cd cliv2 && go test ./pkg/core # exit 0
make build                     # exit 0
./binary-releases/snyk-macos-arm64 --version
./binary-releases/snyk-macos-arm64 whoami
```

GAF TOON presenter/output-workflow tests (run from local GAF checkout at same commit):

```sh
go test ./internal/presenters/... -count=1 -run 'Ufm|TOON|Toon|toon' -v
go test ./pkg/local_workflows/output_workflow/... -count=1 -run 'Toon|toon|TOON'
```

### Evidence

| Check | Command | Result |
| --- | --- | --- |
| CLI Go tests | `cd cliv2 && make test` | exit 0; all packages `ok` |
| CLI core tests | `cd cliv2 && go test ./pkg/core` | exit 0 (`10.966s`) |
| CLI build | `make build` | exit 0; installed `binary-releases/snyk-macos-arm64` |
| CLI smoke | `./binary-releases/snyk-macos-arm64 --version` / `whoami` | version prints; auth works |
| GAF TOON goldens | `go test ./internal/presenters/... -run 'Ufm\|TOON\|Toon\|toon' -v` | `TestRenderTemplate_TOON_goldens` SCA/Secrets representative + empty: PASS |
| GAF output workflow | `go test ./pkg/local_workflows/output_workflow/... -run 'Toon\|toon\|TOON'` | exit 0 |

**Note:** `snyk test --help` and `snyk secrets test --help` do not yet expose `--toon`; end-user TOON output requires a follow-up CLI change to register output-workflow flags. This PR confirms the bumped GAF integrates cleanly with the CLI build and test suite.

## What's the product update that needs to be communicated to CLI users?

None from this dependency bump alone.

## Risk assessment (Low | Medium | High)?

Low. Dependency-only bump to a GAF pre-release commit; no CLI source changes.

## What are the relevant tickets?

- [CLI-1826](https://snyksec.atlassian.net/browse/CLI-1826)
- [CLI-1824](https://snyksec.atlassian.net/browse/CLI-1824)
- GAF: [snyk/go-application-framework#739](https://github.com/snyk/go-application-framework/pull/739)


Made with [Cursor](https://cursor.com)

[CLI-1826]: https://snyksec.atlassian.net/browse/CLI-1826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ