### PR TITLE
chore: update agents.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,6 +271,12 @@ go run ./scripts/upgrade-snyk-go-dependencies.go -name=go-application-framework
 make tidy
 ```
 
+### Handling `go.sum` and private modules
+
+Always use Go tooling (`go get`, `go mod tidy`, `make tidy`) to update `go.mod` and `go.sum`. Never edit `go.sum` manually — its entries must be in lexicographic order, and manual edits easily break sorting.
+
+When private modules (e.g. `ambient-canary`) block `go mod tidy`, use `go mod tidy -e` to tolerate fetch errors while still maintaining correct formatting and sort order. If manual `go.sum` editing is truly unavoidable (last resort only), entries must be inserted in sorted position — never appended to the end of the file. Verify with `sort -c go.sum` after any manual edit.
+
 ## Building with Local Dependencies
 
 **Go** — add to `cliv2/go.mod`:


### PR DESCRIPTION
## Pull Request Submission Checklist

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
Clarify dependency update in agents.md

## Where should the reviewer start?

## How should this be manually tested?

## What's the product update that needs to be communicated to CLI users?

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent instructions; no runtime, build, or dependency behavior changes.
> 
> **Overview**
> Adds a **Handling `go.sum` and private modules** subsection under **Updating Go Dependencies** in `AGENTS.md`.
> 
> The new text tells agents and contributors to refresh `go.mod`/`go.sum` only via `go get`, `go mod tidy`, or `make tidy`, and not to hand-edit `go.sum` because entries must stay lexicographically sorted. It documents using `go mod tidy -e` when private modules (e.g. `ambient-canary`) prevent a normal tidy, and gives a last-resort workflow for manual `go.sum` edits (insert in sorted order, then run `sort -c go.sum`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a47a5742ce73c30953ddcf6d227de5532d76f6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->