### PR TITLE
DO NOT MERGE

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -225,7 +225,7 @@ require (
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 // indirect
-	github.com/snyk/go-application-framework v0.21.1-0.20260907101838-dbdc1656f5de // indirect
+	github.com/snyk/go-application-framework v0.21.1-0.20260907105707-85be588d49a1 // indirect
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect

--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -225,7 +225,7 @@ require (
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 // indirect
-	github.com/snyk/go-application-framework v0.21.0 // indirect
+	github.com/snyk/go-application-framework v0.21.1-0.20260907101838-dbdc1656f5de // indirect
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -609,8 +609,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.21.1-0.20260907101838-dbdc1656f5de h1:zC3hRjyRrX9e4DNTj3eQ78AhTK5p0jbhq7I462WjGdU=
-github.com/snyk/go-application-framework v0.21.1-0.20260907101838-dbdc1656f5de/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
+github.com/snyk/go-application-framework v0.21.1-0.20260907105707-85be588d49a1 h1:5uIjLAy5LP+jWOdoprfySdJGy2HLTMtMBcFSkOSU98A=
+github.com/snyk/go-application-framework v0.21.1-0.20260907105707-85be588d49a1/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -609,8 +609,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.21.0 h1:nsTxFM5+FkzK1HtkNyNwhTQ2C6KJH5nilL63O9W8+2E=
-github.com/snyk/go-application-framework v0.21.0/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
+github.com/snyk/go-application-framework v0.21.1-0.20260907101838-dbdc1656f5de h1:zC3hRjyRrX9e4DNTj3eQ78AhTK5p0jbhq7I462WjGdU=
+github.com/snyk/go-application-framework v0.21.1-0.20260907101838-dbdc1656f5de/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.31.8
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6
-	github.com/snyk/go-application-framework v0.21.0
+	github.com/snyk/go-application-framework v0.21.1-0.20260907101838-dbdc1656f5de
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260902080529-bf1230ca471b

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.31.8
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6
-	github.com/snyk/go-application-framework v0.21.1-0.20260907101838-dbdc1656f5de
+	github.com/snyk/go-application-framework v0.21.1-0.20260907105707-85be588d49a1
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260902080529-bf1230ca471b

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -556,8 +556,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.21.0 h1:nsTxFM5+FkzK1HtkNyNwhTQ2C6KJH5nilL63O9W8+2E=
-github.com/snyk/go-application-framework v0.21.0/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
+github.com/snyk/go-application-framework v0.21.1-0.20260907101838-dbdc1656f5de h1:zC3hRjyRrX9e4DNTj3eQ78AhTK5p0jbhq7I462WjGdU=
+github.com/snyk/go-application-framework v0.21.1-0.20260907101838-dbdc1656f5de/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -556,8 +556,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.21.1-0.20260907101838-dbdc1656f5de h1:zC3hRjyRrX9e4DNTj3eQ78AhTK5p0jbhq7I462WjGdU=
-github.com/snyk/go-application-framework v0.21.1-0.20260907101838-dbdc1656f5de/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
+github.com/snyk/go-application-framework v0.21.1-0.20260907105707-85be588d49a1 h1:5uIjLAy5LP+jWOdoprfySdJGy2HLTMtMBcFSkOSU98A=
+github.com/snyk/go-application-framework v0.21.1-0.20260907105707-85be588d49a1/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=


### PR DESCRIPTION
## Summary

Verifies [GAF PR #749](https://github.com/snyk/go-application-framework/pull/749) (CLI-1838) by bumping `github.com/snyk/go-application-framework` from `v0.21.0` to pre-release `v0.21.1-0.20260907101838-dbdc1656f5de` (`dbdc165`) in `cliv2` and `cliv2-private`.

This GAF change defines the UFM TOON output contract with fixtures and byte-exact goldens for SCA, Secrets, empty and mixed results. This CLI PR is dependency-only.

## Where should the reviewer start?

Review `cliv2/go.mod` and `cliv2-private/go.mod`; remaining changes are generated `go.sum` updates.

## Test plan

- [x] `cd cliv2 && make test` — exit 0
- [ ] CI passes on this branch
- [ ] Update to latest GAF main commit once GAF #749 merges

## Related

- [CLI-1838](https://snyksec.atlassian.net/browse/CLI-1838)
- GAF: [snyk/go-application-framework#749](https://github.com/snyk/go-application-framework/pull/749)

Made with [Cursor](https://cursor.com)

[CLI-1838]: https://snyksec.atlassian.net/browse/CLI-1838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ