### PR TITLE
chore: bump GAF

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -225,7 +225,7 @@ require (
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 // indirect
-	github.com/snyk/go-application-framework v0.21.0 // indirect
+	github.com/snyk/go-application-framework v0.22.2-0.20260908104610-c41b258683da // indirect
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect

--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -225,7 +225,7 @@ require (
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 // indirect
-	github.com/snyk/go-application-framework v0.22.2-0.20260908104610-c41b258683da // indirect
+	github.com/snyk/go-application-framework v0.23.0 // indirect
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -609,8 +609,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.22.2-0.20260908104610-c41b258683da h1:WBeBUP/SPThXBsfSTY1pCyNtXwLu11f8EUxiXOuD1ek=
-github.com/snyk/go-application-framework v0.22.2-0.20260908104610-c41b258683da/go.mod h1:3OTJn8QqzBFOXNZxpzGs0CREubF48BRXJrszsKa2zNc=
+github.com/snyk/go-application-framework v0.23.0 h1:/15uRlhQ0AnP9ETdciKvDkobkuhDWVWSieZ/uY1GXc4=
+github.com/snyk/go-application-framework v0.23.0/go.mod h1:3OTJn8QqzBFOXNZxpzGs0CREubF48BRXJrszsKa2zNc=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -609,8 +609,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.21.0 h1:nsTxFM5+FkzK1HtkNyNwhTQ2C6KJH5nilL63O9W8+2E=
-github.com/snyk/go-application-framework v0.21.0/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
+github.com/snyk/go-application-framework v0.22.2-0.20260908104610-c41b258683da h1:WBeBUP/SPThXBsfSTY1pCyNtXwLu11f8EUxiXOuD1ek=
+github.com/snyk/go-application-framework v0.22.2-0.20260908104610-c41b258683da/go.mod h1:3OTJn8QqzBFOXNZxpzGs0CREubF48BRXJrszsKa2zNc=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.31.8
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6
-	github.com/snyk/go-application-framework v0.21.0
+	github.com/snyk/go-application-framework v0.22.2-0.20260908104610-c41b258683da
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260907062128-ef4a43fa0dbf

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.31.8
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6
-	github.com/snyk/go-application-framework v0.22.2-0.20260908104610-c41b258683da
+	github.com/snyk/go-application-framework v0.23.0
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260907062128-ef4a43fa0dbf

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -556,8 +556,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.22.2-0.20260908104610-c41b258683da h1:WBeBUP/SPThXBsfSTY1pCyNtXwLu11f8EUxiXOuD1ek=
-github.com/snyk/go-application-framework v0.22.2-0.20260908104610-c41b258683da/go.mod h1:3OTJn8QqzBFOXNZxpzGs0CREubF48BRXJrszsKa2zNc=
+github.com/snyk/go-application-framework v0.23.0 h1:/15uRlhQ0AnP9ETdciKvDkobkuhDWVWSieZ/uY1GXc4=
+github.com/snyk/go-application-framework v0.23.0/go.mod h1:3OTJn8QqzBFOXNZxpzGs0CREubF48BRXJrszsKa2zNc=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -556,8 +556,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.21.0 h1:nsTxFM5+FkzK1HtkNyNwhTQ2C6KJH5nilL63O9W8+2E=
-github.com/snyk/go-application-framework v0.21.0/go.mod h1:UJMR1Tk4OPGFa03O9cko4ic0GeaqmSO03fx55HpOFp0=
+github.com/snyk/go-application-framework v0.22.2-0.20260908104610-c41b258683da h1:WBeBUP/SPThXBsfSTY1pCyNtXwLu11f8EUxiXOuD1ek=
+github.com/snyk/go-application-framework v0.22.2-0.20260908104610-c41b258683da/go.mod h1:3OTJn8QqzBFOXNZxpzGs0CREubF48BRXJrszsKa2zNc=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are release-note ready
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [x] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Bumps `github.com/snyk/go-application-framework` to **v0.23.0** in both `cliv2` and `cliv2-private` ([GAF PR #739](https://github.com/snyk/go-application-framework/pull/739)).

GAF v0.23.0 adds generic UFM TOON output: native scan results are encoded through GAF's `UfmPresenter` using the [CLI-1838](https://snyksec.atlassian.net/browse/CLI-1838) contract. The encoder preserves the full `FindingData` JSON shape and envelope fields (not a product-specific projection), with template-owned rendering and TOON 4.1-compliant quoting/escaping.

This PR is dependency-only — no CLI source changes. It wires the CLI to the released GAF build so TOON output can be exercised end-to-end before any CLI-specific follow-ups.

## Where should the reviewer start?

`cliv2/go.mod`, `cliv2/go.sum`, `cliv2-private/go.mod`, `cliv2-private/go.sum`.

## How should this be manually tested?

1. Build the CLI from this branch (`make build` or your usual local build flow).
2. Run a UFM scan with TOON output selected (e.g. `--output-format=toon` or the equivalent config for your test target).
3. Confirm the output matches the CLI-1838 contract shape: `results` envelope, findings rendered as generic TOON (not SCA/Secrets-only projection).
4. Spot-check edge cases covered in GAF:
   - comma-bearing string arrays (e.g. `["Doe, Jane", "Smith"]`) decode as two values, not three
   - integers beyond 2^53 retain precision
   - control characters in values and keys render as escaped TOON, not hard failures
5. Compare against an existing format (JSON/SARIF) on the same scan to confirm findings are present and structurally equivalent.

## What's the product update that needs to be communicated to CLI users?

CLI users can request UFM scan results in **TOON** format. Output follows the CLI-1838 contract: a generic, product-agnostic encoding of native findings suitable for machine consumption and round-trip decoding. No CLI flags or commands change in this PR — this is the dependency bump that enables TOON output already routed through GAF's output workflow.

## Risk assessment

Low — `go.mod` / `go.sum` only across public and private modules. Behaviour change is additive (new output format availability via GAF); no CLI API or command surface changes.

## Any background context you want to provide?

Companion to GAF [PR #739](https://github.com/snyk/go-application-framework/pull/739) / [CLI-1826](https://snyksec.atlassian.net/browse/CLI-1826). Earlier draft pins to a branch pseudo-version were replaced with the released v0.23.0 from main after GAF merged.

## What are the relevant tickets?

- [CLI-1826](https://snyksec.atlassian.net/browse/CLI-1826)
- [CLI-1838](https://snyksec.atlassian.net/browse/CLI-1838)

[CLI-1826]: https://snyksec.atlassian.net/browse/CLI-1826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aGViLWNvbS1KU1cifQ

[CLI-1838]: https://snyksec.atlassian.net/browse/CLI-1838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only change; behavior is additive (new output format via GAF) with no CLI API or command surface changes in the diff.
> 
> **Overview**
> This PR only updates **`github.com/snyk/go-application-framework`** from **v0.21.0** to **v0.23.0** in **`cliv2`** and **`cliv2-private`** (`go.mod` / `go.sum`). There are no CLI source edits.
> 
> That release pulls in GAF’s generic **UFM TOON** output path (via **`UfmPresenter`** / output workflow), aligned with the **CLI-1838** contract: product-agnostic **`FindingData`** in a **`results`** envelope with TOON 4.1-safe encoding. The CLI already routes scan output through GAF (e.g. **`output_workflow`** in **`cliv2/internal/cliv2`**), so this bump is what makes **TOON** available end-to-end when users select that output format—without changing flags or commands in this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c8bdace5c014abfa5f61b0e354d19085b79d9cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->