### PR TITLE
chore: bump remy-cli-extension to v1.42.0

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/snyk/cli-extension-axi v0.0.0-20260901142946-cb915113acb7
 	github.com/snyk/cli-extension-cos v0.0.0-20260818151318-d63bb9db9484
 	github.com/snyk/cli/cliv2 v0.0.0
-	github.com/snyk/remy-cli-extension v1.41.1
+	github.com/snyk/remy-cli-extension v1.42.0
 	github.com/snyk/rift-cli-extension v1.2.2
 )
 

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -609,8 +609,8 @@ github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJl
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=
 github.com/snyk/policy-engine v1.1.4/go.mod h1:yAlMDZhzORiZcbJCW0GEk/nHkc4DBDKp8BRoiGTWkBE=
-github.com/snyk/remy-cli-extension v1.41.1 h1:NKd2ixEBdqUXMNF7lM0K/vT3ajPGnxCIJ7gux53oEuw=
-github.com/snyk/remy-cli-extension v1.41.1/go.mod h1:vD8vbIkYL0TMc07kYpZvfa6kSFcs4tCal7IN9hG7M5k=
+github.com/snyk/remy-cli-extension v1.42.0 h1:H1/eHd1Lr8PFWcWnXupLw5uN/xMORvZB3eruBhFCc7g=
+github.com/snyk/remy-cli-extension v1.42.0/go.mod h1:vD8vbIkYL0TMc07kYpZvfa6kSFcs4tCal7IN9hG7M5k=
 github.com/snyk/rift-cli-extension v1.2.2 h1:FXNqsby+nZJvrxQzzIc4kIffv4nTQ5IaIM4ICwPtgHc=
 github.com/snyk/rift-cli-extension v1.2.2/go.mod h1:jc+VhpfPQpNoWKpjfKbeRkuevdJpzb81RjxHjl4p9hY=
 github.com/snyk/snyk-iac-capture v0.6.5 h1:992DXCAJSN97KtUh8T5ndaWwd/6ZCal2bDkRXqM1u/E=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable) — N/A, no API changes
- [x] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary) — N/A, dependency-only bump
- [ ] Updates relevant GitBook documentation (PR link: ___) — N/A
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Dependency-only bump of `github.com/snyk/remy-cli-extension` **v1.41.1 → v1.42.0** in `cliv2-private`. No CLI source changes. Only `cliv2-private/go.mod` + `go.sum` change; `go mod tidy -diff` is clean in both `cliv2` and `cliv2-private` (no transitive drift).

Extension change this picks up (v1.41.1..v1.42.0):

- snyk/remy-cli-extension#203 — feat(agent): consume repo `AGENTS.md`/`CLAUDE.md` for build/test guidance. Agentic fix now reads a scanned project's root `AGENTS.md` (or `CLAUDE.md` fallback) and feeds its build/test/validate/install instructions to the fix agents (SCA, SAST, Container, COS) and the setup step, so the agent uses the repo's documented commands instead of guessing.

## Where should the reviewer start?

`cliv2-private/go.mod` — the single line change (`remy-cli-extension v1.41.1 → v1.42.0`). The `go.sum` change is the corresponding checksum update.

## How should this be manually tested?

Not required for a dependency-only bump. The behavior change lives in the extension and is covered by its own tests (merged in snyk/remy-cli-extension#203). If desired: run `snyk fix --agentic --sca` against a repo containing a root `AGENTS.md` that documents a test command, and confirm the agent uses that command.

## What's the product update that needs to be communicated to CLI users?

`snyk fix --agentic` now honors a project's root `AGENTS.md` (or `CLAUDE.md`): if present, its instructions for how to build, test, and validate the project are used by the fix agents instead of being inferred.

## Risk assessment (Low | Medium | High)?

**Low.** Dependency-only version bump, no CLI source changes, `go mod tidy -diff` clean in both modules, no transitive drift. The extension change is additive (absent AGENTS.md ⇒ unchanged behavior) and gated by the existing folder-trust and sandbox controls.

## What are the relevant tickets?

snyk/remy-cli-extension#203

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump in the private module; behavior change is additive in the extension and gated by existing agentic fix and trust controls.
> 
> **Overview**
> This PR only updates **`cliv2-private`** to depend on **`github.com/snyk/remy-cli-extension` v1.42.0** (from v1.41.1), with matching **`go.sum`** checksums. There are no CLI source edits in this repo.
> 
> That extension release adds behavior for **`snyk fix --agentic`**: when a scanned project has a root **`AGENTS.md`** (or **`CLAUDE.md`** fallback), build/test/validate guidance from that file is passed into the fix agents and setup step instead of inferred commands. Repos without those files should behave as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a11344928bec991d86bde5f02abe706f0b56eddc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->