### PR TITLE
fix(ci): align test timeouts to avoid flakiness

### DIFF
--- a/test/jest/acceptance/snyk-container/container.spec.ts
+++ b/test/jest/acceptance/snyk-container/container.spec.ts
@@ -174,7 +174,7 @@ describe('snyk container', () => {
       expect(jsonOutput.ok).toEqual(false);
       expect(jsonOutput.uniqueCount).toBeGreaterThan(0);
       expect(code).toEqual(1);
-    }, 30000);
+    });
 
     it('detects stripped Go binaries and reports fleet-server dependencies', async () => {
       const { code, stdout } = await runSnykCLI(
@@ -208,7 +208,7 @@ describe('snyk container', () => {
       expect(jsonOutput).toBeDefined();
       expect(jsonOutput.vulnerabilities).toBeDefined();
       expect(Array.isArray(jsonOutput.vulnerabilities)).toBe(true);
-    }, 180000);
+    });
 
     it('npm depGraph is generated in an npm image with lockfiles', async () => {
       const { code, stdout, stderr } = await runSnykCLIWithDebug(


### PR DESCRIPTION
## Pull Request Submission Checklist

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?
Ensure consistent and increased timeouts for all tests to avoid randomly timing out tests.

## Where should the reviewer start?

## How should this be manually tested?

## What's the product update that needs to be communicated to CLI users?

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timeout cleanup with no production or CLI behavior changes.
> 
> **Overview**
> Removes **per-test Jest timeout overrides** on two `snyk container` acceptance cases in `container.spec.ts`, so they use the file-level `jest.setTimeout(1000 * 300)` (5 minutes) like the rest of the suite.
> 
> The **archive `.tar` path prefix** case no longer caps at 30s, and the **OCI image with manifest missing platform** case no longer uses a separate 180s limit. Test assertions and CLI invocations are unchanged—only timeout configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27e959314bfa7db21ee9a26eb40b71b6840aa7f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->