### PR TITLE
fix: remove daemon initializer from private CLI build

### DIFF
--- a/cliv2-private/cmd/cliv2/main.go
+++ b/cliv2-private/cmd/cliv2/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"os"
 
-	"github.com/snyk/ambient-canary/pkg/daemon"
 	"github.com/snyk/cli-extension-axi/pkg/agent"
 	"github.com/snyk/cli-extension-cos/pkg/cos"
 	"github.com/snyk/remy-cli-extension/pkg/remy"
@@ -17,7 +16,6 @@ func main() {
 		core.WithAdditionalExtensions(agent.Init),
 		core.WithAdditionalExtensions(remy.Init),
 		core.WithAdditionalExtensions(cos.Init),
-		core.WithAdditionalExtensions(daemon.Init),
 		core.WithAdditionalExtensions(rift.Init),
 	))
 }

--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -3,7 +3,6 @@ module github.com/snyk/cli/cliv2-private
 go 1.26.6
 
 require (
-	github.com/snyk/ambient-canary v0.0.0-20260722064253-fba619a134a9
 	github.com/snyk/cli-extension-axi v0.0.0-20260901142946-cb915113acb7
 	github.com/snyk/cli-extension-cos v0.0.0-20260818151318-d63bb9db9484
 	github.com/snyk/cli/cliv2 v0.0.0
@@ -180,8 +179,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oapi-codegen/runtime v1.6.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/opcoder0/capabilities v0.0.0-20221222060822-17fd73bffd2a // indirect
-	github.com/opcoder0/fanotify v0.4.2 // indirect
 	github.com/open-policy-agent/opa v0.69.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/otiai10/copy v1.14.1 // indirect
@@ -241,7 +238,6 @@ require (
 	github.com/standard-webhooks/standard-webhooks/libraries v0.0.1 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/syncthing/notify v0.0.0-20250528144937-c7027d4f7465 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
@@ -329,7 +325,5 @@ replace github.com/snyk/cli/cliv2 => ../cliv2
 // replace github.com/snyk/cli-extension-secrets => ../../cli-extension-secrets
 
 // replace github.com/snyk/cli-extension-cos => ../../cli-extension-cos
-
-// replace github.com/snyk/ambient-canary => ../../ambient-canary
 
 // replace github.com/snyk/rift-cli-extension => ../../rift-cli-extension

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -498,10 +498,6 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/gomega v1.38.0 h1:c/WX+w8SLAinvuKKQFh77WEucCnPk4j2OTUr7lt7BeY=
 github.com/onsi/gomega v1.38.0/go.mod h1:OcXcwId0b9QsE7Y49u+BTrL4IdKOBOKnD6VQNTJEB6o=
-github.com/opcoder0/capabilities v0.0.0-20221222060822-17fd73bffd2a h1:sbMMqulR2c6d2aeqOg5kzWv87unK0O4V78Dl1+YG4ys=
-github.com/opcoder0/capabilities v0.0.0-20221222060822-17fd73bffd2a/go.mod h1:77JxdABQ4m37PtO4WMtRBrI+DDphomu/8tGeijYXspk=
-github.com/opcoder0/fanotify v0.4.2 h1:Bp7h8scp/LNoWmC16Z1kf7GfxehhQLcDPxqJ31+SThs=
-github.com/opcoder0/fanotify v0.4.2/go.mod h1:S0LITNqjkZwifQ+0qB1fT1S/SmDmnFH+h0SLBzoKW2Q=
 github.com/open-policy-agent/opa v0.69.0 h1:s2igLw2Z6IvGWGuXSfugWkVultDMsM9pXiDuMp7ckWw=
 github.com/open-policy-agent/opa v0.69.0/go.mod h1:+qyXJGkpEJ6kpB1kGo8JSwHtVXbTdsGdQYPWWNYNj+4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
@@ -579,8 +575,6 @@ github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/skeema/knownhosts v1.3.2 h1:EDL9mgf4NzwMXCTfaxSD/o/a5fxDw/xL9nkU28JjdBg=
 github.com/skeema/knownhosts v1.3.2/go.mod h1:bEg3iQAuw+jyiw+484wwFJoKSLwcfd7fqRy+N0QTiow=
-github.com/snyk/ambient-canary v0.0.0-20260722064253-fba619a134a9 h1:d69mS5cTIs1eOcmMMUwr1kfvtiDyuSNLxET4lp/mCa4=
-github.com/snyk/ambient-canary v0.0.0-20260722064253-fba619a134a9/go.mod h1:n6GYt41xPhThEEEl/0RZuWpTX68iv6k+6HZ94uGNDGE=
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260821092236-dc228259a004 h1:7A+MUWAat7cn80gNB26J2gb2PnD/tpwVVcck8NJrSRk=
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260821092236-dc228259a004/go.mod h1:u4d7qoWWVx3II+ZnpLQGjAegaJLmgPefXKXJD/jp/wM=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172 h1:dZQ2DnEnxV+v2yFRyuqUioSAGfXkiMcRQXndAeVsqi0=
@@ -661,8 +655,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/syncthing/notify v0.0.0-20250528144937-c7027d4f7465 h1:yhxdTGmFkAM2TFA65c3NgGwpnIkUM8oVqPX2e9S7IVg=
-github.com/syncthing/notify v0.0.0-20250528144937-c7027d4f7465/go.mod h1:J0q59IWjLtpRIJulohwqEZvjzwOfTEPp8SVhDJl+y0Y=
 github.com/tchap/go-patricia/v2 v2.3.1 h1:6rQp39lgIYZ+MHmdEq4xzuk1t7OdC35z/xm0BGhTkes=
 github.com/tchap/go-patricia/v2 v2.3.1/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
@@ -802,7 +794,6 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
 golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
-golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Removes the `daemon` extension (`github.com/snyk/ambient-canary`) registration from the private CLI binary's initialization (`cliv2-private/cmd/cliv2/main.go`), and tidies `cliv2-private/go.mod`/`go.sum` accordingly (drops the now-unused `ambient-canary` dependency and its exclusively-owned transitive deps: `opcoder0/capabilities`, `opcoder0/fanotify`, `syncthing/notify`).

## Verification

- `go build ./...` succeeds in `cliv2-private`
- `go vet ./...` passes in `cliv2-private`
- `go mod tidy -diff` is clean for both `cliv2` (public) and `cliv2-private`
- `make validate-gomod-sync` confirms the public/private `go.mod` files remain in sync
- `gofmt -l` reports no issues on the changed file


