### PR TITLE
feat: enable stdout and file TOON for OS and Secrets

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -222,7 +222,7 @@ require (
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 // indirect
-	github.com/snyk/go-application-framework v0.24.0 // indirect
+	github.com/snyk/go-application-framework v0.25.0 // indirect
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -603,8 +603,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.24.0 h1:IfPDkapoPv8keQbk1OM07KJVXSdhX2TN3sVXYDM+D3Y=
-github.com/snyk/go-application-framework v0.24.0/go.mod h1:3OTJn8QqzBFOXNZxpzGs0CREubF48BRXJrszsKa2zNc=
+github.com/snyk/go-application-framework v0.25.0 h1:X2UNzt9Cy+YNUKBujwe2doMX5W8MgCY0fAsgWujYsfk=
+github.com/snyk/go-application-framework v0.25.0/go.mod h1:3OTJn8QqzBFOXNZxpzGs0CREubF48BRXJrszsKa2zNc=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.31.8
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6
-	github.com/snyk/go-application-framework v0.24.0
+	github.com/snyk/go-application-framework v0.25.0
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260907062128-ef4a43fa0dbf

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -556,8 +556,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.24.0 h1:IfPDkapoPv8keQbk1OM07KJVXSdhX2TN3sVXYDM+D3Y=
-github.com/snyk/go-application-framework v0.24.0/go.mod h1:3OTJn8QqzBFOXNZxpzGs0CREubF48BRXJrszsKa2zNc=
+github.com/snyk/go-application-framework v0.25.0 h1:X2UNzt9Cy+YNUKBujwe2doMX5W8MgCY0fAsgWujYsfk=
+github.com/snyk/go-application-framework v0.25.0/go.mod h1:3OTJn8QqzBFOXNZxpzGs0CREubF48BRXJrszsKa2zNc=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -337,19 +337,6 @@ func getGlobalFLags() *pflag.FlagSet {
 	return globalFLags
 }
 
-// TODO to be removed after CLI-1828
-func addToonOutputFlag(flags *pflag.FlagSet) {
-	if flags.Lookup(output_workflow.OUTPUT_CONFIG_KEY_TOON) == nil {
-		flags.Bool(output_workflow.OUTPUT_CONFIG_KEY_TOON, false, "Print toon output to console")
-	}
-}
-
-func addToonFileOutputFlag(flags *pflag.FlagSet) {
-	if flags.Lookup(output_workflow.OUTPUT_CONFIG_KEY_TOON_FILE) == nil {
-		flags.String(output_workflow.OUTPUT_CONFIG_KEY_TOON_FILE, "", "Write toon output to file")
-	}
-}
-
 func emptyCommandFunction(_ *cobra.Command, _ []string) error {
 	return fmt.Errorf("%s", unknownCommandMessage)
 }
@@ -696,8 +683,6 @@ func mainWithErrorCode(additionalExts []workflow.ExtensionInit) int {
 	// add output flags as persistent flags
 	outputWorkflow, _ := globalEngine.GetWorkflow(localworkflows.WORKFLOWID_OUTPUT_WORKFLOW)
 	outputFlags := workflow.FlagsetFromConfigurationOptions(outputWorkflow.GetConfigurationOptions())
-	addToonOutputFlag(outputFlags)
-	addToonFileOutputFlag(outputFlags)
 	rootCommand.PersistentFlags().AddFlagSet(outputFlags)
 
 	// add workflows as commands

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -260,7 +260,7 @@ func runLegacyHelp() error {
 	return defaultCmd(append(filteredArgs, "--help"))
 }
 
-func runTestCommandWithSarifEqualJson(cmd *cobra.Command, args []string, templateFiles []string) error {
+func runTestCommandWithSarifEqualJson(cmd *cobra.Command, args []string, templateFiles []string, extraFileWriters ...output_workflow.FileWriter) error {
 	// ensure legacy behavior, where sarif and json can be used interchangeably
 	globalConfiguration.AddAlternativeKeys(output_workflow.OUTPUT_CONFIG_KEY_SARIF, []string{output_workflow.OUTPUT_CONFIG_KEY_JSON})
 
@@ -278,6 +278,7 @@ func runTestCommandWithSarifEqualJson(cmd *cobra.Command, args []string, templat
 			WriteEmptyContent: false,
 		},
 	}
+	fileWriters = append(fileWriters, extraFileWriters...)
 	globalConfiguration.Set(output_workflow.OUTPUT_CONFIG_KEY_FILE_WRITERS, fileWriters)
 
 	// ensure that json is translated to sarif for the default writer as well
@@ -294,7 +295,24 @@ func runCodeTestCommand(cmd *cobra.Command, args []string) error {
 }
 
 func runSecretsTestCommand(cmd *cobra.Command, args []string) error {
-	return runTestCommandWithSarifEqualJson(cmd, args, output_workflow.ApplicationSarifTemplatesUfm)
+	return runTestCommandWithSarifEqualJson(cmd, args, output_workflow.ApplicationSarifTemplatesUfm, output_workflow.FileWriter{
+		NameConfigKey:     output_workflow.OUTPUT_CONFIG_KEY_TOON_FILE,
+		MimeType:          output_workflow.TOON_MIME_TYPE,
+		WriteEmptyContent: true,
+	})
+}
+
+// os-flows-owned key; skips local unified render so GAF can present stdout TOON.
+const internalUseUfmPresenterConfigKey = "internal_use_ufm_presenter"
+
+func runTestCommand(cmd *cobra.Command, args []string) error {
+	if err := globalConfiguration.AddFlagSet(cmd.Flags()); err != nil {
+		return err
+	}
+	if globalConfiguration.GetBool(output_workflow.OUTPUT_CONFIG_KEY_TOON) {
+		globalConfiguration.Set(internalUseUfmPresenterConfigKey, true)
+	}
+	return runCommand(cmd, args)
 }
 
 func runAuthCommand(cmd *cobra.Command, args []string) error {
@@ -317,6 +335,19 @@ func getGlobalFLags() *pflag.FlagSet {
 	globalFLags.String(integrationNameFlag, "", "")
 	globalFLags.Int(maxNetworkRequestAttempts, -1, "Maximum total network attempts, including the initial request (minimum: 1)")
 	return globalFLags
+}
+
+// TODO to be removed after CLI-1828
+func addToonOutputFlag(flags *pflag.FlagSet) {
+	if flags.Lookup(output_workflow.OUTPUT_CONFIG_KEY_TOON) == nil {
+		flags.Bool(output_workflow.OUTPUT_CONFIG_KEY_TOON, false, "Print toon output to console")
+	}
+}
+
+func addToonFileOutputFlag(flags *pflag.FlagSet) {
+	if flags.Lookup(output_workflow.OUTPUT_CONFIG_KEY_TOON_FILE) == nil {
+		flags.String(output_workflow.OUTPUT_CONFIG_KEY_TOON_FILE, "", "Write toon output to file")
+	}
 }
 
 func emptyCommandFunction(_ *cobra.Command, _ []string) error {
@@ -376,7 +407,10 @@ func createCommandsForWorkflows(rootCommand *cobra.Command, engine workflow.Engi
 		case "secrets test":
 			// use the special run command to ensure that the non-standard behavior of the command can be kept
 			parentCommand.RunE = runSecretsTestCommand
-		case "test", "monitor":
+		case "test":
+			legacy.SetupTestMonitorCommand(parentCommand)
+			parentCommand.RunE = runTestCommand
+		case "monitor":
 			legacy.SetupTestMonitorCommand(parentCommand)
 		case "auth":
 			parentCommand.RunE = runAuthCommand
@@ -662,6 +696,8 @@ func mainWithErrorCode(additionalExts []workflow.ExtensionInit) int {
 	// add output flags as persistent flags
 	outputWorkflow, _ := globalEngine.GetWorkflow(localworkflows.WORKFLOWID_OUTPUT_WORKFLOW)
 	outputFlags := workflow.FlagsetFromConfigurationOptions(outputWorkflow.GetConfigurationOptions())
+	addToonOutputFlag(outputFlags)
+	addToonFileOutputFlag(outputFlags)
 	rootCommand.PersistentFlags().AddFlagSet(outputFlags)
 
 	// add workflows as commands

--- a/cliv2/pkg/core/main_test.go
+++ b/cliv2/pkg/core/main_test.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -22,9 +24,11 @@ import (
 	"github.com/snyk/go-application-framework/pkg/local_workflows/content_type"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/local_models"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/output_workflow"
 	"github.com/snyk/go-application-framework/pkg/logging"
 	"github.com/snyk/go-application-framework/pkg/mocks"
 	"github.com/snyk/go-application-framework/pkg/networking"
+	"github.com/snyk/go-application-framework/pkg/runtimeinfo"
 	"github.com/snyk/go-application-framework/pkg/utils/ufm"
 	"github.com/snyk/go-application-framework/pkg/workflow"
 	"github.com/spf13/cobra"
@@ -45,6 +49,130 @@ func cleanup() {
 	helpProvided = false
 	globalConfiguration = nil
 	globalEngine = nil
+}
+
+type nopOutputDest struct{}
+
+func (nopOutputDest) Println(a ...any) (int, error) { return fmt.Fprintln(io.Discard, a...) }
+func (nopOutputDest) Remove(p string) error         { return os.Remove(p) }
+func (nopOutputDest) WriteFile(p string, b []byte, _ fs.FileMode) error {
+	return os.WriteFile(p, b, 0644)
+}
+func (nopOutputDest) GetWriter() io.Writer { return io.Discard }
+
+func Test_runSecretsTestCommand_toonFileOutput(t *testing.T) {
+	dir := t.TempDir()
+	toonFile := filepath.Join(dir, "out.toon")
+	sarifFile := filepath.Join(dir, "out.sarif")
+	templates := output_workflow.ApplicationSarifTemplatesUfm
+
+	config := configuration.NewWithOpts()
+	config.Set(output_workflow.OUTPUT_CONFIG_KEY_FILE_WRITERS, []output_workflow.FileWriter{
+		{
+			NameConfigKey: output_workflow.OUTPUT_CONFIG_KEY_SARIF_FILE, MimeType: output_workflow.SARIF_MIME_TYPE,
+			TemplateFiles: templates, WriteEmptyContent: true,
+		},
+		{
+			NameConfigKey: output_workflow.OUTPUT_CONFIG_KEY_TOON_FILE, MimeType: output_workflow.TOON_MIME_TYPE,
+			WriteEmptyContent: true,
+		},
+	})
+	config.Set(output_workflow.OUTPUT_CONFIG_KEY_TOON_FILE, toonFile)
+	config.Set(output_workflow.OUTPUT_CONFIG_KEY_SARIF_FILE, sarifFile)
+	config.Set(configuration.MAX_THREADS, 1)
+
+	logger := zerolog.Nop()
+	mockCtl := gomock.NewController(t)
+	ctx := mocks.NewMockInvocationContext(mockCtl)
+	ctx.EXPECT().GetEnhancedLogger().Return(&logger).AnyTimes()
+	ctx.EXPECT().GetConfiguration().Return(config).AnyTimes()
+	ctx.EXPECT().GetRuntimeInfo().Return(runtimeinfo.New(runtimeinfo.WithName("snyk-cli"), runtimeinfo.WithVersion("1.1301.0"))).AnyTimes()
+	ctx.EXPECT().Context().Return(t.Context()).AnyTimes()
+
+	testResults, err := ufm.NewSerializableTestResultFromBytes([]byte(`[{"testId":"11111111-2222-3333-4444-555555555555","passFail":"fail","findings":[],"executionState":"finished"}]`))
+	require.NoError(t, err)
+	input := []workflow.Data{ufm.CreateWorkflowDataFromTestResults(workflow.NewWorkflowIdentifier("secrets"), testResults)}
+
+	writerMap := output_workflow.GetWritersFromConfiguration(config, nopOutputDest{})
+	_, err = output_workflow.HandleContentTypeUnifiedModel(input, ctx, writerMap)
+	require.NoError(t, err)
+
+	toonBytes, err := os.ReadFile(toonFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(toonBytes), "results[1]:")
+
+	sarifBytes, err := os.ReadFile(sarifFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(sarifBytes), "\"version\": \"2.1.0\"")
+}
+
+func Test_runTestCommand_internalUseUfmPresenterWhenToon(t *testing.T) {
+	defer cleanup()
+	cmd := &cobra.Command{Use: "test"}
+	setup := func(config configuration.Configuration) {
+		globalConfiguration = config
+		globalEngine = workflow.NewWorkFlowEngine(config)
+		require.NoError(t, globalEngine.Init())
+		globalContext = t.Context()
+		noopLog := zerolog.New(io.Discard)
+		globalLogger = &noopLog
+	}
+	t.Run("toon stdout", func(t *testing.T) {
+		config := configuration.NewWithOpts()
+		setup(config)
+		root := &cobra.Command{Use: "snyk", SilenceErrors: true, SilenceUsage: true}
+		addToonOutputFlag(root.PersistentFlags())
+		root.AddCommand(&cobra.Command{Use: "test", RunE: runTestCommand})
+		root.SetArgs([]string{"test", "--toon"})
+		_ = root.Execute()
+		assert.True(t, globalConfiguration.GetBool(internalUseUfmPresenterConfigKey))
+	})
+	t.Run("toon file only", func(t *testing.T) {
+		config := configuration.NewWithOpts()
+		config.Set(output_workflow.OUTPUT_CONFIG_KEY_TOON_FILE, t.TempDir()+"/out.toon")
+		setup(config)
+		_ = runTestCommand(cmd, nil)
+		assert.False(t, globalConfiguration.GetBool(internalUseUfmPresenterConfigKey))
+	})
+	t.Run("default", func(t *testing.T) {
+		setup(configuration.NewWithOpts())
+		_ = runTestCommand(cmd, nil)
+		assert.False(t, globalConfiguration.GetBool(internalUseUfmPresenterConfigKey))
+	})
+}
+
+func Test_addToonOutputFlag(t *testing.T) {
+	flags := pflag.NewFlagSet("output", pflag.ContinueOnError)
+	addToonOutputFlag(flags)
+	addToonOutputFlag(flags)
+
+	config := configuration.New()
+	require.NoError(t, config.AddFlagSet(flags))
+	require.NoError(t, flags.Parse([]string{"--toon"}))
+	assert.True(t, config.GetBool(output_workflow.OUTPUT_CONFIG_KEY_TOON))
+}
+
+func Test_addToonFileOutputFlag(t *testing.T) {
+	for _, args := range [][]string{
+		{"--toon-file-output=result.toon", "project"},
+		{"--toon-file-output", "result.toon", "project"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			flags := pflag.NewFlagSet("output", pflag.ContinueOnError)
+			addToonFileOutputFlag(flags)
+			addToonFileOutputFlag(flags)
+			config := configuration.NewWithOpts()
+			require.NoError(t, config.AddFlagSet(flags))
+			require.NoError(t, flags.Parse(args))
+			assert.Equal(t, "result.toon", config.GetString("toon-file-output"))
+			assert.Equal(t, []string{"project"}, flags.Args())
+		})
+	}
+	t.Run("missing value", func(t *testing.T) {
+		flags := pflag.NewFlagSet("output", pflag.ContinueOnError)
+		addToonFileOutputFlag(flags)
+		require.Error(t, flags.Parse([]string{"--toon-file-output"}))
+	})
 }
 
 func Test_mainWithErrorCode(t *testing.T) {

--- a/cliv2/pkg/core/main_test.go
+++ b/cliv2/pkg/core/main_test.go
@@ -121,7 +121,10 @@ func Test_runTestCommand_internalUseUfmPresenterWhenToon(t *testing.T) {
 		config := configuration.NewWithOpts()
 		setup(config)
 		root := &cobra.Command{Use: "snyk", SilenceErrors: true, SilenceUsage: true}
-		addToonOutputFlag(root.PersistentFlags())
+		require.NoError(t, localworkflows.InitOutputWorkflow(globalEngine))
+		outputWorkflow, ok := globalEngine.GetWorkflow(localworkflows.WORKFLOWID_OUTPUT_WORKFLOW)
+		require.True(t, ok)
+		root.PersistentFlags().AddFlagSet(workflow.FlagsetFromConfigurationOptions(outputWorkflow.GetConfigurationOptions()))
 		root.AddCommand(&cobra.Command{Use: "test", RunE: runTestCommand})
 		root.SetArgs([]string{"test", "--toon"})
 		_ = root.Execute()
@@ -138,40 +141,6 @@ func Test_runTestCommand_internalUseUfmPresenterWhenToon(t *testing.T) {
 		setup(configuration.NewWithOpts())
 		_ = runTestCommand(cmd, nil)
 		assert.False(t, globalConfiguration.GetBool(internalUseUfmPresenterConfigKey))
-	})
-}
-
-func Test_addToonOutputFlag(t *testing.T) {
-	flags := pflag.NewFlagSet("output", pflag.ContinueOnError)
-	addToonOutputFlag(flags)
-	addToonOutputFlag(flags)
-
-	config := configuration.New()
-	require.NoError(t, config.AddFlagSet(flags))
-	require.NoError(t, flags.Parse([]string{"--toon"}))
-	assert.True(t, config.GetBool(output_workflow.OUTPUT_CONFIG_KEY_TOON))
-}
-
-func Test_addToonFileOutputFlag(t *testing.T) {
-	for _, args := range [][]string{
-		{"--toon-file-output=result.toon", "project"},
-		{"--toon-file-output", "result.toon", "project"},
-	} {
-		t.Run(strings.Join(args, " "), func(t *testing.T) {
-			flags := pflag.NewFlagSet("output", pflag.ContinueOnError)
-			addToonFileOutputFlag(flags)
-			addToonFileOutputFlag(flags)
-			config := configuration.NewWithOpts()
-			require.NoError(t, config.AddFlagSet(flags))
-			require.NoError(t, flags.Parse(args))
-			assert.Equal(t, "result.toon", config.GetString("toon-file-output"))
-			assert.Equal(t, []string{"project"}, flags.Args())
-		})
-	}
-	t.Run("missing value", func(t *testing.T) {
-		flags := pflag.NewFlagSet("output", pflag.ContinueOnError)
-		addToonFileOutputFlag(flags)
-		require.Error(t, flags.Parse([]string{"--toon-file-output"}))
 	})
 }
 


### PR DESCRIPTION
To be merged after https://github.com/snyk/cli/pull/7239

> ./binary-releases/snyk-macos-arm64 test --toon

```yaml
results[1]:
  - effectiveSummary:
      count: 8
      count_by:
        result_type:
          sca: 8
        severity:
          critical: 0
          high: 0
          low: 0
          medium: 8
    errors: null
    executionState: finished
    findings[11]:
      - attributes:
          cause_of_failure: false
          description: "## Overview\n\nAffected versions of this package are vulnerable to Uncontrolled Recursion in the `compose/resolve` phase due to using recursive function calls without a depth bound. An attacker can cause the application to throw a `RangeError` and potentially terminate the Node.js process by supplying a deeply nested YAML payload that exhausts the call stack.\n## PoC\n```js\r\nconst YAML = require('yaml');\r\n\r\n// ~10 KB payload: 5000 levels of nested flow sequences\r\nconst payload = '['.repeat(5000) + '1' + ']'.repeat(5000)
```

... cut because github does not allow such long text

> ./snyk-macos-arm64 test --toon-file-output=os.toon >> snyk_test.toon && cat os.toon
```yaml
results[1]:
  - effectiveSummary:
      count: 8
      count_by:
        result_type:
          sca: 8
        severity:
          critical: 0
          high: 0
          low: 0
          medium: 8
    errors: null
    executionState: finished
    findings[11]:
      - attributes:
          cause_of_failure: false
          description: "## Overview\n[shescape](https://www.npmjs.org/package/shescape) is a simple shell escape library\n\nAffected versions of this package are vulnerable to Improper Encoding or Escaping of Output via the `getEscapeFunction` logic in `src/internal/unix/busybox.js`. An attacker can reveal the user's home directory and alter how a comman
```

... cut because github does not allow such long text

> cat snyk_test.toon
```yaml
<details>
results[1]:
  - effectiveSummary:
      count: 8
      count_by:
        result_type:
          sca: 8
        severity:
          critical: 0
          high: 0
          low: 0
          medium: 8
    errors: null
    executionState: finished
    findings[11]:
      - attributes:
          cause_of_failure: false
          description: "## Overview\n\nAffected versions of this package are vulnerable to Uncontrolled Recursion in the `compose/resolve` phase due to using recursive function cal
```

... cut because github does not allow such long text

> ./snyk-macos-arm64 test --toon --toon-file-output=os-both.toon && cat os-both.toon
```yaml
results[1]:
  - effectiveSummary:
      count: 8
      count_by:
        result_type:
          sca: 8
        severity:
          critical: 0
          high: 0
          low: 0
          medium: 8
    errors: null
    executionState: finished
    findings[11]:
      - attributes:
          cause_of_failure: false
          description: "## Overview\n\nAffected versions of this package are vulnerable to Open Redirect due to missing verification of requested URLs. It allowed a victim to be redirected to a UNIX socket.\n## Remediation\nUpgrade `got` to version 11.8.5, 12.1.0 or higher.\n## References\n- [GitHub Diff](https://github.com/sindresorhus/got/compare/v12.0.3...v12.1.0)\n- [GitHub PR](https://github.com/sindresorhus/got/pull/2047)\n"
          evidence[2]:
            - path[4]{name,version}:
                snyk,1.0.0-monorepo
                snyk-nodejs-lockfile-parser,2.10.0
                @yarnpkg/core,4.5.0
                got,11.8.2
              source: dependency_path
            - path[5]{name,version}:
                snyk,1.0.0-monorepo
                snyk-docker-plugin,9.20.0
                snyk-nodejs-lockfile-parser,2.10.0
                @yarnpkg/core,4.5.0
                got,11.8.2
              source: dependency_path
```

... cut because github does not allow such long text

> cat os-both.toon
```yaml
results[1]:
  - effectiveSummary:
      count: 8
      count_by:
        result_type:
          sca: 8
        severity:
          critical: 0
          high: 0
          low: 0
          medium: 8
    errors: null
    executionState: finished
    findings[11]:
      - attributes:
          cause_of_failure: false
          description: "## Overview\n\nAffected versions of this package are vulnerable to Open Redirect due to missing verification of requested URLs. It allowed a victim to be redirected to a UNIX socket.\n## Remediation\nUpgrade `got` to version 11.8.5, 12.1.0 or higher.\n## References\n- [GitHub Diff](https://github.com/sindresorhus/got/compare/v12.0.3...v12.1.0)\n- [GitHub PR](https://github.com/sindresorhus/got/pull/2047)\n"
          evidence[2]:
            - path[4]{name,version}:
                snyk,1.0.0-monorepo
                snyk-nodejs-lockfile-parser,2.10.0
```

... cut because github does not allow such long text

> ./snyk-macos-arm64 test --toon --sarif-file-output=os.sarif

```yaml
results[1]:
  - effectiveSummary:
      count: 8
      count_by:
        result_type:
          sca: 8
        severity:
          critical: 0
          high: 0
          low: 0
          medium: 8
    errors: null
    executionState: finished
    findings[11]:
      - attributes:
          cause_of_failure: false
          description: "## Overview\n[marked](https://marked.js.org/) is a low-level compiler for parsing markdown without caching or blocking for long periods of time.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) when passing unsanitized user input to `inline.reflinkSearch`, if it is not being parsed by a time-limited worker thread.\r\n\r\n## PoC\r\n```js\r\nimport * as marked from 'marked';\r\n\r\nconsole.log(marked.parse(`[x]: x\r\n\r\n\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](\\\\[\\\\](`));\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by gen
```

... cut because github does not allow such long text

> cat os.sarif

```json
{"$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json","version": "2.1.0","runs": [{"tool": {"driver" : {"name" : "Snyk Open Source","semanticVersion" : "1.1307.0-preview.c3e52bd2b8af9be2a8d746dd1e8623c4c1ceb0b4","version" : "1.1307.0-preview.c3e52bd2b8af9be2a8d746dd1e8623c4c1ceb0b4","informationUri" : 
asd
```

... cut because github does not allow such long text


> ./snyk-macos-arm64 secrets test --toon

```yamlresults[1]:
  - effectiveSummary:
      count: 33
      count_by:
        result_type:
          secrets: 33
        severity:
          critical: 2
          high: 31
          low: 0
          medium: 0
    errors: null
    executionState: finished
    findings[33]:
      - attributes:
          cause_of_failure: false
          component_key: secrets
          description: Detected a JSON Web Token, which may lead to unauthorized access to web application and sensitive data.
          evidence: []
          finding_type: secrets
          key: 7ddc12bd-4b1c-5991-8533-e27002eebf2c
          locations[1]{file_path,from_column,from_line,to_column,to_line,type}:
            test/jest/unit/lib/ecosystems/resolve-monitor.facts.spec.ts,6,14,233,14,source
          policy_modifications: []
          problems[2]:
            - id: CWE-798
              source: cwe
            - categories[1]: Security
              help: Detected a JSON Web Token, which may lead to unauthorized access to web application and sensitive data.
              id: json-web-token
              name: JSON Web Token
              precision: very-high
              severity: high
              short_description: JSON Web Token
              source: secret

```

... cut because github does not allow such long text

> ./snyk-macos-arm64 secrets test --toon-file-output=secrets.toon

```yaml
Testing  (/Users/roberto/go/cli) ...

Open Secrets issues: 33

 ✗ [HIGH] Generic Secret Key
   Finding ID: 05836e3f-e37a-54ac-ab68-290fc65403cb
   Info: Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.
   Path: test/fixtures/demo-os/core/test/utils/fixtures/export/export-003-badValidation.json, line 64 to 64

 ✗ [HIGH] Generic Secret Key
   Finding ID: 1ca01ed1-61cd-5973-80a8-521ef9481c96
   Info: Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.
   Path: ts-binary-wrapper/src/common.ts, line 385 to 385

 ✗ [HIGH] Generic Secret Key
   Finding ID: 2a90c607-69b7-5123-88b8-687778b4923d
   Info: Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.
   Path: test/fixtures/demo-os/core/test/utils/fixtures/export/export-003-mu-noOwner.json, line 75 to 75

 ✗ [HIGH] Generic Secret Key
   Finding ID: 2fe719fd-f05b-5a4b-998a-340e07987d3b
   Info: Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.
   Path: test/fixtures/demo-os/core/test/utils/fixtures/data-generator.js, line 87 to 87
   Path: test/fixtures/demo-os/core/test/utils/fixtures/data-generator.js, line 93 to 93
   Path: test/fixtures/demo-os/core/test/utils/fixtures/data-generator.js, line 99 to 99
   Path: test/fixtures/demo-os/core/test/utils/fixtures/data-generator.js, line 105 to 105
   Path: test/fixtures/demo-os/core/test/utils/fixtures/data-generator.js, line 111 to 111
   Path: test/fixtures/demo-os/core/test/utils/fixtures/data-generator.js, line 306 to 306

 ✗ [HIGH] Generic Secret Key
   Finding ID: 32ba2ff1-a0e2-57fd-84bf-0733d827eb96
   Info: Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.
   Path: test/fixtures/sast/shallow_sast_webgoat/DeserializeTest.java, line 82 to 82

 ✗ [HIGH] Generic Secret Key

```

... cut because github does not allow such long text

> cat secrets.toon

```yaml
results[1]:
  - effectiveSummary:
      count: 33
      count_by:
        result_type:
          secrets: 33
        severity:
          critical: 2
          high: 31
          low: 0
          medium: 0
    errors: null
    executionState: finished
    findings[33]:
      - attributes:
          cause_of_failure: false
          component_key: secrets
          description: Detected a JSON Web Token, which may lead to unauthorized access to web application and sensitive data.
          evidence: []
          finding_type: secrets
          key: 7ddc12bd-4b1c-5991-8533-e27002eebf2c
          locations[1]{file_path,from_column,from_line,to_column,to_line,type}:
            test/jest/unit/lib/ecosystems/resolve-monitor.facts.spec.ts,6,14,233,14,source
          policy_modifications: []
          problems[2]:
            - id: CWE-798
              source: cwe
            - categories[1]: Security
              help: Detected a JSON Web Token, which may lead to unauthorized access to web application and sensitive data.
              id: json-web-token
              name: JSON Web Token
              precision: very-high
              severity: high
              short_description: JSON Web Token
              source: secret

```

... cut because github does not allow such long text

> ./snyk-macos-arm64 secrets test --toon --toon-file-output=secrets-both.toon

```yaml
results[1]:
  - effectiveSummary:
      count: 34
      count_by:
        result_type:
          secrets: 34
        severity:
          critical: 2
          high: 32
          low: 0
          medium: 0
    errors: null
    executionState: finished
    findings[34]:
      - attributes:
          cause_of_failure: false
          component_key: secrets
          description: Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.
          evidence: []
          finding_type: secrets
          key: 6170ee8c-5471-5820-b991-f5ac25952c7c
          locations[1]{file_path,from_column,from_line,to_column,to_line,type}:
            test/jest/unit/lib/ecosystems/fixtures/scan-results.ts,28,18,50,18,source
          policy_modifications: []
          problems[2]:
            - categories[1]: Security
              help: Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.
              id: generic-secret
              name: Generic Secret Key
              precision: very-high
              severity: high
              short_description: Generic Secret Key
              source: secret
              tags[2]: "type:secret-key","provider:generic"
            - id: CWE-798

```

... cut because github does not allow such long text

> cat secrets-both.toon

```yaml
results[1]:
  - effectiveSummary:
      count: 34
      count_by:
        result_type:
          secrets: 34
        severity:
          critical: 2
          high: 32
          low: 0
          medium: 0
    errors: null
    executionState: finished
    findings[34]:
      - attributes:
          cause_of_failure: false
          component_key: secrets
          description: Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.
          evidence: []
          finding_type: secrets
          key: 6170ee8c-5471-5820-b991-f5ac25952c7c
          locations[1]{file_path,from_column,from_line,to_column,to_line,type}:
            test/jest/unit/lib/ecosystems/fixtures/scan-results.ts,28,18,50,18,source
          policy_modifications: []
          problems[2]:
            - categories[1]: Security
              help: Detected a generic secret, which could lead to unauthorized access and sensitive data exposure.
              id: generic-secret
              name: Generic Secret Key
              precision: very-high
              severity: high
              short_description: Generic Secret Key
              source: secret
              tags[2]: "type:secret-key","provider:generic"
            - id: CWE-798

```

... cut because github does not allow such long text

> ./snyk-macos-arm64 secrets test --toon --sarif-file-output=secrets.sarif

```yaml
results[1]:
  - effectiveSummary:
      count: 34
      count_by:
        result_type:
          secrets: 34
        severity:
          critical: 2
          high: 32
          low: 0
          medium: 0
    errors: null
    executionState: finished
    findings[34]:
      - attributes:
          cause_of_failure: false
          component_key: secrets
          description: Detected a JSON Web Token, which may lead to unauthorized access to web application and sensitive data.
          evidence: []
          finding_type: secrets
          key: 7ddc12bd-4b1c-5991-8533-e27002eebf2c
          locations[1]{file_path,from_column,from_line,to_column,to_line,type}:
            test/jest/unit/lib/ecosystems/resolve-monitor.facts.spec.ts,6,14,233,14,source
          policy_modifications: []
          problems[2]:
            - categories[1]: Security
              help: Detected a JSON Web Token, which may lead to unauthorized access to web application and sensitive data.
              id: json-web-token
              name: JSON Web Token
              precision: very-high
              severity: high
              short_description: JSON Web Token
              source: secret
              tags[2]: "type:web-token","provider:JWT"
            - id: CWE-798

```

... cut because github does not allow such long text

> cat secrets.sarif

```json
{"$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json","version": "2.1.0","runs": [{"tool": {"driver" : {"name" : "Snyk Secrets","semanticVersion" : "1.1307.0-preview.c3e52bd2b8af9be2a8d746dd1e8623c4c1ceb0b4","version" : "1.1307.0-preview.c3e52bd2b8af9be2a8d746dd1e8623c4c1ceb0b4","informationUri" : "https://docs.snyk.io/","rules" : [{"id": "generic-secret","shortDescription": {"text": "Generic Secret Key"},
```

... cut because github does not allow such long text

## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

Wires TOON output for OS and Secrets using the existing GAF renderer.

- Registers `--toon` and `--toon-file-output`.
- Routes OS stdout through GAF when `--toon` is set.
- Exposes existing Secrets stdout support and adds TOON to its custom file writers.
- It does not handle errors nor perform validation: that's to be done in CLI-1828.

## Where should the reviewer start?

`cliv2/pkg/core/main.go`: flag registration, `runTestCommand`, and `runSecretsTestCommand`. Then `main_test.go` for coverage.

Check that parsed `--toon` reaches configuration before the OS presenter flag is read; the open review thread covers this.

## How should this be manually tested?

Build with `make build`. From projects supported by OS and Secrets, run the built CLI with `test` and `secrets test`:

- `--toon`: TOON on stdout.
- `--toon-file-output=result.toon`: TOON in the file, normal stdout.
- Both flags: TOON on stdout and in the file.

Check clean and failing scans. Confirm exit codes and existing JSON/SARIF output still work.

## What's the product update that needs to be communicated to CLI users?

TOON output for Open Source and Secrets scans via `--toon` and `--toon-file-output`.

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how primary `test` and `secrets test` commands route structured output, which can affect CI and tooling that parse stdout; behavior is flag-gated and covered by new tests.
> 
> **Overview**
> Adds **TOON** as a scan output option for Open Source (`snyk test`) and Secrets (`snyk secrets test`) by wiring new CLI flags into the existing GAF output workflow.
> 
> Registers persistent **`--toon`** (console) and **`--toon-file-output`** flags on the root command. **`snyk test`** now uses a dedicated **`runTestCommand`** handler: when **`--toon`** is set, it sets **`internal_use_ufm_presenter`** so stdout TOON is rendered via GAF instead of the local unified presenter; file-only TOON does not flip that flag. **`snyk secrets test`** extends the SARIF/JSON file-writer setup with an optional TOON file writer (via **`extraFileWriters`** on **`runTestCommandWithSarifEqualJson`**). The **`test`** and **`monitor`** workflow branches are split so only **`test`** gets the new runner.
> 
> Unit tests cover TOON file emission for secrets, presenter-flag behavior, and flag parsing/idempotency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dca39aef383c079ed144295a02f8bfe5a5a9a68a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->