### PR TITLE
feat: enable TOON and HTML renders

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -223,7 +223,7 @@ require (
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea // indirect
 	github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 // indirect
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 // indirect
-	github.com/snyk/go-application-framework v0.24.0 // indirect
+	github.com/snyk/go-application-framework v0.25.0 // indirect
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc // indirect
 	github.com/snyk/policy-engine v1.1.4 // indirect
 	github.com/snyk/snyk-iac-capture v0.6.5 // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -605,8 +605,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.24.0 h1:IfPDkapoPv8keQbk1OM07KJVXSdhX2TN3sVXYDM+D3Y=
-github.com/snyk/go-application-framework v0.24.0/go.mod h1:3OTJn8QqzBFOXNZxpzGs0CREubF48BRXJrszsKa2zNc=
+github.com/snyk/go-application-framework v0.25.0 h1:X2UNzt9Cy+YNUKBujwe2doMX5W8MgCY0fAsgWujYsfk=
+github.com/snyk/go-application-framework v0.25.0/go.mod h1:3OTJn8QqzBFOXNZxpzGs0CREubF48BRXJrszsKa2zNc=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/snyk/code-client-go v1.31.8
 	github.com/snyk/container-cli v0.0.0-20260213211631-cd2b2cf8f3ea
 	github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6
-	github.com/snyk/go-application-framework v0.24.0
+	github.com/snyk/go-application-framework v0.25.0
 	github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc
 	github.com/snyk/snyk-iac-capture v0.6.5
 	github.com/snyk/snyk-ls v0.0.0-20260907062128-ef4a43fa0dbf

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -556,8 +556,8 @@ github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62 h1:kgZNQ5ztI4+n3
 github.com/snyk/dep-graph/go v0.0.0-20260127160647-c836da762c62/go.mod h1:hTr91da/4ze2nk9q6ZW1BmfM2Z8rLUZSEZ3kK+6WGpc=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6 h1:XUPFP85nBh+zDCTvxxBuouZP9yG7H1qXZiMGFVMWVKM=
 github.com/snyk/error-catalog-golang-public v0.0.0-20260806122555-28dc45bbbde6/go.mod h1:0dz+HUR/r7VLlQpLfF0a/F1tdHH84NLTZzCxjZ+Q1nk=
-github.com/snyk/go-application-framework v0.24.0 h1:IfPDkapoPv8keQbk1OM07KJVXSdhX2TN3sVXYDM+D3Y=
-github.com/snyk/go-application-framework v0.24.0/go.mod h1:3OTJn8QqzBFOXNZxpzGs0CREubF48BRXJrszsKa2zNc=
+github.com/snyk/go-application-framework v0.25.0 h1:X2UNzt9Cy+YNUKBujwe2doMX5W8MgCY0fAsgWujYsfk=
+github.com/snyk/go-application-framework v0.25.0/go.mod h1:3OTJn8QqzBFOXNZxpzGs0CREubF48BRXJrszsKa2zNc=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc h1:tuZVhmJFxS4qJlwYIIIw8xgw3VaVqIR3IAV0WaaFVnI=
 github.com/snyk/go-httpauth v0.0.0-20260810142636-0f6182aaccbc/go.mod h1:f42qLL7WXOS0od7dXJV/hK3myjms/r6HsXgLrg1HRRY=
 github.com/snyk/policy-engine v1.1.4 h1:0XpaMpl7ixSk4+dlpHYg2iKEBuv+5Ci+QIcbsmhktao=

--- a/cliv2/pkg/core/main.go
+++ b/cliv2/pkg/core/main.go
@@ -261,8 +261,13 @@ func runLegacyHelp() error {
 }
 
 func runTestCommandWithSarifEqualJson(cmd *cobra.Command, args []string, templateFiles []string) error {
+	configureSarifEqualJSON(globalConfiguration, templateFiles)
+	return runCommand(cmd, args)
+}
+
+func configureSarifEqualJSON(config configuration.Configuration, templateFiles []string) {
 	// ensure legacy behavior, where sarif and json can be used interchangeably
-	globalConfiguration.AddAlternativeKeys(output_workflow.OUTPUT_CONFIG_KEY_SARIF, []string{output_workflow.OUTPUT_CONFIG_KEY_JSON})
+	config.AddAlternativeKeys(output_workflow.OUTPUT_CONFIG_KEY_SARIF, []string{output_workflow.OUTPUT_CONFIG_KEY_JSON})
 
 	fileWriters := []output_workflow.FileWriter{
 		{
@@ -277,16 +282,26 @@ func runTestCommandWithSarifEqualJson(cmd *cobra.Command, args []string, templat
 			TemplateFiles:     templateFiles,
 			WriteEmptyContent: false,
 		},
+		{
+			NameConfigKey:     output_workflow.OUTPUT_CONFIG_KEY_HTML_FILE,
+			MimeType:          output_workflow.HTML_MIME_TYPE,
+			TemplateFiles:     nil,
+			WriteEmptyContent: true,
+		},
+		{
+			NameConfigKey:     output_workflow.OUTPUT_CONFIG_KEY_TOON_FILE,
+			MimeType:          output_workflow.TOON_MIME_TYPE,
+			TemplateFiles:     nil,
+			WriteEmptyContent: true,
+		},
 	}
-	globalConfiguration.Set(output_workflow.OUTPUT_CONFIG_KEY_FILE_WRITERS, fileWriters)
+	config.Set(output_workflow.OUTPUT_CONFIG_KEY_FILE_WRITERS, fileWriters)
 
 	// ensure that json is translated to sarif for the default writer as well
 	defaultWriterLookup := map[string]string{
 		output_workflow.JSON_MIME_TYPE: output_workflow.SARIF_MIME_TYPE,
 	}
-	globalConfiguration.Set(output_workflow.OUTPUT_CONFIG_KEY_DEFAULT_WRITER_LUT, defaultWriterLookup)
-
-	return runCommand(cmd, args)
+	config.Set(output_workflow.OUTPUT_CONFIG_KEY_DEFAULT_WRITER_LUT, defaultWriterLookup)
 }
 
 func runCodeTestCommand(cmd *cobra.Command, args []string) error {

--- a/cliv2/pkg/core/main_test.go
+++ b/cliv2/pkg/core/main_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/snyk/go-application-framework/pkg/local_workflows/content_type"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/json_schemas"
 	"github.com/snyk/go-application-framework/pkg/local_workflows/local_models"
+	"github.com/snyk/go-application-framework/pkg/local_workflows/output_workflow"
 	"github.com/snyk/go-application-framework/pkg/logging"
 	"github.com/snyk/go-application-framework/pkg/mocks"
 	"github.com/snyk/go-application-framework/pkg/networking"
@@ -45,6 +46,32 @@ func cleanup() {
 	helpProvided = false
 	globalConfiguration = nil
 	globalEngine = nil
+}
+
+func Test_configureSarifEqualJSON_IncludesHTMLFileWriter(t *testing.T) {
+	config := configuration.NewWithOpts()
+
+	configureSarifEqualJSON(config, nil)
+
+	writers, ok := config.Get(output_workflow.OUTPUT_CONFIG_KEY_FILE_WRITERS).([]output_workflow.FileWriter)
+	require.True(t, ok)
+	require.Len(t, writers, 4)
+	assert.Equal(t, output_workflow.OUTPUT_CONFIG_KEY_HTML_FILE, writers[2].NameConfigKey)
+	assert.Equal(t, output_workflow.HTML_MIME_TYPE, writers[2].MimeType)
+	assert.Empty(t, writers[2].TemplateFiles)
+}
+
+func Test_configureSarifEqualJSON_IncludesTOONFileWriter(t *testing.T) {
+	config := configuration.NewWithOpts()
+
+	configureSarifEqualJSON(config, nil)
+
+	writers, ok := config.Get(output_workflow.OUTPUT_CONFIG_KEY_FILE_WRITERS).([]output_workflow.FileWriter)
+	require.True(t, ok)
+	require.Len(t, writers, 4)
+	assert.Equal(t, output_workflow.OUTPUT_CONFIG_KEY_TOON_FILE, writers[3].NameConfigKey)
+	assert.Equal(t, output_workflow.TOON_MIME_TYPE, writers[3].MimeType)
+	assert.Empty(t, writers[3].TemplateFiles)
 }
 
 func Test_mainWithErrorCode(t *testing.T) {


### PR DESCRIPTION
## Pull Request Submission Checklist

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [ ] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [ ] Includes detailed description of changes
- [ ] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [ ] Includes product update to be announced in the next stable release notes

## What does this PR do?

## Where should the reviewer start?

## How should this be manually tested?

## What's the product update that needs to be communicated to CLI users?

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes output configuration for code/secrets test commands and depends on a minor framework bump; behavior is additive but affects structured output paths users may rely on in CI.
> 
> **Overview**
> Bumps **`go-application-framework`** to **v0.25.0** and wires **HTML** and **TOON** file output into **`snyk code test`** and **`snyk secrets test`**.
> 
> SARIF/JSON compatibility setup is refactored into **`configureSarifEqualJSON`**, which now registers four file writers (SARIF, JSON, HTML, TOON) on the output workflow config instead of only SARIF/JSON. HTML and TOON writers use framework MIME types, allow empty output, and do not use SARIF templates.
> 
> Unit tests assert the HTML and TOON writers are present in the configured writer list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e10434fdb632639177530b2bef62295a9dd5763. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->