### PR TITLE
chore: use package.json prettier version to format docs files

### DIFF
--- a/.github/workflows/sync-cli-help-to-user-docs.yml
+++ b/.github/workflows/sync-cli-help-to-user-docs.yml
@@ -62,8 +62,11 @@ jobs:
           cp ./user-docs/developer-tools/snyk-cli/commands/*.md ./cli/help/cli-commands/
 
       - name: Format with Prettier
-        run: npx prettier --write '**/*.md'
         working-directory: cli
+        run: |
+          PRETTIER_VERSION=$(node -p "require('./package-lock.json').packages['node_modules/prettier'].version")
+          echo "Using prettier@${PRETTIER_VERSION}"
+          npx -y "prettier@${PRETTIER_VERSION}" --write '**/*.md'
 
       - name: Check for changes
         id: check_changes


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages
  are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing
  _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment - Low
- [ ] Highlights breaking API changes (if applicable)
- [ ] Links to automated tests covering new functionality
- [ ] Includes manual testing instructions (if necessary)
- [ ] Updates relevant GitBook documentation (PR link: ___)
- [x] Includes product update to be announced in the next stable release notes

## What does this PR do?

Uses the same prettier version when formatting the Markdown files from a documentation update. Previously, the docs only check would fail since the files were not formatter properly, thus requiring extra help to merge the opened PR.

## Where should the reviewer start?

Changes to the GH action file.

## How should this be manually tested?

## What's the product update that needs to be communicated to CLI users?

N/A - general CI/automation chore

<!---
## Risk assessment (Low | Medium | High)?

## Any background context you want to provide?

## What are the relevant tickets?

## Screenshots (if appropriate)

Uncomment and fill in any sections above that are relevant to your PR.
--->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to doc sync formatting; no runtime CLI or product behavior.
> 
> **Overview**
> The **Synchronize CLI Help to User Docs** workflow now formats copied Markdown using the **Prettier version locked in `cli/package-lock.json`**, instead of whatever `npx prettier` resolves at run time.
> 
> The **Format with Prettier** step reads that version with Node, logs it, and runs `npx -y "prettier@${PRETTIER_VERSION}" --write '**/*.md'` under the `cli` working directory so automated doc sync PRs match local/CI formatting checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d05ee3f4499f66b1fd1d1aaa0e859f2457b9b5a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->