### PR TITLE
fix: bump snyk-nuget-plugin to 4.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "snyk-mvn-plugin": "4.9.2",
         "snyk-nodejs-lockfile-parser": "2.10.0",
         "snyk-nodejs-plugin": "^2.2.1",
-        "snyk-nuget-plugin": "^4.5.1",
+        "snyk-nuget-plugin": "^4.5.3",
         "snyk-php-plugin": "1.12.1",
         "snyk-policy": "^4.1.6",
         "snyk-python-plugin": "^3.3.1",
@@ -20403,9 +20403,9 @@
       "license": "ISC"
     },
     "node_modules/snyk-nuget-plugin": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-4.5.1.tgz",
-      "integrity": "sha512-odUxjYv32rV8XQKTn7gw5ILPwDt5A9egiEAPHvfvtrzC76xeWGFnz1tbUaNejMPTgI23mK9UDScN9U+cKOmhOw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-4.5.3.tgz",
+      "integrity": "sha512-noL5JN+4uJO3Z9PvVJnWvSOXnDs+tkr6fYXWFaWjvgsEioCmaiFRcNp6Y86u37NBDh4faKDVWSt4tp8qLx5bYw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@snyk/cli-interface": "^2.14.0",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "snyk-mvn-plugin": "4.9.2",
     "snyk-nodejs-lockfile-parser": "2.10.0",
     "snyk-nodejs-plugin": "^2.2.1",
-    "snyk-nuget-plugin": "^4.5.1",
+    "snyk-nuget-plugin": "^4.5.3",
     "snyk-php-plugin": "1.12.1",
     "snyk-policy": "^4.1.6",
     "snyk-python-plugin": "^3.3.1",


### PR DESCRIPTION
Bump the CLI’s NuGet plugin from 4.5.1 to 4.5.3.

## What does this PR do?

**Fix offline parser restore.** Includes [plugin #304](https://github.com/snyk/snyk-nuget-plugin/pull/304), preventing global source-mapping rules from excluding bundled packages ([OSM-3938](https://snyksec.atlassian.net/browse/OSM-3938)).

**Fix missing-dotnet and stale-path crashes.** Includes [plugin #303](https://github.com/snyk/snyk-nuget-plugin/pull/303), restoring legacy fallback when dotnet is unavailable and using the scan root when the original build directory is gone ([OSM-3923](https://snyksec.atlassian.net/browse/OSM-3923), [OSM-3924](https://snyksec.atlassian.net/browse/OSM-3924)).

## Where should the reviewer start?

`package.json` and `package-lock.json`; no transitive dependency changes.

## How should this be manually tested?

Scan pre-restored .NET projects without dotnet on PATH, with a stale absolute build path, and with global source-mapping rules excluding the bundled source. Confirm dependency scanning completes.

Validation: `npm ci`, `make format`, `make lint`, 26 test/monitor tests and installed-plugin subprocess smoke checks passed.

## What's the product update that needs to be communicated to CLI users?

.NET scans now fall back to legacy scanning when the .NET SDK is unavailable, handle dependency files restored in another build directory, and restore the internal parser’s bundled dependencies when global NuGet source-mapping rules are configured.

## Risk assessment (Low | Medium | High)?

Low: two upstream patch fixes; no new flags or breaking API changes.


[OSM-3938]: https://snyksec.atlassian.net/browse/OSM-3938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OSM-3923]: https://snyksec.atlassian.net/browse/OSM-3923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OSM-3924]: https://snyksec.atlassian.net/browse/OSM-3924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ