### PR TITLE
fix: bump snyk-gradle-plugin to 7.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "snyk-cpp-plugin": "^2.24.3",
         "snyk-docker-plugin": "9.20.0",
         "snyk-go-plugin": "2.2.1",
-        "snyk-gradle-plugin": "7.1.2",
+        "snyk-gradle-plugin": "7.1.3",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "4.9.2",
         "snyk-nodejs-lockfile-parser": "2.10.0",
@@ -19897,9 +19897,9 @@
       "integrity": "sha512-N5ixXjzTy4QDQH0Q9YFjqIWd6zH6936Djpl2m9QNFmDv5Fum8q8BjkpAcHNMzOFE0IwQrFhJWex3AN6kS0OSwg=="
     },
     "node_modules/snyk-gradle-plugin": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-7.1.2.tgz",
-      "integrity": "sha512-hP+ga9IQKSTZjkt/pFhSVXBQYOwSufvxZiYLqnZ+QYLKhxMJe5ZR94h/L5hLeSwjUEHR9g9qrLT3+wbozUSfsg==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-7.1.3.tgz",
+      "integrity": "sha512-7RQ/e130WmM0i5BkienhYfJ9k5bV82pWHKdxnH/fIWR9dF7YFDK41Xa/GUyCWLfxvsxRjXTi+sdCthU4usEtBg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@common.js/yocto-queue": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "snyk-cpp-plugin": "^2.24.3",
     "snyk-docker-plugin": "9.20.0",
     "snyk-go-plugin": "2.2.1",
-    "snyk-gradle-plugin": "7.1.2",
+    "snyk-gradle-plugin": "7.1.3",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "4.9.2",
     "snyk-nodejs-lockfile-parser": "2.10.0",


### PR DESCRIPTION
Bump the CLI's Gradle plugin from 7.1.2 to 7.1.3.

## What does this PR do?

**Fix stack overflow on deep Gradle dependency chains.** Includes [plugin #354](https://github.com/snyk/snyk-gradle-plugin/pull/354) for [OSM-3933](https://snyksec.atlassian.net/browse/OSM-3933) / [CMPA-770](https://snyksec.atlassian.net/browse/CMPA-770), replacing recursive dependency traversal with an iterative walk.

## Where should the reviewer start?

`package.json` and `package-lock.json`; no transitive dependency changes. [Upstream regression test](https://github.com/snyk/snyk-gradle-plugin/blob/v7.1.3/test/system/deep-dependency-chain.test.ts) covers a 400-module chain.

## How should this be manually tested?

Scan a deep inter-module Gradle chain with default JVM thread-stack settings and confirm the complete dependency graph is returned without StackOverflowError.

Validation: manifest/lockfile consistency, npm lockfile resolution, Prettier and diff checks pass. Full format/lint were blocked locally by Go cache permissions and missing npm tooling. CI is green after retrying the failed acceptance jobs.

## What's the product update that needs to be communicated to CLI users?

Gradle scans now handle deeply nested inter-module dependencies without exhausting the JVM thread stack. Heap-related memory limits remain unchanged.

## Risk assessment (Low | Medium | High)?

Medium: dependency traversal affects graph completeness; upstream regression coverage and CLI CI provide validation. No API changes.


[OSM-3933]: https://snyksec.atlassian.net/browse/OSM-3933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CMPA-770]: https://snyksec.atlassian.net/browse/CMPA-770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Gradle dependency graphs are built, which can affect scan completeness; risk is mitigated by upstream regression tests and unchanged CLI API surface.
> 
> **Overview**
> Bumps the bundled **`snyk-gradle-plugin`** from **7.1.2** to **7.1.3** in `package.json` and `package-lock.json` only; no other dependency tree changes in this diff.
> 
> That plugin release fixes **StackOverflowError** on deeply nested inter-module Gradle graphs by switching dependency traversal from **recursive** to **iterative** (upstream plugin #354). CLI Gradle scans should complete with default JVM thread-stack settings where they previously failed on long chains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc4f8ec07f76e2bb5aecf290335af2f44c5658e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->