### PR TITLE
docs: require complete PR descriptions in agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,6 +255,8 @@ Keep the first line under 72 characters. This format is enforced on every commit
 
 ## Pull Request Checks
 
+Before creating or editing a PR, read `.github/PULL_REQUEST_TEMPLATE.md` and fill its relevant sections, including **"What's the product update that needs to be communicated to CLI users?"**, manual testing instructions, and a risk assessment. This applies to dependency-only bumps too: describe the user-visible fix brought in by the dependency, link the upstream change and regression coverage, and state any remaining limitations. Check previous reviewer feedback before asking for review. Keep the description within 200 words (250 hard ceiling), and distinguish completed validation from pending or blocked checks.
+
 PR conventions are enforced by **Danger** (`dangerfile.js` is authoritative). To pass first time:
 
 - **Squash to a single commit** before merging — multiple commits are flagged.


### PR DESCRIPTION
Clarify PR-description requirements for coding agents.

## What does this PR do?

**Require agents to use the PR template.** AGENTS.md now calls out the product update, manual testing instructions and risk assessment, including for dependency-only bumps. It also asks agents to check previous feedback, link upstream fixes and tests, state residual limitations, and distinguish completed validation from pending checks within a 200-word target (250 maximum).

## Where should the reviewer start?

The added paragraph under “Pull Request Checks” in `AGENTS.md`.

## How should this be manually tested?

Compare the guidance with `.github/PULL_REQUEST_TEMPLATE.md`. Prettier and `git diff --check` pass; documentation only.

## What's the product update that needs to be communicated to CLI users?

None. This changes contributor guidance, with no CLI runtime behaviour change.

## Risk assessment (Low | Medium | High)?

Low: instructions only; no code, dependency or CI configuration changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor/agent guidance; no runtime, dependency, or CI behavior changes.
> 
> **Overview**
> **Pull Request Checks** in `AGENTS.md` now tells coding agents to read `.github/PULL_REQUEST_TEMPLATE.md` and complete the relevant sections before opening or updating a PR.
> 
> The new paragraph calls out the CLI **product update** blurb, manual testing steps, and risk assessment. Dependency-only bumps must still explain user-visible impact, link upstream fixes and tests, and note limitations. Agents are also asked to review prior feedback, stay within a **200-word** target (**250** max), and separate done validation from pending or blocked checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d31bb52b083ffe9db17445b5d3dc81b5d249ae0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->