### PR TITLE
chore: bump cli-extension-dep-graph to v2.16.0

### DIFF
--- a/cliv2-private/go.mod
+++ b/cliv2-private/go.mod
@@ -213,7 +213,7 @@ require (
 	github.com/skeema/knownhosts v1.3.2 // indirect
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260821092236-dc228259a004 // indirect
 	github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172 // indirect
-	github.com/snyk/cli-extension-dep-graph/v2 v2.15.0 // indirect
+	github.com/snyk/cli-extension-dep-graph/v2 v2.16.0 // indirect
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 // indirect
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f // indirect
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260903073306-ad447d86c87d // indirect

--- a/cliv2-private/go.sum
+++ b/cliv2-private/go.sum
@@ -583,8 +583,8 @@ github.com/snyk/cli-extension-axi v0.0.0-20260901142946-cb915113acb7 h1:lPR3FkwH
 github.com/snyk/cli-extension-axi v0.0.0-20260901142946-cb915113acb7/go.mod h1:C45YTforGksm9KhbB7RtgMCqeXP1fk/zjN+8ly4EQVg=
 github.com/snyk/cli-extension-cos v0.0.0-20260818151318-d63bb9db9484 h1:lgFISU/Opo4I1w7tHdivXR9OU6tsgbfmo4t9SewjuQE=
 github.com/snyk/cli-extension-cos v0.0.0-20260818151318-d63bb9db9484/go.mod h1:YpcOdcMBJOzwtla/OOoBOArx27Bc2v42Vcwd/FeGl9M=
-github.com/snyk/cli-extension-dep-graph/v2 v2.15.0 h1:STGpOc3LP7jJKrDbR4yaTNIPPSBq1840YODywUfKqEY=
-github.com/snyk/cli-extension-dep-graph/v2 v2.15.0/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
+github.com/snyk/cli-extension-dep-graph/v2 v2.16.0 h1:UDGayE+5kWzWwZJtwRagqvxXbBdKM4t6p8MQgQ6esxw=
+github.com/snyk/cli-extension-dep-graph/v2 v2.16.0/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSoQL0zYyFcGQjEPZcQgDkzM5PcgIHlIgzRuhg=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f h1:EPaHfaWDJq/lrsrATMqAyKJRfstb9LZnPXYNwXdL32c=

--- a/cliv2/go.mod
+++ b/cliv2/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/snyk/cli-extension-agent-scan v0.0.0-20260821092236-dc228259a004
 	github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172
-	github.com/snyk/cli-extension-dep-graph/v2 v2.15.0
+	github.com/snyk/cli-extension-dep-graph/v2 v2.16.0
 	github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077
 	github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f
 	github.com/snyk/cli-extension-os-flows v0.0.0-20260903073306-ad447d86c87d

--- a/cliv2/go.sum
+++ b/cliv2/go.sum
@@ -536,8 +536,8 @@ github.com/snyk/cli-extension-agent-scan v0.0.0-20260821092236-dc228259a004 h1:7
 github.com/snyk/cli-extension-agent-scan v0.0.0-20260821092236-dc228259a004/go.mod h1:u4d7qoWWVx3II+ZnpLQGjAegaJLmgPefXKXJD/jp/wM=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172 h1:dZQ2DnEnxV+v2yFRyuqUioSAGfXkiMcRQXndAeVsqi0=
 github.com/snyk/cli-extension-ai-bom v0.0.0-20260817214817-d0a81ac40172/go.mod h1:ieThzrb8z/Z88cDKdfqdfGh01xs6RkDKt5LbA+AE6U8=
-github.com/snyk/cli-extension-dep-graph/v2 v2.15.0 h1:STGpOc3LP7jJKrDbR4yaTNIPPSBq1840YODywUfKqEY=
-github.com/snyk/cli-extension-dep-graph/v2 v2.15.0/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
+github.com/snyk/cli-extension-dep-graph/v2 v2.16.0 h1:UDGayE+5kWzWwZJtwRagqvxXbBdKM4t6p8MQgQ6esxw=
+github.com/snyk/cli-extension-dep-graph/v2 v2.16.0/go.mod h1:I0GXbV6Rk8T0AEC9EugE4AgYE5SbDn0m0bGgAjZqy5U=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077 h1:lteivlSoQL0zYyFcGQjEPZcQgDkzM5PcgIHlIgzRuhg=
 github.com/snyk/cli-extension-iac v0.0.0-20260515092252-505c498f1077/go.mod h1:wRpQrWCjzWTPA5WK1xaHjWWI5zfY0qKe12PfKb+lcMk=
 github.com/snyk/cli-extension-iac-rules v0.0.0-20260818142329-df932cc1794f h1:EPaHfaWDJq/lrsrATMqAyKJRfstb9LZnPXYNwXdL32c=


### PR DESCRIPTION
## Pull Request Submission Checklist

- [x] Follows [CONTRIBUTING](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md) guidelines
- [x] Commit messages are [release-note ready](https://github.com/snyk/cli/blob/main/CONTRIBUTING.md#writing-commit-messages), emphasizing _what_ was changed, not _how_.
- [x] Includes detailed description of changes
- [x] Contains risk assessment (Low | Medium | High)
- [ ] Highlights breaking API changes (if applicable) — N/A, no breaking changes
- [ ] Links to automated tests covering new functionality — N/A, dependency bump only
- [ ] Includes manual testing instructions (if necessary) — N/A
- [ ] Updates relevant GitBook documentation (PR link: ___) — N/A
- [ ] Includes product update to be announced in the next stable release notes — N/A

## What does this PR do?

Bumps `github.com/snyk/cli-extension-dep-graph/v2` from v2.15.0 to v2.16.0 in both the public (`cliv2/go.mod`) and private (`cliv2-private/go.mod`) Go modules, and updates the corresponding `go.sum` files.

This picks up [snyk/cli-extension-dep-graph#260](https://github.com/snyk/cli-extension-dep-graph/pull/260) (`feat(discovery): honour --detection-depth [CMPA-792]`), which is what triggered the [v2.16.0 tag](https://github.com/snyk/cli-extension-dep-graph/releases/tag/v2.16.0).

## Where should the reviewer start?

The `go.mod`/`go.sum` diffs in `cliv2/` and `cliv2-private/`.

Note: `cliv2-private/go.mod`/`go.sum` could not be regenerated with `go mod tidy` in the environment this PR was prepared in (no access to the other private Snyk Go modules the private build depends on, e.g. `cli-extension-axi`, `remy-cli-extension`). The version bump and its `go.sum` hash were instead applied by hand, reusing the module hash already verified via the public `cliv2` module (Go module hashes are content-addressed per module version, not per consumer). Worth a second pair of eyes given the manual edit.

## How should this be manually tested?

N/A — dependency version bump only.

## Risk assessment (Low | Medium | High)?

Low. Version bump of an already-integrated extension; no code changes in this repo.


---
_Generated by [Claude Code](https://claude.ai/code/session_0196debUzuLcCXcEw8Kizbum)_

[CMPA-792]: https://snyksec.atlassian.net/browse/CMPA-792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no in-repo code changes; behaviour change is limited to dep-graph discovery depth handling in an already-integrated extension.
> 
> **Overview**
> Bumps **`github.com/snyk/cli-extension-dep-graph/v2`** from **v2.15.0** to **v2.16.0** in `cliv2` and `cliv2-private`, with matching **`go.sum`** updates.
> 
> That version includes discovery behavior that **honours `--detection-depth`** (from upstream v2.16.0 / CMPA-792). There are **no CLI source changes** here—only module pins. Reviewers should note **`cliv2-private/go.sum`** was updated manually (not via `go mod tidy`) using the same content hash as the public `cliv2` module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8605b8e2d326af5258b0ee5f8e34f01b842b594d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->